### PR TITLE
feat: add folder customization with persistent custom name, description and a custom cover.

### DIFF
--- a/client/src/api/gallery.ts
+++ b/client/src/api/gallery.ts
@@ -68,6 +68,22 @@ export function fetchFolderImages(slug: string, page = 1, limit = 24, mediaType?
   return requestJson<FolderImagesPayload>(`/api/folders/${encodeURIComponent(slug)}/images?${params.toString()}`);
 }
 
+export function updateFolderProfile(slug: string, name: string, description: string | null) {
+  return requestJson<FolderSummary>(`/api/folders/${encodeURIComponent(slug)}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name, description })
+  });
+}
+
+export function setFolderCover(slug: string, imageId: number) {
+  return requestJson<{ ok: boolean }>(`/api/folders/${encodeURIComponent(slug)}/cover`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ imageId })
+  });
+}
+
 export function fetchImage(id: number, mediaType?: 'image' | 'video') {
   const params = new URLSearchParams();
   if (mediaType) {

--- a/client/src/components/FolderHeader.vue
+++ b/client/src/components/FolderHeader.vue
@@ -1,7 +1,21 @@
 <template>
   <section class="grid grid-cols-[10.75rem_minmax(0,1fr)] items-start gap-x-[2.65rem] pt-[0.6rem] pb-[2.4rem] max-md:grid-cols-[9rem_minmax(0,1fr)] max-md:gap-x-[2rem] max-sm:grid-cols-1 max-sm:gap-y-[1.35rem] max-sm:pb-[1.85rem] max-sm:text-center">
     <div class="grid place-items-center">
-      <div class="rounded-full p-[0.22rem] shadow-[0_16px_34px_rgba(246,106,61,0.12)]" style="background: var(--story-ring);">
+      <RouterLink v-if="folder.avatarImageId" custom :to="buildAvatarRoute(folder.avatarImageId)" v-slot="{ href, navigate }">
+        <a
+          :href="href"
+          class="block rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text/55 focus-visible:ring-offset-4 focus-visible:ring-offset-bg"
+          aria-label="Open folder avatar"
+          @click="handleAvatarNavigation($event, navigate)"
+        >
+          <div class="rounded-full p-[0.22rem] shadow-[0_16px_34px_rgba(246,106,61,0.12)] transition-transform duration-[180ms] hover:scale-[1.02]" style="background: var(--story-ring);">
+            <div class="rounded-full bg-bg p-[0.22rem]">
+              <Avatar class="w-[9.35rem] h-[9.35rem] max-md:w-[7.75rem] max-md:h-[7.75rem]" :name="folder.name" :src="folder.avatarUrl" />
+            </div>
+          </div>
+        </a>
+      </RouterLink>
+      <div v-else class="rounded-full p-[0.22rem] shadow-[0_16px_34px_rgba(246,106,61,0.12)]" style="background: var(--story-ring);">
         <div class="rounded-full bg-bg p-[0.22rem]">
           <Avatar class="w-[9.35rem] h-[9.35rem] max-md:w-[7.75rem] max-md:h-[7.75rem]" :name="folder.name" :src="folder.avatarUrl" />
         </div>
@@ -10,7 +24,14 @@
     <div class="grid gap-[1rem] pt-[0.35rem]">
       <div class="flex items-center gap-[0.75rem] flex-wrap max-sm:justify-center">
         <h1 class="m-0 text-[clamp(1.6rem,2.4vw,2rem)] font-medium leading-none tracking-[-0.04em]">{{ folder.name }}</h1>
-        <span class="inline-flex items-center rounded-full bg-surface-hover px-[0.72rem] py-[0.34rem] text-[0.78rem] font-semibold text-muted">App folder</span>
+        <button
+          v-if="authStore.canManageLibrary"
+          type="button"
+          class="inline-flex items-center justify-center px-4 pt-2 pb-1.5 text-[0.75rem] font-semibold leading-none rounded-lg bg-surface-hover text-text hover:bg-border transition-colors border border-border cursor-pointer"
+          @click="isEditingProfile = true"
+        >
+          Edit App Folder
+        </button>
       </div>
       <p v-if="folder.breadcrumb" class="m-0 text-[0.84rem] font-medium tracking-[0.02em] text-muted">{{ folder.breadcrumb }}</p>
       <div class="flex items-center gap-[1.6rem] flex-wrap text-[0.95rem] leading-none max-sm:justify-center">
@@ -22,18 +43,45 @@
         <span class="text-[0.74rem] font-bold tracking-[0.1em] text-muted uppercase">Library path</span>
         <p class="m-0 font-mono text-[0.8rem] leading-[1.5] text-muted break-all">{{ folder.folderPath }}</p>
       </div>
+      <div v-if="folder.description" class="max-w-[34rem] pt-[0.25rem]">
+        <p class="m-0 text-[0.95rem] leading-[1.4] whitespace-pre-wrap">{{ folder.description }}</p>
+      </div>
     </div>
+
+    <Teleport to="body">
+      <FolderProfileModal
+        v-if="isEditingProfile"
+        :initial-name="folder.name"
+        :initial-description="folder.description"
+        :loading="savingProfile"
+        @cancel="isEditingProfile = false"
+        @save="handleSaveProfile"
+      />
+    </Teleport>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
+import { RouterLink, useRoute } from 'vue-router';
 import type { FolderSummary } from '../types/api';
 import Avatar from './Avatar.vue';
+import FolderProfileModal from './FolderProfileModal.vue';
+import { useAppStore } from '../stores/app';
+import { useAuthStore } from '../stores/auth';
+import { useFoldersStore } from '../stores/folders';
 
 const props = defineProps<{
   folder: FolderSummary;
 }>();
+
+const appStore = useAppStore();
+const authStore = useAuthStore();
+const foldersStore = useFoldersStore();
+const route = useRoute();
+
+const isEditingProfile = ref(false);
+const savingProfile = ref(false);
 
 const formattedUpdatedDate = computed(() =>
   props.folder.latestImageMtimeMs
@@ -44,4 +92,34 @@ const formattedUpdatedDate = computed(() =>
       })
     : ''
 );
+
+async function handleSaveProfile(data: { name: string; description: string | null }) {
+  try {
+    savingProfile.value = true;
+    await foldersStore.updateFolderProfile(props.folder.slug, data.name, data.description);
+    isEditingProfile.value = false;
+  } catch (error) {
+    alert(error instanceof Error ? error.message : 'Failed to update profile');
+  } finally {
+    savingProfile.value = false;
+  }
+}
+
+function buildAvatarRoute(id: number) {
+  return {
+    name: 'image',
+    params: { id: String(id) },
+    query: route.query
+  };
+}
+
+function handleAvatarNavigation(event: MouseEvent, navigate: () => void) {
+  if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+    return;
+  }
+
+  event.preventDefault();
+  appStore.setImageModalBackground(route.fullPath);
+  navigate();
+}
 </script>

--- a/client/src/components/FolderProfileModal.vue
+++ b/client/src/components/FolderProfileModal.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="fixed inset-0 z-60 flex items-center justify-center p-6 bg-black/55" @click.self="$emit('cancel')">
+    <section class="w-[min(100%,32rem)] p-[1.4rem] bg-surface border border-border rounded-[1.2rem] shadow-[var(--shadow)]" role="dialog" aria-modal="true" :aria-labelledby="titleId">
+      <div class="grid gap-[1.2rem]">
+        <h2 :id="titleId" class="m-0 text-[1.25rem] font-semibold">Edit App Folder</h2>
+
+        <form @submit.prevent="submit" class="grid gap-[1.1rem]">
+          <div class="grid gap-[0.4rem]">
+            <label for="profile-name" class="text-[0.85rem] font-semibold text-text">Name</label>
+            <input
+              id="profile-name"
+              v-model="formData.name"
+              type="text"
+              class="w-full px-3 py-2 text-[0.95rem] bg-bg border border-border rounded-lg text-text focus:outline-none focus:border-[#4B5563] transition-colors"
+              required
+              maxlength="255"
+              placeholder="Folder display name"
+            />
+          </div>
+
+          <div class="grid gap-[0.35rem]">
+            <div class="flex items-center justify-between">
+              <label for="profile-description" class="text-[0.85rem] font-semibold text-text">Description</label>
+              <span class="text-[0.75rem] text-muted">{{ formData.description?.length || 0 }} / 300</span>
+            </div>
+            <textarea
+              id="profile-description"
+              v-model="formData.description"
+              class="w-full min-h-[6rem] rounded-lg border border-border bg-surface px-[0.75rem] py-[0.6rem] text-[0.95rem] text-text placeholder-muted resize-y focus:border-text focus:outline-none focus:ring-1 focus:ring-text"
+              placeholder="Add a description to this folder..."
+              maxlength="300"
+            ></textarea>
+          </div>
+
+          <p v-if="error" class="m-0 text-[0.85rem] text-[#d93025]">{{ error }}</p>
+
+          <div class="flex justify-end gap-3 mt-2">
+            <button class="min-h-[2.5rem] px-4 py-[0.6rem] border border-transparent rounded-[0.75rem] font-semibold cursor-pointer bg-surface-hover text-text disabled:opacity-70 disabled:cursor-wait" type="button" @click="$emit('cancel')">
+              Cancel
+            </button>
+            <button class="min-h-[2.5rem] px-4 py-[0.6rem] border border-transparent rounded-[0.75rem] font-semibold cursor-pointer bg-text text-bg disabled:opacity-70 disabled:cursor-wait" type="submit" :disabled="loading">
+              {{ loading ? 'Saving...' : 'Save' }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive } from 'vue';
+
+const props = defineProps<{
+  initialName: string;
+  initialDescription: string | null;
+  loading?: boolean;
+}>();
+
+const emit = defineEmits<{
+  cancel: [];
+  save: [data: { name: string; description: string | null }];
+}>();
+
+const titleId = `profile-dialog-title-${Math.random().toString(36).slice(2, 10)}`;
+const error = ref<string | null>(null);
+
+const formData = reactive({
+  name: props.initialName,
+  description: props.initialDescription ?? ''
+});
+
+function submit() {
+  if (!formData.name.trim()) {
+    error.value = 'Name is required.';
+    return;
+  }
+
+  error.value = null;
+  emit('save', {
+    name: formData.name.trim(),
+    description: formData.description.trim() || null
+  });
+}
+</script>

--- a/client/src/components/ImageModal.vue
+++ b/client/src/components/ImageModal.vue
@@ -377,6 +377,18 @@
           </button>
 
           <div class="flex items-center gap-4">
+            <!-- Set as cover -->
+            <button
+              v-if="authStore.canManageLibrary && image.mediaType === 'image'"
+              class="inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer text-text transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px disabled:opacity-45 disabled:cursor-wait disabled:transform-none"
+              type="button"
+              aria-label="Set as folder cover"
+              title="Set as folder cover"
+              :disabled="settingCover || isCurrentCover"
+              @click="handleSetCover"
+            >
+              <span :class="[isCurrentCover ? 'i-fluent-folder-add-20-filled text-accent' : 'i-fluent-folder-add-20-regular', 'w-[1.5rem] h-[1.5rem]']" aria-hidden="true" />
+            </button>
             <!-- Open original -->
             <a
               class="inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer text-text transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px"
@@ -458,6 +470,7 @@
   import { useAppStore } from "../stores/app"
   import { useAuthStore } from "../stores/auth"
   import { useLikesStore } from "../stores/likes"
+  import { useFoldersStore } from "../stores/folders"
   import Avatar from "./Avatar.vue"
   import ResilientImage from "./ResilientImage.vue"
   import { formatMediaDuration, videoPreviewWouldDownscale } from "../utils/media"
@@ -477,6 +490,7 @@
   const likesStore = useLikesStore()
   const appStore = useAppStore()
   const authStore = useAuthStore()
+  const foldersStore = useFoldersStore()
   const route = useRoute()
   const router = useRouter()
   const playerElement = ref<MediaPlayerElement | null>(null)
@@ -488,6 +502,7 @@
   const isSidebarCollapsible = ref(false)
   const isSidebarExpanded = ref(true)
   const isPlayingHd = ref(false)
+  const settingCover = ref(false)
 
   const WHEEL_NAVIGATION_THRESHOLD = 72
   const NAVIGATION_COOLDOWN_MS = 320
@@ -548,6 +563,23 @@
       "--viewer-media-aspect-ratio": `${props.image.width} / ${props.image.height}`,
       "--viewer-media-intrinsic-width": `${props.image.width}px`,
     }
+  })
+
+  const locallySetCover = ref(false)
+
+  const isCurrentCover = computed(() => {
+    if (locallySetCover.value) return true;
+    if (!props.image) return false;
+
+    if ('folderAvatarImageId' in props.image && typeof props.image.folderAvatarImageId === 'number') {
+      return props.image.id === props.image.folderAvatarImageId;
+    }
+
+    if (foldersStore.currentFolder?.avatarUrl) {
+      return foldersStore.currentFolder.avatarUrl.includes(`/api/images/${props.image.id}/`);
+    }
+
+    return false;
   })
 
   const folderAvatar = computed(() => props.folder?.avatarUrl ?? null)
@@ -1042,6 +1074,19 @@
     event.preventDefault()
     wheelDeltaAccumulator.value = 0
     void navigateByDirection(direction)
+  }
+
+  async function handleSetCover() {
+    if (!props.image || settingCover.value) return;
+    try {
+      settingCover.value = true;
+      await foldersStore.setFolderCover(props.image.folderSlug, props.image.id);
+      locallySetCover.value = true;
+    } catch (error) {
+      alert(error instanceof Error ? error.message : 'Failed to set cover');
+    } finally {
+      settingCover.value = false;
+    }
   }
 
   onMounted(() => {

--- a/client/src/stores/folders.ts
+++ b/client/src/stores/folders.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 
-import { fetchFolderImages, fetchFolders } from '../api/gallery';
+import { fetchFolderImages, fetchFolders, updateFolderProfile, setFolderCover } from '../api/gallery';
 import type { FeedItem, FolderSummary } from '../types/api';
 
 type FolderMediaFilter = 'all' | 'video';
@@ -163,6 +163,25 @@ export const useFoldersStore = defineStore('folders', {
         this.folderError = error instanceof Error ? error.message : 'Unable to load folder';
       } finally {
         this.loadingFolder = false;
+      }
+    },
+
+    async updateFolderProfile(slug: string, name: string, description: string | null) {
+      const updated = await updateFolderProfile(slug, name, description);
+      this.items = this.items.map((folder) => (folder.slug === slug ? updated : folder));
+      
+      if (this.currentFolder?.slug === slug) {
+        this.currentFolder = updated;
+      }
+    },
+
+    async setFolderCover(slug: string, imageId: number) {
+      await setFolderCover(slug, imageId);
+      await this.fetchFolders(true);
+      
+      if (this.currentFolder?.slug === slug) {
+        const payload = await fetchFolderImages(slug, 1, this.currentLimit, this.currentFilter === 'video' ? 'video' : undefined);
+        this.currentFolder = payload.folder;
       }
     }
   }

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -24,11 +24,13 @@ export interface FolderSummary {
   id: number;
   slug: string;
   name: string;
+  description: string | null;
   folderPath: string;
   breadcrumb: string | null;
   imageCount: number;
   videoCount: number;
   latestImageMtimeMs: number | null;
+  avatarImageId: number | null;
   avatarUrl: string | null;
 }
 
@@ -89,6 +91,7 @@ export interface LikesPayload {
 }
 
 export interface ImageDetail extends FeedItem {
+  folderAvatarImageId: number | null;
   relativePath: string;
   mimeType: string;
   fileSize: number;

--- a/client/uno.config.ts
+++ b/client/uno.config.ts
@@ -15,6 +15,8 @@ export default defineConfig({
     "i-fluent-square-20-regular",
     "i-fluent-folder-16-filled",
     "i-fluent-folder-16-regular",
+    "i-fluent-folder-add-20-filled",
+    "i-fluent-folder-add-20-regular",
     "i-fluent-line-horizontal-3-20-filled",
     "i-fluent-panel-left-expand-16-filled",
   ],

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -27,6 +27,13 @@ No. Foldergram ignores files placed directly in `GALLERY_ROOT`.
 No. Nested folders become separate albums when they directly contain supported
 media.
 
+## How does the app select a folder's avatar or cover image?
+
+By default, Foldergram automatically selects a `cover.jpg` (or `.png`, `.webp`, `.avif`, `.gif`) file within the folder if one exists.
+If no explicit cover file is found, it falls back to the most recent (newest) supported media file in that folder.
+Admins can also use the "Set as Cover" action from the detail view of any image to set it as the cover without renaming files.
+Any explicit `cover.*` files, or any files manually set as the cover via the UI, are hidden from the normal folder grid so they don't appear as duplicate posts.
+
 ## Are likes shared with other users?
 
 Admin and viewer sessions share SQLite likes for the current library.

--- a/docs/features.md
+++ b/docs/features.md
@@ -69,7 +69,8 @@ A folder page is available at:
 
 Folder pages include:
 
-- a folder header with avatar and counts
+- a folder header with avatar, posts counts, and descriptions
+- editable folder name and description via an admin "Edit App Folder" flow
 - a posts grid
 - a reels tab when the folder contains videos
 - infinite loading
@@ -96,6 +97,7 @@ The detail view includes:
 - size, dimensions, MIME type, and duration metadata
 - like toggle
 - original-file link
+- an admin-only "Set as Cover" action to customize the folder avatar, which highlights dynamically if the image is already the cover
 - delete action with confirmation for admin sessions only
 
 ## Likes and Favorites

--- a/server/src/db/database.ts
+++ b/server/src/db/database.ts
@@ -47,6 +47,14 @@ class DatabaseManager {
   }
 
   private applyCompatColumnMigrations(): void {
+    if (this.tableExists('folders') && !this.tableHasColumn('folders', 'description')) {
+      this.database.exec('ALTER TABLE folders ADD COLUMN description TEXT NULL');
+    }
+
+    if (this.tableExists('folders') && !this.tableHasColumn('folders', 'avatar_source')) {
+      this.database.exec("ALTER TABLE folders ADD COLUMN avatar_source TEXT NOT NULL DEFAULT 'auto'");
+    }
+
     if (this.tableExists('images') && !this.tableHasColumn('images', 'media_type')) {
       this.database.exec("ALTER TABLE images ADD COLUMN media_type TEXT NOT NULL DEFAULT 'image'");
     }

--- a/server/src/db/repositories.ts
+++ b/server/src/db/repositories.ts
@@ -3,6 +3,7 @@ import { normalizePath } from '../utils/path-utils.js';
 import type {
   AppSettingRecord,
   FeedImage,
+  FolderAvatarSource,
   FolderScanStateRecord,
   ImageDetail,
   ImageRecord,
@@ -18,8 +19,10 @@ import type {
 
 const database = databaseManager.connection;
 const EFFECTIVE_FEED_TIME_SQL = 'COALESCE(images.taken_at, images.sort_timestamp)';
-const VISIBLE_IMAGE_WHERE_SQL = 'images.is_deleted = 0 AND images.is_trashed = 0';
-const VISIBLE_IMAGE_WHERE_UNSCOPED_SQL = 'is_deleted = 0 AND is_trashed = 0';
+const COVER_FILENAMES = ['cover.jpg', 'cover.jpeg', 'cover.png', 'cover.webp', 'cover.gif'] as const;
+const COVER_FILENAME_SQL = COVER_FILENAMES.map((name) => `'${name}'`).join(', ');
+const VISIBLE_IMAGE_WHERE_SQL = `images.is_deleted = 0 AND images.is_trashed = 0 AND LOWER(images.filename) NOT IN (${COVER_FILENAME_SQL})`;
+const VISIBLE_IMAGE_WHERE_UNSCOPED_SQL = `is_deleted = 0 AND is_trashed = 0 AND LOWER(filename) NOT IN (${COVER_FILENAME_SQL})`;
 const FEED_IMAGE_SELECT_SQL = `
   SELECT
     images.id,
@@ -132,7 +135,7 @@ export const folderRepository = {
           SUM(CASE WHEN images.media_type = 'video' THEN 1 ELSE 0 END) AS video_count,
           MAX(images.mtime_ms) AS latest_image_mtime_ms
         FROM folders
-        INNER JOIN images ON images.folder_id = folders.id AND images.is_deleted = 0 AND images.is_trashed = 0
+        INNER JOIN images ON images.folder_id = folders.id AND ${VISIBLE_IMAGE_WHERE_SQL}
         GROUP BY folders.id
         ORDER BY latest_image_mtime_ms DESC, folders.name COLLATE NOCASE ASC, folders.folder_path COLLATE NOCASE ASC
         `
@@ -164,7 +167,7 @@ export const folderRepository = {
           SUM(CASE WHEN images.media_type = 'video' THEN 1 ELSE 0 END) AS video_count,
           MAX(images.mtime_ms) AS latest_image_mtime_ms
         FROM folders
-        INNER JOIN images ON images.folder_id = folders.id AND images.is_deleted = 0 AND images.is_trashed = 0
+        INNER JOIN images ON images.folder_id = folders.id AND ${VISIBLE_IMAGE_WHERE_SQL}
         WHERE folders.slug = ?
         GROUP BY folders.id
         `
@@ -191,10 +194,19 @@ export const folderRepository = {
   save(input: UpsertFolderInput): SaveFolderResult {
     const normalizedFolderPath = normalizePath(input.folderPath);
     const existing = this.getByFolderPath(normalizedFolderPath);
-    if (existing && existing.slug === input.slug && existing.name === input.name) {
+    if (existing && existing.slug === input.slug) {
       return {
         folder: existing,
         wrote: false
+      };
+    }
+
+    if (existing) {
+      database.prepare('UPDATE folders SET slug = ?, updated_at = ? WHERE id = ?').run(input.slug, nowIso(), existing.id);
+
+      return {
+        folder: this.getById(existing.id) as FolderRecord,
+        wrote: true
       };
     }
 
@@ -227,17 +239,76 @@ export const folderRepository = {
     );
   },
 
-  setAvatar(folderId: number, imageId: number | null): void {
-    database.prepare('UPDATE folders SET avatar_image_id = ?, updated_at = ? WHERE id = ? AND avatar_image_id IS NOT ?').run(
+  setAvatar(folderId: number, imageId: number | null, source: FolderAvatarSource = 'auto'): void {
+    database.prepare(
+      'UPDATE folders SET avatar_image_id = ?, avatar_source = ?, updated_at = ? WHERE id = ? AND (avatar_image_id IS NOT ? OR avatar_source != ?)'
+    ).run(
       imageId,
+      source,
       nowIso(),
       folderId,
-      imageId
+      imageId,
+      source
     );
+  },
+
+  updateMetadata(slug: string, name: string, description: string | null): FolderRecord | undefined {
+    database.prepare('UPDATE folders SET name = ?, description = ?, updated_at = ? WHERE slug = ?').run(
+      name,
+      description,
+      nowIso(),
+      slug
+    );
+    return this.getBySlug(slug);
   },
 
   delete(id: number): void {
     database.prepare('DELETE FROM folders WHERE id = ?').run(id);
+  },
+
+  resolveAvatarSelection(folderId: number): { imageId: number | null; source: FolderAvatarSource } | null {
+    const folder = this.getById(folderId);
+    if (!folder) {
+      return null;
+    }
+
+    const explicitCoverImageId = imageRepository.getExplicitCoverImageId(folderId);
+    if (explicitCoverImageId !== null) {
+      return {
+        imageId: explicitCoverImageId,
+        source: 'cover'
+      };
+    }
+
+    if (folder.avatar_source === 'manual' && folder.avatar_image_id !== null) {
+      const manualImage = imageRepository.getById(folder.avatar_image_id);
+      if (
+        manualImage &&
+        manualImage.folder_id === folderId &&
+        manualImage.is_deleted === 0 &&
+        manualImage.is_trashed === 0 &&
+        manualImage.media_type === 'image'
+      ) {
+        return {
+          imageId: manualImage.id,
+          source: 'manual'
+        };
+      }
+    }
+
+    return {
+      imageId: imageRepository.getLatestFolderImageId(folderId),
+      source: 'auto'
+    };
+  },
+
+  syncAvatarSelection(folderId: number): void {
+    const nextSelection = this.resolveAvatarSelection(folderId);
+    if (!nextSelection) {
+      return;
+    }
+
+    this.setAvatar(folderId, nextSelection.imageId, nextSelection.source);
   }
 };
 
@@ -691,7 +762,34 @@ export const imageRepository = {
     return row?.id ?? null;
   },
 
-  getImageDetail(id: number, mediaType?: MediaType): ImageDetail | undefined {
+  getExplicitCoverImageId(folderId: number): number | null {
+    const row = database.prepare(
+      `
+      SELECT id
+      FROM images
+      WHERE folder_id = ?
+        AND is_deleted = 0
+        AND is_trashed = 0
+        AND LOWER(filename) IN (${COVER_FILENAME_SQL})
+      ORDER BY
+        CASE LOWER(filename)
+          WHEN 'cover.jpg' THEN 1
+          WHEN 'cover.jpeg' THEN 2
+          WHEN 'cover.png' THEN 3
+          WHEN 'cover.webp' THEN 4
+          WHEN 'cover.gif' THEN 5
+          ELSE 6
+        END,
+        id ASC
+      LIMIT 1
+      `
+    ).get(folderId) as { id: number } | undefined;
+
+    return row?.id ?? null;
+  },
+
+  getImageDetail(id: number, mediaType?: MediaType, allowHiddenCover = false): ImageDetail | undefined {
+    const whereClause = allowHiddenCover ? 'images.is_deleted = 0 AND images.is_trashed = 0' : VISIBLE_IMAGE_WHERE_SQL;
     const detail = database.prepare(
       `
       SELECT
@@ -700,6 +798,7 @@ export const imageRepository = {
         folders.slug AS folderSlug,
         folders.name AS folderName,
         folders.folder_path AS folderPath,
+        folders.avatar_image_id AS folderAvatarImageId,
         images.filename,
         images.width,
         images.height,
@@ -718,7 +817,7 @@ export const imageRepository = {
         images.taken_at AS takenAt
       FROM images
       INNER JOIN folders ON folders.id = images.folder_id
-      WHERE images.id = ? AND ${VISIBLE_IMAGE_WHERE_SQL}
+      WHERE images.id = ? AND ${whereClause}
       `
     ).get(id) as (Omit<ImageDetail, 'nextImageId' | 'previousImageId' | 'exif'> & { originalUrl: string; exifJson: string | null }) | undefined;
 

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -6,7 +6,9 @@ CREATE TABLE IF NOT EXISTS folders (
   slug TEXT NOT NULL UNIQUE,
   name TEXT NOT NULL,
   folder_path TEXT NOT NULL,
+  description TEXT NULL,
   avatar_image_id INTEGER NULL,
+  avatar_source TEXT NOT NULL DEFAULT 'auto',
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (avatar_image_id) REFERENCES images(id)

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -50,6 +50,16 @@ const momentIdSchema = z.object({
 const imageIdSchema = z.object({
   id: z.coerce.number().int().positive()
 });
+
+export const patchFolderBodySchema = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(300).nullable().optional()
+});
+
+export const folderCoverBodySchema = z.object({
+  imageId: z.coerce.number().int().positive()
+});
+
 const submittedPasswordSchema = z
   .string()
   .min(1, 'Password is required.')
@@ -299,6 +309,32 @@ router.get('/folders/:slug', (request, response) => {
   }
 
   response.json(folder);
+});
+
+router.patch('/folders/:slug', requireCapability('canManageLibrary', 'Admin access is required.'), (request, response) => {
+  const params = slugSchema.parse(request.params);
+  const body = patchFolderBodySchema.parse(request.body);
+  const updated = galleryService.updateFolderMetadata(params.slug, body.name, body.description ?? null);
+
+  if (!updated) {
+    response.status(404).json({ message: 'Folder not found' });
+    return;
+  }
+
+  response.json(updated);
+});
+
+router.post('/folders/:slug/cover', requireCapability('canManageLibrary', 'Admin access is required.'), (request, response) => {
+  const params = slugSchema.parse(request.params);
+  const body = folderCoverBodySchema.parse(request.body);
+  const success = galleryService.setFolderAvatar(params.slug, body.imageId);
+
+  if (!success) {
+    response.status(404).json({ message: 'Folder or image not found' });
+    return;
+  }
+
+  response.json({ ok: true });
 });
 
 router.delete('/folders/:slug', requireCapability('canDeleteMedia', 'Admin access is required.'), async (request, response) => {

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -247,18 +247,25 @@ function mapTrashImage(image: IndexedTrashImage, thumbnailVersion = getThumbnail
 
 function buildFolderSummary(folder: FolderSummaryRecord) {
   const thumbnailVersion = getThumbnailAssetVersion();
-  const avatarImageId = folder.avatar_image_id ?? imageRepository.getLatestFolderImageId(folder.id);
-  const avatar = avatarImageId ? imageRepository.getImageDetail(avatarImageId) : undefined;
+  const preferredAvatarImageId = folder.avatar_image_id ?? imageRepository.getLatestFolderImageId(folder.id);
+  let avatar = preferredAvatarImageId ? imageRepository.getImageDetail(preferredAvatarImageId, undefined, true) : undefined;
+
+  if (!avatar) {
+    const fallbackAvatarImageId = imageRepository.getLatestFolderImageId(folder.id);
+    avatar = fallbackAvatarImageId ? imageRepository.getImageDetail(fallbackAvatarImageId, undefined, true) : undefined;
+  }
 
   return {
     id: folder.id,
     slug: folder.slug,
     name: folder.name,
+    description: folder.description,
     folderPath: folder.folder_path,
     breadcrumb: getPathBreadcrumb(folder.folder_path),
     imageCount: folder.image_count,
     videoCount: folder.video_count,
     latestImageMtimeMs: folder.latest_image_mtime_ms,
+    avatarImageId: avatar?.id ?? null,
     avatarUrl: avatar ? mapImageDetail(avatar, thumbnailVersion).thumbnailUrl : null
   };
 }
@@ -717,6 +724,39 @@ export const galleryService = {
     return buildFolderSummary(folder);
   },
 
+  updateFolderMetadata(slug: string, name: string, description: string | null) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    folderRepository.updateMetadata(slug, name, description);
+    const folder = folderRepository.getSummaryBySlug(slug);
+    if (!folder) {
+      return null;
+    }
+
+    return buildFolderSummary(folder);
+  },
+
+  setFolderAvatar(slug: string, imageId: number) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const folder = folderRepository.getBySlug(slug);
+    if (!folder) {
+      return null;
+    }
+
+    const image = imageRepository.getById(imageId);
+    if (!image || image.folder_id !== folder.id || image.is_deleted !== 0 || image.is_trashed !== 0 || image.media_type !== 'image') {
+      return null;
+    }
+
+    folderRepository.setAvatar(folder.id, imageId, 'manual');
+    return true;
+  },
+
   getFolderImages(slug: string, page: number, limit: number, mediaType?: MediaType) {
     if (!storageService.getState().libraryAvailable) {
       return null;
@@ -745,7 +785,14 @@ export const galleryService = {
       return null;
     }
 
-    const detail = imageRepository.getImageDetail(id, mediaType);
+    let detail = imageRepository.getImageDetail(id, mediaType);
+    if (!detail) {
+      const avatarDetail = imageRepository.getImageDetail(id, mediaType, true);
+      if (avatarDetail && avatarDetail.folderAvatarImageId === avatarDetail.id) {
+        detail = avatarDetail;
+      }
+    }
+
     if (!detail) {
       return null;
     }
@@ -836,7 +883,7 @@ export const galleryService = {
 
     if (imageRecord.is_trashed === 0) {
       imageRepository.moveToTrash(id);
-      folderRepository.setAvatar(imageRecord.folder_id, imageRepository.getLatestFolderImageId(imageRecord.folder_id));
+      folderRepository.syncAvatarSelection(imageRecord.folder_id);
     }
 
     return {
@@ -861,7 +908,7 @@ export const galleryService = {
     }
 
     imageRepository.restoreFromTrash(id);
-    folderRepository.setAvatar(imageRecord.folder_id, imageRepository.getLatestFolderImageId(imageRecord.folder_id));
+    folderRepository.syncAvatarSelection(imageRecord.folder_id);
 
     return {
       id: imageRecord.id,
@@ -989,11 +1036,11 @@ export const galleryService = {
     ]);
 
     if (folder.avatar_image_id === imageRecord.id) {
-      folderRepository.setAvatar(imageRecord.folder_id, null);
+      folderRepository.setAvatar(imageRecord.folder_id, null, 'auto');
     }
 
     imageRepository.deleteById(imageRecord.id);
-    folderRepository.setAvatar(imageRecord.folder_id, imageRepository.getLatestFolderImageId(imageRecord.folder_id));
+    folderRepository.syncAvatarSelection(imageRecord.folder_id);
 
     return {
       id: imageRecord.id,
@@ -1030,7 +1077,7 @@ export const galleryService = {
       folderScanStateRepository.deleteTree(normalizedFolderPath);
 
       for (const affectedFolder of affectedFolders) {
-        folderRepository.setAvatar(affectedFolder.id, null);
+        folderRepository.setAvatar(affectedFolder.id, null, 'auto');
         folderRepository.delete(affectedFolder.id);
       }
 
@@ -1068,7 +1115,7 @@ export const galleryService = {
       })
     );
 
-    folderRepository.setAvatar(folder.id, null);
+    folderRepository.setAvatar(folder.id, null, 'auto');
     folderScanStateRepository.delete(normalizedFolderPath);
     folderRepository.delete(folder.id);
 

--- a/server/src/services/scanner-service.ts
+++ b/server/src/services/scanner-service.ts
@@ -549,7 +549,7 @@ class ScannerService {
     const removedFiles = existingFolder ? imageRepository.markAllDeletedByFolder(existingFolder.id) : 0;
 
     if (existingFolder) {
-      folderRepository.setAvatar(existingFolder.id, null);
+      folderRepository.setAvatar(existingFolder.id, null, 'auto');
     }
 
     folderScanStateRepository.delete(sourceFolderPath);
@@ -743,7 +743,7 @@ class ScannerService {
     );
 
     const removedFiles = imageRepository.markFolderImagesDeleted(folder.id, activeRelativePaths);
-    folderRepository.setAvatar(folder.id, imageRepository.getLatestFolderImageId(folder.id));
+    folderRepository.syncAvatarSelection(folder.id);
 
     if (!folderHadErrors) {
       folderScanStateRepository.upsert({
@@ -1043,7 +1043,7 @@ class ScannerService {
       for (const folder of existingFolders) {
         if (!discoveredFolderIds.has(folder.id)) {
           summary.removed_files += imageRepository.markAllDeletedByFolder(folder.id);
-          folderRepository.setAvatar(folder.id, null);
+          folderRepository.setAvatar(folder.id, null, 'auto');
         }
       }
 

--- a/server/src/types/models.ts
+++ b/server/src/types/models.ts
@@ -1,6 +1,7 @@
 export type MediaType = 'image' | 'video';
 export type TakenAtSource = 'exif' | 'mtime' | 'first_seen' | 'sort_timestamp';
 export type PlaybackStrategy = 'preview' | 'original';
+export type FolderAvatarSource = 'auto' | 'manual' | 'cover';
 
 export interface ImageExifData {
   cameraMake?: string;
@@ -21,7 +22,9 @@ export interface FolderRecord {
   slug: string;
   name: string;
   folder_path: string;
+  description: string | null;
   avatar_image_id: number | null;
+  avatar_source: FolderAvatarSource;
   created_at: string;
   updated_at: string;
 }
@@ -114,6 +117,7 @@ export interface FeedImage {
 }
 
 export interface ImageDetail extends FeedImage {
+  folderAvatarImageId: number | null;
   relativePath: string;
   mimeType: string;
   fileSize: number;

--- a/server/test/folder-cover-scanner.test.ts
+++ b/server/test/folder-cover-scanner.test.ts
@@ -1,0 +1,138 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getMediaTypeFromExtension,
+  getPreviewRelativePath,
+  getThumbnailRelativePath
+} from '../src/utils/image-utils.js';
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type ScannerServiceModule = typeof import('../src/services/scanner-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+
+const generateThumbnailDerivativeMock = vi.fn();
+const generateDerivativesMock = vi.fn();
+const readMediaMetadataMock = vi.fn();
+
+describe.sequential('folder cover scanner', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let scannerService: ScannerServiceModule['scannerService'];
+  let imageRepository: RepositoriesModule['imageRepository'];
+  let folderRepository: RepositoriesModule['folderRepository'];
+  let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-folder-cover-scanner-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    generateThumbnailDerivativeMock.mockReset();
+    generateDerivativesMock.mockReset();
+    readMediaMetadataMock.mockReset();
+
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.resetModules();
+    vi.doMock('../src/services/derivative-service.js', () => ({
+      generateDerivatives: generateDerivativesMock,
+      generateThumbnailDerivative: generateThumbnailDerivativeMock,
+      readMediaMetadata: readMediaMetadataMock
+    }));
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ scannerService } = await import('../src/services/scanner-service.js'));
+    ({ imageRepository, folderRepository, maintenanceRepository } = await import('../src/db/repositories.js'));
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+
+    readMediaMetadataMock.mockResolvedValue({
+      width: 1000,
+      height: 1000,
+      takenAt: null,
+      durationMs: null,
+      mediaType: 'image',
+      playbackStrategy: 'preview',
+      isAnimated: false
+    });
+
+    generateDerivativesMock.mockImplementation(async (_sourcePath: string, relativePath: string) => ({
+      width: 1000,
+      height: 1000,
+      takenAt: null,
+      durationMs: null,
+      mediaType: 'image',
+      playbackStrategy: 'preview',
+      isAnimated: false,
+      thumbnailPath: getThumbnailRelativePath(relativePath),
+      previewPath: getPreviewRelativePath(relativePath, 'image'),
+      generatedThumbnail: true,
+      generatedPreview: true
+    }));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('detects cover.jpg in a folder and prioritizes it as the avatar', async () => {
+    maintenanceRepository.resetLibraryIndex();
+
+    await createSourceFile('holiday/photo-1.jpg');
+    await createSourceFile('holiday/photo-2.jpg');
+    // We add cover.jpg as the oldest file to prove it gets prioritized over newer files
+    await createSourceFile('holiday/cover.jpg', 1000);
+
+    await scannerService.scanAll('manual');
+
+    const folder = folderRepository.getBySlug('holiday');
+    expect(folder).toBeDefined();
+
+    const avatarImage = imageRepository.getById(folder!.avatar_image_id!);
+    expect(avatarImage).toBeDefined();
+    expect(avatarImage!.filename).toBe('cover.jpg');
+  });
+
+  it('respects cover.png when cover.jpg is not present', async () => {
+    maintenanceRepository.resetLibraryIndex();
+
+    await createSourceFile('party/photo-1.jpg');
+    await createSourceFile('party/cover.png');
+
+    await scannerService.scanAll('manual');
+
+    const folder = folderRepository.getBySlug('party');
+    const avatarImage = imageRepository.getById(folder!.avatar_image_id!);
+    expect(avatarImage!.filename).toBe('cover.png');
+  });
+
+  async function createSourceFile(relativePath: string, mtimeOffsetMs = 0): Promise<void> {
+    const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, `source:${relativePath}`);
+    
+    if (mtimeOffsetMs) {
+      const now = new Date();
+      now.setMilliseconds(now.getMilliseconds() - mtimeOffsetMs);
+      await fs.utimes(absolutePath, now, now);
+    }
+  }
+});

--- a/server/test/folder-customization-scan-behavior.test.ts
+++ b/server/test/folder-customization-scan-behavior.test.ts
@@ -1,0 +1,172 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getPreviewRelativePath, getThumbnailRelativePath } from '../src/utils/image-utils.js';
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type GalleryServiceModule = typeof import('../src/services/gallery-service.js');
+type ScannerServiceModule = typeof import('../src/services/scanner-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+
+const generateThumbnailDerivativeMock = vi.fn();
+const generateDerivativesMock = vi.fn();
+const readMediaMetadataMock = vi.fn();
+
+describe.sequential('folder customization scan behavior', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let galleryService: GalleryServiceModule['galleryService'];
+  let scannerService: ScannerServiceModule['scannerService'];
+  let imageRepository: RepositoriesModule['imageRepository'];
+  let folderRepository: RepositoriesModule['folderRepository'];
+  let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-folder-customization-scan-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    generateThumbnailDerivativeMock.mockReset();
+    generateDerivativesMock.mockReset();
+    readMediaMetadataMock.mockReset();
+
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.resetModules();
+    vi.doMock('../src/services/derivative-service.js', () => ({
+      generateDerivatives: generateDerivativesMock,
+      generateThumbnailDerivative: generateThumbnailDerivativeMock,
+      readMediaMetadata: readMediaMetadataMock
+    }));
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ galleryService } = await import('../src/services/gallery-service.js'));
+    ({ scannerService } = await import('../src/services/scanner-service.js'));
+    ({ imageRepository, folderRepository, maintenanceRepository } = await import('../src/db/repositories.js'));
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+
+    readMediaMetadataMock.mockResolvedValue({
+      width: 1000,
+      height: 1000,
+      takenAt: null,
+      durationMs: null,
+      mediaType: 'image',
+      playbackStrategy: 'preview',
+      isAnimated: false
+    });
+
+    generateDerivativesMock.mockImplementation(async (_sourcePath: string, relativePath: string) => ({
+      width: 1000,
+      height: 1000,
+      takenAt: null,
+      durationMs: null,
+      mediaType: 'image',
+      playbackStrategy: 'preview',
+      isAnimated: false,
+      thumbnailPath: getThumbnailRelativePath(relativePath),
+      previewPath: getPreviewRelativePath(relativePath, 'image'),
+      generatedThumbnail: true,
+      generatedPreview: true
+    }));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('preserves a customized folder name and description across normal rescans', async () => {
+    maintenanceRepository.resetLibraryIndex();
+
+    await createSourceFile('albums/photo-1.jpg');
+    await scannerService.scanAll('manual');
+
+    const updatedFolder = galleryService.updateFolderMetadata('albums', 'Custom Album', 'Hand-picked description');
+    expect(updatedFolder?.name).toBe('Custom Album');
+    expect(updatedFolder?.description).toBe('Hand-picked description');
+
+    await createSourceFile('albums/photo-2.jpg');
+    await scannerService.scanAll('manual');
+
+    const rescannedFolder = folderRepository.getBySlug('albums');
+    expect(rescannedFolder?.name).toBe('Custom Album');
+    expect(rescannedFolder?.description).toBe('Hand-picked description');
+  });
+
+  it('preserves a manually selected cover across normal rescans', async () => {
+    maintenanceRepository.resetLibraryIndex();
+
+    await createSourceFile('albums/photo-1.jpg', 1000);
+    await createSourceFile('albums/photo-2.jpg');
+    await scannerService.scanAll('manual');
+
+    const manualCover = imageRepository.getByRelativePath('albums/photo-1.jpg');
+    expect(manualCover).toBeDefined();
+    expect(galleryService.setFolderAvatar('albums', manualCover!.id)).toBe(true);
+
+    await createSourceFile('albums/photo-3.jpg');
+    await scannerService.scanAll('manual');
+
+    const rescannedFolder = folderRepository.getBySlug('albums');
+    expect(rescannedFolder?.avatar_image_id).toBe(manualCover!.id);
+    expect(rescannedFolder?.avatar_source).toBe('manual');
+  });
+
+  it('detects case-insensitive cover files in child albums and hides them from the feed, folder grid, and detail view', async () => {
+    maintenanceRepository.resetLibraryIndex();
+
+    await createSourceFile('family/trip/photo-1.jpg');
+    await createSourceFile('family/trip/Cover.JPG', 1000);
+    await scannerService.scanAll('manual');
+
+    const folder = folderRepository.getByFolderPath('family/trip');
+    const coverImage = imageRepository.getByRelativePath('family/trip/Cover.JPG');
+    const visiblePhoto = imageRepository.getByRelativePath('family/trip/photo-1.jpg');
+
+    expect(folder).toBeDefined();
+    expect(coverImage).toBeDefined();
+    expect(visiblePhoto).toBeDefined();
+    expect(folder?.avatar_image_id).toBe(coverImage?.id);
+    expect(folder?.avatar_source).toBe('cover');
+
+    const folderPayload = galleryService.getFolderImages(folder!.slug, 1, 24);
+    expect(folderPayload?.total).toBe(1);
+    expect(folderPayload?.folder.avatarImageId).toBe(coverImage!.id);
+    expect(folderPayload?.items.map((item) => item.id)).toEqual([visiblePhoto!.id]);
+    expect(folderPayload?.items.map((item) => item.id)).not.toContain(coverImage!.id);
+
+    const feedPayload = galleryService.getFeed(1, 24, 'recent');
+    expect(feedPayload.items.map((item) => item.id)).not.toContain(coverImage!.id);
+
+    expect(galleryService.getImageDetail(coverImage!.id)?.id).toBe(coverImage!.id);
+  });
+
+  async function createSourceFile(relativePath: string, mtimeOffsetMs = 0): Promise<void> {
+    const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, `source:${relativePath}`);
+
+    if (mtimeOffsetMs) {
+      const now = new Date();
+      now.setMilliseconds(now.getMilliseconds() - mtimeOffsetMs);
+      await fs.utimes(absolutePath, now, now);
+    }
+  }
+});

--- a/server/test/folder-customization.test.ts
+++ b/server/test/folder-customization.test.ts
@@ -1,0 +1,188 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createFingerprint, getMediaTypeFromExtension, getMimeTypeFromExtension } from '../src/utils/image-utils.js';
+
+vi.mock('../src/services/storage-service.js', () => ({
+  storageService: {
+    getDatabasePath: () => {
+      const dbDir = process.env.DB_DIR || path.join(os.tmpdir(), 'db');
+      return path.join(dbDir, 'gallery.db');
+    },
+    getState: () => ({
+      libraryAvailable: true,
+      lastScanCompletedAt: null,
+      lastScanDurationMs: null,
+      stats: null,
+      libraryStatus: 'ready'
+    }),
+    startSession: vi.fn(),
+    refreshState: vi.fn()
+  }
+}));
+
+type ApiModule = typeof import('../src/routes/api.js');
+type EnvModule = typeof import('../src/config/env.js');
+type GalleryServiceModule = typeof import('../src/services/gallery-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+
+describe.sequential('folder customization', () => {
+  let tempRoot = '';
+  let appConfig: EnvModule['appConfig'];
+  let apiModule: ApiModule;
+  let galleryService: GalleryServiceModule['galleryService'];
+  let folderRepository: RepositoriesModule['folderRepository'];
+  let imageRepository: RepositoriesModule['imageRepository'];
+  let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-folder-customization-'));
+
+    await Promise.all([
+      fs.mkdir(path.join(tempRoot, 'db'), { recursive: true }),
+      fs.mkdir(path.join(tempRoot, 'gallery'), { recursive: true }),
+      fs.mkdir(path.join(tempRoot, 'thumbnails'), { recursive: true }),
+      fs.mkdir(path.join(tempRoot, 'previews'), { recursive: true })
+    ]);
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+
+    vi.resetModules();
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    apiModule = await import('../src/routes/api.js');
+    ({ galleryService } = await import('../src/services/gallery-service.js'));
+    ({ folderRepository, imageRepository, maintenanceRepository } = await import('../src/db/repositories.js'));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    maintenanceRepository.resetLibraryIndex();
+
+    await fs.rm(appConfig.galleryRoot, { recursive: true, force: true });
+    await fs.mkdir(appConfig.galleryRoot, { recursive: true });
+  });
+
+  describe('schema validation', () => {
+    it('validates PATCH folder body correctly', () => {
+      const { patchFolderBodySchema } = apiModule;
+
+      expect(patchFolderBodySchema.parse({ name: 'Valid Name', description: 'Some description' })).toEqual({
+        name: 'Valid Name',
+        description: 'Some description'
+      });
+
+      expect(patchFolderBodySchema.parse({ name: 'Just Name' })).toEqual({
+        name: 'Just Name'
+      });
+
+      expect(() => patchFolderBodySchema.parse({ name: '' })).toThrowError();
+      expect(() => patchFolderBodySchema.parse({ name: 'x'.repeat(256) })).toThrowError();
+      expect(() => patchFolderBodySchema.parse({ name: 'Name', description: 'x'.repeat(301) })).toThrowError();
+    });
+
+    it('validates POST folder body correctly', () => {
+      const { folderCoverBodySchema } = apiModule;
+
+      expect(folderCoverBodySchema.parse({ imageId: 10 })).toEqual({ imageId: 10 });
+      expect(() => folderCoverBodySchema.parse({ imageId: -1 })).toThrowError();
+      expect(() => folderCoverBodySchema.parse({ imageId: 'abc' })).toThrowError();
+    });
+  });
+
+  describe('gallery service operations', () => {
+    it('updates folder metadata', () => {
+      const folder = folderRepository.upsert({ slug: 'test-folder', name: 'Test Folder', folderPath: 'test-folder' });
+      imageRepository.upsert({
+        folderId: folder.id,
+        filename: 'img1.jpg',
+        relativePath: 'test/img1.jpg',
+        absolutePath: '/dummy/test/img1.jpg',
+        fileSize: 100,
+        mtimeMs: 1000,
+        width: 100,
+        height: 100,
+        mediaType: 'image',
+        mimeType: 'image/jpeg',
+        fingerprint: 'test-fingerprint-1',
+        sortTimestamp: 1000,
+        takenAt: 1000,
+        takenAtSource: 'mtime',
+        extension: '.jpg',
+        firstSeenAt: new Date().toISOString(),
+        thumbnailPath: 't/img1.jpg',
+        previewPath: 'p/img1.webp',
+        playbackStrategy: 'preview',
+        durationMs: null,
+        exifJson: null
+      });
+      
+      
+      const updated = galleryService.updateFolderMetadata('test-folder', 'New Name', 'A new bio for testing');
+      
+      expect(updated!.name).toBe('New Name');
+      expect(updated!.description).toBe('A new bio for testing');
+
+      const DBFolder = folderRepository.getBySlug('test-folder');
+      expect(DBFolder?.name).toBe('New Name');
+      expect(DBFolder?.description).toBe('A new bio for testing');
+    });
+
+    it('returns null updating non-existent metadata', () => {
+      expect(galleryService.updateFolderMetadata('non-existent', 'Name', null)).toBeFalsy();
+    });
+
+    it('sets folder cover avatar', () => {
+      const folder = folderRepository.upsert({ slug: 'test-folder-2', name: 'Test 2', folderPath: 'test2' });
+      const image = imageRepository.upsert({
+        folderId: folder.id,
+        filename: 'img1.jpg',
+        relativePath: 'test2/img1.jpg',
+        absolutePath: '/dummy/test2/img1.jpg',
+        fileSize: 100,
+        mtimeMs: 1000,
+        width: 100,
+        height: 100,
+        mediaType: 'image',
+        mimeType: 'image/jpeg',
+        fingerprint: 'test-fingerprint',
+        sortTimestamp: 1000,
+        takenAt: 1000,
+        takenAtSource: 'mtime',
+        extension: '.jpg',
+        firstSeenAt: new Date().toISOString(),
+        thumbnailPath: 't/img1.jpg',
+        previewPath: 'p/img1.webp',
+        playbackStrategy: 'preview',
+        durationMs: null,
+        exifJson: null
+      });
+
+      galleryService.setFolderAvatar('test-folder-2', image.id);
+      
+      const DBFolder = folderRepository.getBySlug('test-folder-2');
+      expect(DBFolder?.avatar_image_id).toBe(image.id);
+      expect(DBFolder?.avatar_source).toBe('manual');
+    });
+
+    it('returns null when setting cover for non-existent items', () => {
+      expect(galleryService.setFolderAvatar('non-existent', 123)).toBeNull();
+      
+      const folder = folderRepository.upsert({ slug: 'test-folder-3', name: 'Test 3', folderPath: 'test3' });
+      expect(galleryService.setFolderAvatar('test-folder-3', 999)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Closes #7 & closes #9 

Allow admins to customize App Folders. This includes modifying the display name, adding an optional description (bio), and setting a custom cover (avatar)