### PR TITLE
feat: add lazy derivative generation and Vidstack video playback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,4 +10,8 @@ SCAN_DISCOVERY_CONCURRENCY=4
 SCAN_DERIVATIVE_CONCURRENCY=4
 PUBLIC_DEMO_MODE=0
 CSRF_TRUSTED_ORIGINS=
+# Controls what the image detail page loads: 'preview' (default) or 'original'
+IMAGE_DETAIL_SOURCE=preview
+# Controls when thumbnails/previews are generated: 'eager' (default, at scan time) or 'lazy' (on first request)
+DERIVATIVE_MODE=eager
 NODE_ENV=development

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 Foldergram is a self-hosted web application that turns your local folders into a beautiful, instagram-style feed and profile. It turns your local folder to app folders (profiles), and serves a lightning-fast Progressive Web App (PWA).
 
-Foldergram indexes supported media from a configured `GALLERY_ROOT`, stores metadata in SQLite, generates thumbnails and previews, and serves a fast feed-style web app for local browsing. The current app includes Home, Explore, Library, Likes, Moments or Highlights, App Folder pages, post detail views, delete actions, scan controls, and rebuild tools.
+Foldergram indexes supported media from a configured `GALLERY_ROOT`, stores metadata in SQLite, generates thumbnails and previews, and serves a fast feed-style web app for local browsing. Derivatives can be generated during scans or lazily on first request, and image detail pages can be configured to use generated previews or originals. The current app includes Home, Explore, Library, Likes, Moments or Highlights, App Folder pages, post detail views, delete actions, scan controls, and rebuild tools.
 
 ## Features
 
@@ -34,9 +34,9 @@ Foldergram indexes supported media from a configured `GALLERY_ROOT`, stores meta
 - Library browsing with App Folder search, sorting, and delete actions.
 - App Folder pages with a posts grid and a `Reels` tab when videos exist.
 - Shared likes in SQLite for signed-in admin/viewer sessions, plus browser-local favorites in public mode.
-- Image and video support with generated derivatives for fast browsing.
+- Image and video support with configurable eager or lazy derivative generation for fast browsing.
 - Optional role-based local access with admin, viewer, and public browse modes.
-- Settings actions for manual scan, thumbnail rebuild, and full library rebuild.
+- Settings actions for manual scan, thumbnail rebuild, and library-index rebuild.
 - A web app manifest plus production service worker registration.
 - A debounced filesystem watcher in development mode only.
 - No multi-user accounts, cloud sync, uploads, comments, messaging, notifications, or remote APIs.
@@ -200,6 +200,8 @@ data/
 | `DB_DIR`                      | `./data/db`         | SQLite database directory.                                                |
 | `THUMBNAILS_DIR`              | `./data/thumbnails` | Generated thumbnail output directory.                                     |
 | `PREVIEWS_DIR`                | `./data/previews`   | Generated preview output directory.                                       |
+| `IMAGE_DETAIL_SOURCE`         | `preview`           | For image detail pages, use generated previews or stream originals.       |
+| `DERIVATIVE_MODE`             | `eager`             | Generate derivatives during scans or lazily on first request.             |
 | `SCAN_DISCOVERY_CONCURRENCY`  | `4`                 | Folder discovery concurrency.                                             |
 | `SCAN_DERIVATIVE_CONCURRENCY` | `4`                 | Derivative generation concurrency.                                        |
 | `PUBLIC_DEMO_MODE`            | `0`                 | When enabled, all API mutations become read-only and return `403`.        |
@@ -207,6 +209,20 @@ data/
 | `NODE_ENV`                    | `development`       | Runtime mode.                                                             |
 
 The shipped `.env.example` only includes the `DEV_*` port values. Docker uses the fixed internal container port `4141`, and other production runtimes continue to use `SERVER_PORT`, which defaults to `4141` in the Docker image.
+
+### Detail Media and Derivative Timing
+
+- `IMAGE_DETAIL_SOURCE=preview` keeps image detail pages on generated previews.
+- `IMAGE_DETAIL_SOURCE=original` makes image detail pages stream `/api/originals/:id`.
+- `DERIVATIVE_MODE=eager` generates thumbnails and previews during scans.
+- `DERIVATIVE_MODE=lazy` indexes metadata during scans, then generates missing files the first time `/thumbnails/...` or `/previews/...` is requested and caches them on disk.
+
+These flags are independent:
+
+- feed cards, folder grids, avatars, and other list surfaces still use generated derivatives
+- `IMAGE_DETAIL_SOURCE` affects images only; videos still default to preview playback
+- `Rebuild Library Index` refreshes the SQLite-backed index; in lazy mode it does not pre-generate missing derivatives
+- `Regenerate Thumbnails` remains a manual thumbnail and video-poster rebuild only; it does not rebuild previews
 
 ### Access Protection
 

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "pinia": "^3.0.1",
+    "vidstack": "^1.12.13",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0"
   },

--- a/client/src/components/FeedCard.vue
+++ b/client/src/components/FeedCard.vue
@@ -70,19 +70,71 @@
       class="relative block overflow-hidden rounded-[0.5rem] border border-border bg-surface-alt"
       :style="{ aspectRatio: mediaAspectRatio }"
     >
-      <video
-        ref="homeVideoElement"
-        class="block h-full w-full bg-black object-cover"
-        :src="item.previewUrl"
-        :poster="item.thumbnailUrl"
-        :controls="isActiveVideo"
-        loop
-        playsinline
+      <media-player
+        ref="homePlayerElement"
+        class="feed-card__player"
+        :src.prop="homeVideoSource"
+        :title.prop="item.filename"
+        :playsInline.prop="true"
+        :muted.prop="appStore.videoMuted"
+        :loop.prop="true"
+        load="visible"
         preload="metadata"
-        @loadedmetadata="syncHomeVideoPlayback"
-        @play="handleHomeVideoPlay"
-        @volumechange="handleHomeVideoVolumeChange"
-      />
+      >
+        <media-provider />
+        <media-poster
+          :src.prop="item.thumbnailUrl"
+          :alt.prop="item.filename"
+        />
+        <media-controls
+          v-if="isActiveVideo"
+          class="feed-card__player-controls"
+        >
+          <media-controls-group class="feed-card__player-controls-group">
+            <media-play-button
+              class="feed-card__player-control"
+              aria-label="Toggle playback"
+            >
+              <span
+                class="feed-card__player-control-icon feed-card__player-play-icon feed-card__player-play-icon--play i-fluent-play-16-filled"
+                aria-hidden="true"
+              />
+              <span
+                class="feed-card__player-control-icon feed-card__player-play-icon feed-card__player-play-icon--pause i-fluent-pause-16-filled"
+                aria-hidden="true"
+              />
+            </media-play-button>
+            <media-mute-button
+              class="feed-card__player-control"
+              aria-label="Toggle sound"
+            >
+              <span
+                class="feed-card__player-control-icon feed-card__player-mute-icon feed-card__player-mute-icon--on i-fluent-speaker-2-16-regular"
+                aria-hidden="true"
+              />
+              <span
+                class="feed-card__player-control-icon feed-card__player-mute-icon feed-card__player-mute-icon--off i-fluent-speaker-mute-16-regular"
+                aria-hidden="true"
+              />
+            </media-mute-button>
+          </media-controls-group>
+          <media-controls-group class="feed-card__player-controls-group">
+            <media-fullscreen-button
+              class="feed-card__player-control"
+              aria-label="Toggle fullscreen"
+            >
+              <span
+                class="feed-card__player-control-icon feed-card__player-fullscreen-icon feed-card__player-fullscreen-icon--enter i-fluent-full-screen-maximize-16-regular"
+                aria-hidden="true"
+              />
+              <span
+                class="feed-card__player-control-icon feed-card__player-fullscreen-icon feed-card__player-fullscreen-icon--exit i-fluent-full-screen-minimize-16-regular"
+                aria-hidden="true"
+              />
+            </media-fullscreen-button>
+          </media-controls-group>
+        </media-controls>
+      </media-player>
       <div
         class="absolute inset-x-0 top-0 flex items-center justify-between gap-3 px-4 py-3 text-white pointer-events-none bg-[linear-gradient(180deg,rgba(10,14,24,0.82)_0%,rgba(10,14,24,0)_100%)]"
       >
@@ -267,8 +319,12 @@
 </template>
 
 <script setup lang="ts">
+import 'vidstack/bundle';
+
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { RouterLink, useRoute } from 'vue-router';
+import type { PlayerSrc } from 'vidstack';
+import type { MediaPlayerElement } from 'vidstack/elements';
 
 import { deleteImage, trashImage } from '../api/gallery';
 import { useAppStore } from '../stores/app';
@@ -323,12 +379,13 @@ const confirmDeleteOpen = ref(false);
 const deleteOriginalFromDisk = ref(false);
 const deleteError = ref<string | null>(null);
 const homeVideoTarget = ref<HTMLElement | null>(null);
-const homeVideoElement = ref<HTMLVideoElement | null>(null);
+const homePlayerElement = ref<MediaPlayerElement | null>(null);
 const lastHomeImageTapAt = ref(0);
 
 let homeImageTapResetTimer: ReturnType<typeof setTimeout> | null = null;
 let homeVideoObserver: IntersectionObserver | null = null;
 let homeVideoMuteSyncToken = 0;
+let removeHomePlayerEventListeners: (() => void) | null = null;
 
 const imageRoute = computed(() => `/image/${props.item.id}`);
 const isHomeContext = computed(() => props.context === 'home');
@@ -350,6 +407,10 @@ const formattedDate = computed(() =>
 const formattedDuration = computed(() => formatMediaDuration(props.item.durationMs));
 const mediaAspectRatio = computed(() => resolveFeedAspectRatio(props.item.width, props.item.height));
 const homeImageSrc = computed(() => (props.item.isAnimated ? props.item.previewUrl : props.item.thumbnailUrl));
+const homeVideoSource = computed<PlayerSrc>(() => ({
+  src: props.item.previewUrl,
+  type: 'video/mp4'
+}));
 const deleteDialogMessage = computed(() =>
   deleteOriginalFromDisk.value
     ? 'This will permanently delete the post from the app and remove original media from disk.'
@@ -459,9 +520,9 @@ function startHomeVideoObserver() {
   homeVideoObserver.observe(homeVideoTarget.value);
 }
 
-function syncHomeVideoMuted(video: HTMLVideoElement, muted: boolean) {
+function syncHomeVideoMuted(player: MediaPlayerElement, muted: boolean) {
   const token = ++homeVideoMuteSyncToken;
-  video.muted = muted;
+  player.muted = muted;
 
   requestAnimationFrame(() => {
     if (homeVideoMuteSyncToken === token) {
@@ -475,21 +536,23 @@ async function syncHomeVideoPlayback() {
     return;
   }
 
-  const video = homeVideoElement.value;
-  if (!video) {
+  const player = homePlayerElement.value;
+  if (!player) {
     return;
   }
 
   if (!props.isActiveVideo) {
-    video.pause();
-    syncHomeVideoMuted(video, appStore.videoMuted);
+    void player.pause().catch(() => {
+      // Ignore pause rejections before the provider is ready.
+    });
+    syncHomeVideoMuted(player, appStore.videoMuted);
     return;
   }
 
-  syncHomeVideoMuted(video, appStore.videoMuted);
+  syncHomeVideoMuted(player, appStore.videoMuted);
 
   try {
-    await video.play();
+    await player.play();
     return;
   } catch {
     if (appStore.videoMuted) {
@@ -498,10 +561,10 @@ async function syncHomeVideoPlayback() {
     }
   }
 
-  syncHomeVideoMuted(video, true);
+  syncHomeVideoMuted(player, true);
 
   try {
-    await video.play();
+    await player.play();
   } catch {
     // Ignore autoplay rejections and leave manual controls available when focused.
   }
@@ -509,18 +572,55 @@ async function syncHomeVideoPlayback() {
 
 function handleHomeVideoPlay() {
   if (!props.isActiveVideo) {
-    homeVideoElement.value?.pause();
+    void homePlayerElement.value?.pause().catch(() => {
+      // Ignore pause rejections before the provider is ready.
+    });
   }
 }
 
 function handleHomeVideoVolumeChange() {
-  const video = homeVideoElement.value;
-  if (!video || homeVideoMuteSyncToken !== 0) {
+  const player = homePlayerElement.value;
+  if (!player || homeVideoMuteSyncToken !== 0) {
     return;
   }
 
-  if (video.muted !== appStore.videoMuted) {
-    appStore.setVideoMuted(video.muted);
+  if (player.muted !== appStore.videoMuted) {
+    appStore.setVideoMuted(player.muted);
+  }
+}
+
+function bindHomePlayerEventListeners(player: MediaPlayerElement | null) {
+  removeHomePlayerEventListeners?.();
+  removeHomePlayerEventListeners = null;
+
+  if (!player) {
+    return;
+  }
+
+  const handleReady = () => {
+    void syncHomeVideoPlayback();
+  };
+  const handleVolume = () => {
+    handleHomeVideoVolumeChange();
+  };
+  const handlePlay = () => {
+    handleHomeVideoPlay();
+  };
+
+  player.addEventListener('loaded-metadata', handleReady);
+  player.addEventListener('can-play', handleReady);
+  player.addEventListener('volume-change', handleVolume);
+  player.addEventListener('play', handlePlay);
+
+  removeHomePlayerEventListeners = () => {
+    player.removeEventListener('loaded-metadata', handleReady);
+    player.removeEventListener('can-play', handleReady);
+    player.removeEventListener('volume-change', handleVolume);
+    player.removeEventListener('play', handlePlay);
+  };
+
+  if (player.hasAttribute('data-can-play')) {
+    void syncHomeVideoPlayback();
   }
 }
 
@@ -590,14 +690,18 @@ watch(
 watch(
   () => appStore.videoMuted,
   (videoMuted) => {
-    const video = homeVideoElement.value;
-    if (!video) {
+    const player = homePlayerElement.value;
+    if (!player) {
       return;
     }
 
-    syncHomeVideoMuted(video, videoMuted);
+    syncHomeVideoMuted(player, videoMuted);
   }
 );
+
+watch(homePlayerElement, (player) => {
+  bindHomePlayerEventListeners(player);
+});
 
 watch(
   () => props.context,
@@ -609,7 +713,9 @@ watch(
     }
 
     stopHomeVideoObserver();
-    homeVideoElement.value?.pause();
+    void homePlayerElement.value?.pause().catch(() => {
+      // Ignore pause rejections before the provider is ready.
+    });
   }
 );
 
@@ -621,6 +727,10 @@ onMounted(() => {
 onBeforeUnmount(() => {
   clearHomeImageTapResetTimer();
   stopHomeVideoObserver();
-  homeVideoElement.value?.pause();
+  removeHomePlayerEventListeners?.();
+  removeHomePlayerEventListeners = null;
+  void homePlayerElement.value?.pause().catch(() => {
+    // Ignore pause rejections before the provider is ready.
+  });
 });
 </script>

--- a/client/src/components/ImageModal.vue
+++ b/client/src/components/ImageModal.vue
@@ -122,20 +122,100 @@
           },
         ]"
       >
-        <video
-          v-if="image.mediaType === 'video'"
-          ref="videoElement"
-          :src="image.previewUrl"
-          :poster="image.thumbnailUrl"
-          :width="image.width"
-          :height="image.height"
-          controls
-          loop
-          playsinline
-          preload="metadata"
-          @loadedmetadata="attemptVideoPlayback"
-          @volumechange="handleVideoVolumeChange"
-        />
+        <template v-if="image.mediaType === 'video'">
+          <div
+            class="viewer__video-shell"
+            :style="videoShellStyle"
+          >
+            <media-player
+              ref="playerElement"
+              class="viewer__player"
+              :src.prop="videoSource"
+              :title.prop="image.filename"
+              :playsInline.prop="true"
+              :muted.prop="appStore.videoMuted"
+              :loop.prop="true"
+              load="eager"
+              preload="metadata"
+            >
+              <media-provider />
+              <media-poster
+                class="viewer__player-poster"
+                :src.prop="image.thumbnailUrl"
+                :alt.prop="image.filename"
+              />
+              <media-controls class="viewer__player-controls">
+                <media-controls-group class="viewer__player-controls-group">
+                  <media-play-button
+                    class="viewer__player-control"
+                    aria-label="Toggle playback"
+                  >
+                    <span
+                      class="viewer__player-control-icon viewer__player-play-icon viewer__player-play-icon--play i-fluent-play-16-filled"
+                      aria-hidden="true"
+                    />
+                    <span
+                      class="viewer__player-control-icon viewer__player-play-icon viewer__player-play-icon--pause i-fluent-pause-16-filled"
+                      aria-hidden="true"
+                    />
+                  </media-play-button>
+                  <media-mute-button
+                    class="viewer__player-control"
+                    aria-label="Toggle sound"
+                  >
+                    <span
+                      class="viewer__player-control-icon viewer__player-mute-icon viewer__player-mute-icon--on i-fluent-speaker-2-16-regular"
+                      aria-hidden="true"
+                    />
+                    <span
+                      class="viewer__player-control-icon viewer__player-mute-icon viewer__player-mute-icon--off i-fluent-speaker-mute-16-regular"
+                      aria-hidden="true"
+                    />
+                  </media-mute-button>
+                </media-controls-group>
+                <media-controls-group class="viewer__player-controls-group">
+                  <button
+                    v-if="showHdButton"
+                    class="viewer__player-control"
+                    :class="{ 'viewer__player-control--active': isPlayingHd }"
+                    type="button"
+                    :aria-label="
+                      isPlayingHd
+                        ? 'Switch to preview quality'
+                        : 'Switch to HD original'
+                    "
+                    :aria-pressed="isPlayingHd"
+                    :title="isPlayingHd ? 'Preview quality' : 'HD original'"
+                    @click.stop="toggleHdSource"
+                  >
+                    <span
+                      class="viewer__player-control-icon"
+                      :class="
+                        isPlayingHd
+                          ? 'i-fluent-hd-16-filled'
+                          : 'i-fluent-hd-16-regular'
+                      "
+                      aria-hidden="true"
+                    />
+                  </button>
+                  <media-fullscreen-button
+                    class="viewer__player-control"
+                    aria-label="Toggle fullscreen"
+                  >
+                    <span
+                      class="viewer__player-control-icon viewer__player-fullscreen-icon viewer__player-fullscreen-icon--enter i-fluent-full-screen-maximize-16-regular"
+                      aria-hidden="true"
+                    />
+                    <span
+                      class="viewer__player-control-icon viewer__player-fullscreen-icon viewer__player-fullscreen-icon--exit i-fluent-full-screen-minimize-16-regular"
+                      aria-hidden="true"
+                    />
+                  </media-fullscreen-button>
+                </media-controls-group>
+              </media-controls>
+            </media-player>
+          </div>
+        </template>
         <ResilientImage
           v-else
           :src="image.previewUrl"
@@ -367,8 +447,12 @@
 </template>
 
 <script setup lang="ts">
+  import "vidstack/bundle"
+
   import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue"
   import { RouterLink, useRoute, useRouter } from "vue-router"
+  import type { PlayerSrc } from "vidstack"
+  import type { MediaPlayerElement } from "vidstack/elements"
 
   import type { ImageDetail, FolderSummary } from "../types/api"
   import { useAppStore } from "../stores/app"
@@ -376,7 +460,7 @@
   import { useLikesStore } from "../stores/likes"
   import Avatar from "./Avatar.vue"
   import ResilientImage from "./ResilientImage.vue"
-  import { formatMediaDuration } from "../utils/media"
+  import { formatMediaDuration, videoPreviewWouldDownscale } from "../utils/media"
 
   const props = defineProps<{
     image: ImageDetail | null
@@ -395,7 +479,7 @@
   const authStore = useAuthStore()
   const route = useRoute()
   const router = useRouter()
-  const videoElement = ref<HTMLVideoElement | null>(null)
+  const playerElement = ref<MediaPlayerElement | null>(null)
   const cardWrapperElement = ref<HTMLElement | null>(null)
   const sidebarElement = ref<HTMLElement | null>(null)
   const sidebarToggleElement = ref<HTMLButtonElement | null>(null)
@@ -403,6 +487,7 @@
   const navigationLockedUntil = ref(0)
   const isSidebarCollapsible = ref(false)
   const isSidebarExpanded = ref(true)
+  const isPlayingHd = ref(false)
 
   const WHEEL_NAVIGATION_THRESHOLD = 72
   const NAVIGATION_COOLDOWN_MS = 320
@@ -414,6 +499,8 @@
   }
 
   let videoMuteSyncToken = 0
+  let pendingVideoRestore: { currentTime: number; wasPaused: boolean } | null = null
+  let removePlayerEventListeners: (() => void) | null = null
 
   const fileSize = computed(() => {
     if (!props.image) {
@@ -422,6 +509,45 @@
 
     const megabytes = props.image.fileSize / (1024 * 1024)
     return `${megabytes.toFixed(2)} MB`
+  })
+
+  const showHdButton = computed(
+    () =>
+      props.image?.mediaType === 'video' &&
+      props.image?.playbackStrategy === 'original' &&
+      videoPreviewWouldDownscale(props.image.width, props.image.height),
+  )
+
+  const videoSrc = computed(() => {
+    if (!props.image || props.image.mediaType !== 'video') {
+      return props.image?.previewUrl ?? ''
+    }
+
+    if (isPlayingHd.value && props.image.originalUrl) {
+      return props.image.originalUrl
+    }
+
+    return props.image.previewUrl
+  })
+  const videoSource = computed<PlayerSrc>(() => {
+    if (!props.image || props.image.mediaType !== "video") {
+      return { src: props.image?.previewUrl ?? "", type: "video/mp4" }
+    }
+
+    return {
+      src: videoSrc.value,
+      type: "video/mp4",
+    }
+  })
+  const videoShellStyle = computed(() => {
+    if (!props.image || props.image.mediaType !== "video") {
+      return undefined
+    }
+
+    return {
+      "--viewer-media-aspect-ratio": `${props.image.width} / ${props.image.height}`,
+      "--viewer-media-intrinsic-width": `${props.image.width}px`,
+    }
   })
 
   const folderAvatar = computed(() => props.folder?.avatarUrl ?? null)
@@ -533,9 +659,9 @@
     () => isModalSidebarCollapsible.value && isSidebarExpanded.value,
   )
 
-  function syncVideoMuted(video: HTMLVideoElement, muted: boolean) {
+  function syncVideoMuted(player: MediaPlayerElement, muted: boolean) {
     const token = ++videoMuteSyncToken
-    video.muted = muted
+    player.muted = muted
 
     requestAnimationFrame(() => {
       if (videoMuteSyncToken === token) {
@@ -698,15 +824,15 @@
     }
 
     await nextTick()
-    const video = videoElement.value
-    if (!video) {
+    const player = playerElement.value
+    if (!player) {
       return
     }
 
-    syncVideoMuted(video, appStore.videoMuted)
+    syncVideoMuted(player, appStore.videoMuted)
 
     try {
-      await video.play()
+      await player.play()
       return
     } catch {
       if (appStore.videoMuted) {
@@ -715,23 +841,85 @@
       }
     }
 
-    syncVideoMuted(video, true)
+    syncVideoMuted(player, true)
 
     try {
-      await video.play()
+      await player.play()
     } catch {
       // Ignore autoplay rejections and leave manual controls available.
     }
   }
 
-  function handleVideoVolumeChange() {
-    const video = videoElement.value
-    if (!video || videoMuteSyncToken !== 0) {
+  function handlePlayerVolumeChange() {
+    const player = playerElement.value
+    if (!player || videoMuteSyncToken !== 0) {
       return
     }
 
-    if (video.muted !== appStore.videoMuted) {
-      appStore.setVideoMuted(video.muted)
+    if (player.muted !== appStore.videoMuted) {
+      appStore.setVideoMuted(player.muted)
+    }
+  }
+
+  function toggleHdSource() {
+    const player = playerElement.value
+    const image = props.image
+    if (!player || !image || image.mediaType !== 'video') {
+      return
+    }
+
+    const savedTime = player.currentTime
+    pendingVideoRestore = {
+      currentTime: savedTime,
+      wasPaused: player.paused
+    }
+    isPlayingHd.value = !isPlayingHd.value
+  }
+
+  async function handlePlayerReadyForPlayback(): Promise<void> {
+    const player = playerElement.value
+    if (player && pendingVideoRestore) {
+      const restoreState = pendingVideoRestore
+      pendingVideoRestore = null
+      player.currentTime = restoreState.currentTime
+
+      if (!restoreState.wasPaused) {
+        void player.play().catch(() => { /* ignore */ })
+      }
+
+      return
+    }
+
+    await attemptVideoPlayback()
+  }
+
+  function bindPlayerEventListeners(player: MediaPlayerElement | null) {
+    removePlayerEventListeners?.()
+    removePlayerEventListeners = null
+
+    if (!player) {
+      return
+    }
+
+    const handleReady = () => {
+      void handlePlayerReadyForPlayback()
+    }
+    const handleVolume = () => {
+      handlePlayerVolumeChange()
+    }
+
+    player.addEventListener("loaded-metadata", handleReady)
+    player.addEventListener("can-play", handleReady)
+    player.addEventListener("volume-change", handleVolume)
+
+    removePlayerEventListeners = () => {
+      player.removeEventListener("loaded-metadata", handleReady)
+      player.removeEventListener("can-play", handleReady)
+      player.removeEventListener("volume-change", handleVolume)
+    }
+
+    if (player.hasAttribute("data-can-play")) {
+      void handlePlayerReadyForPlayback()
     }
   }
 
@@ -740,6 +928,8 @@
     () => {
       wheelDeltaAccumulator.value = 0
       navigationLockedUntil.value = 0
+      isPlayingHd.value = false
+      pendingVideoRestore = null
       void attemptVideoPlayback()
     },
   )
@@ -747,14 +937,18 @@
   watch(
     () => appStore.videoMuted,
     videoMuted => {
-      const video = videoElement.value
-      if (!video) {
+      const player = playerElement.value
+      if (!player) {
         return
       }
 
-      syncVideoMuted(video, videoMuted)
+      syncVideoMuted(player, videoMuted)
     },
   )
+
+  watch(playerElement, player => {
+    bindPlayerEventListeners(player)
+  })
 
   watch(
     () => props.isModal,
@@ -860,6 +1054,8 @@
   onUnmounted(() => {
     window.removeEventListener("resize", updateSidebarLayout)
     window.removeEventListener("keydown", handleKeydown)
-    videoElement.value?.pause()
+    removePlayerEventListeners?.()
+    removePlayerEventListeners = null
+    void playerElement.value?.pause().catch(() => { /* ignore */ })
   })
 </script>

--- a/client/src/styles/base.css
+++ b/client/src/styles/base.css
@@ -258,6 +258,276 @@ img[data-loaded="true"] {
   transform: translateY(-1px);
 }
 
+.viewer__video-shell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: min(var(--viewer-media-intrinsic-width, 100%), 100%);
+  max-width: 100%;
+  max-height: 100%;
+  aspect-ratio: var(--viewer-media-aspect-ratio);
+  background: #000;
+  overflow: hidden;
+}
+
+.viewer__player {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  aspect-ratio: inherit;
+  color: #fff;
+  background: #000;
+}
+
+.viewer__player[data-view-type="video"] {
+  aspect-ratio: inherit;
+}
+
+.viewer__player media-provider,
+.viewer__player media-poster,
+.viewer__player video,
+.viewer__player img {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.viewer__player video,
+.viewer__player img {
+  object-fit: contain;
+}
+
+.viewer__player-controls {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.55rem 0.7rem 0.7rem;
+  background:
+    linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0) 0%,
+      rgba(0, 0, 0, 0.55) 58%,
+      rgba(0, 0, 0, 0.82) 100%
+    );
+}
+
+.viewer__player-controls-group {
+  display: flex;
+  align-items: center;
+  gap: 0.1rem;
+}
+
+.viewer__player-control {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.94);
+  cursor: pointer;
+  transition:
+    color 0.18s ease,
+    opacity 0.18s ease,
+    transform 0.15s ease;
+}
+
+.viewer__player-control:hover {
+  color: #fff;
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+.viewer__player-control--active {
+  color: rgba(103, 199, 255, 0.98);
+}
+
+.viewer__player-control--active:hover {
+  color: rgba(132, 210, 255, 1);
+}
+
+.viewer__player-control-icon {
+  position: absolute;
+  inset: 0;
+  width: 1.1rem;
+  height: 1.1rem;
+  margin: auto;
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease;
+}
+
+.viewer__player-play-icon--pause,
+.viewer__player-mute-icon--off,
+.viewer__player-fullscreen-icon--exit {
+  opacity: 0;
+  transform: scale(0.9);
+}
+
+.viewer__player media-play-button:not([data-paused]) .viewer__player-play-icon--play,
+.viewer__player media-mute-button[data-muted] .viewer__player-mute-icon--on,
+.viewer__player media-fullscreen-button[data-fullscreen] .viewer__player-fullscreen-icon--enter {
+  opacity: 0;
+  transform: scale(0.9);
+}
+
+.viewer__player media-play-button:not([data-paused]) .viewer__player-play-icon--pause,
+.viewer__player media-mute-button[data-muted] .viewer__player-mute-icon--off,
+.viewer__player media-fullscreen-button[data-fullscreen] .viewer__player-fullscreen-icon--exit {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.viewer__player media-controls,
+.viewer__player media-controls-group,
+.viewer__player media-play-button,
+.viewer__player media-mute-button,
+.viewer__player media-fullscreen-button {
+  box-sizing: border-box;
+}
+
+.feed-card__player {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  color: #fff;
+  background: #000;
+}
+
+.feed-card__player[data-view-type="video"] {
+  aspect-ratio: inherit;
+}
+
+.feed-card__player media-provider,
+.feed-card__player media-poster,
+.feed-card__player video,
+.feed-card__player img {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.feed-card__player video,
+.feed-card__player img {
+  object-fit: cover;
+}
+
+.feed-card__player-controls {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 0.7rem 0.55rem;
+  background:
+    linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0) 0%,
+      rgba(0, 0, 0, 0.52) 54%,
+      rgba(0, 0, 0, 0.82) 100%
+    );
+}
+
+.feed-card__player-controls-group {
+  display: flex;
+  align-items: center;
+  gap: 0.1rem;
+}
+
+.feed-card__player-control {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.95rem;
+  height: 1.95rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.94);
+  cursor: pointer;
+  transition:
+    color 0.18s ease,
+    opacity 0.18s ease,
+    transform 0.15s ease;
+}
+
+.feed-card__player-control:hover {
+  color: #fff;
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+.feed-card__player-control-icon {
+  position: absolute;
+  inset: 0;
+  width: 1rem;
+  height: 1rem;
+  margin: auto;
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease;
+}
+
+.feed-card__player-play-icon--pause,
+.feed-card__player-mute-icon--off,
+.feed-card__player-fullscreen-icon--exit {
+  opacity: 0;
+  transform: scale(0.9);
+}
+
+.feed-card__player media-play-button:not([data-paused]) .feed-card__player-play-icon--play,
+.feed-card__player media-mute-button[data-muted] .feed-card__player-mute-icon--on,
+.feed-card__player media-fullscreen-button[data-fullscreen] .feed-card__player-fullscreen-icon--enter {
+  opacity: 0;
+  transform: scale(0.9);
+}
+
+.feed-card__player media-play-button:not([data-paused]) .feed-card__player-play-icon--pause,
+.feed-card__player media-mute-button[data-muted] .feed-card__player-mute-icon--off,
+.feed-card__player media-fullscreen-button[data-fullscreen] .feed-card__player-fullscreen-icon--exit {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.feed-card__player media-controls,
+.feed-card__player media-controls-group,
+.feed-card__player media-play-button,
+.feed-card__player media-mute-button,
+.feed-card__player media-fullscreen-button {
+  box-sizing: border-box;
+}
+
+@media (max-width: 768px) {
+  .viewer__player-controls {
+    padding: 0.48rem 0.55rem 0.6rem;
+  }
+
+  .viewer__player-control {
+    width: 1.8rem;
+    height: 1.8rem;
+  }
+
+  .viewer__player-control-icon {
+    width: 1rem;
+    height: 1rem;
+  }
+}
+
 @media (max-width: 768px) {
   .viewer__card-wrapper {
     flex-direction: column;

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -94,6 +94,7 @@ export interface ImageDetail extends FeedItem {
   fileSize: number;
   exif: ImageExifData | null;
   originalUrl: string;
+  playbackStrategy?: 'preview' | 'original' | null;
   nextImageId: number | null;
   previousImageId: number | null;
 }

--- a/client/src/utils/media.ts
+++ b/client/src/utils/media.ts
@@ -15,8 +15,18 @@ export function formatMediaDuration(durationMs: number | null | undefined): stri
   return `${minutes}:${String(seconds).padStart(2, '0')}`;
 }
 
+export const VIDEO_PREVIEW_MAX_LONG_EDGE = 1280;
+export const VIDEO_PREVIEW_MAX_SHORT_EDGE = 720;
 const INSTAGRAM_MIN_ASPECT_RATIO = 4 / 5;
 const INSTAGRAM_MAX_ASPECT_RATIO = 1.91;
+
+export function videoPreviewWouldDownscale(width: number | null | undefined, height: number | null | undefined): boolean {
+  if (!width || !height || width <= 0 || height <= 0) {
+    return false;
+  }
+
+  return width > height ? width > VIDEO_PREVIEW_MAX_LONG_EDGE : width > VIDEO_PREVIEW_MAX_SHORT_EDGE;
+}
 
 export function clampFeedAspectRatio(width: number | null | undefined, height: number | null | undefined): number {
   if (!width || !height || width <= 0 || height <= 0) {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -15,7 +15,8 @@
       "DOM.Iterable"
     ],
     "types": [
-      "node"
+      "node",
+      "vidstack/vue"
     ]
   },
   "include": [

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig, loadEnv } from 'vite';
 import UnoCSS from 'unocss/vite';
 import vue from '@vitejs/plugin-vue';
+import { vite as vidstack } from 'vidstack/plugins';
 
 const appPackage = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf-8')
@@ -58,7 +59,19 @@ export default defineConfig(async ({ command, mode }) => {
     define: {
       __APP_VERSION__: JSON.stringify(appPackage.version)
     },
-    plugins: [UnoCSS(), vue()],
+    plugins: [
+      UnoCSS(),
+      vidstack({
+        include: /src\/components\//
+      }),
+      vue({
+        template: {
+          compilerOptions: {
+            isCustomElement: tag => tag.startsWith('media-')
+          }
+        }
+      })
+    ],
     server: {
       host: devHost,
       port: resolvedDevClientPort,

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -30,7 +30,7 @@ html {
   -webkit-text-fill-color: transparent;
   background-clip: text;
   color: transparent;
-  padding: 2px 6px;
+  padding: 2px 0;
   border-radius: 4px;
   animation: gradient-shift 6s ease infinite;
   background-size: 200% 200%;

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,10 +1,33 @@
 import DefaultTheme from 'vitepress/theme';
 import type { Theme } from 'vitepress';
+import { watch } from 'vue';
 
 import './custom.css';
+import './rainbow.css';
+
+function updateHomePageClass(enabled: boolean) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  document.documentElement.classList.toggle('fg-home-rainbow', enabled);
+}
 
 const theme: Theme = {
-  extends: DefaultTheme
+  extends: DefaultTheme,
+  enhanceApp({ router }) {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    watch(
+      () => router.route.data.relativePath,
+      (relativePath) => {
+        updateHomePageClass(relativePath === 'index.md' || relativePath === '');
+      },
+      { immediate: true }
+    );
+  }
 };
 
 export default theme;

--- a/docs/.vitepress/theme/rainbow.css
+++ b/docs/.vitepress/theme/rainbow.css
@@ -1,0 +1,265 @@
+:root {
+  --fg-home-glow-1: rgba(14, 165, 233, 0.28);
+  --fg-home-glow-2: rgba(99, 102, 241, 0.24);
+  --fg-home-glow-3: rgba(236, 72, 153, 0.2);
+  --fg-home-glow-4: rgba(245, 158, 11, 0.18);
+}
+
+:root.fg-home-rainbow {
+  animation: foldergram-rainbow 38s linear infinite;
+}
+
+:root.fg-home-rainbow .VPHome .VPHero {
+  isolation: isolate;
+}
+
+:root.fg-home-rainbow .VPHome .VPHero .container {
+  position: relative;
+  z-index: 1;
+}
+
+:root.fg-home-rainbow .VPHome .VPHero::before,
+:root.fg-home-rainbow .VPHome .VPHero::after {
+  content: '';
+  position: absolute;
+  border-radius: 999px;
+  pointer-events: none;
+  z-index: -1;
+  filter: blur(56px);
+}
+
+:root.fg-home-rainbow .VPHome .VPHero::before {
+  top: -7rem;
+  left: -5rem;
+  width: 24rem;
+  height: 24rem;
+  background: radial-gradient(circle at center, var(--fg-home-glow-1) 0%, transparent 72%);
+  animation: foldergram-orbit-a 16s ease-in-out infinite alternate;
+}
+
+:root.fg-home-rainbow .VPHome .VPHero::after {
+  right: -4rem;
+  bottom: -8rem;
+  width: 26rem;
+  height: 26rem;
+  background: radial-gradient(circle at center, var(--fg-home-glow-3) 0%, transparent 74%);
+  animation: foldergram-orbit-b 19s ease-in-out infinite alternate;
+}
+
+:root.fg-home-rainbow .VPHome .heading .name.clip {
+  background: linear-gradient(135deg, var(--vp-c-brand-1) 0%, var(--vp-c-brand-2) 48%, var(--vp-c-brand-3) 100%);
+  background-size: 220% 220%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  animation: gradient-shift 8s ease infinite;
+}
+
+:root.fg-home-rainbow .VPHome .tagline {
+  max-width: 38rem;
+}
+
+:root.fg-home-rainbow .VPHome .actions .VPButton.brand {
+  box-shadow: 0 14px 32px var(--fg-home-glow-2);
+}
+
+:root.fg-home-rainbow .VPHome .VPHero.has-image .image-container {
+  isolation: isolate;
+}
+
+:root.fg-home-rainbow .VPHome .VPHero.has-image .image-container::before,
+:root.fg-home-rainbow .VPHome .VPHero.has-image .image-container::after {
+  content: none;
+}
+
+:root.fg-home-rainbow .VPHome .VPHero.has-image .image-bg {
+  z-index: 0;
+  width: 360px;
+  height: 360px;
+  background:
+    radial-gradient(circle at 26% 28%, var(--fg-home-glow-3) 0%, transparent 34%),
+    radial-gradient(circle at 72% 34%, var(--fg-home-glow-1) 0%, transparent 36%),
+    radial-gradient(circle at 52% 72%, var(--fg-home-glow-4) 0%, transparent 38%),
+    radial-gradient(circle at 50% 50%, var(--fg-home-glow-2) 0%, transparent 46%);
+  filter: blur(82px) saturate(138%);
+  opacity: 0.96;
+  transition:
+    transform 1.35s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 1.35s cubic-bezier(0.22, 1, 0.36, 1),
+    filter 1.35s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+:root.fg-home-rainbow .VPHome .VPHero.has-image:hover .image-bg {
+  transform: translate(-50%, -50%) scale(0.72);
+  opacity: 0.46;
+  filter: blur(62px) saturate(144%);
+}
+
+:root.fg-home-rainbow .VPHome .VPHero.has-image .image-src {
+  z-index: 1;
+  filter: drop-shadow(0 20px 46px rgba(15, 23, 42, 0.18));
+}
+
+:root.fg-home-rainbow .VPNavBarTitle .logo {
+  filter: brightness(0) invert(1);
+}
+
+@keyframes foldergram-rainbow {
+  0% {
+    --vp-c-brand-1: #10b981;
+    --vp-c-brand-2: #0ea5e9;
+    --vp-c-brand-3: #6366f1;
+    --vp-c-brand-soft: rgba(16, 185, 129, 0.14);
+    --vp-button-brand-bg: #10b981;
+    --vp-button-brand-hover-bg: #0f9f92;
+    --vp-button-brand-active-bg: #0b7f74;
+    --fg-home-glow-1: rgba(14, 165, 233, 0.3);
+    --fg-home-glow-2: rgba(99, 102, 241, 0.24);
+    --fg-home-glow-3: rgba(16, 185, 129, 0.22);
+    --fg-home-glow-4: rgba(236, 72, 153, 0.18);
+  }
+
+  16% {
+    --vp-c-brand-1: #06b6d4;
+    --vp-c-brand-2: #3b82f6;
+    --vp-c-brand-3: #8b5cf6;
+    --vp-c-brand-soft: rgba(6, 182, 212, 0.15);
+    --vp-button-brand-bg: #06b6d4;
+    --vp-button-brand-hover-bg: #0891b2;
+    --vp-button-brand-active-bg: #0e7490;
+    --fg-home-glow-1: rgba(59, 130, 246, 0.3);
+    --fg-home-glow-2: rgba(139, 92, 246, 0.24);
+    --fg-home-glow-3: rgba(6, 182, 212, 0.24);
+    --fg-home-glow-4: rgba(236, 72, 153, 0.18);
+  }
+
+  32% {
+    --vp-c-brand-1: #6366f1;
+    --vp-c-brand-2: #a855f7;
+    --vp-c-brand-3: #ec4899;
+    --vp-c-brand-soft: rgba(99, 102, 241, 0.15);
+    --vp-button-brand-bg: #6366f1;
+    --vp-button-brand-hover-bg: #4f46e5;
+    --vp-button-brand-active-bg: #4338ca;
+    --fg-home-glow-1: rgba(99, 102, 241, 0.28);
+    --fg-home-glow-2: rgba(168, 85, 247, 0.22);
+    --fg-home-glow-3: rgba(236, 72, 153, 0.24);
+    --fg-home-glow-4: rgba(244, 114, 182, 0.18);
+  }
+
+  48% {
+    --vp-c-brand-1: #ec4899;
+    --vp-c-brand-2: #f97316;
+    --vp-c-brand-3: #f59e0b;
+    --vp-c-brand-soft: rgba(236, 72, 153, 0.16);
+    --vp-button-brand-bg: #ec4899;
+    --vp-button-brand-hover-bg: #db2777;
+    --vp-button-brand-active-bg: #be185d;
+    --fg-home-glow-1: rgba(236, 72, 153, 0.26);
+    --fg-home-glow-2: rgba(249, 115, 22, 0.24);
+    --fg-home-glow-3: rgba(245, 158, 11, 0.2);
+    --fg-home-glow-4: rgba(251, 191, 36, 0.18);
+  }
+
+  64% {
+    --vp-c-brand-1: #f59e0b;
+    --vp-c-brand-2: #84cc16;
+    --vp-c-brand-3: #10b981;
+    --vp-c-brand-soft: rgba(245, 158, 11, 0.14);
+    --vp-button-brand-bg: #f59e0b;
+    --vp-button-brand-hover-bg: #d97706;
+    --vp-button-brand-active-bg: #b45309;
+    --fg-home-glow-1: rgba(245, 158, 11, 0.26);
+    --fg-home-glow-2: rgba(132, 204, 22, 0.22);
+    --fg-home-glow-3: rgba(16, 185, 129, 0.24);
+    --fg-home-glow-4: rgba(14, 165, 233, 0.18);
+  }
+
+  80% {
+    --vp-c-brand-1: #22c55e;
+    --vp-c-brand-2: #14b8a6;
+    --vp-c-brand-3: #0ea5e9;
+    --vp-c-brand-soft: rgba(34, 197, 94, 0.14);
+    --vp-button-brand-bg: #22c55e;
+    --vp-button-brand-hover-bg: #16a34a;
+    --vp-button-brand-active-bg: #15803d;
+    --fg-home-glow-1: rgba(34, 197, 94, 0.24);
+    --fg-home-glow-2: rgba(20, 184, 166, 0.22);
+    --fg-home-glow-3: rgba(14, 165, 233, 0.24);
+    --fg-home-glow-4: rgba(99, 102, 241, 0.18);
+  }
+
+  100% {
+    --vp-c-brand-1: #10b981;
+    --vp-c-brand-2: #0ea5e9;
+    --vp-c-brand-3: #6366f1;
+    --vp-c-brand-soft: rgba(16, 185, 129, 0.14);
+    --vp-button-brand-bg: #10b981;
+    --vp-button-brand-hover-bg: #0f9f92;
+    --vp-button-brand-active-bg: #0b7f74;
+    --fg-home-glow-1: rgba(14, 165, 233, 0.3);
+    --fg-home-glow-2: rgba(99, 102, 241, 0.24);
+    --fg-home-glow-3: rgba(16, 185, 129, 0.22);
+    --fg-home-glow-4: rgba(236, 72, 153, 0.18);
+  }
+}
+
+@keyframes foldergram-orbit-a {
+  0% {
+    transform: translate3d(0, 0, 0) scale(0.94);
+  }
+
+  100% {
+    transform: translate3d(2.5rem, 1.5rem, 0) scale(1.08);
+  }
+}
+
+@keyframes foldergram-orbit-b {
+  0% {
+    transform: translate3d(0, 0, 0) scale(0.94);
+  }
+
+  100% {
+    transform: translate3d(-2rem, -1.75rem, 0) scale(1.08);
+  }
+}
+
+@media (max-width: 960px) {
+  :root.fg-home-rainbow .VPHome .VPHero::before {
+    width: 18rem;
+    height: 18rem;
+    left: -4rem;
+  }
+
+  :root.fg-home-rainbow .VPHome .VPHero::after {
+    width: 20rem;
+    height: 20rem;
+    right: -3rem;
+  }
+}
+
+@media (max-width: 640px) {
+  :root.fg-home-rainbow .VPHome .VPHero.has-image .image-bg {
+    width: 300px;
+    height: 300px;
+  }
+
+  :root.fg-home-rainbow .VPHome .VPHero::before,
+  :root.fg-home-rainbow .VPHome .VPHero::after {
+    filter: blur(42px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root.fg-home-rainbow {
+    animation: none;
+  }
+
+  :root.fg-home-rainbow .VPHome .VPHero::before,
+  :root.fg-home-rainbow .VPHome .VPHero::after,
+  :root.fg-home-rainbow .VPHome .heading .name.clip,
+  :root.fg-home-rainbow .VPHome .VPHero.has-image .image-bg {
+    animation: none;
+  }
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,8 +12,8 @@ All documented routes come from `server/src/routes/api.ts`.
 | Base path | Purpose |
 | --- | --- |
 | `/api` | JSON API |
-| `/thumbnails` | Static thumbnail derivatives |
-| `/previews` | Static preview derivatives |
+| `/thumbnails` | Protected thumbnail derivatives, served from cache or generated on demand in lazy mode |
+| `/previews` | Protected preview derivatives, served from cache or generated on demand in lazy mode |
 
 ## Authentication and protected routes
 
@@ -62,7 +62,7 @@ The shipped frontend adds `x-foldergram-intent: 1` automatically for `POST`,
 | `400` | Validation or request-shape errors surfaced through the Express error handler. |
 | `403` | Missing intent header, failed local-origin check, or a viewer session hitting an admin-only route. |
 | `404` | Missing folder, post, moment, or original media. |
-| `409` | A scan or thumbnail rebuild was requested while the library requires a full rebuild after a gallery-root change. |
+| `409` | A scan or thumbnail rebuild was requested while the library requires a library-index rebuild after a gallery-root change. |
 
 ## Read endpoints
 
@@ -135,7 +135,7 @@ Notes:
 
 - `items` contain both images and videos.
 - `thumbnailUrl` points to `/thumbnails/...`.
-- `previewUrl` points to `/previews/...` unless a video is served directly from its original file.
+- `previewUrl` points to `/previews/...`.
 
 ### `GET /api/feed/moments`
 
@@ -275,11 +275,18 @@ Returns one post detail payload with:
 - `mimeType`
 - `fileSize`
 - `originalUrl`
+- `playbackStrategy` for videos when an original MP4 is browser-compatible
 - `nextImageId`
 - `previousImageId`
 
 `nextImageId` and `previousImageId` are resolved within the same folder and the
 same active `mediaType` filter when one is supplied.
+
+Detail media rules:
+
+- if `IMAGE_DETAIL_SOURCE=original` and the item is an image, `previewUrl` points to `/api/originals/:id`
+- videos keep `previewUrl` on `/previews/...`
+- compatible original MP4 videos can set `playbackStrategy: "original"` so the client can expose an optional original-quality switch
 
 Errors:
 
@@ -329,8 +336,8 @@ additional fields below:
 | Field | Notes |
 | --- | --- |
 | `deletedImages` | Soft-deleted post count. |
-| `thumbnailCount` | Active posts with a thumbnail path. |
-| `previewCount` | Active items with a preview output. Videos served directly from originals are excluded here. |
+| `thumbnailCount` | Actual generated thumbnail files currently present on disk. |
+| `previewCount` | Actual generated preview files currently present on disk. |
 | `storage.usingInMemoryDatabase` | Whether SQLite had to fall back to in-memory mode. |
 | `libraryIndex.currentGalleryRoot` | Current configured gallery root. |
 | `libraryIndex.previousGalleryRoot` | Prior configured gallery root when the root changed. |
@@ -637,6 +644,10 @@ Errors:
 Stops the watcher, clears the indexed library tables, rescans the current
 gallery root, and then restarts the watcher.
 
+Matching cached derivatives already on disk are left in place and can be reused.
+In `DERIVATIVE_MODE=lazy`, this rebuild does not pre-generate missing thumbnails
+or previews.
+
 This resets:
 
 - `likes`
@@ -659,7 +670,7 @@ It does **not** reset:
 
 Errors:
 
-- `409` with the library-rebuild-required message when a full rebuild is required
+- `409` with the library-rebuild-required message when a library-index rebuild is required
 - `403` for viewer sessions
 
 ## Client helpers

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,8 @@ Foldergram reads `.env` from the repository root and validates it in
 | `DB_DIR` | `./data/db` | SQLite directory. Database file is `gallery.sqlite`. |
 | `THUMBNAILS_DIR` | `./data/thumbnails` | Generated thumbnail output root. |
 | `PREVIEWS_DIR` | `./data/previews` | Generated preview output root. |
+| `IMAGE_DETAIL_SOURCE` | `preview` | For image detail pages, use generated previews or stream originals. Videos ignore this flag. |
+| `DERIVATIVE_MODE` | `eager` | Generate derivatives during scans or lazily on the first protected derivative request. |
 | `LOG_VERBOSE` | `0` | Truthy values are `1`, `true`, `yes`, and `on`. |
 | `SCAN_DISCOVERY_CONCURRENCY` | `4` | Discovery concurrency, validated from `1` to `32`. |
 | `SCAN_DERIVATIVE_CONCURRENCY` | `4` | Derivative concurrency, validated from `1` to `32`. |
@@ -52,6 +54,51 @@ instance, not a multi-user account system.
 Foldergram normalizes path separators so the same rules work with POSIX-style and
 Windows-style paths.
 
+## Detail source and derivative timing
+
+### `IMAGE_DETAIL_SOURCE`
+
+Accepted values:
+
+- `preview`
+- `original`
+
+Behavior:
+
+- applies to image detail pages only
+- `preview` keeps `/image/:id` on generated preview assets
+- `original` makes image detail pages use `/api/originals/:id`
+- does not change feed cards, folder grids, avatars, or other list surfaces
+- does not change video default playback behavior
+
+### `DERIVATIVE_MODE`
+
+Accepted values:
+
+- `eager`
+- `lazy`
+
+Behavior:
+
+- `eager` generates thumbnails and previews during scans
+- `lazy` still indexes metadata during scans, but missing files are generated on the first request to `/thumbnails/...` or `/previews/...` and then cached on disk
+- lazy mode applies to thumbnails and previews
+- lazy mode keeps derivative URLs deterministic because the indexed relative derivative paths are still stored in SQLite
+
+### Recommended combinations
+
+| Goal | Suggested config |
+| --- | --- |
+| Current behavior | `IMAGE_DETAIL_SOURCE=preview`, `DERIVATIVE_MODE=eager` |
+| Lowest upfront processing for large libraries | `IMAGE_DETAIL_SOURCE=original`, `DERIVATIVE_MODE=lazy` |
+
+### Settings actions and lazy mode
+
+- `Scan Library` always refreshes index metadata.
+- `Rebuild Library Index` resets and rebuilds the SQLite-backed index, then reuses any matching derivatives already on disk.
+- In `DERIVATIVE_MODE=lazy`, neither a normal scan nor `Rebuild Library Index` pre-generates missing thumbnails or previews.
+- `Regenerate Thumbnails` remains a manual thumbnail and video-poster rebuild only. It does not rebuild previews.
+
 ## Managed path ignores
 
 If your configured database, thumbnails, or previews directories live inside the
@@ -72,6 +119,8 @@ GALLERY_ROOT=./data/gallery
 DB_DIR=./data/db
 THUMBNAILS_DIR=./data/thumbnails
 PREVIEWS_DIR=./data/previews
+IMAGE_DETAIL_SOURCE=preview
+DERIVATIVE_MODE=eager
 LOG_VERBOSE=0
 SCAN_DISCOVERY_CONCURRENCY=4
 SCAN_DERIVATIVE_CONCURRENCY=4

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -53,14 +53,24 @@ several payload fields still use `image` terminology while carrying mixed media.
 
 ## Can Foldergram play videos directly from the original file?
 
-Yes, sometimes. Compatible MP4 files within the current playback budget can skip
-preview transcoding and stream directly from `/api/originals/:id`.
+Yes, sometimes. Compatible MP4 originals can be exposed as an optional `HD`
+source in the detail player while the generated preview remains the default
+playback source.
 
-## Why would I use thumbnail rebuild instead of full rebuild?
+## Why are thumbnails or previews being created while I browse?
 
-Use thumbnail rebuild when the index is still correct and you only want to
-regenerate feed/profile thumbnails and video poster images. Use full rebuild
-when the gallery root changed or the index itself needs to be reset.
+That is expected when `DERIVATIVE_MODE=lazy`.
+
+Foldergram still indexes metadata during scans, but it waits to generate
+missing thumbnails and previews until `/thumbnails/...` or `/previews/...` is
+requested. Once generated, those files are cached on disk for later requests.
+
+## Why would I use `Regenerate Thumbnails` instead of `Rebuild Library Index`?
+
+Use `Regenerate Thumbnails` when the index is still correct and you only want to
+regenerate feed/profile thumbnails and video poster images. Use `Rebuild
+Library Index` when the gallery root changed or the index itself needs to be
+reset.
 
 ## Is the local-origin mutation check the same as authentication?
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -15,6 +15,7 @@ It includes:
 
 - three feed modes: Recent, Rediscover, and Random
 - a top rail that can show Moments or Highlights
+- an active home-feed video player that promotes one visible video card at a time and gives that card play, mute, and fullscreen controls
 - a startup scan state when the first index is still being built
 - a rebuild notice when the configured gallery root changed
 - desktop recommendations for folders based on recency, likes, and recent navigation
@@ -87,7 +88,9 @@ Behavior depends on how the route is opened:
 
 The detail view includes:
 
-- preview media
+- image detail media sourced from either generated previews or originals, depending on `IMAGE_DETAIL_SOURCE`
+- video detail playback that defaults to the generated preview source
+- an optional `HD` toggle for compatible higher-resolution MP4 originals
 - previous and next navigation within the same folder and active media filter
 - folder link and breadcrumb context
 - size, dimensions, MIME type, and duration metadata
@@ -134,7 +137,7 @@ It exposes:
 - last completed scan details
 - manual scan
 - thumbnail-only rebuild
-- full library rebuild
+- library-index rebuild
 
 ### Access protection
 
@@ -164,7 +167,7 @@ Current non-admin behavior:
 | --- | --- |
 | Scan Library | Runs a normal scan against the current gallery root. |
 | Regenerate Thumbnails | Clears generated thumbnails and video poster images, then rebuilds them from indexed media only. |
-| Rebuild Library | Clears indexed folders, posts, likes, folder scan state, and scan history, then rescans the active gallery root and reuses matching cached derivatives when possible. |
+| Rebuild Library Index | Clears indexed folders, posts, likes, folder scan state, and scan history, then rescans the active gallery root and reuses matching cached derivatives when possible. In lazy derivative mode it does not pre-generate missing thumbnails or previews. |
 
 ## Theme and local UI preferences
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,9 +25,9 @@ features:
   - title: Fast feed-style browsing
     details: Runtime reads come from SQLite and generated derivatives instead of filesystem walks during every request.
   - title: Photos and videos
-    details: Foldergram indexes supported image and video formats, generates thumbnails, and creates previews or direct-playback links when videos already fit the playback budget.
+    details: Foldergram indexes supported image and video formats, generates thumbnails, creates previews eagerly or lazily, and can expose compatible original MP4 playback in the detail player.
   - title: Honest scope
-    details: The current app includes feed browsing, explore, library, likes and favorites, moments, settings, optional admin/viewer/public access control, and local maintenance controls without cloud sync or social features.
+    details: The current app includes feed browsing, explore, library, likes and favorites, moments, optional admin/viewer/public access control, and admin-only maintenance controls without cloud sync or social features.
 ---
 
 ## Foldergram at a Glance
@@ -36,7 +36,7 @@ features:
 
 <div class="cs-feature">
 <h3>What ships today</h3>
-<p>The current repository includes Home, Explore, Library, Likes and Favorites, Moments, Settings, folder pages, a post detail view and modal flow, shared SQLite likes, browser-local favorites in public mode, delete actions, optional admin/viewer/public access control, manual scans, full library rebuilds, and thumbnail-only rebuilds.</p>
+<p>The current repository includes Home, Explore, Library, Likes and Favorites, Moments, Settings, folder pages, a post detail view and modal flow, shared SQLite likes, browser-local favorites in public mode, delete actions, optional admin/viewer/public access control, and local scan/rebuild tooling.</p>
 </div>
 
 <div class="cs-feature">
@@ -45,13 +45,13 @@ features:
 </div>
 
 <div class="cs-feature">
-<h3>Supported formats</h3>
-<p>Images: <code>.jpg</code>, <code>.jpeg</code>, <code>.png</code>, <code>.webp</code>, <code>.gif</code>. Videos: <code>.mp4</code>, <code>.mov</code>, <code>.m4v</code>, <code>.webm</code>, <code>.mkv</code>.</p>
+<h3>Formats and storage</h3>
+<p>Foldergram indexes images like <code>.jpg</code>, <code>.png</code>, <code>.webp</code>, and <code>.gif</code>, plus videos like <code>.mp4</code>, <code>.mov</code>, <code>.m4v</code>, <code>.webm</code>, and <code>.mkv</code>. Originals stay in the gallery root, SQLite stores indexed metadata, thumbnails are written under <code>thumbnails/</code>, and previews under <code>previews/</code>.</p>
 </div>
 
 <div class="cs-feature">
-<h3>Storage model</h3>
-<p>Originals remain in the gallery root. SQLite stores indexed metadata. Thumbnails are generated under <code>thumbnails/</code> and previews under <code>previews/</code>.</p>
+<h3>Access modes</h3>
+<p>Foldergram starts without a password gate by default. Settings can enable admin-only access, a separate viewer password, or anonymous public browsing. Once protection is enabled, only admins can open Settings or use Trash, scans, rebuilds, and delete actions.</p>
 </div>
 
 </div>
@@ -72,7 +72,7 @@ features:
 
 <div class="cs-feature">
 <h3>3. Generate derivatives</h3>
-<p>Create `640px` thumbnails and up to `1500px` previews, with direct-original playback for already compatible MP4 files.</p>
+<p>Create `640px` thumbnails, up to `1500px` image previews, and 720p-class video previews. Derivatives can be generated during scans or lazily on first request.</p>
 </div>
 
 <div class="cs-feature">
@@ -87,7 +87,7 @@ features:
 
 <div class="cs-feature">
 <h3>6. Maintain the library locally</h3>
-<p>Settings includes optional admin/viewer/public access control plus manual scan, thumbnail rebuild, and full library rebuild actions so you can protect access and refresh the index without touching the source files by hand.</p>
+<p>Admins can enable access protection and run manual scans, thumbnail rebuilds, and library-index rebuilds from Settings. If protection is still off, those controls are available immediately to whoever can reach the app.</p>
 </div>
 
 </div>

--- a/docs/media-processing.md
+++ b/docs/media-processing.md
@@ -6,7 +6,9 @@ description: Supported formats, derivative generation rules, and video playback 
 # Media Processing
 
 Foldergram generates derivatives so feed and detail views can stay fast without
-touching original files at request time.
+touching original files on every request. Depending on configuration, those
+derivatives are either created during scans or lazily on first request and then
+cached on disk.
 
 ## Supported formats
 
@@ -34,6 +36,18 @@ These values are defined in `server/src/utils/image-utils.ts`.
 | --- | --- | --- |
 | `THUMBNAIL_SIZE` | `640` | Feed cards, folder grids, avatars, and video posters |
 | `PREVIEW_MAX_WIDTH` | `1500` | Detail-view previews and transcodes |
+
+## Derivative timing
+
+`DERIVATIVE_MODE` controls when missing derivatives are created:
+
+| Mode | Behavior |
+| --- | --- |
+| `eager` | Scans queue derivative generation during indexing. |
+| `lazy` | Scans index metadata only. Missing thumbnails and previews are generated when `/thumbnails/...` or `/previews/...` is first requested. |
+
+Lazy mode still writes the generated files to the configured derivative
+directories, so subsequent requests use the cached file on disk.
 
 ## Derivative mapping
 
@@ -67,6 +81,18 @@ Images are processed with Sharp.
 - resized to width `1500` without enlargement
 - encoded as WebP with `quality: 86`
 
+## Image detail source
+
+`IMAGE_DETAIL_SOURCE` affects image detail pages only:
+
+| Value | Behavior |
+| --- | --- |
+| `preview` | `/image/:id` uses the generated preview asset. |
+| `original` | `/image/:id` uses `/api/originals/:id` for images. |
+
+This setting does not change feed cards, folder grids, avatars, or any video
+playback behavior.
+
 ## Video metadata
 
 Videos are probed with `ffprobe`.
@@ -94,26 +120,27 @@ When a video needs a derived preview, Foldergram transcodes it with `ffmpeg` to:
 - AAC audio when audio is present
 - `yuv420p`
 - `+faststart`
-- maximum width `1500`
+- landscape-equivalent output up to `1280x720`
+- portrait and square output that keeps the short edge at or below `720`
+- even-numbered output dimensions for encoder compatibility
 
 ## Direct-original video playback
 
-Foldergram can skip preview generation and stream the original video file
-directly when all of these are true:
+Foldergram can mark the original video as eligible for direct playback in the
+detail player when all of these are true:
 
 - the file extension is `.mp4`
 - the container is compatible with MP4
 - the video codec is H.264
 - the pixel format is `yuv420p`
 - the audio codec is AAC, or there is no audio track
-- file size is `<= 24 MiB`
-- width is `<= 1500`
 
 When that happens:
 
 - `playbackStrategy` is set to `original`
-- the preview file is removed if it exists
-- the client receives `previewUrl` pointing at `/api/originals/:id`
+- generated previews still remain the default playback source
+- the detail player can expose an `HD` switch when the original is compatible and higher resolution than the generated preview
+- feed cards and other list surfaces continue to use generated preview media
 
 ## GIF handling
 
@@ -142,7 +169,8 @@ The thumbnail rebuild action:
 - recreates it
 - rebuilds thumbnails and video poster images for currently indexed media
 
-It does not regenerate previews.
+It does not regenerate previews. In lazy mode it acts as a thumbnail and poster
+prewarm only; preview generation still happens on demand.
 
 ## Why derivatives are mirrored by relative path
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -72,9 +72,24 @@ docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
 
 On first run, the server performs a startup scan when there is no existing index.
 
+If you want the lowest upfront derivative work for a large library, set these
+before startup:
+
+```env
+IMAGE_DETAIL_SOURCE=original
+DERIVATIVE_MODE=lazy
+```
+
+That combination keeps image detail pages on originals and generates missing
+thumbnails or previews only when they are first requested.
+
 If you plan to expose Foldergram on a homelab or LAN, open Settings after the
 first load and enable the admin password. From there, you can keep admin-only
 access, add a separate viewer password, or switch to public browse mode.
+
+Until you enable password protection, Foldergram starts without an auth gate,
+so Settings and the library-maintenance controls are available immediately to
+whoever can reach the app.
 
 ## Optional: run from source for development
 
@@ -125,6 +140,7 @@ pnpm build:docs
 - Feed, folder pages, likes, explore, and moments read from SQLite, not directly from disk.
 - Thumbnails are generated under `data/thumbnails`.
 - Previews are generated under `data/previews`.
-- Settings exposes admin/viewer access controls, manual scan, thumbnail rebuild, and full library rebuild actions.
+- In the default unprotected state, Settings is available immediately.
+- After access protection is enabled, only admin sessions can open Settings or run scan and rebuild actions. Viewer and public sessions stay browse-only.
 
 If nothing appears, start with [Troubleshooting](/troubleshooting).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -103,7 +103,7 @@ If needed:
 
 ## Likes disappeared after a rebuild
 
-That is expected for a full library rebuild. The rebuild resets the indexed
+That is expected for `Rebuild Library Index`. The rebuild resets the indexed
 library tables, including `likes`.
 
 Thumbnail-only rebuilds do not clear likes.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       pinia:
         specifier: ^3.0.1
         version: 3.0.4(typescript@5.9.3)(vue@3.5.29(typescript@5.9.3))
+      vidstack:
+        specifier: ^1.12.13
+        version: 1.12.13
       vue:
         specifier: ^3.5.13
         version: 3.5.29(typescript@5.9.3)
@@ -681,6 +684,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@iconify-json/fluent@1.2.40':
     resolution: {integrity: sha512-mGHKd14H0RyS2PLRn2Q1n0M+PW+TQRFuk12QjJ6N7yi2BlKaMbEQYDW7rlc5hvvJ2smpp+TpakBc2ooqyQKxZw==}
 
@@ -1182,6 +1194,9 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1801,6 +1816,9 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  lit-html@2.8.0:
+    resolution: {integrity: sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -1822,6 +1840,10 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  media-captions@1.0.4:
+    resolution: {integrity: sha512-cyDNmuZvvO4H27rcBq2Eudxo9IZRDCOX/I7VEyqbxsEiD2Ei7UYUhG/Sc5fvMZjmathgz3fEK7iAKqvpY+Ux1w==}
+    engines: {node: '>=16'}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -2265,6 +2287,10 @@ packages:
     resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
     engines: {node: '>=20.19.0'}
 
+  unplugin@1.16.1:
+    resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
+    engines: {node: '>=14.0.0'}
+
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
@@ -2278,6 +2304,10 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vidstack@1.12.13:
+    resolution: {integrity: sha512-vuNeyRmWoH/7EoFVDYjp9nkgcqtCMmal518LDeb78dYKgWb+p6+vtY0AzDhrkBv5q1UiCn+xwmjMmwvSlPLuhQ==}
+    engines: {node: '>=18'}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -2858,6 +2888,17 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@iconify-json/fluent@1.2.40':
     dependencies:
       '@iconify/types': 2.0.0
@@ -3252,6 +3293,8 @@ snapshots:
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 22.19.15
+
+  '@types/trusted-types@2.0.7': {}
 
   '@types/unist@3.0.3': {}
 
@@ -4032,6 +4075,10 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
+  lit-html@2.8.0:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
   loupe@3.2.1: {}
 
   magic-regexp@0.10.0:
@@ -4065,6 +4112,8 @@ snapshots:
       vfile: 6.0.3
 
   mdn-data@2.27.1: {}
+
+  media-captions@1.0.4: {}
 
   media-typer@1.1.0: {}
 
@@ -4585,6 +4634,11 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.3
 
+  unplugin@1.16.1:
+    dependencies:
+      acorn: 8.16.0
+      webpack-virtual-modules: 0.6.2
+
   unplugin@2.3.11:
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -4603,6 +4657,13 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  vidstack@1.12.13:
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      lit-html: 2.8.0
+      media-captions: 1.0.4
+      unplugin: 1.16.1
 
   vite-node@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0):
     dependencies:

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -8,30 +8,21 @@ import { requireApiAuthentication, requireMediaAuthentication } from './middlewa
 import { requireTrustedMutationRequest } from './middleware/csrf-protection.js';
 import { blockPublicDemoMutations } from './middleware/public-demo-mode.js';
 import { apiRouter } from './routes/api.js';
-import { authService } from './services/auth-service.js';
-
-function createProtectedStaticOptions() {
-  return {
-    fallthrough: false,
-    setHeaders(response: { setHeader(name: string, value: string): void }) {
-      if (authService.isEnabled()) {
-        response.setHeader('Cache-Control', 'private, no-store');
-        response.setHeader('Vary', 'Cookie');
-        return;
-      }
-
-      response.setHeader('Cache-Control', 'public, max-age=604800, immutable');
-    }
-  };
-}
+import { lazyThumbnailsRouter, lazyPreviewsRouter } from './routes/lazy-derivatives.js';
+import { createProtectedStaticOptions } from './utils/media-response.js';
 
 export function createApp() {
   const app = express();
 
   app.use(express.json());
 
-  app.use('/thumbnails', requireMediaAuthentication, express.static(appConfig.thumbnailsDir, createProtectedStaticOptions()));
-  app.use('/previews', requireMediaAuthentication, express.static(appConfig.previewsDir, createProtectedStaticOptions()));
+  if (appConfig.derivativeMode === 'lazy') {
+    app.use('/thumbnails', requireMediaAuthentication, lazyThumbnailsRouter);
+    app.use('/previews', requireMediaAuthentication, lazyPreviewsRouter);
+  } else {
+    app.use('/thumbnails', requireMediaAuthentication, express.static(appConfig.thumbnailsDir, createProtectedStaticOptions()));
+    app.use('/previews', requireMediaAuthentication, express.static(appConfig.previewsDir, createProtectedStaticOptions()));
+  }
 
   app.use('/api', blockPublicDemoMutations, requireTrustedMutationRequest, requireApiAuthentication, apiRouter);
 
@@ -45,7 +36,12 @@ export function createApp() {
     }
   }
 
-  app.use((error: unknown, _request: express.Request, response: express.Response, _next: express.NextFunction) => {
+  app.use((error: unknown, _request: express.Request, response: express.Response, next: express.NextFunction) => {
+    if (response.headersSent) {
+      next(error);
+      return;
+    }
+
     const message = error instanceof Error ? error.message : 'Unexpected server error';
     response.status(400).json({ message });
   });

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -26,6 +26,8 @@ const envSchema = z.object({
   SCAN_DERIVATIVE_CONCURRENCY: z.coerce.number().int().min(1).max(32).default(4),
   PUBLIC_DEMO_MODE: z.string().optional(),
   CSRF_TRUSTED_ORIGINS: z.string().optional(),
+  IMAGE_DETAIL_SOURCE: z.enum(['preview', 'original']).default('preview'),
+  DERIVATIVE_MODE: z.enum(['eager', 'lazy']).default('eager'),
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development')
 });
 
@@ -135,5 +137,7 @@ export const appConfig = {
   csrfTrustedOrigins,
   scanDiscoveryConcurrency: parsed.SCAN_DISCOVERY_CONCURRENCY,
   scanDerivativeConcurrency: parsed.SCAN_DERIVATIVE_CONCURRENCY,
-  databasePath: path.join(dbDir, 'gallery.sqlite')
+  databasePath: path.join(dbDir, 'gallery.sqlite'),
+  imageDetailSource: parsed.IMAGE_DETAIL_SOURCE,
+  derivativeMode: parsed.DERIVATIVE_MODE
 };

--- a/server/src/db/repositories.ts
+++ b/server/src/db/repositories.ts
@@ -791,12 +791,18 @@ export const imageRepository = {
     return Number(
       (
         database
-          .prepare(
-            `SELECT COUNT(*) AS count FROM images WHERE ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL} AND (media_type = 'image' OR COALESCE(playback_strategy, 'preview') = 'preview')`
-          )
+          .prepare(`SELECT COUNT(*) AS count FROM images WHERE ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL} AND preview_path IS NOT NULL`)
           .get() as { count: number }
       ).count
     );
+  },
+
+  getByThumbnailPath(thumbnailPath: string): ImageRecord | undefined {
+    return database.prepare('SELECT * FROM images WHERE thumbnail_path = ? AND is_deleted = 0 LIMIT 1').get(thumbnailPath) as ImageRecord | undefined;
+  },
+
+  getByPreviewPath(previewPath: string): ImageRecord | undefined {
+    return database.prepare('SELECT * FROM images WHERE preview_path = ? AND is_deleted = 0 LIMIT 1').get(previewPath) as ImageRecord | undefined;
   }
 };
 

--- a/server/src/routes/lazy-derivatives.ts
+++ b/server/src/routes/lazy-derivatives.ts
@@ -1,0 +1,206 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import express from 'express';
+import pLimit from 'p-limit';
+
+import { appConfig } from '../config/env.js';
+import { imageRepository } from '../db/repositories.js';
+import { log } from '../services/log-service.js';
+import { generateThumbnailDerivative, writeImagePreview, writeVideoPreview } from '../services/derivative-service.js';
+import { getMediaTypeFromExtension } from '../utils/image-utils.js';
+import { applyDerivativeErrorHeaders, applyProtectedMediaHeaders } from '../utils/media-response.js';
+import { normalizePath, safeJoin } from '../utils/path-utils.js';
+
+// In-memory map to deduplicate concurrent generation requests for the same derivative path.
+const inflightGenerations = new Map<string, Promise<void>>();
+const generationLimit = pLimit(appConfig.scanDerivativeConcurrency);
+
+type SendDerivativeResult = 'sent' | 'aborted';
+
+function getRequestedPath(request: express.Request): string | null {
+  const rawPath = request.params.path;
+  const relativePath = Array.isArray(rawPath) ? rawPath.join('/') : rawPath ?? '';
+  const normalizedPath = normalizePath(relativePath).replace(/^\/+/, '');
+
+  return normalizedPath.length > 0 ? normalizedPath : null;
+}
+
+function resolveDerivativePath(rootDir: string, requestedPath: string): string | null {
+  try {
+    return safeJoin(rootDir, requestedPath);
+  } catch {
+    return null;
+  }
+}
+
+function isConnectionTerminationError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const code = 'code' in error ? error.code : null;
+  return code === 'ECONNABORTED' || code === 'ECONNRESET' || code === 'ERR_STREAM_PREMATURE_CLOSE';
+}
+
+function sendDerivativeFile(response: express.Response, absolutePath: string): Promise<SendDerivativeResult> {
+  applyProtectedMediaHeaders(response);
+
+  return new Promise((resolve, reject) => {
+    response.sendFile(absolutePath, (error) => {
+      if (error) {
+        if (response.headersSent || isConnectionTerminationError(error)) {
+          resolve('aborted');
+          return;
+        }
+
+        reject(error);
+        return;
+      }
+
+      resolve('sent');
+    });
+  });
+}
+
+async function serveOrGenerate(
+  request: express.Request,
+  response: express.Response,
+  rootDir: string,
+  kind: 'thumbnail' | 'preview'
+): Promise<void> {
+  const requestedPath = getRequestedPath(request);
+  if (!requestedPath) {
+    applyDerivativeErrorHeaders(response);
+    response.status(400).json({ message: 'Invalid derivative path.' });
+    return;
+  }
+
+  const absoluteOutputPath = resolveDerivativePath(rootDir, requestedPath);
+  if (!absoluteOutputPath) {
+    applyDerivativeErrorHeaders(response);
+    response.status(400).json({ message: 'Invalid derivative path.' });
+    return;
+  }
+
+  // Fast path: file already exists.
+  try {
+    await fs.access(absoluteOutputPath);
+    try {
+      const result = await sendDerivativeFile(response, absoluteOutputPath);
+      if (result === 'aborted') {
+        return;
+      }
+    } catch {
+      if (response.headersSent) {
+        return;
+      }
+
+      applyDerivativeErrorHeaders(response);
+      response.status(500).json({ message: 'Failed to serve derivative.' });
+    }
+    return;
+  } catch {
+    // File does not exist — fall through to generation.
+  }
+
+  // Look up the source row by derivative path.
+  const imageRecord =
+    kind === 'thumbnail'
+      ? imageRepository.getByThumbnailPath(requestedPath)
+      : imageRepository.getByPreviewPath(requestedPath);
+
+  if (!imageRecord) {
+    applyDerivativeErrorHeaders(response);
+    response.status(404).json({ message: 'Derivative not found.' });
+    return;
+  }
+
+  const mediaType = getMediaTypeFromExtension(path.extname(imageRecord.relative_path));
+  let generationPromise = inflightGenerations.get(absoluteOutputPath);
+
+  if (!generationPromise) {
+    log.info('Lazy derivative generate', {
+      kind,
+      file: requestedPath,
+      source: imageRecord.relative_path
+    });
+
+    generationPromise = generationLimit(async () => {
+      try {
+        if (kind === 'thumbnail') {
+          await generateThumbnailDerivative(imageRecord.absolute_path, imageRecord.relative_path, false);
+          return;
+        }
+
+        if (mediaType === 'video') {
+          const previewAbsolutePath = resolveDerivativePath(appConfig.previewsDir, requestedPath);
+          if (!previewAbsolutePath) {
+            throw new Error('Invalid derivative path.');
+          }
+
+          await writeVideoPreview(imageRecord.absolute_path, previewAbsolutePath);
+          return;
+        }
+
+        const previewAbsolutePath = resolveDerivativePath(appConfig.previewsDir, requestedPath);
+        if (!previewAbsolutePath) {
+          throw new Error('Invalid derivative path.');
+        }
+
+        await writeImagePreview(imageRecord.absolute_path, previewAbsolutePath);
+      } finally {
+        inflightGenerations.delete(absoluteOutputPath);
+      }
+    });
+
+    inflightGenerations.set(absoluteOutputPath, generationPromise);
+  }
+
+  const queuedGeneration = generationPromise;
+  if (!queuedGeneration) {
+    applyDerivativeErrorHeaders(response);
+    response.status(500).json({ message: 'Failed to queue derivative generation.' });
+    return;
+  }
+
+  try {
+    await queuedGeneration;
+  } catch (error) {
+    if (response.headersSent) {
+      return;
+    }
+
+    const message = error instanceof Error ? error.message : 'Failed to generate derivative.';
+    applyDerivativeErrorHeaders(response);
+    response.status(500).json({ message });
+    return;
+  }
+
+  try {
+    const result = await sendDerivativeFile(response, absoluteOutputPath);
+    if (result === 'aborted') {
+      return;
+    }
+  } catch {
+    if (response.headersSent) {
+      return;
+    }
+
+    applyDerivativeErrorHeaders(response);
+    response.status(500).json({ message: 'Failed to serve derivative.' });
+  }
+}
+
+const lazyThumbnailsRouter = express.Router();
+const lazyPreviewsRouter = express.Router();
+
+lazyThumbnailsRouter.get('/*path', async (request, response) => {
+  await serveOrGenerate(request, response, appConfig.thumbnailsDir, 'thumbnail');
+});
+
+lazyPreviewsRouter.get('/*path', async (request, response) => {
+  await serveOrGenerate(request, response, appConfig.previewsDir, 'preview');
+});
+
+export { lazyThumbnailsRouter, lazyPreviewsRouter };

--- a/server/src/services/derivative-service.ts
+++ b/server/src/services/derivative-service.ts
@@ -18,9 +18,10 @@ import {
 import { safeJoin } from '../utils/path-utils.js';
 
 const execFileAsync = promisify(execFile);
-const DIRECT_VIDEO_PLAYBACK_MAX_FILE_SIZE_BYTES = 24 * 1024 * 1024;
 const DIRECT_VIDEO_PLAYBACK_ALLOWED_AUDIO_CODECS = new Set(['aac']);
 const DIRECT_VIDEO_PLAYBACK_ALLOWED_PIXEL_FORMATS = new Set(['yuv420p']);
+export const VIDEO_PREVIEW_MAX_LONG_EDGE = 1280;
+export const VIDEO_PREVIEW_MAX_SHORT_EDGE = 720;
 
 interface FfprobeStream {
   codec_type?: string;
@@ -112,17 +113,6 @@ async function readVideoProbe(sourcePath: string): Promise<FfprobePayload> {
   return JSON.parse(stdout) as FfprobePayload;
 }
 
-async function removeFileIfPresent(filePath: string): Promise<void> {
-  try {
-    await fs.unlink(filePath);
-  } catch (error) {
-    const fileError = error as NodeJS.ErrnoException;
-    if (fileError.code !== 'ENOENT') {
-      throw error;
-    }
-  }
-}
-
 async function readImageMetadata(sourcePath: string): Promise<MediaMetadata> {
   const [metadata, imageExif] = await Promise.all([
     sharp(sourcePath, { animated: false }).metadata(),
@@ -143,9 +133,7 @@ async function readImageMetadata(sourcePath: string): Promise<MediaMetadata> {
 
 async function resolveVideoPlaybackStrategy(
   sourcePath: string,
-  payload: FfprobePayload,
-  width: number,
-  fileSize?: number
+  payload: FfprobePayload
 ): Promise<PlaybackStrategy> {
   if (path.extname(sourcePath).toLowerCase() !== '.mp4') {
     return 'preview';
@@ -154,7 +142,6 @@ async function resolveVideoPlaybackStrategy(
   const videoStream = payload.streams?.find((stream) => stream.codec_type === 'video');
   const audioStream = payload.streams?.find((stream) => stream.codec_type === 'audio');
   const formatName = payload.format?.format_name?.toLowerCase() ?? '';
-  const effectiveFileSize = typeof fileSize === 'number' ? fileSize : (await fs.stat(sourcePath)).size;
 
   if (!videoStream) {
     return 'preview';
@@ -164,15 +151,11 @@ async function resolveVideoPlaybackStrategy(
   const hasCompatibleVideoCodec = videoStream.codec_name === 'h264';
   const hasCompatiblePixelFormat = DIRECT_VIDEO_PLAYBACK_ALLOWED_PIXEL_FORMATS.has(videoStream.pix_fmt ?? '');
   const hasCompatibleAudioCodec = !audioStream || DIRECT_VIDEO_PLAYBACK_ALLOWED_AUDIO_CODECS.has(audioStream.codec_name ?? '');
-  const isWithinSizeBudget = effectiveFileSize <= DIRECT_VIDEO_PLAYBACK_MAX_FILE_SIZE_BYTES;
-  const isWithinResolutionBudget = width > 0 && width <= PREVIEW_MAX_WIDTH;
 
   return hasCompatibleContainer &&
     hasCompatibleVideoCodec &&
     hasCompatiblePixelFormat &&
-    hasCompatibleAudioCodec &&
-    isWithinSizeBudget &&
-    isWithinResolutionBudget
+    hasCompatibleAudioCodec
     ? 'original'
     : 'preview';
 }
@@ -183,7 +166,6 @@ async function readVideoMetadata(sourcePath: string, options: ReadMediaMetadataO
   const durationSeconds = payload.format?.duration ? Number.parseFloat(payload.format.duration) : Number.NaN;
   const durationMs = Number.isFinite(durationSeconds) ? Math.round(durationSeconds * 1000) : null;
   const takenAt = normalizeTakenAtValue(videoStream?.tags?.creation_time ?? payload.format?.tags?.creation_time ?? null);
-  const playbackWidth = videoStream?.width ?? 0;
   const width = videoStream?.width ?? THUMBNAIL_SIZE;
 
   return {
@@ -193,7 +175,7 @@ async function readVideoMetadata(sourcePath: string, options: ReadMediaMetadataO
     exif: null,
     durationMs,
     mediaType: 'video',
-    playbackStrategy: await resolveVideoPlaybackStrategy(sourcePath, payload, playbackWidth, options.fileSize),
+    playbackStrategy: await resolveVideoPlaybackStrategy(sourcePath, payload),
     isAnimated: false
   };
 }
@@ -218,7 +200,7 @@ async function writeImageThumbnail(sourcePath: string, thumbnailAbsolutePath: st
     .toFile(thumbnailAbsolutePath);
 }
 
-async function writeImagePreview(sourcePath: string, previewAbsolutePath: string): Promise<void> {
+export async function writeImagePreview(sourcePath: string, previewAbsolutePath: string): Promise<void> {
   await ensureParentDirectory(previewAbsolutePath);
   await sharp(sourcePath, { animated: true })
     .rotate()
@@ -252,8 +234,15 @@ async function writeVideoThumbnail(sourcePath: string, thumbnailAbsolutePath: st
   ]);
 }
 
-async function writeVideoPreview(sourcePath: string, previewAbsolutePath: string): Promise<void> {
+export async function writeVideoPreview(sourcePath: string, previewAbsolutePath: string): Promise<void> {
   await ensureParentDirectory(previewAbsolutePath);
+  // Landscape videos target up to 1280x720. Portrait and square videos cap their
+  // short edge at 720 while preserving aspect ratio. Output dimensions are rounded
+  // to even numbers for yuv420p compatibility.
+  const scaleFilter =
+    `scale=` +
+    `'trunc(if(gt(iw,ih),min(${VIDEO_PREVIEW_MAX_LONG_EDGE},iw),min(${VIDEO_PREVIEW_MAX_SHORT_EDGE},iw))/2)*2':` +
+    `'trunc(if(gt(iw,ih),min(${VIDEO_PREVIEW_MAX_LONG_EDGE},iw)*ih/iw,min(${VIDEO_PREVIEW_MAX_SHORT_EDGE},iw)*ih/iw)/2)*2':flags=lanczos`;
   await runBinary('ffmpeg', [
     '-y',
     '-v',
@@ -265,7 +254,7 @@ async function writeVideoPreview(sourcePath: string, previewAbsolutePath: string
     '-map',
     '0:a?',
     '-vf',
-    `scale='min(${PREVIEW_MAX_WIDTH},iw)':-2:flags=lanczos`,
+    scaleFilter,
     '-c:v',
     'libx264',
     '-preset',
@@ -311,18 +300,13 @@ async function generateVideoDerivatives(
   sourcePath: string,
   thumbnailAbsolutePath: string,
   previewAbsolutePath: string,
-  playbackStrategy: PlaybackStrategy,
   force: boolean
 ): Promise<Pick<DerivativeResult, 'generatedThumbnail' | 'generatedPreview'>> {
   const shouldWriteThumbnail = force || !(await fileExists(thumbnailAbsolutePath));
-  const shouldWritePreview = playbackStrategy === 'preview' && (force || !(await fileExists(previewAbsolutePath)));
+  const shouldWritePreview = force || !(await fileExists(previewAbsolutePath));
 
   if (shouldWriteThumbnail) {
     await writeVideoThumbnail(sourcePath, thumbnailAbsolutePath);
-  }
-
-  if (playbackStrategy === 'original') {
-    await removeFileIfPresent(previewAbsolutePath);
   }
 
   if (shouldWritePreview) {
@@ -368,7 +352,7 @@ export async function generateDerivatives(sourcePath: string, relativePath: stri
   const metadata = await readMediaMetadata(sourcePath, mediaType);
   const generated =
     mediaType === 'video'
-      ? await generateVideoDerivatives(sourcePath, thumbnailAbsolutePath, previewAbsolutePath, metadata.playbackStrategy, force)
+      ? await generateVideoDerivatives(sourcePath, thumbnailAbsolutePath, previewAbsolutePath, force)
       : await generateImageDerivatives(sourcePath, thumbnailAbsolutePath, previewAbsolutePath, force);
 
   return {

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -92,13 +92,15 @@ function buildOriginalUrl(id: number): string {
   return `/api/originals/${id}`;
 }
 
-function buildPreviewUrl(image: {
-  id: number;
-  mediaType: MediaType;
-  previewUrl: string;
-  playbackStrategy?: PlaybackStrategy | null;
-}): string {
-  if (image.mediaType === 'video' && image.playbackStrategy === 'original') {
+function buildPreviewUrl(
+  image: {
+    id: number;
+    mediaType: MediaType;
+    previewUrl: string;
+  },
+  useOriginalForImages = false
+): string {
+  if (useOriginalForImages && image.mediaType === 'image') {
     return buildOriginalUrl(image.id);
   }
 
@@ -161,6 +163,35 @@ async function removeDirectoryTree(targetPath: string | null): Promise<void> {
   }
 }
 
+function countDerivativeFilesOnDisk(rootPath: string): number {
+  try {
+    const entries = fs.readdirSync(rootPath, { withFileTypes: true });
+    let count = 0;
+
+    for (const entry of entries) {
+      const entryPath = path.join(rootPath, entry.name);
+
+      if (entry.isDirectory()) {
+        count += countDerivativeFilesOnDisk(entryPath);
+        continue;
+      }
+
+      if (entry.isFile() && entry.name !== '.gitkeep') {
+        count += 1;
+      }
+    }
+
+    return count;
+  } catch (error) {
+    const filesystemError = error as NodeJS.ErrnoException;
+    if (filesystemError.code === 'ENOENT') {
+      return 0;
+    }
+
+    throw error;
+  }
+}
+
 function isSameOrDescendantFolderPath(rootFolderPath: string, candidateFolderPath: string): boolean {
   return candidateFolderPath === rootFolderPath || candidateFolderPath.startsWith(`${rootFolderPath}/`);
 }
@@ -175,14 +206,14 @@ function mapFeedImage(image: IndexedFeedImage, thumbnailVersion = getThumbnailAs
     previewUrl: buildPreviewUrl({
       id: rest.id,
       mediaType: rest.mediaType,
-      previewUrl: rest.previewUrl,
-      playbackStrategy
+      previewUrl: rest.previewUrl
     })
   };
 }
 
 function mapImageDetail(image: IndexedImageDetail, thumbnailVersion = getThumbnailAssetVersion()): ImageDetail {
   const { playbackStrategy, exifJson, ...rest } = image;
+  const useOriginalForImages = appConfig.imageDetailSource === 'original';
   return {
     ...rest,
     isAnimated: Boolean(rest.isAnimated),
@@ -192,10 +223,10 @@ function mapImageDetail(image: IndexedImageDetail, thumbnailVersion = getThumbna
     previewUrl: buildPreviewUrl({
       id: rest.id,
       mediaType: rest.mediaType,
-      previewUrl: rest.previewUrl,
-      playbackStrategy
-    }),
-    originalUrl: buildOriginalUrl(rest.id)
+      previewUrl: rest.previewUrl
+    }, useOriginalForImages),
+    originalUrl: buildOriginalUrl(rest.id),
+    playbackStrategy
   };
 }
 
@@ -209,8 +240,7 @@ function mapTrashImage(image: IndexedTrashImage, thumbnailVersion = getThumbnail
     previewUrl: buildPreviewUrl({
       id: rest.id,
       mediaType: rest.mediaType,
-      previewUrl: rest.previewUrl,
-      playbackStrategy
+      previewUrl: rest.previewUrl
     })
   };
 }
@@ -880,8 +910,8 @@ export const galleryService = {
       indexedImages: storageState.libraryAvailable ? imageRepository.countFeed() : 0,
       indexedVideos: storageState.libraryAvailable ? imageRepository.countByMediaType('video') : 0,
       deletedImages: storageState.libraryAvailable ? imageRepository.countDeleted() : 0,
-      thumbnailCount: storageState.libraryAvailable ? imageRepository.countWithThumbnail() : 0,
-      previewCount: storageState.libraryAvailable ? imageRepository.countWithPreview() : 0,
+      thumbnailCount: storageState.libraryAvailable ? countDerivativeFilesOnDisk(appConfig.thumbnailsDir) : 0,
+      previewCount: storageState.libraryAvailable ? countDerivativeFilesOnDisk(appConfig.previewsDir) : 0,
       lastScan: lastCompletedScan,
       scan: {
         ...scanProgress,

--- a/server/src/services/scanner-service.ts
+++ b/server/src/services/scanner-service.ts
@@ -1460,13 +1460,15 @@ class ScannerService {
 
       return {
         status: 'unchanged',
-        derivativeJob: shouldQueueDerivativeJobForStatus('unchanged', options) || needsPlaybackStrategyBackfill
-          ? {
-              absolutePath: file.absolutePath,
-              relativePath: file.relativePath,
-              force: false,
-              kind: 'all'
-            }
+        derivativeJob: !appConfig.derivativeMode || appConfig.derivativeMode === 'eager'
+          ? (shouldQueueDerivativeJobForStatus('unchanged', options) || needsPlaybackStrategyBackfill
+            ? {
+                absolutePath: file.absolutePath,
+                relativePath: file.relativePath,
+                force: false,
+                kind: 'all'
+              }
+            : null)
           : null,
         refreshedIndexedRow,
         relativePath: file.relativePath
@@ -1529,15 +1531,17 @@ class ScannerService {
 
       return {
         status: existing ? 'updated' : 'new',
-        derivativeJob: {
-          absolutePath: file.absolutePath,
-          relativePath: file.relativePath,
-          force: existing ? true : options.forceNewFileDerivatives,
-          kind: 'all'
-        },
-      refreshedIndexedRow: false,
-      relativePath: file.relativePath
-    };
+        derivativeJob: appConfig.derivativeMode === 'lazy'
+          ? null
+          : {
+              absolutePath: file.absolutePath,
+              relativePath: file.relativePath,
+              force: existing ? true : options.forceNewFileDerivatives,
+              kind: 'all'
+            },
+        refreshedIndexedRow: false,
+        relativePath: file.relativePath
+      };
   }
 }
 

--- a/server/src/types/models.ts
+++ b/server/src/types/models.ts
@@ -119,6 +119,7 @@ export interface ImageDetail extends FeedImage {
   fileSize: number;
   exif: ImageExifData | null;
   originalUrl: string;
+  playbackStrategy?: PlaybackStrategy | null;
   nextImageId: number | null;
   previousImageId: number | null;
 }

--- a/server/src/utils/media-response.ts
+++ b/server/src/utils/media-response.ts
@@ -1,0 +1,32 @@
+import { authService } from '../services/auth-service.js';
+
+type HeaderResponse = {
+  setHeader(name: string, value: string): void;
+};
+
+export function applyProtectedMediaHeaders(response: HeaderResponse): void {
+  if (authService.isEnabled()) {
+    response.setHeader('Cache-Control', 'private, no-store');
+    response.setHeader('Vary', 'Cookie');
+    return;
+  }
+
+  response.setHeader('Cache-Control', 'public, max-age=604800, immutable');
+}
+
+export function applyDerivativeErrorHeaders(response: HeaderResponse): void {
+  response.setHeader('Cache-Control', 'no-store');
+
+  if (authService.isEnabled()) {
+    response.setHeader('Vary', 'Cookie');
+  }
+}
+
+export function createProtectedStaticOptions() {
+  return {
+    fallthrough: false,
+    setHeaders(response: HeaderResponse) {
+      applyProtectedMediaHeaders(response);
+    }
+  };
+}

--- a/server/test/env-config.test.ts
+++ b/server/test/env-config.test.ts
@@ -1,0 +1,62 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type EnvModule = typeof import('../src/config/env.js');
+
+describe.sequential('derivative mode env config', () => {
+  let tempRoot = '';
+
+  async function stubBaseEnv() {
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  }
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-env-config-'));
+  });
+
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('uses preview and eager defaults when the new env vars are unset', async () => {
+    await stubBaseEnv();
+    vi.doMock('dotenv', () => ({
+      default: {
+        config: vi.fn()
+      }
+    }));
+
+    const { appConfig } = await import('../src/config/env.js') as EnvModule;
+
+    expect(appConfig.imageDetailSource).toBe('preview');
+    expect(appConfig.derivativeMode).toBe('eager');
+  });
+
+  it('rejects invalid enum values for derivative-related env vars', async () => {
+    await stubBaseEnv();
+    vi.stubEnv('IMAGE_DETAIL_SOURCE', 'fullres');
+    vi.stubEnv('DERIVATIVE_MODE', 'background');
+    vi.doMock('dotenv', () => ({
+      default: {
+        config: vi.fn()
+      }
+    }));
+
+    await expect(import('../src/config/env.js')).rejects.toThrow();
+  });
+});

--- a/server/test/image-detail-source.test.ts
+++ b/server/test/image-detail-source.test.ts
@@ -1,0 +1,168 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createFingerprint,
+  getMediaTypeFromExtension,
+  getMimeTypeFromExtension,
+  getPreviewRelativePath,
+  getThumbnailRelativePath
+} from '../src/utils/image-utils.js';
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type GalleryServiceModule = typeof import('../src/services/gallery-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type ModelsModule = typeof import('../src/types/models.js');
+
+type FolderRecord = ModelsModule['FolderRecord'];
+type PlaybackStrategy = ModelsModule['PlaybackStrategy'];
+
+describe.sequential('IMAGE_DETAIL_SOURCE config', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let galleryService: GalleryServiceModule['galleryService'];
+  let folderRepository: RepositoriesModule['folderRepository'];
+  let imageRepository: RepositoriesModule['imageRepository'];
+  let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+
+  async function setup(imageDetailSource: string) {
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('IMAGE_DETAIL_SOURCE', imageDetailSource);
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+
+    vi.resetModules();
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ galleryService } = await import('../src/services/gallery-service.js'));
+    ({ folderRepository, imageRepository, maintenanceRepository } = await import('../src/db/repositories.js'));
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+  }
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-image-detail-source-'));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns a preview URL for image detail when IMAGE_DETAIL_SOURCE=preview (default)', async () => {
+    await setup('preview');
+
+    maintenanceRepository.resetLibraryIndex();
+    const folder = folderRepository.upsert({ slug: 'album', name: 'Album', folderPath: 'album' });
+    const image = createIndexedMedia(folder, 'photo.jpg', 1000, 'preview');
+
+    const detail = galleryService.getImageDetail(image.id);
+    expect(detail?.previewUrl).toMatch(/^\/previews\//);
+    expect(detail?.previewUrl).not.toMatch(/^\/api\/originals\//);
+  });
+
+  it('returns an original URL for image detail when IMAGE_DETAIL_SOURCE=original', async () => {
+    await setup('original');
+
+    maintenanceRepository.resetLibraryIndex();
+    const folder = folderRepository.upsert({ slug: 'album2', name: 'Album2', folderPath: 'album2' });
+    const image = createIndexedMedia(folder, 'photo.jpg', 1000, 'preview');
+
+    const detail = galleryService.getImageDetail(image.id);
+    expect(detail?.previewUrl).toBe(`/api/originals/${image.id}`);
+  });
+
+  it('keeps preview URL for videos with playbackStrategy=preview regardless of IMAGE_DETAIL_SOURCE', async () => {
+    await setup('original');
+
+    maintenanceRepository.resetLibraryIndex();
+    const folder = folderRepository.upsert({ slug: 'vids', name: 'Vids', folderPath: 'vids' });
+    const video = createIndexedMedia(folder, 'clip.webm', 2000, 'preview', 8000);
+
+    const detail = galleryService.getImageDetail(video.id);
+    expect(detail?.previewUrl).toMatch(/^\/previews\//);
+    expect(detail?.playbackStrategy).toBe('preview');
+  });
+
+  it('keeps preview URLs for compatible videos while exposing playbackStrategy=original', async () => {
+    await setup('preview');
+
+    maintenanceRepository.resetLibraryIndex();
+    const folder = folderRepository.upsert({ slug: 'vids2', name: 'Vids2', folderPath: 'vids2' });
+    const compatibleMp4 = createIndexedMedia(folder, 'compatible.mp4', 3000, 'original', 5000);
+
+    const detail = galleryService.getImageDetail(compatibleMp4.id);
+    expect(detail?.previewUrl).toBe('/previews/vids2/compatible.mp4');
+    expect(detail?.originalUrl).toBe(`/api/originals/${compatibleMp4.id}`);
+    expect(detail?.playbackStrategy).toBe('original');
+  });
+
+  it('feed items always use preview URLs regardless of IMAGE_DETAIL_SOURCE=original', async () => {
+    await setup('original');
+
+    maintenanceRepository.resetLibraryIndex();
+    const folder = folderRepository.upsert({ slug: 'feed', name: 'Feed', folderPath: 'feed' });
+    createIndexedMedia(folder, 'photo.jpg', 1000, 'preview');
+    folderRepository.setAvatar(folder.id, imageRepository.getLatestFolderImageId(folder.id));
+
+    const feedItems = galleryService.getFeed(1, 10, 'recent').items;
+    expect(feedItems.length).toBe(1);
+    // Feed images always use preview URLs, not originals
+    expect(feedItems[0]!.previewUrl).toMatch(/^\/previews\//);
+  });
+
+  function createIndexedMedia(
+    folder: FolderRecord,
+    filename: string,
+    mtimeMs: number,
+    playbackStrategy: PlaybackStrategy,
+    durationMs: number | null = null
+  ) {
+    const relativePath = `${folder.folder_path}/${filename}`;
+    const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+    const extension = path.extname(filename).toLowerCase();
+    const mediaType = getMediaTypeFromExtension(extension);
+    const previewRelativePath = getPreviewRelativePath(relativePath, mediaType);
+    const thumbnailRelativePath = getThumbnailRelativePath(relativePath);
+    const fileSize = 2_048 + mtimeMs;
+
+    return imageRepository.upsert({
+      folderId: folder.id,
+      filename,
+      extension,
+      relativePath,
+      absolutePath,
+      fileSize,
+      width: 1280,
+      height: 960,
+      mediaType,
+      mimeType: getMimeTypeFromExtension(extension),
+      durationMs,
+      fingerprint: createFingerprint(relativePath, fileSize, mtimeMs),
+      mtimeMs,
+      firstSeenAt: '2026-01-01T00:00:00.000Z',
+      sortTimestamp: mtimeMs,
+      takenAt: mtimeMs,
+      takenAtSource: 'mtime',
+      exifJson: mediaType === 'image' ? '{}' : null,
+      thumbnailPath: thumbnailRelativePath,
+      previewPath: previewRelativePath,
+      playbackStrategy
+    });
+  }
+});

--- a/server/test/lazy-derivatives.test.ts
+++ b/server/test/lazy-derivatives.test.ts
@@ -1,0 +1,514 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type express from 'express';
+
+import {
+  createFingerprint,
+  getMediaTypeFromExtension,
+  getMimeTypeFromExtension,
+  getPreviewRelativePath,
+  getThumbnailRelativePath
+} from '../src/utils/image-utils.js';
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type LazyRoutesModule = typeof import('../src/routes/lazy-derivatives.js');
+type ScannerServiceModule = typeof import('../src/services/scanner-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type ModelsModule = typeof import('../src/types/models.js');
+
+type FolderRecord = ModelsModule['FolderRecord'];
+type PlaybackStrategy = ModelsModule['PlaybackStrategy'];
+
+const generateThumbnailDerivativeMock = vi.fn();
+const generateDerivativesMock = vi.fn();
+const readMediaMetadataMock = vi.fn();
+const writeImagePreviewMock = vi.fn();
+const writeVideoPreviewMock = vi.fn();
+
+describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let lazyThumbnailsRouter: LazyRoutesModule['lazyThumbnailsRouter'];
+  let lazyPreviewsRouter: LazyRoutesModule['lazyPreviewsRouter'];
+  let scannerService: ScannerServiceModule['scannerService'];
+  let folderRepository: RepositoriesModule['folderRepository'];
+  let imageRepository: RepositoriesModule['imageRepository'];
+  let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+
+  async function reset(derivativeMode = 'lazy', scanDerivativeConcurrency = 4) {
+    generateThumbnailDerivativeMock.mockReset();
+    generateDerivativesMock.mockReset();
+    readMediaMetadataMock.mockReset();
+    writeImagePreviewMock.mockReset();
+    writeVideoPreviewMock.mockReset();
+
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.resetModules();
+    vi.doMock('../src/services/derivative-service.js', () => ({
+      generateDerivatives: generateDerivativesMock,
+      generateThumbnailDerivative: generateThumbnailDerivativeMock,
+      readMediaMetadata: readMediaMetadataMock,
+      writeImagePreview: writeImagePreviewMock,
+      writeVideoPreview: writeVideoPreviewMock
+    }));
+
+    vi.stubEnv('DERIVATIVE_MODE', derivativeMode);
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+    vi.stubEnv('SCAN_DERIVATIVE_CONCURRENCY', String(scanDerivativeConcurrency));
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ lazyThumbnailsRouter, lazyPreviewsRouter } = await import('../src/routes/lazy-derivatives.js'));
+    ({ scannerService } = await import('../src/services/scanner-service.js'));
+    ({ folderRepository, imageRepository, maintenanceRepository } = await import('../src/db/repositories.js'));
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+
+    readMediaMetadataMock.mockImplementation(async (sourcePath: string) => {
+      const mediaType = getMediaTypeFromExtension(path.extname(sourcePath));
+      return {
+        width: 1280,
+        height: 960,
+        takenAt: null,
+        durationMs: mediaType === 'video' ? 5000 : null,
+        mediaType,
+        playbackStrategy: sourcePath.endsWith('.mp4') ? 'original' : 'preview',
+        isAnimated: false
+      };
+    });
+
+    generateDerivativesMock.mockImplementation(async (_src: string, relativePath: string) => {
+      const mediaType = getMediaTypeFromExtension(path.extname(relativePath));
+      return {
+        width: 1280,
+        height: 960,
+        takenAt: null,
+        durationMs: mediaType === 'video' ? 5000 : null,
+        mediaType,
+        playbackStrategy: relativePath.endsWith('.mp4') ? 'original' : 'preview',
+        isAnimated: false,
+        thumbnailPath: getThumbnailRelativePath(relativePath),
+        previewPath: getPreviewRelativePath(relativePath, mediaType),
+        generatedThumbnail: true,
+        generatedPreview: true
+      };
+    });
+
+    generateThumbnailDerivativeMock.mockImplementation(async (_src: string, relativePath: string) => {
+      const thumbnailPath = getThumbnailRelativePath(relativePath);
+      const thumbnailAbsolutePath = path.join(appConfig.thumbnailsDir, thumbnailPath);
+      await fs.mkdir(path.dirname(thumbnailAbsolutePath), { recursive: true });
+      await fs.writeFile(thumbnailAbsolutePath, `thumbnail:${relativePath}`);
+      return {
+        thumbnailPath,
+        generatedThumbnail: true
+      };
+    });
+
+    writeImagePreviewMock.mockImplementation(async (_src: string, previewAbsolutePath: string) => {
+      await fs.mkdir(path.dirname(previewAbsolutePath), { recursive: true });
+      await fs.writeFile(previewAbsolutePath, `image-preview:${path.basename(previewAbsolutePath)}`);
+    });
+
+    writeVideoPreviewMock.mockImplementation(async (_src: string, previewAbsolutePath: string) => {
+      await fs.mkdir(path.dirname(previewAbsolutePath), { recursive: true });
+      await fs.writeFile(previewAbsolutePath, `video-preview:${path.basename(previewAbsolutePath)}`);
+    });
+  }
+
+  async function dispatchRoute(
+    router: LazyRoutesModule['lazyThumbnailsRouter'] | LazyRoutesModule['lazyPreviewsRouter'],
+    routePath: string,
+    options: {
+      sendFile?: (
+        filePath: string,
+        callback: ((error?: Error) => void) | undefined,
+        helpers: {
+          finish(): void;
+          fail(error: unknown): void;
+          response: express.Response;
+        }
+      ) => void;
+    } = {}
+  ) {
+    return await new Promise<{
+      body: unknown;
+      headers: Map<string, string>;
+      jsonCalls: number;
+      statusCode: number;
+    }>((resolve, reject) => {
+      const headers = new Map<string, string>();
+      const responseState = {
+        body: null as unknown,
+        jsonCalls: 0,
+        statusCode: 200
+      };
+      let settled = false;
+
+      const finish = () => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        resolve({
+          ...responseState,
+          headers
+        });
+      };
+
+      const fail = (error: unknown) => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        reject(error);
+      };
+
+      const response = {
+        headersSent: false,
+        json(payload: unknown) {
+          responseState.body = payload;
+          responseState.jsonCalls += 1;
+          this.headersSent = true;
+          finish();
+          return this;
+        },
+        sendFile(filePath: string, callback?: (error?: Error) => void) {
+          if (options.sendFile) {
+            options.sendFile(filePath, callback, {
+              fail,
+              finish,
+              response: this as unknown as express.Response
+            });
+            return this;
+          }
+
+          void fs.readFile(filePath, 'utf8')
+            .then((body) => {
+              responseState.body = body;
+              this.headersSent = true;
+              callback?.();
+              finish();
+            })
+            .catch((error) => {
+              callback?.(error as Error);
+              fail(error);
+            });
+
+          return this;
+        },
+        setHeader(name: string, value: string) {
+          headers.set(name.toLowerCase(), value);
+        },
+        status(code: number) {
+          responseState.statusCode = code;
+          return this;
+        }
+      } satisfies Pick<express.Response, 'json' | 'sendFile' | 'setHeader' | 'status'>;
+
+      const request = {
+        get() {
+          return undefined;
+        },
+        method: 'GET',
+        originalUrl: routePath,
+        url: routePath
+      } as unknown as express.Request;
+
+      router.handle(request, response as unknown as express.Response, (error?: unknown) => {
+        if (error) {
+          fail(error);
+          return;
+        }
+      });
+    });
+  }
+
+  function encodeRelativePath(relativePath: string): string {
+    return relativePath.split('/').map((segment) => encodeURIComponent(segment)).join('/');
+  }
+
+  function createIndexedMedia(
+    folder: FolderRecord,
+    filename: string,
+    mtimeMs: number,
+    playbackStrategy: PlaybackStrategy,
+    durationMs: number | null = null
+  ) {
+    const relativePath = `${folder.folder_path}/${filename}`;
+    const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+    const extension = path.extname(filename).toLowerCase();
+    const mediaType = getMediaTypeFromExtension(extension);
+    const previewRelativePath = getPreviewRelativePath(relativePath, mediaType);
+    const thumbnailRelativePath = getThumbnailRelativePath(relativePath);
+    const fileSize = 2_048 + mtimeMs;
+
+    return imageRepository.upsert({
+      folderId: folder.id,
+      filename,
+      extension,
+      relativePath,
+      absolutePath,
+      fileSize,
+      width: mediaType === 'video' ? 1080 : 1600,
+      height: mediaType === 'video' ? 1920 : 1200,
+      mediaType,
+      mimeType: getMimeTypeFromExtension(extension),
+      durationMs,
+      fingerprint: createFingerprint(relativePath, fileSize, mtimeMs),
+      mtimeMs,
+      firstSeenAt: '2026-01-01T00:00:00.000Z',
+      sortTimestamp: mtimeMs,
+      takenAt: mtimeMs,
+      takenAtSource: 'mtime',
+      exifJson: mediaType === 'image' ? '{}' : null,
+      thumbnailPath: thumbnailRelativePath,
+      previewPath: previewRelativePath,
+      playbackStrategy
+    });
+  }
+
+  async function createSourceFile(relativePath: string): Promise<void> {
+    const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, `source:${relativePath}`);
+  }
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-lazy-derivatives-'));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('does not call generateDerivatives for new files when DERIVATIVE_MODE=lazy', async () => {
+    await reset('lazy');
+
+    await createSourceFile('album/photo.jpg');
+    await scannerService.scanAll('test');
+
+    expect(generateDerivativesMock).not.toHaveBeenCalled();
+    expect(generateThumbnailDerivativeMock).not.toHaveBeenCalled();
+    expect(imageRepository.countFeed()).toBe(1);
+  });
+
+  it('still calls generateDerivatives for new files when DERIVATIVE_MODE=eager', async () => {
+    await reset('eager');
+
+    await createSourceFile('album2/photo.jpg');
+    await scannerService.scanAll('test');
+
+    expect(generateDerivativesMock).toHaveBeenCalledOnce();
+  });
+
+  it('rebuildThumbnails still generates thumbnails in lazy mode', async () => {
+    await reset('lazy');
+
+    maintenanceRepository.resetLibraryIndex();
+    const folder = folderRepository.upsert({ slug: 'rb', name: 'RB', folderPath: 'rb' });
+    createIndexedMedia(folder, 'photo.jpg', 1000, 'preview');
+
+    await scannerService.rebuildThumbnails('test');
+
+    expect(generateThumbnailDerivativeMock).toHaveBeenCalledOnce();
+  });
+
+  it('image index contains deterministic thumbnail and preview paths even in lazy mode', async () => {
+    await reset('lazy');
+
+    await createSourceFile('album3/photo.jpg');
+    await scannerService.scanAll('test');
+
+    const images = imageRepository.listActive();
+    expect(images).toHaveLength(1);
+    expect(images[0]!.thumbnail_path).toMatch(/album3/);
+    expect(images[0]!.preview_path).toMatch(/album3/);
+  });
+
+  it('generates a missing thumbnail on first request, reuses it on later requests, and preserves cache headers', async () => {
+    await reset('lazy');
+
+    maintenanceRepository.resetLibraryIndex();
+    const folder = folderRepository.upsert({ slug: 'thumbs', name: 'Thumbs', folderPath: 'thumbs' });
+    const image = createIndexedMedia(folder, 'photo.jpg', 2000, 'preview');
+    const requestPath = `/${encodeRelativePath(image.thumbnail_path)}`;
+    const firstResponse = await dispatchRoute(lazyThumbnailsRouter, requestPath);
+    expect(firstResponse.statusCode).toBe(200);
+    expect(firstResponse.headers.get('cache-control')).toBe('public, max-age=604800, immutable');
+    expect(firstResponse.body).toBe(`thumbnail:${image.relative_path}`);
+    expect(generateThumbnailDerivativeMock).toHaveBeenCalledOnce();
+
+    const secondResponse = await dispatchRoute(lazyThumbnailsRouter, requestPath);
+    expect(secondResponse.statusCode).toBe(200);
+    expect(secondResponse.body).toBe(`thumbnail:${image.relative_path}`);
+    expect(generateThumbnailDerivativeMock).toHaveBeenCalledOnce();
+  });
+
+  it('generates a missing image preview on first request', async () => {
+    await reset('lazy');
+
+    maintenanceRepository.resetLibraryIndex();
+    const folder = folderRepository.upsert({ slug: 'previews', name: 'Previews', folderPath: 'previews' });
+    const image = createIndexedMedia(folder, 'photo.jpg', 3000, 'preview');
+    const response = await dispatchRoute(lazyPreviewsRouter, `/${encodeRelativePath(image.preview_path)}`);
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe('image-preview:photo.webp');
+    expect(writeImagePreviewMock).toHaveBeenCalledOnce();
+    expect(writeVideoPreviewMock).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates concurrent requests for the same missing video preview', async () => {
+    await reset('lazy');
+
+    maintenanceRepository.resetLibraryIndex();
+    const folder = folderRepository.upsert({ slug: 'videos', name: 'Videos', folderPath: 'videos' });
+    const video = createIndexedMedia(folder, 'clip.mp4', 4000, 'original', 5000);
+    let releaseGeneration: (() => void) | null = null;
+    const generationStarted = new Promise<void>((resolve) => {
+      writeVideoPreviewMock.mockImplementationOnce(async (_src: string, previewAbsolutePath: string) => {
+        resolve();
+        await new Promise<void>((generationResolve) => {
+          releaseGeneration = generationResolve;
+        });
+        await fs.mkdir(path.dirname(previewAbsolutePath), { recursive: true });
+        await fs.writeFile(previewAbsolutePath, 'video-preview:clip.mp4');
+      });
+    });
+
+    const previewPath = `/${encodeRelativePath(video.preview_path)}`;
+    const firstRequest = dispatchRoute(lazyPreviewsRouter, previewPath);
+    await generationStarted;
+    const secondRequest = dispatchRoute(lazyPreviewsRouter, previewPath);
+    releaseGeneration?.();
+
+    const [firstResponse, secondResponse] = await Promise.all([firstRequest, secondRequest]);
+    expect(firstResponse.statusCode).toBe(200);
+    expect(secondResponse.statusCode).toBe(200);
+    expect(firstResponse.body).toBe('video-preview:clip.mp4');
+    expect(secondResponse.body).toBe('video-preview:clip.mp4');
+    expect(writeVideoPreviewMock).toHaveBeenCalledOnce();
+  });
+
+  it('limits concurrent generation for different missing derivatives', async () => {
+    await reset('lazy', 1);
+
+    maintenanceRepository.resetLibraryIndex();
+    const folder = folderRepository.upsert({ slug: 'queue', name: 'Queue', folderPath: 'queue' });
+    const firstImage = createIndexedMedia(folder, 'photo-1.jpg', 5000, 'preview');
+    const secondImage = createIndexedMedia(folder, 'photo-2.jpg', 6000, 'preview');
+
+    let activeGenerations = 0;
+    let maxActiveGenerations = 0;
+    let releaseFirstGeneration: (() => void) | null = null;
+    let firstGenerationSeen = false;
+
+    generateThumbnailDerivativeMock.mockImplementation(async (_src: string, relativePath: string) => {
+      activeGenerations += 1;
+      maxActiveGenerations = Math.max(maxActiveGenerations, activeGenerations);
+
+      if (!firstGenerationSeen) {
+        firstGenerationSeen = true;
+        await new Promise<void>((resolve) => {
+          releaseFirstGeneration = resolve;
+        });
+      }
+
+      const thumbnailPath = getThumbnailRelativePath(relativePath);
+      const thumbnailAbsolutePath = path.join(appConfig.thumbnailsDir, thumbnailPath);
+      await fs.mkdir(path.dirname(thumbnailAbsolutePath), { recursive: true });
+      await fs.writeFile(thumbnailAbsolutePath, `thumbnail:${relativePath}`);
+      activeGenerations -= 1;
+
+      return {
+        thumbnailPath,
+        generatedThumbnail: true
+      };
+    });
+
+    const firstRequest = dispatchRoute(lazyThumbnailsRouter, `/${encodeRelativePath(firstImage.thumbnail_path)}`);
+    await vi.waitFor(() => {
+      expect(maxActiveGenerations).toBe(1);
+      expect(generateThumbnailDerivativeMock).toHaveBeenCalledTimes(1);
+    });
+
+    const secondRequest = dispatchRoute(lazyThumbnailsRouter, `/${encodeRelativePath(secondImage.thumbnail_path)}`);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(generateThumbnailDerivativeMock).toHaveBeenCalledTimes(1);
+    expect(maxActiveGenerations).toBe(1);
+
+    releaseFirstGeneration?.();
+
+    const [firstResponse, secondResponse] = await Promise.all([firstRequest, secondRequest]);
+    expect(firstResponse.statusCode).toBe(200);
+    expect(secondResponse.statusCode).toBe(200);
+    expect(firstResponse.body).toBe(`thumbnail:${firstImage.relative_path}`);
+    expect(secondResponse.body).toBe(`thumbnail:${secondImage.relative_path}`);
+    expect(generateThumbnailDerivativeMock).toHaveBeenCalledTimes(2);
+    expect(maxActiveGenerations).toBe(1);
+  });
+
+  it('returns 404 when no indexed row matches the requested derivative path', async () => {
+    await reset('lazy');
+
+    maintenanceRepository.resetLibraryIndex();
+    const response = await dispatchRoute(lazyPreviewsRouter, '/missing/path.webp');
+    expect(response.statusCode).toBe(404);
+    expect(response.body).toEqual({ message: 'Derivative not found.' });
+    expect(response.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('does not emit a JSON error after sendFile fails once headers are already sent', async () => {
+    await reset('lazy');
+
+    maintenanceRepository.resetLibraryIndex();
+    const folder = folderRepository.upsert({ slug: 'abort', name: 'Abort', folderPath: 'abort' });
+    const video = createIndexedMedia(folder, 'clip.mp4', 4500, 'original', 5000);
+    const previewAbsolutePath = path.join(appConfig.previewsDir, video.preview_path);
+
+    await fs.mkdir(path.dirname(previewAbsolutePath), { recursive: true });
+    await fs.writeFile(previewAbsolutePath, 'video-preview:clip.mp4');
+
+    const response = await dispatchRoute(lazyPreviewsRouter, `/${encodeRelativePath(video.preview_path)}`, {
+      sendFile(_filePath, callback, { finish, response: routeResponse }) {
+        Object.assign(routeResponse, { headersSent: true });
+        callback?.(Object.assign(new Error('request aborted'), { code: 'ECONNABORTED' }));
+        setImmediate(finish);
+      }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBeNull();
+    expect(response.jsonCalls).toBe(0);
+  });
+
+  it('rejects traversal attempts with a 400 response', async () => {
+    await reset('lazy');
+
+    maintenanceRepository.resetLibraryIndex();
+    const response = await dispatchRoute(lazyThumbnailsRouter, '/%2E%2E/outside.webp');
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toEqual({ message: 'Invalid derivative path.' });
+  });
+});

--- a/server/test/library-rebuild.test.ts
+++ b/server/test/library-rebuild.test.ts
@@ -28,6 +28,7 @@ describe.sequential('library rebuild reuses existing derivatives', () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-library-rebuild-'));
 
     vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DERIVATIVE_MODE', 'eager');
     vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
     vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
     vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));

--- a/server/test/video-derivative-strategy.test.ts
+++ b/server/test/video-derivative-strategy.test.ts
@@ -56,14 +56,14 @@ describe.sequential('video derivative strategy', () => {
     ]);
   });
 
-  it('skips preview transcoding for browser-safe MP4 originals and removes stale preview files', async () => {
+  it('keeps preview transcoding for large high-resolution browser-safe MP4 originals while preserving original playback eligibility', async () => {
     execFileAsyncMock.mockImplementation(createExecFileAsyncMock({
       format: {
         duration: '4.0',
         format_name: 'mov,mp4,m4a,3gp,3g2,mj2'
       },
       streams: [
-        { codec_type: 'video', codec_name: 'h264', width: 1080, height: 1920, pix_fmt: 'yuv420p' },
+        { codec_type: 'video', codec_name: 'h264', width: 2160, height: 3840, pix_fmt: 'yuv420p' },
         { codec_type: 'audio', codec_name: 'aac' }
       ]
     }));
@@ -73,19 +73,18 @@ describe.sequential('video derivative strategy', () => {
 
     await fs.mkdir(path.dirname(sourcePath), { recursive: true });
     await fs.mkdir(path.dirname(stalePreviewPath), { recursive: true });
-    await fs.writeFile(sourcePath, Buffer.alloc(1024 * 1024));
-    await fs.writeFile(stalePreviewPath, 'stale-preview');
+    await fs.writeFile(sourcePath, Buffer.alloc(32 * 1024 * 1024));
 
     const result = await generateDerivatives(sourcePath, 'clips/reel-1.mp4');
 
     expect(result.playbackStrategy).toBe('original');
-    expect(result.generatedPreview).toBe(false);
-    await expect(fs.stat(stalePreviewPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(result.generatedPreview).toBe(true);
 
     const ffmpegCalls = execFileAsyncMock.mock.calls.filter(([command]) => command === 'ffmpeg');
-    expect(ffmpegCalls).toHaveLength(1);
+    expect(ffmpegCalls).toHaveLength(2);
     expect(ffmpegCalls[0]?.[1]).toContain('libwebp');
-    expect(ffmpegCalls[0]?.[1]).not.toContain('libx264');
+    expect(ffmpegCalls[1]?.[1]).toContain('libx264');
+    expect(ffmpegCalls[1]?.[1]).toContain(expectedVideoScaleFilter());
   });
 
   it('keeps preview transcoding for incompatible MP4 files', async () => {
@@ -114,8 +113,13 @@ describe.sequential('video derivative strategy', () => {
     expect(ffmpegCalls).toHaveLength(2);
     expect(ffmpegCalls[0]?.[1]).toContain('libwebp');
     expect(ffmpegCalls[1]?.[1]).toContain('libx264');
+    expect(ffmpegCalls[1]?.[1]).toContain(expectedVideoScaleFilter());
   });
 });
+
+function expectedVideoScaleFilter(): string {
+  return "scale='trunc(if(gt(iw,ih),min(1280,iw),min(720,iw))/2)*2':'trunc(if(gt(iw,ih),min(1280,iw)*ih/iw,min(720,iw)*ih/iw)/2)*2':flags=lanczos";
+}
 
 function createExecFileAsyncMock(payload: unknown) {
   return async (command: string) => {

--- a/server/test/video-playback-strategy.test.ts
+++ b/server/test/video-playback-strategy.test.ts
@@ -66,7 +66,7 @@ describe.sequential('video playback strategy mapping', () => {
     ]);
   });
 
-  it('reuses original URLs for compatible MP4 videos and only counts generated previews', async () => {
+  it('uses generated previews by default for videos while preserving original playback eligibility', async () => {
     const folder = folderRepository.upsert({
       slug: 'clips',
       name: 'Clips',
@@ -82,15 +82,23 @@ describe.sequential('video playback strategy mapping', () => {
     const feedItems = new Map(galleryService.getFeed(1, 10, 'recent').items.map((item) => [item.id, item]));
 
     expect(feedItems.get(image.id)?.previewUrl).toBe('/previews/clips/photo-1.webp');
-    expect(feedItems.get(compatibleVideo.id)?.previewUrl).toBe(`/api/originals/${compatibleVideo.id}`);
+    expect(feedItems.get(compatibleVideo.id)?.previewUrl).toBe('/previews/clips/reel-1.mp4');
     expect(feedItems.get(transcodedVideo.id)?.previewUrl).toBe('/previews/clips/reel-2.mp4');
 
     const compatibleVideoDetail = galleryService.getImageDetail(compatibleVideo.id, 'video');
-    expect(compatibleVideoDetail?.previewUrl).toBe(`/api/originals/${compatibleVideo.id}`);
+    expect(compatibleVideoDetail?.previewUrl).toBe('/previews/clips/reel-1.mp4');
     expect(compatibleVideoDetail?.originalUrl).toBe(`/api/originals/${compatibleVideo.id}`);
+    expect(compatibleVideoDetail?.playbackStrategy).toBe('original');
+
+    await fs.mkdir(path.join(appConfig.previewsDir, 'clips'), { recursive: true });
+    await Promise.all([
+      fs.writeFile(path.join(appConfig.previewsDir, 'clips', 'photo-1.webp'), 'preview-image'),
+      fs.writeFile(path.join(appConfig.previewsDir, 'clips', 'reel-1.mp4'), 'preview-video-hd'),
+      fs.writeFile(path.join(appConfig.previewsDir, 'clips', 'reel-2.mp4'), 'preview-video-transcoded')
+    ]);
 
     const stats = galleryService.getStats();
-    expect(stats.previewCount).toBe(2);
+    expect(stats.previewCount).toBe(3);
   });
 
   it('reports the latest completed scan in stats even when a newer run is still in progress', () => {


### PR DESCRIPTION
Closes #5 

Adds configurable lazy derivative generation for large libraries, allowing Foldergram to index first and create missing thumbnails and previews on demand. It also improves video handling with better preview transcodes, optional HD playback for compatible MP4 originals, Vidstack-based players in the feed and media modal, plus docs, tests, and route hardening for the new behavior.