### PR TITLE
Add admin-managed default home feed mode

### DIFF
--- a/client/src/api/gallery.ts
+++ b/client/src/api/gallery.ts
@@ -3,6 +3,7 @@ import type {
   AppStats,
   AuthMutationResult,
   AuthStatus,
+  HomeFeedDefaultSetting,
   ViewerAccessMode,
   DeleteImageResult,
   DeleteFolderResult,
@@ -24,7 +25,7 @@ import type {
 } from '../types/api';
 import { requestJson } from './http';
 
-export function fetchFeed(page = 1, limit = 24, mode: FeedMode = 'recent', seed?: number) {
+export function fetchFeed(page = 1, limit = 24, mode: FeedMode = 'random', seed?: number) {
   const params = new URLSearchParams({
     page: String(page),
     limit: String(limit),
@@ -240,5 +241,13 @@ export function triggerLibraryRebuild() {
 export function triggerThumbnailRebuild() {
   return requestJson<RebuildThumbnailsResult>('/api/admin/rebuild-thumbnails', {
     method: 'POST'
+  });
+}
+
+export function updateHomeFeedDefault(defaultMode: FeedMode) {
+  return requestJson<HomeFeedDefaultSetting>('/api/admin/settings/home-feed-default', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ defaultMode })
   });
 }

--- a/client/src/stores/app.ts
+++ b/client/src/stores/app.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 
 import { fetchStats } from '../api/gallery';
-import type { AppStatus } from '../types/api';
+import type { AppStatus, FeedMode } from '../types/api';
 
 interface AppState {
   stats: AppStatus | null;
@@ -63,7 +63,8 @@ export const useAppStore = defineStore('app', {
     isScanning: (state) => state.stats?.scan.isScanning === true,
     isRebuilding: (state) => state.stats?.scan.isScanning === true && state.stats?.scan.scanReason === 'rebuild',
     hasCompletedScan: (state) => state.stats?.scan.lastCompletedScan !== null,
-    isInitialScan: (state) => state.stats?.scan.isScanning === true && state.stats?.scan.lastCompletedScan === null
+    isInitialScan: (state) => state.stats?.scan.isScanning === true && state.stats?.scan.lastCompletedScan === null,
+    defaultHomeFeedMode: (state): FeedMode => state.stats?.preferences.defaultHomeFeedMode ?? 'random'
   },
   actions: {
     persistOpenedFolderState() {

--- a/client/src/stores/feed.ts
+++ b/client/src/stores/feed.ts
@@ -37,8 +37,8 @@ export const useFeedStore = defineStore('feed', {
     randomSeed: null
   }),
   actions: {
-    initializeMode() {
-      this.mode = 'random';
+    initializeMode(mode: FeedMode = 'random') {
+      this.mode = mode;
       this.randomSeed = null;
     },
 

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -1,6 +1,10 @@
 export type FeedMode = 'recent' | 'rediscover' | 'random';
 export type FeedRailKind = 'moments' | 'highlights';
 
+export interface HomeFeedDefaultSetting {
+  defaultMode: FeedMode;
+}
+
 export interface FeedItem {
   id: number;
   folderId: number;
@@ -193,6 +197,9 @@ export interface AppStatus {
     rebuildRequired: boolean;
     reason: 'gallery_root_changed' | null;
     ignoredRootMediaCount: number;
+  };
+  preferences: {
+    defaultHomeFeedMode: FeedMode;
   };
 }
 

--- a/client/src/views/HomeView.vue
+++ b/client/src/views/HomeView.vue
@@ -463,11 +463,15 @@ onMounted(async () => {
     window.addEventListener('resize', updateHomeLayout);
   }
 
+  if (!appStore.stats) {
+    await appStore.fetchStats().catch(() => {});
+  }
+
   if (appStore.isLibraryUnavailable) {
     return;
   }
 
-  feedStore.initializeMode();
+  feedStore.initializeMode(appStore.defaultHomeFeedMode);
   await Promise.all([feedStore.loadInitial(), momentsStore.fetchMoments()]);
 });
 

--- a/client/src/views/SettingsView.vue
+++ b/client/src/views/SettingsView.vue
@@ -4,7 +4,7 @@
       <div>
         <span class="eyebrow">Settings</span>
         <h1 class="mt-[0.15rem] mb-0 text-[clamp(1.55rem,2.4vw,2rem)] font-medium tracking-[-0.04em]">Library Controls</h1>
-        <p class="m-0 text-muted">Manage access, run scans, or reset the library index.</p>
+        <p class="m-0 text-muted">Manage feed defaults, access, scans, and the library index.</p>
       </div>
     </header>
 
@@ -66,7 +66,7 @@
           <span class="w-[1.25rem] h-[1.25rem] shrink-0 mt-[0.1rem]" :class="currentCategory === 'library' ? 'i-fluent-folder-sync-20-filled' : 'i-fluent-folder-sync-20-regular'" aria-hidden="true"></span>
           <span class="flex flex-col gap-[0.1rem]">
             <span>Scan & Library</span>
-            <span class="text-[0.75rem] font-normal text-muted">Index media & build thumbnails</span>
+            <span class="text-[0.75rem] font-normal text-muted">Index media, rebuild derivatives, and set feed defaults</span>
           </span>
         </button>
         <button
@@ -351,6 +351,53 @@
 
         <!-- CATEGORY: LIBRARY -->
         <template v-if="currentCategory === 'library'">
+          <section class="card grid gap-[0.95rem] p-6">
+            <div class="flex items-start justify-between gap-4 max-sm:flex-col max-sm:items-start">
+              <div>
+                <h2 class="m-0 text-[1.18rem]">Home Feed Default</h2>
+                <p class="m-0 mt-[0.25rem] text-muted">Choose the first feed mode shown on Home.</p>
+              </div>
+              <span class="inline-flex items-center justify-center min-h-8 px-[0.7rem] py-[0.35rem] rounded-full text-[0.76rem] font-bold whitespace-nowrap text-accent-strong bg-[color-mix(in_srgb,var(--accent-soft)_78%,transparent_22%)]">
+                Current: {{ savedHomeFeedDefaultModeLabel }}
+              </span>
+            </div>
+
+            <div
+              v-if="homeFeedDefaultFeedback"
+              class="rounded-[0.95rem] px-4 py-3 text-[0.9rem]"
+              :class="homeFeedDefaultFeedback.tone === 'error' ? 'border border-[rgba(214,48,49,0.24)] text-[#c0392b] bg-[rgba(214,48,49,0.08)]' : 'border border-[rgba(24,119,242,0.2)] text-accent-strong bg-[rgba(24,119,242,0.08)]'"
+            >
+              {{ homeFeedDefaultFeedback.message }}
+            </div>
+
+            <div class="grid grid-cols-3 gap-3 mt-1">
+              <label
+                v-for="mode in homeFeedDefaultOptions"
+                :key="mode.id"
+                class="flex min-w-0 items-start gap-[0.6rem] rounded-[0.85rem] border border-border px-3 py-[0.8rem] cursor-pointer"
+              >
+                <input
+                  v-model="homeFeedDefaultMode"
+                  class="mt-[0.2rem]"
+                  type="radio"
+                  :value="mode.id"
+                  :disabled="savingHomeFeedDefault || waitingForInitialStatus"
+                />
+                <span class="grid min-w-0 gap-[0.08rem]">
+                  <span class="text-[0.88rem] font-semibold text-text">{{ mode.label }}</span>
+                  <span class="overflow-hidden text-ellipsis whitespace-nowrap text-[0.75rem] text-muted">{{ mode.description }}</span>
+                </span>
+              </label>
+            </div>
+
+            <div class="flex flex-col md:flex-row items-center gap-3 max-sm:items-stretch">
+              <p class="m-0 flex-1 text-muted">{{ homeFeedDefaultActionNote }}</p>
+              <button class="btn-primary min-w-[13rem]" type="button" :disabled="homeFeedDefaultSaveDisabled" @click="saveHomeFeedDefault">
+                {{ homeFeedDefaultButtonLabel }}
+              </button>
+            </div>
+          </section>
+
           <section class="card grid gap-[1.15rem] p-8">
             <div class="flex items-start justify-between gap-4 max-sm:flex-col max-sm:items-start">
               <div>
@@ -524,12 +571,12 @@
     />
   </section>
 </template>
-\n<script setup lang="ts">
+<script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 
 import ConfirmDialog from '../components/ConfirmDialog.vue';
-import { fetchAdminStats, triggerLibraryRebuild, triggerManualScan, triggerThumbnailRebuild } from '../api/gallery';
+import { fetchAdminStats, triggerLibraryRebuild, triggerManualScan, triggerThumbnailRebuild, updateHomeFeedDefault } from '../api/gallery';
 import { useAppStore } from '../stores/app';
 import { useAuthStore } from '../stores/auth';
 import { useFeedStore } from '../stores/feed';
@@ -537,7 +584,7 @@ import { useFoldersStore } from '../stores/folders';
 import { useLikesStore } from '../stores/likes';
 import { useMomentsStore } from '../stores/moments';
 import { useViewerStore } from '../stores/viewer';
-import type { AppStats, ViewerAccessMode } from '../types/api';
+import type { AppStats, FeedMode, ViewerAccessMode } from '../types/api';
 
 const appStore = useAppStore();
 const authStore = useAuthStore();
@@ -554,10 +601,12 @@ const thumbnailRebuildError = ref<string | null>(null);
 const requestingScan = ref(false);
 const rebuilding = ref(false);
 const rebuildingThumbnails = ref(false);
+const savingHomeFeedDefault = ref(false);
 const confirmRebuildOpen = ref(false);
 const confirmThumbnailRebuildOpen = ref(false);
 const authFeedback = ref<{ tone: 'success' | 'error'; message: string } | null>(null);
 const viewerFeedback = ref<{ tone: 'success' | 'error'; message: string } | null>(null);
+const homeFeedDefaultFeedback = ref<{ tone: 'success' | 'error'; message: string } | null>(null);
 const adminStats = ref<AppStats | null>(null);
 const showChangePasswordForm = ref(false);
 const showDisablePasswordForm = ref(false);
@@ -567,6 +616,7 @@ const currentPassword = ref('');
 const nextPassword = ref('');
 const nextPasswordConfirmation = ref('');
 const disablePassword = ref('');
+const homeFeedDefaultMode = ref<FeedMode>('random');
 const viewerAccessMode = ref<ViewerAccessMode>(authStore.accessMode);
 const viewerPassword = ref('');
 const viewerPasswordConfirmation = ref('');
@@ -637,6 +687,10 @@ function clearViewerFeedback() {
   authStore.clearError();
 }
 
+function clearHomeFeedDefaultFeedback() {
+  homeFeedDefaultFeedback.value = null;
+}
+
 function setAuthError(message: string) {
   authFeedback.value = {
     tone: 'error',
@@ -660,6 +714,20 @@ function setViewerError(message: string) {
 
 function setViewerSuccess(message: string) {
   viewerFeedback.value = {
+    tone: 'success',
+    message
+  };
+}
+
+function setHomeFeedDefaultError(message: string) {
+  homeFeedDefaultFeedback.value = {
+    tone: 'error',
+    message
+  };
+}
+
+function setHomeFeedDefaultSuccess(message: string) {
+  homeFeedDefaultFeedback.value = {
     tone: 'success',
     message
   };
@@ -708,6 +776,23 @@ function validatePasswordConfirmation(password: string, confirmation: string): s
 const scan = computed(() => appStore.stats?.scan ?? null);
 const lastCompletedScan = computed(() => scan.value?.lastCompletedScan ?? adminStats.value?.lastScan ?? null);
 const activeScanReason = computed(() => scan.value?.scanReason ?? null);
+const homeFeedDefaultOptions: Array<{ id: FeedMode; label: string; description: string }> = [
+  {
+    id: 'random',
+    label: 'Random',
+    description: 'Steady shuffle.'
+  },
+  {
+    id: 'recent',
+    label: 'Recent',
+    description: 'Newest first.'
+  },
+  {
+    id: 'rediscover',
+    label: 'Rediscover',
+    description: 'Bring older picks back.'
+  }
+];
 const isLibraryRebuildActive = computed(
   () => rebuilding.value || (appStore.isScanning && activeScanReason.value === 'rebuild')
 );
@@ -718,6 +803,32 @@ const isRebuildOperationActive = computed(() => isLibraryRebuildActive.value || 
 const scanProgressActive = computed(() => requestingScan.value || Boolean(scan.value?.isScanning && !isRebuildOperationActive.value));
 const highlightRebuildAction = computed(() => route.query.action === 'rebuild');
 const waitingForInitialStatus = computed(() => !appStore.stats || appStore.loadingStats);
+const savedHomeFeedDefaultMode = computed(() => appStore.defaultHomeFeedMode);
+const savedHomeFeedDefaultModeLabel = computed(
+  () => homeFeedDefaultOptions.find((mode) => mode.id === savedHomeFeedDefaultMode.value)?.label ?? 'Random'
+);
+const homeFeedDefaultDirty = computed(() => homeFeedDefaultMode.value !== savedHomeFeedDefaultMode.value);
+const homeFeedDefaultSaveDisabled = computed(
+  () => waitingForInitialStatus.value || savingHomeFeedDefault.value || !homeFeedDefaultDirty.value
+);
+const homeFeedDefaultButtonLabel = computed(() => {
+  if (savingHomeFeedDefault.value) {
+    return 'Saving...';
+  }
+
+  return homeFeedDefaultDirty.value ? 'Save Home Feed Default' : 'Saved';
+});
+const homeFeedDefaultActionNote = computed(() => {
+  if (waitingForInitialStatus.value) {
+    return 'Loading the current app preference...';
+  }
+
+  if (homeFeedDefaultDirty.value) {
+    return 'This updates the first feed mode shown on Home for this app. Visitors can still switch modes from the homepage.';
+  }
+
+  return 'This is the current app-wide default for the homepage feed.';
+});
 const scanActionDisabled = computed(
   () =>
     waitingForInitialStatus.value ||
@@ -1239,6 +1350,31 @@ async function signOut() {
   }
 }
 
+async function saveHomeFeedDefault() {
+  if (homeFeedDefaultSaveDisabled.value) {
+    return;
+  }
+
+  savingHomeFeedDefault.value = true;
+  clearHomeFeedDefaultFeedback();
+
+  try {
+    const payload = await updateHomeFeedDefault(homeFeedDefaultMode.value);
+    if (appStore.stats) {
+      appStore.stats.preferences.defaultHomeFeedMode = payload.defaultMode;
+    }
+    await appStore.fetchStats({ background: true });
+    homeFeedDefaultMode.value = payload.defaultMode;
+    setHomeFeedDefaultSuccess(
+      `The homepage now opens with ${homeFeedDefaultOptions.find((mode) => mode.id === payload.defaultMode)?.label ?? 'Random'}.`
+    );
+  } catch (error) {
+    setHomeFeedDefaultError(error instanceof Error ? error.message : 'Unable to update the home feed default.');
+  } finally {
+    savingHomeFeedDefault.value = false;
+  }
+}
+
 async function warmScanStatus() {
   for (let attempt = 0; attempt < 12; attempt += 1) {
     await wait(attempt === 0 ? 150 : 250);
@@ -1352,8 +1488,21 @@ onMounted(async () => {
     await appStore.fetchStats();
   }
 
+  homeFeedDefaultMode.value = appStore.defaultHomeFeedMode;
   await loadAdminStats().catch(() => {});
 });
+
+watch(
+  () => savedHomeFeedDefaultMode.value,
+  (mode) => {
+    if (!homeFeedDefaultDirty.value || savingHomeFeedDefault.value) {
+      homeFeedDefaultMode.value = mode;
+    }
+  },
+  {
+    immediate: true
+  }
+);
 
 watch(
   () => authStore.enabled,

--- a/server/src/constants/app-setting-keys.ts
+++ b/server/src/constants/app-setting-keys.ts
@@ -1,6 +1,7 @@
 export const LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY = 'scanner.last_successful_gallery_root';
 export const LIBRARY_REBUILD_REQUIRED_SETTING_KEY = 'scanner.library_rebuild_required';
 export const PREVIOUS_GALLERY_ROOT_SETTING_KEY = 'scanner.previous_gallery_root';
+export const HOME_FEED_DEFAULT_MODE_SETTING_KEY = 'feed.default_home_mode';
 export const AUTH_PASSWORD_HASH_SETTING_KEY = 'auth.password_hash';
 export const AUTH_PASSWORD_SALT_SETTING_KEY = 'auth.password_salt';
 export const AUTH_SESSION_SECRET_SETTING_KEY = 'auth.session_secret';

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -36,8 +36,11 @@ const deleteFolderQuerySchema = z.object({
   }, z.boolean())
 });
 const feedQuerySchema = paginationQuerySchema.extend({
-  mode: z.enum(['recent', 'rediscover', 'random']).default('recent'),
+  mode: z.enum(['recent', 'rediscover', 'random']).default('random'),
   seed: z.coerce.number().int().nonnegative().optional()
+});
+const homeFeedDefaultBodySchema = z.object({
+  defaultMode: z.enum(['recent', 'rediscover', 'random'])
 });
 
 const slugSchema = z.object({
@@ -107,6 +110,10 @@ export const authRequestBodySchemas = {
   changePassword: changePasswordBodySchema,
   disablePassword: disablePasswordBodySchema,
   viewerAccess: viewerAccessBodySchema
+};
+
+export const settingsRequestBodySchemas = {
+  homeFeedDefault: homeFeedDefaultBodySchema
 };
 
 const authRateLimiter = createRateLimiter({
@@ -275,6 +282,15 @@ router.get('/feed', (request, response) => {
 router.get('/status', (_request, response) => {
   response.json(galleryService.getStatus());
 });
+
+router.put(
+  '/admin/settings/home-feed-default',
+  requireCapability('canAccessSettings', 'Admin access is required.'),
+  (request, response) => {
+    const body = homeFeedDefaultBodySchema.parse(request.body);
+    response.json(galleryService.setDefaultHomeFeedMode(body.defaultMode));
+  }
+);
 
 router.get('/feed/moments', (_request, response) => {
   response.json(galleryService.listMoments());

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -3,6 +3,7 @@ import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 
 import {
+  HOME_FEED_DEFAULT_MODE_SETTING_KEY,
   LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY,
   LIBRARY_REBUILD_REQUIRED_SETTING_KEY,
   PREVIOUS_GALLERY_ROOT_SETTING_KEY
@@ -72,6 +73,14 @@ function toViewerSafeScanSummary(scan: ScanSummaryRecord | null) {
 
 function buildViewerSafeStorageReason(libraryAvailable: boolean): string | null {
   return libraryAvailable ? null : 'Configured library storage is unavailable.';
+}
+
+function parseFeedMode(value: string | null): FeedMode {
+  return value === 'recent' || value === 'rediscover' || value === 'random' ? value : 'random';
+}
+
+function getDefaultHomeFeedMode(): FeedMode {
+  return parseFeedMode(appSettingsRepository.get(HOME_FEED_DEFAULT_MODE_SETTING_KEY));
 }
 
 function getThumbnailAssetVersion(): string | null {
@@ -602,7 +611,7 @@ function getSelectedFeedRail(now = new Date()) {
 }
 
 export const galleryService = {
-  getFeed(page: number, limit: number, mode: FeedMode = 'recent', randomSeed?: number) {
+  getFeed(page: number, limit: number, mode: FeedMode = 'random', randomSeed?: number) {
     if (!storageService.getState().libraryAvailable) {
       return {
         mode,
@@ -921,6 +930,7 @@ export const galleryService = {
     const storageState = storageService.getState();
     const scanProgress = scannerService.getProgress();
     const rebuildRequired = appSettingsRepository.get(LIBRARY_REBUILD_REQUIRED_SETTING_KEY) === '1';
+    const defaultHomeFeedMode = getDefaultHomeFeedMode();
 
     return {
       folders: storageState.libraryAvailable ? folderRepository.count() : 0,
@@ -939,6 +949,9 @@ export const galleryService = {
         rebuildRequired,
         reason: rebuildRequired ? 'gallery_root_changed' : null,
         ignoredRootMediaCount: storageState.libraryAvailable ? countSupportedRootMediaFiles(appConfig.galleryRoot) : 0
+      },
+      preferences: {
+        defaultHomeFeedMode
       }
     };
   },
@@ -951,6 +964,7 @@ export const galleryService = {
     const previousGalleryRoot = appSettingsRepository.get(PREVIOUS_GALLERY_ROOT_SETTING_KEY);
     const rebuildRequired = appSettingsRepository.get(LIBRARY_REBUILD_REQUIRED_SETTING_KEY) === '1';
     const lastSuccessfulGalleryRoot = appSettingsRepository.get(LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY);
+    const defaultHomeFeedMode = getDefaultHomeFeedMode();
 
     return {
       folders: storageState.libraryAvailable ? folderRepository.count() : 0,
@@ -976,7 +990,18 @@ export const galleryService = {
         previousGalleryRoot,
         lastSuccessfulGalleryRoot,
         ignoredRootMediaCount: storageState.libraryAvailable ? countSupportedRootMediaFiles(currentGalleryRoot) : 0
+      },
+      preferences: {
+        defaultHomeFeedMode
       }
+    };
+  },
+
+  setDefaultHomeFeedMode(mode: FeedMode) {
+    appSettingsRepository.set(HOME_FEED_DEFAULT_MODE_SETTING_KEY, mode);
+
+    return {
+      defaultMode: mode
     };
   },
 

--- a/server/test/auth-route-validation.test.ts
+++ b/server/test/auth-route-validation.test.ts
@@ -9,6 +9,7 @@ type ApiModule = typeof import('../src/routes/api.js');
 describe.sequential('auth route validation', () => {
   let tempRoot = '';
   let authRequestBodySchemas: ApiModule['authRequestBodySchemas'];
+  let settingsRequestBodySchemas: ApiModule['settingsRequestBodySchemas'];
 
   beforeAll(async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-auth-route-validation-'));
@@ -26,7 +27,7 @@ describe.sequential('auth route validation', () => {
     await fs.mkdir(tempRoot, { recursive: true });
 
     vi.resetModules();
-    ({ authRequestBodySchemas } = await import('../src/routes/api.js'));
+    ({ authRequestBodySchemas, settingsRequestBodySchemas } = await import('../src/routes/api.js'));
   });
 
   afterAll(async () => {
@@ -76,6 +77,24 @@ describe.sequential('auth route validation', () => {
       })
     ).toEqual({
       mode: 'public'
+    });
+  });
+
+  it('rejects invalid home-feed default modes', () => {
+    expect(() =>
+      settingsRequestBodySchemas.homeFeedDefault.parse({
+        defaultMode: 'latest'
+      })
+    ).toThrowError();
+  });
+
+  it('accepts random as a valid home-feed default mode', () => {
+    expect(
+      settingsRequestBodySchemas.homeFeedDefault.parse({
+        defaultMode: 'random'
+      })
+    ).toEqual({
+      defaultMode: 'random'
     });
   });
 });

--- a/server/test/viewer-status.test.ts
+++ b/server/test/viewer-status.test.ts
@@ -8,14 +8,17 @@ type AppConfigModule = typeof import('../src/config/env.js');
 type GalleryServiceModule = typeof import('../src/services/gallery-service.js');
 type RepositoriesModule = typeof import('../src/db/repositories.js');
 type StorageServiceModule = typeof import('../src/services/storage-service.js');
+type AppSettingKeysModule = typeof import('../src/constants/app-setting-keys.js');
 
 describe.sequential('viewer-safe status payload', () => {
   let tempRoot = '';
   let appConfig: AppConfigModule['appConfig'];
   let galleryService: GalleryServiceModule['galleryService'];
   let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+  let appSettingsRepository: RepositoriesModule['appSettingsRepository'];
   let scanRunRepository: RepositoriesModule['scanRunRepository'];
   let storageService: StorageServiceModule['storageService'];
+  let HOME_FEED_DEFAULT_MODE_SETTING_KEY: AppSettingKeysModule['HOME_FEED_DEFAULT_MODE_SETTING_KEY'];
 
   beforeAll(async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-viewer-status-'));
@@ -31,12 +34,14 @@ describe.sequential('viewer-safe status payload', () => {
 
     ({ appConfig } = await import('../src/config/env.js'));
     ({ galleryService } = await import('../src/services/gallery-service.js'));
-    ({ maintenanceRepository, scanRunRepository } = await import('../src/db/repositories.js'));
+    ({ maintenanceRepository, appSettingsRepository, scanRunRepository } = await import('../src/db/repositories.js'));
     ({ storageService } = await import('../src/services/storage-service.js'));
+    ({ HOME_FEED_DEFAULT_MODE_SETTING_KEY } = await import('../src/constants/app-setting-keys.js'));
   });
 
   beforeEach(async () => {
     maintenanceRepository.resetLibraryIndex();
+    appSettingsRepository.remove(HOME_FEED_DEFAULT_MODE_SETTING_KEY);
     await Promise.all([
       fs.rm(appConfig.galleryRoot, { recursive: true, force: true }),
       fs.rm(appConfig.thumbnailsDir, { recursive: true, force: true }),
@@ -101,5 +106,23 @@ describe.sequential('viewer-safe status payload', () => {
     expect(status.indexedVideos).toBe(0);
 
     storageStateSpy.mockRestore();
+  });
+
+  it('uses random as the viewer-safe home-feed default when nothing is configured', () => {
+    const status = galleryService.getStatus();
+
+    expect(status.preferences).toEqual({
+      defaultHomeFeedMode: 'random'
+    });
+  });
+
+  it('includes the configured home-feed default in the viewer-safe status payload', () => {
+    appSettingsRepository.set(HOME_FEED_DEFAULT_MODE_SETTING_KEY, 'rediscover');
+
+    const status = galleryService.getStatus();
+
+    expect(status.preferences).toEqual({
+      defaultHomeFeedMode: 'rediscover'
+    });
   });
 });


### PR DESCRIPTION
Closes #10 

This adds an admin-only `Home Feed Default` setting to the existing `Scan & Library` tab in Settings.

Admins can now choose which mode the homepage opens with:
- Random
- Recent
- Rediscover

The selected mode is persisted as an app-wide setting. Home now initializes from that saved preference, and `random` remains the single fallback when no preference has been configured yet.

Visitors can still switch feed modes from the Home page without changing the saved default.