### PR TITLE
Improve mobile media viewer UX, highlights controls, and modal stability

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -13,7 +13,7 @@
   <AuthGate v-else-if="authStore.requiresLogin" />
   <AppShell v-else>
     <RouterView :route="displayRoute" />
-    <div v-if="showImageModal" class="fixed inset-0 z-40 flex items-center justify-center px-8 py-8 max-md:px-4 max-md:py-4 bg-black/72" @click.self="closeImageModal">
+    <div v-if="showImageModal" class="app__image-modal-layer" @click.self="closeImageModal">
       <ImageView :id="String(route.params.id ?? '')" modal @close="closeImageModal" />
     </div>
   </AppShell>
@@ -258,3 +258,31 @@ async function closeImageModal() {
   await router.replace(targetPath);
 }
 </script>
+
+<style scoped>
+.app__image-modal-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  padding:
+    max(0.85rem, env(safe-area-inset-top))
+    max(0.85rem, env(safe-area-inset-right))
+    max(0.85rem, env(safe-area-inset-bottom))
+    max(0.85rem, env(safe-area-inset-left));
+  min-height: 100vh;
+  min-height: 100dvh;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.72);
+  overscroll-behavior: contain;
+}
+
+@media (min-width: 769px) {
+  .app__image-modal-layer {
+    align-items: center;
+    padding: 2rem;
+  }
+}
+</style>

--- a/client/src/components/FeedCard.vue
+++ b/client/src/components/FeedCard.vue
@@ -75,11 +75,13 @@
         class="feed-card__player"
         :src.prop="homeVideoSource"
         :title.prop="item.filename"
+        :fullscreenOrientation.prop="'none'"
         :playsInline.prop="true"
         :muted.prop="appStore.videoMuted"
         :loop.prop="true"
         load="visible"
         preload="metadata"
+        @fullscreen-change="handleHomeVideoFullscreenChange"
       >
         <media-provider />
         <media-poster
@@ -87,7 +89,7 @@
           :alt.prop="item.filename"
         />
         <media-controls
-          v-if="isActiveVideo"
+          v-if="showHomeVideoControls"
           class="feed-card__player-controls"
         >
           <media-controls-group class="feed-card__player-controls-group">
@@ -122,6 +124,7 @@
             <media-fullscreen-button
               class="feed-card__player-control"
               aria-label="Toggle fullscreen"
+              target="media"
             >
               <span
                 class="feed-card__player-control-icon feed-card__player-fullscreen-icon feed-card__player-fullscreen-icon--enter i-fluent-full-screen-maximize-16-regular"
@@ -247,15 +250,14 @@
           :disabled="deleting"
           @click="handleDelete"
         >
-          <svg class="w-[1.15rem] h-[1.15rem] shrink-0" viewBox="0 0 24 24" role="presentation">
+          <svg class="w-[1.15rem] h-[1.15rem] shrink-0" viewBox="0 0 32 32" role="presentation">
+            <path d="M12 12h2v12h-2z" fill="currentColor" />
+            <path d="M18 12h2v12h-2z" fill="currentColor" />
             <path
-              d="M9 4.75h6m-8 3h10m-8.5 0v10a1.25 1.25 0 0 0 1.25 1.25h4.5A1.25 1.25 0 0 0 15.5 17.75v-10m-4 3v5m4-5v5"
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1.8"
+              d="M4 6v2h2v20a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8h2V6zm4 22V8h16v20z"
+              fill="currentColor"
             />
+            <path d="M12 2h8v2h-8z" fill="currentColor" />
           </svg>
           <span>{{ deleting ? 'Deleting...' : 'Delete post' }}</span>
         </button>
@@ -380,6 +382,7 @@ const deleteOriginalFromDisk = ref(false);
 const deleteError = ref<string | null>(null);
 const homeVideoTarget = ref<HTMLElement | null>(null);
 const homePlayerElement = ref<MediaPlayerElement | null>(null);
+const isHomeVideoFullscreen = ref(false);
 const lastHomeImageTapAt = ref(0);
 
 let homeImageTapResetTimer: ReturnType<typeof setTimeout> | null = null;
@@ -411,6 +414,7 @@ const homeVideoSource = computed<PlayerSrc>(() => ({
   src: props.item.previewUrl,
   type: 'video/mp4'
 }));
+const showHomeVideoControls = computed(() => props.isActiveVideo || isHomeVideoFullscreen.value);
 const deleteDialogMessage = computed(() =>
   deleteOriginalFromDisk.value
     ? 'This will permanently delete the post from the app and remove original media from disk.'
@@ -488,13 +492,15 @@ function emitHomeVideoVisibility(ratio: number, centerOffset = Number.POSITIVE_I
   });
 }
 
-function stopHomeVideoObserver() {
+function stopHomeVideoObserver(options: { clearVisibility?: boolean } = {}) {
   if (homeVideoObserver) {
     homeVideoObserver.disconnect();
     homeVideoObserver = null;
   }
 
-  emitHomeVideoVisibility(0);
+  if (options.clearVisibility ?? true) {
+    emitHomeVideoVisibility(0);
+  }
 }
 
 function startHomeVideoObserver() {
@@ -541,7 +547,7 @@ async function syncHomeVideoPlayback() {
     return;
   }
 
-  if (!props.isActiveVideo) {
+  if (!props.isActiveVideo && !isHomeVideoFullscreen.value) {
     void player.pause().catch(() => {
       // Ignore pause rejections before the provider is ready.
     });
@@ -571,11 +577,30 @@ async function syncHomeVideoPlayback() {
 }
 
 function handleHomeVideoPlay() {
-  if (!props.isActiveVideo) {
+  if (!props.isActiveVideo && !isHomeVideoFullscreen.value) {
     void homePlayerElement.value?.pause().catch(() => {
       // Ignore pause rejections before the provider is ready.
     });
   }
+}
+
+function handleHomeVideoFullscreenChange(event: Event) {
+  const nextFullscreen =
+    event instanceof CustomEvent && typeof event.detail === 'boolean'
+      ? event.detail
+      : homePlayerElement.value?.hasAttribute('data-fullscreen') === true;
+
+  isHomeVideoFullscreen.value = nextFullscreen;
+
+  if (nextFullscreen) {
+    stopHomeVideoObserver({ clearVisibility: false });
+    emitHomeVideoVisibility(1, -1);
+    void syncHomeVideoPlayback();
+    return;
+  }
+
+  startHomeVideoObserver();
+  void syncHomeVideoPlayback();
 }
 
 function handleHomeVideoVolumeChange() {
@@ -687,6 +712,10 @@ watch(
   }
 );
 
+watch(isHomeVideoFullscreen, () => {
+  void syncHomeVideoPlayback();
+});
+
 watch(
   () => appStore.videoMuted,
   (videoMuted) => {
@@ -707,7 +736,9 @@ watch(
   () => props.context,
   (context) => {
     if (context === 'home' && props.item.mediaType === 'video') {
-      startHomeVideoObserver();
+      if (!isHomeVideoFullscreen.value) {
+        startHomeVideoObserver();
+      }
       void syncHomeVideoPlayback();
       return;
     }
@@ -720,7 +751,9 @@ watch(
 );
 
 onMounted(() => {
-  startHomeVideoObserver();
+  if (!isHomeVideoFullscreen.value) {
+    startHomeVideoObserver();
+  }
   void syncHomeVideoPlayback();
 });
 

--- a/client/src/components/ImageModal.vue
+++ b/client/src/components/ImageModal.vue
@@ -7,13 +7,13 @@
     <!-- Close button (modal only) -->
     <button
       v-if="isModal"
-      class="fixed top-[0.6rem] right-[0.6rem] z-55 inline-flex items-center justify-center w-[3rem] h-[3rem] p-0 border-0 text-white/85 bg-transparent cursor-pointer transition-opacity duration-150 hover:text-white"
+      class="viewer__modal-close"
       type="button"
       aria-label="Close post"
       @click="$emit('close')"
     >
       <svg
-        class="w-8 h-8"
+        class="viewer__modal-close-icon"
         viewBox="0 0 24 24"
         role="presentation"
       >
@@ -96,16 +96,21 @@
       @click="toggleSidebar"
     >
       <span
-        class="i-fluent-panel-left-expand-16-filled w-8 h-8"
+        :class="
+          isSidebarExpanded
+            ? 'i-fluent-panel-left-contract-16-filled'
+            : 'i-fluent-panel-left-expand-16-filled'
+        "
+        class="viewer__sidebar-toggle-icon"
         aria-hidden="true"
       />
     </button>
 
     <!-- Card -->
-    <div
-      ref="cardWrapperElement"
-      :class="[
-        'card viewer__card-wrapper',
+      <div
+        ref="cardWrapperElement"
+        :class="[
+          'card viewer__card-wrapper',
         {
           'viewer__card-wrapper--modal': isModal,
           'viewer__card-wrapper--compact': isModalSidebarCollapsible,
@@ -119,19 +124,25 @@
           {
             'viewer__media--modal': isModal,
             'viewer__media--page': !isModal,
+            'viewer__media--swipe-enabled': isModal,
           },
         ]"
+        @pointercancel="handleMediaPointercancel"
+        @pointerdown="handleMediaPointerdown"
+        @pointermove="handleMediaPointermove"
+        @pointerup="handleMediaPointerup"
       >
         <template v-if="image.mediaType === 'video'">
           <div
-            class="viewer__video-shell"
-            :style="videoShellStyle"
+            class="viewer__media-shell viewer__media-shell--video"
+            :style="mediaShellStyle"
           >
             <media-player
               ref="playerElement"
               class="viewer__player"
               :src.prop="videoSource"
               :title.prop="image.filename"
+              :fullscreenOrientation.prop="'none'"
               :playsInline.prop="true"
               :muted.prop="appStore.videoMuted"
               :loop.prop="true"
@@ -144,7 +155,7 @@
                 :src.prop="image.thumbnailUrl"
                 :alt.prop="image.filename"
               />
-              <media-controls class="viewer__player-controls">
+              <media-controls class="viewer__player-controls" data-swipe-ignore="true">
                 <media-controls-group class="viewer__player-controls-group">
                   <media-play-button
                     class="viewer__player-control"
@@ -201,6 +212,7 @@
                   <media-fullscreen-button
                     class="viewer__player-control"
                     aria-label="Toggle fullscreen"
+                    target="media"
                   >
                     <span
                       class="viewer__player-control-icon viewer__player-fullscreen-icon viewer__player-fullscreen-icon--enter i-fluent-full-screen-maximize-16-regular"
@@ -216,15 +228,21 @@
             </media-player>
           </div>
         </template>
-        <ResilientImage
+        <div
           v-else
-          :src="image.previewUrl"
-          :alt="image.filename"
-          :width="image.width"
-          :height="image.height"
-          loading="eager"
-          :retry-while="appStore.isScanning"
-        />
+          class="viewer__media-shell viewer__media-shell--image"
+          :style="mediaShellStyle"
+        >
+          <ResilientImage
+            class="viewer__media-image"
+            :src="image.previewUrl"
+            :alt="image.filename"
+            :width="image.width"
+            :height="image.height"
+            loading="eager"
+            :retry-while="appStore.isScanning"
+          />
+        </div>
       </div>
 
       <button
@@ -232,7 +250,7 @@
         class="viewer__drawer-backdrop"
         type="button"
         aria-label="Hide post details"
-        @click="closeSidebar"
+        @click="handleSidebarBackdropClick"
       />
 
       <!-- Sidebar -->
@@ -245,17 +263,29 @@
             'viewer__sidebar--drawer': isModalSidebarCollapsible,
             'viewer__sidebar--drawer-open':
               isModalSidebarCollapsible && isSidebarExpanded,
+            'viewer__sidebar--dragging': isSidebarSheetDragging,
           },
         ]"
+        :style="sidebarSheetStyle"
         :aria-hidden="isModalSidebarCollapsible && !isSidebarExpanded"
         :inert="isModalSidebarCollapsible && !isSidebarExpanded"
+        @pointercancel="handleSidebarSheetPointercancel"
+        @pointerdown="handleSidebarSheetPointerdown"
+        @pointermove="handleSidebarSheetPointermove"
+        @pointerup="handleSidebarSheetPointerup"
       >
+        <div
+          v-if="isModalSidebarCollapsible"
+          class="viewer__sidebar-handle"
+          aria-hidden="true"
+        />
+
         <!-- Header -->
         <div
-          class="flex items-center justify-between gap-4 border-b border-border px-5 pt-[1.1rem] pb-4"
+          class="viewer__sidebar-header flex items-center justify-between gap-4 border-b border-border px-5 pt-[1.1rem] pb-4"
         >
           <RouterLink
-            class="flex items-center gap-[0.85rem] min-w-0"
+            class="viewer__sidebar-folder-link flex items-center gap-[0.85rem] min-w-0"
             :to="{ name: 'folder', params: { slug: image.folderSlug } }"
             aria-label="Open folder"
           >
@@ -264,11 +294,11 @@
               :name="image.folderName"
               :src="folderAvatar"
             />
-            <div class="min-w-0">
-              <h2 class="m-0 text-[0.9rem] font-semibold truncate">
+            <div class="viewer__sidebar-folder-meta min-w-0">
+              <h2 class="viewer__sidebar-title m-0 text-[0.9rem] font-semibold truncate">
                 {{ image.folderName }}
               </h2>
-              <p class="m-0 text-muted truncate">
+              <p class="viewer__sidebar-breadcrumb m-0 text-muted truncate">
                 {{
                   folder?.breadcrumb ??
                   image.folderBreadcrumb ??
@@ -277,39 +307,35 @@
               </p>
             </div>
           </RouterLink>
-          <span class="text-muted text-[0.78rem] whitespace-nowrap">{{
+          <span class="viewer__sidebar-date text-muted text-[0.78rem] whitespace-nowrap">{{
             formattedDate
           }}</span>
         </div>
 
         <!-- Description -->
-        <div class="grid gap-[0.3rem] px-5 pt-[1.1rem]">
-          <p class="m-0 text-text">
+        <div class="viewer__sidebar-summary grid gap-[0.3rem] px-5 pt-[1.1rem]">
+          <p class="viewer__sidebar-caption m-0 text-text">
             <strong class="mr-[0.35rem]">{{ image.folderName }}</strong>
             {{ readableFilename }}
           </p>
-          <p class="m-0 text-muted">{{ image.relativePath }}</p>
+          <p class="viewer__sidebar-path m-0 text-muted">{{ image.relativePath }}</p>
         </div>
 
-        <!-- Meta -->
-        <dl class="grid gap-[0.9rem] m-0 px-5 pt-[0.35rem]">
-          <div>
-            <dt
-              class="text-muted text-[0.75rem] mb-[0.25rem] uppercase tracking-[0.05em]"
-            >
+        <!-- Quick stats -->
+        <dl class="viewer__sidebar-stats m-0 px-5 pt-[0.9rem]">
+          <div class="viewer__sidebar-stat">
+            <dt class="viewer__sidebar-stat-label">
               Dimensions
             </dt>
-            <dd class="m-0 text-[0.96rem] font-semibold">
+            <dd class="viewer__sidebar-stat-value m-0 text-[0.96rem] font-semibold">
               {{ image.width }} × {{ image.height }}
             </dd>
           </div>
-          <div>
-            <dt
-              class="text-muted text-[0.75rem] mb-[0.25rem] uppercase tracking-[0.05em]"
-            >
+          <div class="viewer__sidebar-stat">
+            <dt class="viewer__sidebar-stat-label">
               Type
             </dt>
-            <dd class="m-0 text-[0.96rem] font-semibold">
+            <dd class="viewer__sidebar-stat-value m-0 text-[0.96rem] font-semibold">
               {{
                 image.mediaType === "video"
                   ? `Video (${image.mimeType})`
@@ -317,34 +343,39 @@
               }}
             </dd>
           </div>
-          <div v-if="image.durationMs">
-            <dt
-              class="text-muted text-[0.75rem] mb-[0.25rem] uppercase tracking-[0.05em]"
-            >
+          <div
+            v-if="image.durationMs"
+            class="viewer__sidebar-stat"
+          >
+            <dt class="viewer__sidebar-stat-label">
               Duration
             </dt>
-            <dd class="m-0 text-[0.96rem] font-semibold">
+            <dd class="viewer__sidebar-stat-value m-0 text-[0.96rem] font-semibold">
               {{ formattedDuration }}
             </dd>
           </div>
-          <div>
-            <dt
-              class="text-muted text-[0.75rem] mb-[0.25rem] uppercase tracking-[0.05em]"
-            >
+          <div class="viewer__sidebar-stat">
+            <dt class="viewer__sidebar-stat-label">
               Size
             </dt>
-            <dd class="m-0 text-[0.96rem] font-semibold">{{ fileSize }}</dd>
+            <dd class="viewer__sidebar-stat-value m-0 text-[0.96rem] font-semibold">{{ fileSize }}</dd>
           </div>
+        </dl>
+
+        <!-- Metadata -->
+        <dl
+          v-if="exifDetails.length > 0"
+          class="viewer__sidebar-metadata m-0 px-5 pt-[0.75rem]"
+        >
           <div
             v-for="detail in exifDetails"
             :key="detail.label"
+            class="viewer__sidebar-metadata-item"
           >
-            <dt
-              class="text-muted text-[0.75rem] mb-[0.25rem] uppercase tracking-[0.05em]"
-            >
+            <dt class="viewer__sidebar-metadata-label">
               {{ detail.label }}
             </dt>
-            <dd class="m-0 text-[0.96rem] font-semibold break-words">
+            <dd class="viewer__sidebar-metadata-value m-0 text-[0.96rem] font-semibold break-words">
               {{ detail.value }}
             </dd>
           </div>
@@ -352,12 +383,12 @@
 
         <!-- Actions -->
         <div
-          class="flex items-center justify-between gap-4 px-5 pt-[0.7rem] pb-5 mt-auto"
+          class="viewer__sidebar-actions flex items-center justify-between gap-4 px-5 pt-[0.7rem] pb-5 mt-auto"
         >
           <!-- Like -->
           <button
             v-if="authStore.canUseSavedItems"
-            class="inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer transition-[opacity,transform,color] duration-180 hover:opacity-72 hover:-translate-y-px disabled:opacity-45 disabled:cursor-wait disabled:transform-none"
+            class="viewer__sidebar-action inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer transition-[opacity,transform,color] duration-180 hover:opacity-72 hover:-translate-y-px disabled:opacity-45 disabled:cursor-wait disabled:transform-none"
             :class="{ 'text-[#e5484d]': likesStore.isLiked(image.id) }"
             type="button"
             :aria-label="likesStore.toggleAriaLabel(likesStore.isLiked(image.id))"
@@ -376,11 +407,11 @@
             />
           </button>
 
-          <div class="flex items-center gap-4">
+          <div class="viewer__sidebar-actions-group flex items-center gap-4">
             <!-- Set as cover -->
             <button
               v-if="authStore.canManageLibrary && image.mediaType === 'image'"
-              class="inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer text-text transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px disabled:opacity-45 disabled:cursor-wait disabled:transform-none"
+              class="viewer__sidebar-action inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer text-text transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px disabled:opacity-45 disabled:cursor-wait disabled:transform-none"
               type="button"
               aria-label="Set as folder cover"
               title="Set as folder cover"
@@ -391,7 +422,7 @@
             </button>
             <!-- Open original -->
             <a
-              class="inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer text-text transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px"
+              class="viewer__sidebar-action inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer text-text transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px"
               :href="image.originalUrl"
               target="_blank"
               rel="noreferrer"
@@ -431,7 +462,7 @@
             <!-- Delete -->
             <button
               v-if="authStore.canDeleteMedia"
-              class="inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer text-[#d93025] transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px disabled:opacity-45 disabled:cursor-wait disabled:transform-none"
+              class="viewer__sidebar-action inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer text-[#d93025] transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px disabled:opacity-45 disabled:cursor-wait disabled:transform-none"
               type="button"
               aria-label="Delete post"
               :disabled="deleting"
@@ -466,6 +497,7 @@
   import type { PlayerSrc } from "vidstack"
   import type { MediaPlayerElement } from "vidstack/elements"
 
+  import { useHorizontalSwipe } from "../composables/useHorizontalSwipe"
   import type { ImageDetail, FolderSummary } from "../types/api"
   import { useAppStore } from "../stores/app"
   import { useAuthStore } from "../stores/auth"
@@ -501,12 +533,18 @@
   const navigationLockedUntil = ref(0)
   const isSidebarCollapsible = ref(false)
   const isSidebarExpanded = ref(true)
+  const isSidebarSheetDragging = ref(false)
   const isPlayingHd = ref(false)
+  const sidebarSheetDragOffset = ref(0)
   const settingCover = ref(false)
 
   const WHEEL_NAVIGATION_THRESHOLD = 72
   const NAVIGATION_COOLDOWN_MS = 320
   const MODAL_SIDEBAR_COLLAPSE_BREAKPOINT = 960
+  const SHEET_SWIPE_MIN_DISTANCE = 56
+  const SHEET_SWIPE_MAX_HORIZONTAL_DISTANCE = 96
+  const SHEET_SWIPE_MIN_VERTICAL_RATIO = 1.15
+  const SHEET_MAX_DRAG_OFFSET = 240
 
   type MetadataDetail = {
     label: string
@@ -516,6 +554,15 @@
   let videoMuteSyncToken = 0
   let pendingVideoRestore: { currentTime: number; wasPaused: boolean } | null = null
   let removePlayerEventListeners: (() => void) | null = null
+  let sidebarSheetPointerId: number | null = null
+  let sidebarSheetCapturedElement: Element | null = null
+  let sidebarSheetStartX = 0
+  let sidebarSheetStartY = 0
+  let sidebarSheetStartScrollTop = 0
+  let mediaSheetRevealPointerId: number | null = null
+  let mediaSheetRevealCapturedElement: Element | null = null
+  let mediaSheetRevealStartX = 0
+  let mediaSheetRevealStartY = 0
 
   const fileSize = computed(() => {
     if (!props.image) {
@@ -554,8 +601,8 @@
       type: "video/mp4",
     }
   })
-  const videoShellStyle = computed(() => {
-    if (!props.image || props.image.mediaType !== "video") {
+  const mediaShellStyle = computed(() => {
+    if (!props.image) {
       return undefined
     }
 
@@ -690,6 +737,25 @@
   const isModalSidebarOverlayVisible = computed(
     () => isModalSidebarCollapsible.value && isSidebarExpanded.value,
   )
+  const sidebarSheetStyle = computed(() =>
+    isModalSidebarCollapsible.value
+      ? {
+          "--viewer-sidebar-drag-offset": `${sidebarSheetDragOffset.value}px`,
+        }
+      : undefined,
+  )
+  const swipeNavigation = useHorizontalSwipe({
+    canStart: canStartSwipeNavigation,
+    isEnabled: () => props.isModal === true && props.image !== null,
+    onSwipeLeft: () => {
+      wheelDeltaAccumulator.value = 0
+      void navigateByDirection("next")
+    },
+    onSwipeRight: () => {
+      wheelDeltaAccumulator.value = 0
+      void navigateByDirection("previous")
+    },
+  })
 
   function syncVideoMuted(player: MediaPlayerElement, muted: boolean) {
     const token = ++videoMuteSyncToken
@@ -810,7 +876,70 @@
     })
   }
 
+  function releaseCapturedPointer(
+    capturedElement: Element | null,
+    pointerId: number | null,
+  ) {
+    if (!capturedElement || pointerId === null || !("releasePointerCapture" in capturedElement)) {
+      return
+    }
+
+    try {
+      capturedElement.releasePointerCapture(pointerId)
+    } catch {
+      // Ignore failures if the pointer has already been released.
+    }
+  }
+
+  function isGestureIgnoredTarget(target: EventTarget | null) {
+    if (!(target instanceof Element)) {
+      return false
+    }
+
+    return Boolean(
+      target.closest(
+        [
+          '[data-swipe-ignore="true"]',
+          '[data-sheet-swipe-ignore="true"]',
+          "button",
+          "a",
+          "input",
+          "select",
+          "textarea",
+          "label",
+          '[role="button"]',
+          '[role="link"]',
+        ].join(", "),
+      ),
+    )
+  }
+
+  function resetSidebarSheetGesture() {
+    releaseCapturedPointer(sidebarSheetCapturedElement, sidebarSheetPointerId)
+    sidebarSheetPointerId = null
+    sidebarSheetCapturedElement = null
+    sidebarSheetStartX = 0
+    sidebarSheetStartY = 0
+    sidebarSheetStartScrollTop = 0
+    sidebarSheetDragOffset.value = 0
+    isSidebarSheetDragging.value = false
+  }
+
+  function resetMediaSheetRevealGesture() {
+    releaseCapturedPointer(
+      mediaSheetRevealCapturedElement,
+      mediaSheetRevealPointerId,
+    )
+    mediaSheetRevealPointerId = null
+    mediaSheetRevealCapturedElement = null
+    mediaSheetRevealStartX = 0
+    mediaSheetRevealStartY = 0
+  }
+
   function updateSidebarLayout() {
+    resetSidebarSheetGesture()
+    resetMediaSheetRevealGesture()
+
     if (!props.isModal) {
       isSidebarCollapsible.value = false
       isSidebarExpanded.value = true
@@ -833,21 +962,216 @@
     }
   }
 
+  function openSidebar() {
+    if (!isModalSidebarCollapsible.value) {
+      return
+    }
+
+    resetSidebarSheetGesture()
+    isSidebarExpanded.value = true
+  }
+
   function toggleSidebar() {
     if (!isModalSidebarCollapsible.value) {
       return
     }
 
-    isSidebarExpanded.value = !isSidebarExpanded.value
+    if (isSidebarExpanded.value) {
+      closeSidebar()
+      return
+    }
+
+    openSidebar()
   }
 
-  function closeSidebar() {
+  function closeSidebar(options: { restoreFocus?: boolean } = {}) {
     if (!isModalSidebarCollapsible.value) {
       return
     }
 
+    resetSidebarSheetGesture()
     isSidebarExpanded.value = false
-    focusSidebarToggle(true)
+
+    if (options.restoreFocus !== false) {
+      focusSidebarToggle(true)
+    }
+  }
+
+  function handleSidebarBackdropClick() {
+    closeSidebar()
+  }
+
+  function handleMediaPointerdown(event: PointerEvent) {
+    swipeNavigation.onPointerdown(event)
+    handleMediaSheetRevealPointerdown(event)
+  }
+
+  function handleMediaPointermove(event: PointerEvent) {
+    swipeNavigation.onPointermove(event)
+    handleMediaSheetRevealPointermove(event)
+  }
+
+  async function handleMediaPointerup(event: PointerEvent) {
+    await swipeNavigation.onPointerup(event)
+    await handleMediaSheetRevealPointerup(event)
+  }
+
+  function handleMediaPointercancel(event: PointerEvent) {
+    swipeNavigation.onPointercancel()
+    handleMediaSheetRevealPointercancel(event)
+  }
+
+  function handleMediaSheetRevealPointerdown(event: PointerEvent) {
+    if (
+      !event.isPrimary ||
+      event.pointerType === "mouse" ||
+      !isModalSidebarCollapsible.value ||
+      isSidebarExpanded.value ||
+      Date.now() < navigationLockedUntil.value ||
+      isGestureIgnoredTarget(event.target)
+    ) {
+      return
+    }
+
+    mediaSheetRevealPointerId = event.pointerId
+    mediaSheetRevealStartX = event.clientX
+    mediaSheetRevealStartY = event.clientY
+
+    if (event.currentTarget instanceof Element && "setPointerCapture" in event.currentTarget) {
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId)
+        mediaSheetRevealCapturedElement = event.currentTarget
+      } catch {
+        mediaSheetRevealCapturedElement = null
+      }
+    }
+  }
+
+  function handleMediaSheetRevealPointermove(event: PointerEvent) {
+    if (event.pointerId !== mediaSheetRevealPointerId) {
+      return
+    }
+
+    const deltaX = Math.abs(event.clientX - mediaSheetRevealStartX)
+    const deltaY = mediaSheetRevealStartY - event.clientY
+
+    if (deltaY > 10 && deltaY > deltaX) {
+      event.preventDefault()
+    }
+  }
+
+  async function handleMediaSheetRevealPointerup(event: PointerEvent) {
+    if (event.pointerId !== mediaSheetRevealPointerId) {
+      return
+    }
+
+    const deltaX = event.clientX - mediaSheetRevealStartX
+    const deltaY = event.clientY - mediaSheetRevealStartY
+
+    resetMediaSheetRevealGesture()
+
+    if (-deltaY < SHEET_SWIPE_MIN_DISTANCE) {
+      return
+    }
+
+    if (Math.abs(deltaX) > SHEET_SWIPE_MAX_HORIZONTAL_DISTANCE) {
+      return
+    }
+
+    if (Math.abs(deltaY) <= Math.abs(deltaX) * SHEET_SWIPE_MIN_VERTICAL_RATIO) {
+      return
+    }
+
+    openSidebar()
+  }
+
+  function handleMediaSheetRevealPointercancel(_event: PointerEvent) {
+    resetMediaSheetRevealGesture()
+  }
+
+  function handleSidebarSheetPointerdown(event: PointerEvent) {
+    if (
+      !event.isPrimary ||
+      event.pointerType === "mouse" ||
+      !isModalSidebarCollapsible.value ||
+      !isSidebarExpanded.value ||
+      isGestureIgnoredTarget(event.target)
+    ) {
+      return
+    }
+
+    sidebarSheetPointerId = event.pointerId
+    sidebarSheetStartX = event.clientX
+    sidebarSheetStartY = event.clientY
+    sidebarSheetStartScrollTop = sidebarElement.value?.scrollTop ?? 0
+
+    if (event.currentTarget instanceof Element && "setPointerCapture" in event.currentTarget) {
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId)
+        sidebarSheetCapturedElement = event.currentTarget
+      } catch {
+        sidebarSheetCapturedElement = null
+      }
+    }
+  }
+
+  function handleSidebarSheetPointermove(event: PointerEvent) {
+    if (event.pointerId !== sidebarSheetPointerId) {
+      return
+    }
+
+    const sidebar = sidebarElement.value
+    if (!sidebar || sidebarSheetStartScrollTop > 0 || sidebar.scrollTop > 0) {
+      return
+    }
+
+    const deltaX = event.clientX - sidebarSheetStartX
+    const deltaY = event.clientY - sidebarSheetStartY
+
+    if (deltaY <= 0) {
+      if (isSidebarSheetDragging.value) {
+        sidebarSheetDragOffset.value = 0
+      }
+      return
+    }
+
+    if (deltaY > 10 && deltaY > Math.abs(deltaX)) {
+      event.preventDefault()
+      isSidebarSheetDragging.value = true
+      sidebarSheetDragOffset.value = Math.min(deltaY, SHEET_MAX_DRAG_OFFSET)
+    }
+  }
+
+  function handleSidebarSheetPointerup(event: PointerEvent) {
+    if (event.pointerId !== sidebarSheetPointerId) {
+      return
+    }
+
+    const deltaX = event.clientX - sidebarSheetStartX
+    const deltaY = event.clientY - sidebarSheetStartY
+    const shouldClose =
+      isSidebarSheetDragging.value &&
+      deltaY >= SHEET_SWIPE_MIN_DISTANCE &&
+      deltaY > Math.abs(deltaX) * SHEET_SWIPE_MIN_VERTICAL_RATIO
+
+    resetSidebarSheetGesture()
+
+    if (shouldClose) {
+      closeSidebar({ restoreFocus: false })
+    }
+  }
+
+  function handleSidebarSheetPointercancel(_event: PointerEvent) {
+    resetSidebarSheetGesture()
+  }
+
+  function canStartSwipeNavigation(event: PointerEvent) {
+    if (Date.now() < navigationLockedUntil.value) {
+      return false
+    }
+
+    const target = event.target
+    return !isGestureIgnoredTarget(target)
   }
 
   async function attemptVideoPlayback(): Promise<void> {
@@ -960,6 +1284,8 @@
     () => {
       wheelDeltaAccumulator.value = 0
       navigationLockedUntil.value = 0
+      resetSidebarSheetGesture()
+      resetMediaSheetRevealGesture()
       isPlayingHd.value = false
       pendingVideoRestore = null
       void attemptVideoPlayback()
@@ -1097,6 +1423,8 @@
   })
 
   onUnmounted(() => {
+    resetSidebarSheetGesture()
+    resetMediaSheetRevealGesture()
     window.removeEventListener("resize", updateSidebarLayout)
     window.removeEventListener("keydown", handleKeydown)
     removePlayerEventListeners?.()

--- a/client/src/components/RailViewerModal.vue
+++ b/client/src/components/RailViewerModal.vue
@@ -1,12 +1,13 @@
 <template>
   <div class="rail-viewer fixed inset-0 z-[80] bg-black" @click.self="emit('close')">
     <button
-      class="absolute right-4 top-4 z-[6] inline-flex h-11 w-11 items-center justify-center rounded-full border-0 bg-transparent p-0 text-white transition-opacity duration-150 hover:opacity-72"
+      class="rail-viewer__close"
       type="button"
       aria-label="Close viewer"
+      data-swipe-ignore="true"
       @click="emit('close')"
     >
-      <svg class="h-7 w-7" viewBox="0 0 24 24" role="presentation">
+      <svg class="rail-viewer__close-icon" viewBox="0 0 24 24" role="presentation">
         <path
           d="m7 7 10 10M17 7 7 17"
           fill="none"
@@ -64,7 +65,14 @@
           </svg>
         </button>
 
-        <article class="story-stage" :class="{ 'story-stage--capsule-switching': isCapsuleSwitching }">
+        <article
+          class="story-stage"
+          :class="{ 'story-stage--capsule-switching': isCapsuleSwitching }"
+          @pointercancel="swipeNavigation.onPointercancel"
+          @pointerdown="swipeNavigation.onPointerdown"
+          @pointermove="swipeNavigation.onPointermove"
+          @pointerup="swipeNavigation.onPointerup"
+        >
           <div class="story-stage__progress">
             <span
               v-for="(_, index) in progressMarkers"
@@ -97,6 +105,7 @@
                 class="story-stage__control-button"
                 type="button"
                 :aria-label="isPaused ? 'Resume playback' : 'Pause playback'"
+                data-swipe-ignore="true"
                 @click="togglePaused"
               >
                 <svg v-if="isPaused" class="h-4 w-4" viewBox="0 0 24 24" role="presentation">
@@ -199,6 +208,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 
+import { useHorizontalSwipe } from '../composables/useHorizontalSwipe';
 import type { FeedItem, MomentCapsule } from '../types/api';
 import { useAppStore } from '../stores/app';
 import { useMomentsStore } from '../stores/moments';
@@ -286,6 +296,16 @@ const canGoNextImage = computed(
     activeImages.value.length > 0 &&
     (activeImageIndex.value < activeImages.value.length - 1 || momentsStore.currentHasMore)
 );
+const swipeNavigation = useHorizontalSwipe({
+  canStart: canStartStageSwipe,
+  isEnabled: () => !transitionPending.value && activeImages.value.length > 0,
+  onSwipeLeft: () => {
+    void showNextImage();
+  },
+  onSwipeRight: () => {
+    void showPreviousImage();
+  }
+});
 
 watch(
   () => props.initialId,
@@ -376,6 +396,15 @@ function togglePaused() {
   }
 
   startAutoplay();
+}
+
+function canStartStageSwipe(event: PointerEvent) {
+  const target = event.target;
+  if (!(target instanceof Element)) {
+    return true;
+  }
+
+  return !target.closest('[data-swipe-ignore="true"]');
 }
 
 function supportsViewTransitions() {
@@ -565,6 +594,39 @@ onUnmounted(() => {
 .rail-viewer {
   background: #000;
   backdrop-filter: none;
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+.rail-viewer__close {
+  position: absolute;
+  top: max(1rem, env(safe-area-inset-top));
+  right: max(1rem, env(safe-area-inset-right));
+  z-index: 6;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.28);
+  color: #fff;
+  transition: transform 150ms ease, background-color 150ms ease, border-color 150ms ease;
+}
+
+.rail-viewer__close:hover {
+  background: rgba(0, 0, 0, 0.58);
+  border-color: rgba(255, 255, 255, 0.24);
+  transform: translateY(-1px);
+}
+
+.rail-viewer__close-icon {
+  width: 1.3rem;
+  height: 1.3rem;
 }
 
 .story-overlay {
@@ -644,10 +706,12 @@ onUnmounted(() => {
   justify-self: center;
   width: min(100%, 28rem);
   height: min(calc(100vh - 2.5rem), 44rem);
+  height: min(calc(100dvh - 2.5rem), 44rem);
   overflow: hidden;
   border-radius: 1rem;
   background: #000;
   box-shadow: 0 24px 80px rgba(0, 0, 0, 0.56);
+  touch-action: pan-y pinch-zoom;
 }
 
 .story-stage--capsule-switching {
@@ -818,6 +882,37 @@ onUnmounted(() => {
   z-index: 3;
   padding: 5rem 1rem 1rem;
   background: linear-gradient(180deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.8) 44%, rgba(0, 0, 0, 0.96));
+}
+
+@media (max-width: 768px) {
+  .rail-viewer__close {
+    top: max(0.2rem, env(safe-area-inset-top));
+    right: max(0.35rem, env(safe-area-inset-right));
+    left: auto;
+    width: 2.3rem;
+    height: 2.3rem;
+  }
+
+  .rail-viewer__close-icon {
+    width: 0.98rem;
+    height: 0.98rem;
+  }
+
+  .story-overlay {
+    padding:
+      max(1.95rem, calc(env(safe-area-inset-top) + 2.2rem))
+      0.9rem
+      max(0.8rem, env(safe-area-inset-bottom))
+      0.9rem;
+  }
+
+  .story-stage__progress {
+    top: 0.68rem;
+  }
+
+  .story-stage__header {
+    inset: 1.22rem 0.85rem auto 0.85rem;
+  }
 }
 
 @media (min-width: 1024px) {

--- a/client/src/composables/useHorizontalSwipe.ts
+++ b/client/src/composables/useHorizontalSwipe.ts
@@ -1,0 +1,121 @@
+interface HorizontalSwipeOptions {
+  canStart?: (event: PointerEvent) => boolean;
+  isEnabled?: () => boolean;
+  maxVerticalDistance?: number;
+  minDistance?: number;
+  minHorizontalRatio?: number;
+  onSwipeLeft?: (event: PointerEvent) => void | Promise<void>;
+  onSwipeRight?: (event: PointerEvent) => void | Promise<void>;
+}
+
+const DEFAULT_MIN_DISTANCE = 56;
+const DEFAULT_MAX_VERTICAL_DISTANCE = 96;
+const DEFAULT_MIN_HORIZONTAL_RATIO = 1.2;
+
+export function useHorizontalSwipe(options: HorizontalSwipeOptions = {}) {
+  let activePointerId: number | null = null;
+  let capturedElement: Element | null = null;
+  let startX = 0;
+  let startY = 0;
+
+  function releasePointerCapture() {
+    if (capturedElement && activePointerId !== null && 'releasePointerCapture' in capturedElement) {
+      try {
+        capturedElement.releasePointerCapture(activePointerId);
+      } catch {
+        // Ignore failures if the pointer has already been released.
+      }
+    }
+
+    capturedElement = null;
+  }
+
+  function reset() {
+    releasePointerCapture();
+    activePointerId = null;
+    startX = 0;
+    startY = 0;
+  }
+
+  function onPointerdown(event: PointerEvent) {
+    if (!event.isPrimary || event.pointerType === 'mouse') {
+      return;
+    }
+
+    if (options.isEnabled && !options.isEnabled()) {
+      return;
+    }
+
+    if (options.canStart && !options.canStart(event)) {
+      return;
+    }
+
+    activePointerId = event.pointerId;
+    startX = event.clientX;
+    startY = event.clientY;
+
+    if (event.currentTarget instanceof Element && 'setPointerCapture' in event.currentTarget) {
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+        capturedElement = event.currentTarget;
+      } catch {
+        capturedElement = null;
+      }
+    }
+  }
+
+  function onPointermove(event: PointerEvent) {
+    if (event.pointerId !== activePointerId) {
+      return;
+    }
+
+    const deltaX = Math.abs(event.clientX - startX);
+    const deltaY = Math.abs(event.clientY - startY);
+
+    if (deltaX > 10 && deltaX > deltaY) {
+      event.preventDefault();
+    }
+  }
+
+  async function onPointerup(event: PointerEvent) {
+    if (event.pointerId !== activePointerId) {
+      return;
+    }
+
+    const deltaX = event.clientX - startX;
+    const deltaY = event.clientY - startY;
+    const minDistance = options.minDistance ?? DEFAULT_MIN_DISTANCE;
+    const maxVerticalDistance =
+      options.maxVerticalDistance ?? DEFAULT_MAX_VERTICAL_DISTANCE;
+    const minHorizontalRatio =
+      options.minHorizontalRatio ?? DEFAULT_MIN_HORIZONTAL_RATIO;
+
+    reset();
+
+    if (Math.abs(deltaX) < minDistance || Math.abs(deltaY) > maxVerticalDistance) {
+      return;
+    }
+
+    if (Math.abs(deltaX) <= Math.abs(deltaY) * minHorizontalRatio) {
+      return;
+    }
+
+    if (deltaX < 0) {
+      await options.onSwipeLeft?.(event);
+      return;
+    }
+
+    await options.onSwipeRight?.(event);
+  }
+
+  function onPointercancel() {
+    reset();
+  }
+
+  return {
+    onPointercancel,
+    onPointerdown,
+    onPointermove,
+    onPointerup,
+  };
+}

--- a/client/src/stores/viewer.ts
+++ b/client/src/stores/viewer.ts
@@ -10,6 +10,8 @@ interface ViewerState {
   error: string | null;
 }
 
+let viewerLoadToken = 0;
+
 export const useViewerStore = defineStore('viewer', {
   state: (): ViewerState => ({
     image: null,
@@ -19,6 +21,7 @@ export const useViewerStore = defineStore('viewer', {
   }),
   actions: {
     reset() {
+      viewerLoadToken += 1;
       this.image = null;
       this.loading = false;
       this.deleting = false;
@@ -26,16 +29,28 @@ export const useViewerStore = defineStore('viewer', {
     },
 
     async loadImage(id: number, mediaType?: 'image' | 'video') {
+      const requestToken = ++viewerLoadToken;
       this.loading = true;
       this.error = null;
-      this.image = null;
 
       try {
-        this.image = await fetchImage(id, mediaType);
+        const image = await fetchImage(id, mediaType);
+        if (requestToken !== viewerLoadToken) {
+          return;
+        }
+
+        this.image = image;
       } catch (error) {
+        if (requestToken !== viewerLoadToken) {
+          return;
+        }
+
+        this.image = null;
         this.error = error instanceof Error ? error.message : 'Unable to load post';
       } finally {
-        this.loading = false;
+        if (requestToken === viewerLoadToken) {
+          this.loading = false;
+        }
       }
     },
 

--- a/client/src/styles/base.css
+++ b/client/src/styles/base.css
@@ -149,17 +149,23 @@ img[data-loaded="true"] {
   display: flex;
   overflow: hidden;
   width: fit-content;
-  max-width: 100vw;
+  max-width: 100%;
   margin: 0 auto;
 }
 
 .viewer__card-wrapper--modal {
-  height: calc(100vh - 2rem);
+  width: 100%;
+  height: 100%;
+  max-height: 100%;
 }
 
 .viewer__card-wrapper--compact {
   flex-direction: column;
   height: auto;
+}
+
+.viewer__card-wrapper--modal.viewer__card-wrapper--compact {
+  height: 100%;
 }
 
 .viewer__media {
@@ -183,8 +189,14 @@ img[data-loaded="true"] {
 }
 
 .viewer__media--modal {
-  height: calc(100vh - 2rem);
+  width: 100%;
+  height: 100%;
+  max-height: 100%;
   min-height: 0;
+}
+
+.viewer__media--swipe-enabled {
+  touch-action: pan-y pinch-zoom;
 }
 
 .viewer__media--page {
@@ -194,11 +206,53 @@ img[data-loaded="true"] {
 .viewer__sidebar {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0;
   width: 24rem;
   flex-shrink: 0;
   border-left: 1px solid var(--border);
   background: var(--surface);
+}
+
+.viewer__sidebar-handle {
+  display: none;
+}
+
+.viewer__sidebar-header,
+.viewer__sidebar-summary,
+.viewer__sidebar-stats,
+.viewer__sidebar-metadata,
+.viewer__sidebar-actions {
+  flex-shrink: 0;
+}
+
+.viewer__sidebar-folder-link {
+  flex: 1 1 auto;
+}
+
+.viewer__sidebar-folder-meta {
+  min-width: 0;
+}
+
+.viewer__sidebar-caption,
+.viewer__sidebar-path,
+.viewer__sidebar-stat-value,
+.viewer__sidebar-metadata-value {
+  overflow-wrap: anywhere;
+}
+
+.viewer__sidebar-stats,
+.viewer__sidebar-metadata {
+  display: grid;
+}
+
+.viewer__sidebar-actions-group {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.viewer__sidebar-action {
+  flex-shrink: 0;
 }
 
 .viewer__sidebar--modal {
@@ -220,11 +274,20 @@ img[data-loaded="true"] {
   background: var(--surface);
   box-shadow: 0 20px 48px rgba(15, 20, 25, 0.24);
   transform: translateX(100%);
+  opacity: 0;
   pointer-events: none;
+  transition:
+    transform 0.24s ease,
+    opacity 0.24s ease;
+}
+
+.viewer__sidebar--dragging {
+  transition: none;
 }
 
 .viewer__sidebar--drawer-open {
   transform: translateX(0);
+  opacity: 1;
   pointer-events: auto;
 }
 
@@ -233,31 +296,82 @@ img[data-loaded="true"] {
   inset: 0;
   z-index: 20;
   border: 0;
-  background: rgba(0, 0, 0, 0.18);
+  background: rgba(0, 0, 0, 0.28);
   cursor: pointer;
 }
 
 .viewer__sidebar-toggle {
   position: absolute;
-  top: 1rem;
-  left: 1rem;
-  opacity: 0.7;
+  top: max(1rem, env(safe-area-inset-top));
+  left: max(1rem, env(safe-area-inset-left));
   z-index: 40;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 2.9rem;
+  height: 2.9rem;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  background: rgba(10, 14, 24, 0.58);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.28);
   color: #fff;
   cursor: pointer;
   transition:
     background-color 0.18s ease,
+    border-color 0.18s ease,
+    opacity 0.18s ease,
     transform 0.18s ease;
 }
 
 .viewer__sidebar-toggle:hover {
+  background: rgba(10, 14, 24, 0.74);
+  border-color: rgba(255, 255, 255, 0.24);
   transform: translateY(-1px);
 }
 
-.viewer__video-shell {
+.viewer__sidebar-toggle-icon {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.viewer__modal-close {
+  position: fixed;
+  top: max(0.95rem, env(safe-area-inset-top));
+  right: max(0.95rem, env(safe-area-inset-right));
+  z-index: 55;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  background: rgba(10, 14, 24, 0.62);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.28);
+  color: rgba(255, 255, 255, 0.92);
+  cursor: pointer;
+  transition:
+    background-color 0.18s ease,
+    border-color 0.18s ease,
+    transform 0.18s ease;
+}
+
+.viewer__modal-close:hover {
+  background: rgba(10, 14, 24, 0.78);
+  border-color: rgba(255, 255, 255, 0.24);
+  transform: translateY(-1px);
+}
+
+.viewer__modal-close-icon {
+  width: 1.35rem;
+  height: 1.35rem;
+}
+
+.viewer__media-shell {
   position: relative;
   display: flex;
   align-items: center;
@@ -266,8 +380,24 @@ img[data-loaded="true"] {
   max-width: 100%;
   max-height: 100%;
   aspect-ratio: var(--viewer-media-aspect-ratio);
-  background: #000;
   overflow: hidden;
+}
+
+.viewer__media-shell--video {
+  background: #000;
+}
+
+.viewer__media-shell--image {
+  background: color-mix(in srgb, var(--surface-alt) 88%, #fff 12%);
+}
+
+.viewer__media-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
 }
 
 .viewer__player {
@@ -422,6 +552,15 @@ img[data-loaded="true"] {
   object-fit: cover;
 }
 
+.feed-card__player[data-fullscreen] {
+  background: #000;
+}
+
+.feed-card__player[data-fullscreen] video,
+.feed-card__player[data-fullscreen] img {
+  object-fit: contain;
+}
+
 .feed-card__player-controls {
   position: absolute;
   inset-inline: 0;
@@ -528,15 +667,190 @@ img[data-loaded="true"] {
 }
 
 @media (max-width: 768px) {
-  .viewer__card-wrapper {
+  .viewer__card-wrapper:not(.viewer__card-wrapper--modal) {
     flex-direction: column;
     height: auto;
   }
-  
-  .viewer__sidebar {
+
+  .viewer__sidebar:not(.viewer__sidebar--drawer) {
     width: 100%;
     border-left: 0;
     border-top: 1px solid var(--border);
+  }
+
+  .viewer__sidebar--drawer {
+    --viewer-sidebar-base-translate-y: calc(100% + 1rem);
+    position: fixed;
+    top: auto;
+    right: max(0.75rem, env(safe-area-inset-right));
+    bottom: max(0.75rem, env(safe-area-inset-bottom));
+    left: max(0.75rem, env(safe-area-inset-left));
+    width: auto;
+    max-width: none;
+    max-height: min(30rem, calc(100dvh - max(6rem, env(safe-area-inset-top) + 4rem)));
+    height: auto;
+    border: 1px solid color-mix(in srgb, var(--border) 82%, transparent 18%);
+    border-radius: 1.4rem;
+    background: color-mix(in srgb, var(--surface) 95%, var(--surface-alt) 5%);
+    box-shadow: 0 28px 72px rgba(15, 20, 25, 0.28);
+    transform: translateY(
+      calc(var(--viewer-sidebar-base-translate-y) + var(--viewer-sidebar-drag-offset, 0px))
+    );
+    overflow: hidden;
+    overscroll-behavior: contain;
+    touch-action: pan-y;
+  }
+
+  .viewer__sidebar--drawer-open {
+    --viewer-sidebar-base-translate-y: 0px;
+  }
+
+  .viewer__drawer-backdrop {
+    position: fixed;
+  }
+
+  .viewer__sidebar-handle {
+    display: block;
+    width: 2.8rem;
+    height: 0.28rem;
+    margin: 0.72rem auto 0.15rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--muted) 28%, transparent 72%);
+  }
+
+  .viewer__sidebar-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    padding: 0.85rem 1rem 0.95rem;
+    background: color-mix(in srgb, var(--surface) 95%, var(--surface-alt) 5%);
+    backdrop-filter: blur(18px);
+  }
+
+  .viewer__sidebar-folder-link {
+    gap: 0.75rem;
+  }
+
+  .viewer__sidebar-title {
+    font-size: 0.95rem;
+  }
+
+  .viewer__sidebar-breadcrumb {
+    font-size: 0.92rem;
+    line-height: 1.35;
+  }
+
+  .viewer__sidebar-date {
+    padding-top: 0.12rem;
+    font-size: 0.74rem;
+  }
+
+  .viewer__sidebar-summary {
+    gap: 0.45rem;
+    padding: 0.95rem 1rem 0;
+  }
+
+  .viewer__sidebar-caption {
+    font-size: 0.98rem;
+    line-height: 1.55;
+  }
+
+  .viewer__sidebar-path {
+    font-size: 0.84rem;
+    line-height: 1.5;
+  }
+
+  .viewer__sidebar-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+    padding: 0.95rem 1rem 0;
+  }
+
+  .viewer__sidebar-stat {
+    min-width: 0;
+    padding: 0.85rem 0.9rem;
+    border: 1px solid color-mix(in srgb, var(--border) 84%, transparent 16%);
+    border-radius: 1rem;
+    background: color-mix(in srgb, var(--surface-alt) 82%, var(--surface) 18%);
+  }
+
+  .viewer__sidebar-stat-label,
+  .viewer__sidebar-metadata-label {
+    margin-bottom: 0.28rem;
+    color: var(--muted);
+    font-size: 0.72rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .viewer__sidebar-stat-value {
+    font-size: 0.92rem;
+    line-height: 1.45;
+  }
+
+  .viewer__sidebar-metadata {
+    gap: 0.7rem;
+    padding: 0.85rem 1rem 0;
+  }
+
+  .viewer__sidebar-metadata-item {
+    padding: 0.9rem;
+    border: 1px solid color-mix(in srgb, var(--border) 84%, transparent 16%);
+    border-radius: 1rem;
+    background: color-mix(in srgb, var(--surface-alt) 74%, var(--surface) 26%);
+  }
+
+  .viewer__sidebar-metadata-value {
+    font-size: 0.93rem;
+    line-height: 1.5;
+  }
+
+  .viewer__sidebar-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+    margin-top: 0;
+    padding: 0.9rem 1rem calc(0.9rem + env(safe-area-inset-bottom));
+    border-top: 1px solid color-mix(in srgb, var(--border) 84%, transparent 16%);
+    background: color-mix(in srgb, var(--surface) 96%, var(--surface-alt) 4%);
+    backdrop-filter: blur(18px);
+  }
+
+  .viewer__sidebar-actions-group {
+    gap: 0.75rem;
+  }
+
+  .viewer__sidebar-action {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 0.95rem;
+    background: color-mix(in srgb, var(--surface-alt) 82%, var(--surface) 18%);
+    box-shadow: 0 10px 24px rgba(15, 20, 25, 0.08);
+  }
+
+  .viewer__sidebar-toggle {
+    position: fixed;
+    top: max(0.4rem, env(safe-area-inset-top));
+    left: max(0.4rem, env(safe-area-inset-left));
+    width: 2rem;
+    height: 2rem;
+  }
+
+  .viewer__sidebar-toggle-icon {
+    width: 1.05rem;
+    height: 1.05rem;
+  }
+
+  .viewer__modal-close {
+    top: max(0.4rem, env(safe-area-inset-top));
+    right: max(0.4rem, env(safe-area-inset-right));
+    width: 2rem;
+    height: 2rem;
+  }
+
+  .viewer__modal-close-icon {
+    width: 1.05rem;
+    height: 1.05rem;
   }
 
   .viewer__media--page {
@@ -563,4 +877,3 @@ img[data-loaded="true"] {
     opacity: 0.92;
   }
 }
-

--- a/client/src/views/ImageView.vue
+++ b/client/src/views/ImageView.vue
@@ -1,11 +1,8 @@
 <template>
-  <div :class="modal ? 'w-[min(100%,72rem)]' : 'w-[min(100%,72rem)] mx-auto'" @click.stop>
+  <div :class="modal ? 'image-view image-view--modal' : 'image-view image-view--page'" @click.stop>
     <ErrorState v-if="viewerStore.error" title="Could not load post" :message="viewerStore.error" />
-    <div v-else-if="viewerStore.loading" class="card p-8 text-center">
-      <p class="text-muted">Loading post...</p>
-    </div>
     <ImageModal
-      v-else
+      v-else-if="viewerStore.image"
       :image="viewerStore.image"
       :folder="folder"
       :is-modal="modal"
@@ -13,6 +10,9 @@
       @close="emit('close')"
       @delete="openDeleteDialog"
     />
+    <div v-else-if="viewerStore.loading" class="card p-8 text-center">
+      <p class="text-muted">Loading post...</p>
+    </div>
     <ConfirmDialog
       v-if="confirmDeleteOpen"
       title="Delete this post?"
@@ -151,3 +151,21 @@ async function handleDelete() {
   }
 }
 </script>
+
+<style scoped>
+.image-view {
+  width: min(100%, 72rem);
+}
+
+.image-view--modal {
+  display: flex;
+  justify-content: center;
+  min-height: 0;
+  height: 100%;
+  max-height: 100%;
+}
+
+.image-view--page {
+  margin: 0 auto;
+}
+</style>


### PR DESCRIPTION
Fixes #17 

This PR improves the mobile viewing experience across the app, with a focus on ImageModal, feed video fullscreen behavior, and Highlights. It fixes viewport clipping on Android, adds reliable swipe navigation for posts and Highlights, converts the mobile details sidebar into a bottom sheet with gesture support, and stabilizes modal sizing so transitions between posts no longer blink or collapse.

It also polishes mobile controls by refining close/sidebar buttons, tightening Highlights top spacing, aligning the Highlights close button placement, and standardizing the trash icon used in the More menu to match the modal action icon. Overall, the changes are aimed at making mobile interactions smoother, cleaner, and more consistent without affecting desktop behavior.