### PR TITLE
🔒 Fix potential server error information exposure

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import express from 'express';
+import { ZodError } from 'zod';
 
 import { appConfig, repositoryRoot } from './config/env.js';
 import { requireTrustedMutationRequest } from './middleware/csrf-protection.js';
@@ -28,8 +29,18 @@ export function createApp() {
   }
 
   app.use((error: unknown, _request: express.Request, response: express.Response, _next: express.NextFunction) => {
-    const message = error instanceof Error ? error.message : 'Unexpected server error';
-    response.status(400).json({ message });
+    if (error instanceof ZodError) {
+      response.status(400).json({ message: 'Validation error', errors: error.errors });
+      return;
+    }
+
+    if (error instanceof Error) {
+      console.error(error.stack);
+    } else {
+      console.error(error);
+    }
+
+    response.status(500).json({ message: 'Unexpected server error' });
   });
 
   return app;

--- a/server/test/app.test.ts
+++ b/server/test/app.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import { ZodError } from 'zod';
+
+import { createApp } from '../src/app.js';
+
+describe('App Error Handling', () => {
+  let app: express.Express;
+  let errorHandler: express.ErrorRequestHandler;
+
+  beforeAll(() => {
+    // We can spy on express().use to capture the error handler when it's registered
+    const originalUse = express.application.use;
+    vi.spyOn(express.application, 'use').mockImplementation(function (this: any, ...args: any[]) {
+      // Look for a function with 4 arguments (error handler signature)
+      for (const arg of args) {
+        if (typeof arg === 'function' && arg.length === 4) {
+          errorHandler = arg as express.ErrorRequestHandler;
+        }
+      }
+      return originalUse.apply(this, args);
+    });
+
+    app = createApp();
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('handles ZodError correctly', () => {
+    expect(errorHandler).toBeDefined();
+
+    const error = new ZodError([{ code: 'custom', message: 'Test error', path: ['test'] }]);
+    const mockRequest = {} as express.Request;
+    const mockResponse = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis()
+    } as unknown as express.Response;
+    const mockNext = vi.fn() as express.NextFunction;
+
+    errorHandler(error, mockRequest, mockResponse, mockNext);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      message: 'Validation error',
+      errors: error.errors
+    });
+  });
+
+  it('handles unexpected errors generically', () => {
+    expect(errorHandler).toBeDefined();
+
+    const error = new Error('Secret internal error that should not be exposed');
+    const mockRequest = {} as express.Request;
+    const mockResponse = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis()
+    } as unknown as express.Response;
+    const mockNext = vi.fn() as express.NextFunction;
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    errorHandler(error, mockRequest, mockResponse, mockNext);
+
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(mockResponse.status).toHaveBeenCalledWith(500);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      message: 'Unexpected server error'
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** Modified the global express error handler in `server/src/app.ts` to prevent raw error messages from uncaught exceptions being sent to the client. It now specifically returns a 400 status with details for `ZodError` validation failures, and returns a generic 500 status for all other errors, logging the actual stack trace server-side.
⚠️ **Risk:** By returning `error.message` directly to the client, the application was vulnerable to Information Exposure. Uncaught filesystem errors, database errors, or other internal exceptions could leak sensitive information like absolute system paths, database table structures, or internal state to an attacker.
🛡️ **Solution:** The error handling middleware now acts as a secure boundary. Expected client errors (like input validation from Zod) are safely exposed to help users. Unexpected errors are logged securely on the server using `console.error(error.stack)` and a generic, safe message ("Unexpected server error") is returned to the client with a `500 Internal Server Error` status code. Tests were also added to `server/test/app.test.ts` to verify this behavior.

---
*PR created automatically by Jules for task [1787981859546684191](https://jules.google.com/task/1787981859546684191) started by @sajjadalis*