### PR TITLE
Add tabbed Explore search with media results and recent query history

### DIFF
--- a/client/src/api/gallery.ts
+++ b/client/src/api/gallery.ts
@@ -39,6 +39,16 @@ export function fetchFeed(page = 1, limit = 24, mode: FeedMode = 'random', seed?
   return requestJson<PaginatedFeed>(`/api/feed?${params.toString()}`);
 }
 
+export function fetchFeedSearch(query: string, page = 1, limit = 24) {
+  const params = new URLSearchParams({
+    q: query,
+    page: String(page),
+    limit: String(limit)
+  });
+
+  return requestJson<PaginatedFeed>(`/api/feed/search?${params.toString()}`);
+}
+
 export function fetchMoments() {
   return requestJson<MomentsPayload>('/api/feed/moments');
 }

--- a/client/src/components/ExploreGrid.vue
+++ b/client/src/components/ExploreGrid.vue
@@ -5,7 +5,7 @@
         :href="href"
         class="explore-grid__item group"
         :class="getTileClass(index)"
-        @click="handleImageNavigation($event, navigate)"
+        @click="handleImageNavigation($event, item, navigate)"
       >
         <ResilientImage :src="item.thumbnailUrl" :alt="item.filename" loading="lazy" :retry-while="appStore.isScanning" />
         <div v-if="item.mediaType === 'video'" class="absolute inset-x-0 top-0 flex items-center justify-between px-2 py-2 text-white pointer-events-none bg-[linear-gradient(180deg,rgba(10,14,24,0.72)_0%,rgba(10,14,24,0)_100%)]">
@@ -31,6 +31,10 @@ defineProps<{
   items: FeedItem[];
 }>();
 
+const emit = defineEmits<{
+  open: [item: FeedItem];
+}>();
+
 const FEATURE_INDEXES = new Set([2, 8, 13]);
 
 const appStore = useAppStore();
@@ -40,12 +44,13 @@ function getTileClass(index: number): string {
   return FEATURE_INDEXES.has(index % 15) ? 'explore-grid__item--feature' : '';
 }
 
-function handleImageNavigation(event: MouseEvent, navigate: () => void) {
+function handleImageNavigation(event: MouseEvent, item: FeedItem, navigate: () => void) {
   if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
     return;
   }
 
   event.preventDefault();
+  emit('open', item);
   appStore.setImageModalBackground(route.fullPath);
   navigate();
 }

--- a/client/src/stores/explore.ts
+++ b/client/src/stores/explore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 
-import { fetchFeed } from '../api/gallery';
+import { fetchFeed, fetchFeedSearch } from '../api/gallery';
 import type { FeedItem } from '../types/api';
 
 interface ExploreState {
@@ -12,12 +12,22 @@ interface ExploreState {
   error: string | null;
   initialized: boolean;
   randomSeed: number | null;
-  recentSearchSlugs: string[];
+  recentSearchQueries: string[];
   recentSearchesInitialized: boolean;
+  searchQuery: string;
+  searchItems: FeedItem[];
+  searchPage: number;
+  searchLimit: number;
+  searchHasMore: boolean;
+  searchLoading: boolean;
+  searchError: string | null;
+  searchInitialized: boolean;
+  searchRequestToken: number;
 }
 
-const RECENT_SEARCHES_STORAGE_KEY = 'foldergram-recent-searches';
+const RECENT_SEARCHES_STORAGE_KEY = 'foldergram-recent-search-queries';
 const RECENT_SEARCH_LIMIT = 12;
+const MIN_COMMITTED_SEARCH_LENGTH = 3;
 
 function createRandomSeed(): number {
   const cryptoObject = globalThis.crypto;
@@ -28,7 +38,15 @@ function createRandomSeed(): number {
   return Math.floor(Math.random() * 2_147_483_647);
 }
 
-function parseStoredRecentSearchSlugs(value: string | null): string[] {
+function formatSearchQuery(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+function normalizeSearchQuery(value: string): string {
+  return formatSearchQuery(value).toLocaleLowerCase();
+}
+
+function parseStoredRecentSearchQueries(value: string | null): string[] {
   if (!value) {
     return [];
   }
@@ -39,14 +57,32 @@ function parseStoredRecentSearchSlugs(value: string | null): string[] {
       return [];
     }
 
+    const seen = new Set<string>();
+
     return parsed
       .filter((entry): entry is string => typeof entry === 'string')
-      .map((entry) => entry.trim())
-      .filter((entry, index, items) => entry.length > 0 && items.indexOf(entry) === index)
+      .map(formatSearchQuery)
+      .filter((entry) => {
+        if (entry.length < MIN_COMMITTED_SEARCH_LENGTH) {
+          return false;
+        }
+
+        const normalizedEntry = normalizeSearchQuery(entry);
+        if (seen.has(normalizedEntry)) {
+          return false;
+        }
+
+        seen.add(normalizedEntry);
+        return true;
+      })
       .slice(0, RECENT_SEARCH_LIMIT);
   } catch {
     return [];
   }
+}
+
+function isPrefixVariant(previousQuery: string, nextQuery: string): boolean {
+  return previousQuery.startsWith(nextQuery) || nextQuery.startsWith(previousQuery);
 }
 
 export const useExploreStore = defineStore('explore', {
@@ -59,8 +95,17 @@ export const useExploreStore = defineStore('explore', {
     error: null,
     initialized: false,
     randomSeed: null,
-    recentSearchSlugs: [],
-    recentSearchesInitialized: false
+    recentSearchQueries: [],
+    recentSearchesInitialized: false,
+    searchQuery: '',
+    searchItems: [],
+    searchPage: 1,
+    searchLimit: 30,
+    searchHasMore: false,
+    searchLoading: false,
+    searchError: null,
+    searchInitialized: false,
+    searchRequestToken: 0
   }),
   actions: {
     reset() {
@@ -73,19 +118,32 @@ export const useExploreStore = defineStore('explore', {
       this.randomSeed = null;
     },
 
+    resetSearch() {
+      this.searchRequestToken += 1;
+      this.searchQuery = '';
+      this.searchItems = [];
+      this.searchPage = 1;
+      this.searchHasMore = false;
+      this.searchLoading = false;
+      this.searchError = null;
+      this.searchInitialized = false;
+    },
+
     initializeRecentSearches() {
       if (this.recentSearchesInitialized) {
         return;
       }
 
-      this.recentSearchSlugs = parseStoredRecentSearchSlugs(window.localStorage.getItem(RECENT_SEARCHES_STORAGE_KEY));
+      this.recentSearchQueries = parseStoredRecentSearchQueries(
+        window.localStorage.getItem(RECENT_SEARCHES_STORAGE_KEY)
+      );
       this.recentSearchesInitialized = true;
     },
 
     persistRecentSearches() {
       window.localStorage.setItem(
         RECENT_SEARCHES_STORAGE_KEY,
-        JSON.stringify(this.recentSearchSlugs.slice(0, RECENT_SEARCH_LIMIT))
+        JSON.stringify(this.recentSearchQueries.slice(0, RECENT_SEARCH_LIMIT))
       );
     },
 
@@ -98,23 +156,37 @@ export const useExploreStore = defineStore('explore', {
       return this.randomSeed;
     },
 
-    recordRecentSearch(slug: string) {
-      const normalizedSlug = slug.trim();
-      if (normalizedSlug.length === 0) {
+    recordRecentSearch(query: string) {
+      const formattedQuery = formatSearchQuery(query);
+      if (formattedQuery.length < MIN_COMMITTED_SEARCH_LENGTH) {
         return;
       }
 
       this.initializeRecentSearches();
-      this.recentSearchSlugs = [
-        normalizedSlug,
-        ...this.recentSearchSlugs.filter((entry) => entry !== normalizedSlug)
-      ].slice(0, RECENT_SEARCH_LIMIT);
+
+      const normalizedQuery = normalizeSearchQuery(formattedQuery);
+      let nextQueries = this.recentSearchQueries.filter(
+        (entry) => normalizeSearchQuery(entry) !== normalizedQuery
+      );
+      const mostRecentQuery = nextQueries[0];
+
+      if (
+        mostRecentQuery &&
+        isPrefixVariant(normalizeSearchQuery(mostRecentQuery), normalizedQuery)
+      ) {
+        nextQueries = nextQueries.slice(1);
+      }
+
+      this.recentSearchQueries = [formattedQuery, ...nextQueries].slice(
+        0,
+        RECENT_SEARCH_LIMIT
+      );
       this.persistRecentSearches();
     },
 
     clearRecentSearches() {
       this.initializeRecentSearches();
-      this.recentSearchSlugs = [];
+      this.recentSearchQueries = [];
       window.localStorage.removeItem(RECENT_SEARCHES_STORAGE_KEY);
     },
 
@@ -145,15 +217,109 @@ export const useExploreStore = defineStore('explore', {
       this.error = null;
 
       try {
-        const payload = await fetchFeed(this.page, this.limit, 'random', this.ensureRandomSeed());
+        const payload = await fetchFeed(
+          this.page,
+          this.limit,
+          'random',
+          this.ensureRandomSeed()
+        );
         this.items.push(...payload.items);
         this.page += 1;
         this.hasMore = payload.hasMore;
         this.initialized = true;
       } catch (error) {
-        this.error = error instanceof Error ? error.message : 'Unable to load explore feed';
+        this.error =
+          error instanceof Error ? error.message : 'Unable to load explore feed';
       } finally {
         this.loading = false;
+      }
+    },
+
+    startSearch(query: string) {
+      const normalizedQuery = query.trim();
+
+      if (normalizedQuery.length === 0) {
+        this.resetSearch();
+        return;
+      }
+
+      this.searchRequestToken += 1;
+      this.searchQuery = normalizedQuery;
+      this.searchItems = [];
+      this.searchPage = 1;
+      this.searchHasMore = true;
+      this.searchLoading = false;
+      this.searchError = null;
+      this.searchInitialized = false;
+    },
+
+    async loadSearch(query: string, force = false) {
+      const normalizedQuery = query.trim();
+
+      if (normalizedQuery.length === 0) {
+        this.resetSearch();
+        return;
+      }
+
+      if (
+        !force &&
+        this.searchQuery === normalizedQuery &&
+        this.searchInitialized
+      ) {
+        return;
+      }
+
+      this.startSearch(normalizedQuery);
+      await this.loadMoreSearch();
+    },
+
+    async loadMoreSearch() {
+      if (
+        this.searchLoading ||
+        !this.searchHasMore ||
+        this.searchQuery.length === 0
+      ) {
+        return;
+      }
+
+      const requestToken = this.searchRequestToken;
+      const query = this.searchQuery;
+      const page = this.searchPage;
+
+      this.searchLoading = true;
+      this.searchError = null;
+
+      try {
+        const payload = await fetchFeedSearch(query, page, this.searchLimit);
+        if (
+          requestToken !== this.searchRequestToken ||
+          query !== this.searchQuery ||
+          page !== this.searchPage
+        ) {
+          return;
+        }
+
+        this.searchItems.push(...payload.items);
+        this.searchPage += 1;
+        this.searchHasMore = payload.hasMore;
+        this.searchInitialized = true;
+      } catch (error) {
+        if (
+          requestToken !== this.searchRequestToken ||
+          query !== this.searchQuery ||
+          page !== this.searchPage
+        ) {
+          return;
+        }
+
+        this.searchError =
+          error instanceof Error ? error.message : 'Unable to search posts';
+        this.searchHasMore = false;
+        this.searchInitialized = true;
+      } finally {
+        if (requestToken === this.searchRequestToken) {
+          this.searchLoading = false;
+        }
       }
     }
   }

--- a/client/src/styles/base.css
+++ b/client/src/styles/base.css
@@ -98,6 +98,19 @@ select {
   font: inherit;
 }
 
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+input[type="search"]::-ms-clear,
+input[type="search"]::-ms-reveal {
+  display: none;
+}
+
 a {
   color: inherit;
   text-decoration: none;
@@ -563,4 +576,3 @@ img[data-loaded="true"] {
     opacity: 0.92;
   }
 }
-

--- a/client/src/views/ExploreView.vue
+++ b/client/src/views/ExploreView.vue
@@ -1,16 +1,14 @@
 <template>
-  <section
-    class="explore-view min-h-[calc(100vh-4rem)]"
-  >
+  <section class="explore-view min-h-[calc(100vh-4rem)]">
     <div
       class="mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-[72rem] flex-col gap-6 px-4 py-5 md:px-6 md:py-7"
     >
       <header
         class="flex items-center gap-3"
-        :class="isSearchActive ? 'max-w-[35rem]' : 'justify-center'"
+        :class="showSearchChrome ? 'max-w-[35rem]' : 'justify-center'"
       >
         <button
-          v-if="isSearchActive"
+          v-if="showSearchChrome"
           class="inline-flex h-11 w-11 items-center justify-center rounded-full border-0 bg-transparent p-0 text-muted transition-colors duration-150 hover:bg-surface-hover hover:text-text"
           type="button"
           aria-label="Back to explore posts"
@@ -67,6 +65,7 @@
             placeholder="Search"
             spellcheck="false"
             @focus="activateSearch"
+            @keydown.enter.prevent="commitSearch()"
             @keydown.esc.prevent="handleEscape"
           />
           <button
@@ -104,32 +103,152 @@
         <p class="m-0 text-muted">{{ appStore.libraryUnavailableReason }}</p>
       </section>
 
-      <section v-else-if="isSearchActive" class="max-w-[35rem]">
-        <div v-if="trimmedSearchQuery.length === 0" class="grid gap-4 pt-2">
+      <section v-else-if="showRecentSearches" class="max-w-[35rem]">
+        <div class="grid gap-4 pt-2">
           <div class="flex items-center justify-between gap-3">
             <h1
               class="m-0 text-[1.45rem] font-semibold tracking-[-0.03em] text-text"
             >
               Recent
             </h1>
+            <button
+              class="explore-view__recent-clear"
+              type="button"
+              @click="clearRecentSearches"
+            >
+              Clear all
+            </button>
           </div>
 
+          <div class="grid gap-1">
+            <button
+              v-for="query in recentSearchQueries"
+              :key="query"
+              class="explore-view__recent-query"
+              type="button"
+              @click="applyRecentSearch(query)"
+            >
+              <span class="explore-view__recent-query-icon" aria-hidden="true">
+                <svg class="h-[1rem] w-[1rem]" viewBox="0 0 24 24" role="presentation">
+                  <circle
+                    cx="11"
+                    cy="11"
+                    r="7"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.8"
+                  />
+                  <path
+                    d="m21 21-4.35-4.35"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.8"
+                  />
+                </svg>
+              </span>
+              <span class="min-w-0 flex-1 truncate text-left text-[0.96rem] text-text">
+                {{ query }}
+              </span>
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section v-else-if="hasActiveQuery" class="grid gap-5">
+        <div
+          class="explore-view__tabs flex flex-wrap gap-2"
+          role="tablist"
+          aria-label="Search result tabs"
+        >
+          <button
+            class="explore-view__tab"
+            :class="{ 'explore-view__tab--active': activeSearchTab === 'media' }"
+            type="button"
+            role="tab"
+            :aria-selected="activeSearchTab === 'media'"
+            @click="selectSearchTab('media')"
+          >
+            Photos &amp; Videos
+          </button>
+          <button
+            class="explore-view__tab"
+            :class="{ 'explore-view__tab--active': activeSearchTab === 'folders' }"
+            type="button"
+            role="tab"
+            :aria-selected="activeSearchTab === 'folders'"
+            @click="selectSearchTab('folders')"
+          >
+            App Folders
+          </button>
+        </div>
+
+        <template v-if="activeSearchTab === 'media'">
+          <div
+            v-if="showSearchLoading"
+            class="explore-view__skeleton-grid"
+            aria-hidden="true"
+          >
+            <div
+              v-for="index in 15"
+              :key="index"
+              class="explore-view__skeleton"
+              :class="index % 6 === 0 ? 'explore-view__skeleton--feature' : ''"
+            />
+          </div>
+
+          <section
+            v-else-if="exploreStore.searchError"
+            class="explore-view__message-card mx-auto"
+          >
+            <h1 class="m-0 text-[1.15rem] font-semibold text-text">
+              Could not search posts
+            </h1>
+            <p class="m-0 text-muted">{{ exploreStore.searchError }}</p>
+          </section>
+
+          <section
+            v-else-if="
+              exploreStore.searchInitialized &&
+              exploreStore.searchItems.length === 0
+            "
+            class="explore-view__message-card mx-auto"
+          >
+            <h1 class="m-0 text-[1.15rem] font-semibold text-text">
+              No matching photos or videos
+            </h1>
+            <p class="m-0 text-muted">
+              Try a different filename or folder keyword.
+            </p>
+          </section>
+
+          <template v-else>
+            <ExploreGrid
+              :items="exploreStore.searchItems"
+              @open="handleSearchMediaOpen"
+            />
+            <InfiniteLoader
+              :loading="exploreStore.searchLoading"
+              :has-more="exploreStore.searchHasMore"
+              @load-more="loadMoreSearch"
+            />
+          </template>
+        </template>
+
+        <section v-else class="max-w-[35rem]">
           <p
             v-if="foldersStore.loadingList && foldersStore.items.length === 0"
             class="m-0 text-[0.96rem] text-muted"
           >
             Loading folders...
           </p>
-          <p
-            v-else-if="recentSearchFolders.length === 0"
-            class="m-0 text-[1rem] text-muted"
-          >
-            No recent searches.
-          </p>
 
           <div v-else class="grid gap-1">
             <button
-              v-for="folder in recentSearchFolders"
+              v-for="folder in folderSearchResults"
               :key="folder.id"
               class="explore-view__result"
               type="button"
@@ -143,47 +262,23 @@
               <span class="min-w-0 flex-1 text-left">
                 <strong
                   class="block truncate text-[0.96rem] font-semibold text-text"
-                  >{{ folder.name }}</strong
                 >
+                  {{ folder.name }}
+                </strong>
                 <span class="block truncate text-[0.84rem] text-muted">
                   {{ describeFolder(folder) }}
                 </span>
               </span>
             </button>
+
+            <p
+              v-if="folderSearchResults.length === 0"
+              class="m-0 pt-2 text-[1rem] text-muted"
+            >
+              No app folders found.
+            </p>
           </div>
-        </div>
-
-        <div v-else class="grid gap-1 pt-2">
-          <button
-            v-for="folder in searchResults"
-            :key="folder.id"
-            class="explore-view__result"
-            type="button"
-            @click="openFolder(folder)"
-          >
-            <Avatar
-              class="h-12 w-12 flex-shrink-0"
-              :name="folder.name"
-              :src="folder.avatarUrl"
-            />
-            <span class="min-w-0 flex-1 text-left">
-              <strong
-                class="block truncate text-[0.96rem] font-semibold text-text"
-                >{{ folder.name }}</strong
-              >
-              <span class="block truncate text-[0.84rem] text-muted">
-                {{ describeFolder(folder) }}
-              </span>
-            </span>
-          </button>
-
-          <p
-            v-if="searchResults.length === 0"
-            class="m-0 pt-2 text-[1rem] text-muted"
-          >
-            No matching folders.
-          </p>
-        </div>
+        </section>
       </section>
 
       <template v-else>
@@ -236,188 +331,448 @@
 </template>
 
 <script setup lang="ts">
-  import { computed, nextTick, onMounted, onUnmounted, ref } from "vue"
-  import { useRouter } from "vue-router"
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 
-  import Avatar from "../components/Avatar.vue"
-  import ExploreGrid from "../components/ExploreGrid.vue"
-  import InfiniteLoader from "../components/InfiniteLoader.vue"
-  import { useAppStore } from "../stores/app"
-  import { useExploreStore } from "../stores/explore"
-  import { useFoldersStore } from "../stores/folders"
-  import { useLikesStore } from "../stores/likes"
-  import type { FolderSummary } from "../types/api"
-  import { searchFolders, rankExploreItems } from "../utils/explore"
-  import { buildLikedCountByFolder } from "../utils/home-recommendations"
+import Avatar from '../components/Avatar.vue';
+import ExploreGrid from '../components/ExploreGrid.vue';
+import InfiniteLoader from '../components/InfiniteLoader.vue';
+import { useAppStore } from '../stores/app';
+import { useExploreStore } from '../stores/explore';
+import { useFoldersStore } from '../stores/folders';
+import { useLikesStore } from '../stores/likes';
+import type { FolderSummary } from '../types/api';
+import { searchFolders, rankExploreItems } from '../utils/explore';
+import { buildLikedCountByFolder } from '../utils/home-recommendations';
 
-  const RESULT_LIMIT = 12
+type SearchTab = 'media' | 'folders';
 
-  const appStore = useAppStore()
-  const exploreStore = useExploreStore()
-  const foldersStore = useFoldersStore()
-  const likesStore = useLikesStore()
-  const router = useRouter()
+const SEARCH_DEBOUNCE_MS = 180;
 
-  const searchInput = ref<HTMLInputElement | null>(null)
-  const searchQuery = ref("")
-  const isSearchActive = ref(false)
+const appStore = useAppStore();
+const exploreStore = useExploreStore();
+const foldersStore = useFoldersStore();
+const likesStore = useLikesStore();
+const route = useRoute();
+const router = useRouter();
 
-  const likedCountByFolder = computed(() =>
-    buildLikedCountByFolder(likesStore.items),
+const searchInput = ref<HTMLInputElement | null>(null);
+const searchQuery = ref(readRouteQueryValue(route.query.q));
+const isSearchActive = ref(searchQuery.value.trim().length > 0);
+const activeSearchTab = ref<SearchTab>(
+  searchQuery.value.trim().length > 0 ? parseSearchTab(route.query.tab) : 'media'
+);
+
+let searchDebounceTimer: number | null = null;
+
+const likedCountByFolder = computed(() =>
+  buildLikedCountByFolder(likesStore.items)
+);
+const trimmedSearchQuery = computed(() => searchQuery.value.trim());
+const hasActiveQuery = computed(() => trimmedSearchQuery.value.length > 0);
+const recentSearchQueries = computed(() => exploreStore.recentSearchQueries);
+const showRecentSearches = computed(
+  () =>
+    isSearchActive.value &&
+    !hasActiveQuery.value &&
+    recentSearchQueries.value.length > 0
+);
+const showSearchChrome = computed(
+  () => hasActiveQuery.value || showRecentSearches.value
+);
+const folderSearchResults = computed(() =>
+  searchFolders(foldersStore.items, trimmedSearchQuery.value)
+);
+const rankedItems = computed(() =>
+  rankExploreItems(
+    exploreStore.items,
+    foldersStore.items,
+    likedCountByFolder.value,
+    appStore.recentOpenedFolderSlugs,
+    appStore.lastOpenedFolderSlug
   )
-  const trimmedSearchQuery = computed(() => searchQuery.value.trim())
-  const searchResults = computed(() =>
-    searchFolders(foldersStore.items, trimmedSearchQuery.value).slice(
-      0,
-      RESULT_LIMIT,
-    ),
-  )
-  const recentSearchFolders = computed(() =>
-    exploreStore.recentSearchSlugs
-      .map(
-        slug => foldersStore.items.find(folder => folder.slug === slug) ?? null,
-      )
-      .filter((folder): folder is FolderSummary => folder !== null),
-  )
-  const rankedItems = computed(() =>
-    rankExploreItems(
-      exploreStore.items,
-      foldersStore.items,
-      likedCountByFolder.value,
-      appStore.recentOpenedFolderSlugs,
-      appStore.lastOpenedFolderSlug,
-    ),
-  )
-  const showInitialLoading = computed(
-    () =>
-      exploreStore.loading &&
-      exploreStore.items.length === 0 &&
-      !exploreStore.error,
-  )
+);
+const showInitialLoading = computed(
+  () =>
+    exploreStore.loading &&
+    exploreStore.items.length === 0 &&
+    !exploreStore.error
+);
+const showSearchLoading = computed(
+  () =>
+    activeSearchTab.value === 'media' &&
+    exploreStore.searchLoading &&
+    exploreStore.searchItems.length === 0 &&
+    !exploreStore.searchError
+);
 
-  function activateSearch() {
-    isSearchActive.value = true
-  }
+watch(
+  () => [route.query.q, route.query.tab] as const,
+  ([routeQuery, routeTab]) => {
+    const nextQuery = readRouteQueryValue(routeQuery);
+    const hasRouteQuery = nextQuery.trim().length > 0;
 
-  async function closeSearch() {
-    searchQuery.value = ""
-    isSearchActive.value = false
-    await nextTick()
-    searchInput.value?.blur()
-  }
-
-  async function clearSearch() {
-    searchQuery.value = ""
-    await nextTick()
-    searchInput.value?.focus()
-  }
-
-  async function handleEscape() {
-    if (searchQuery.value.length > 0) {
-      await clearSearch()
-      return
+    if (nextQuery !== searchQuery.value) {
+      searchQuery.value = nextQuery;
     }
 
-    await closeSearch()
-  }
-
-  async function openFolder(folder: FolderSummary) {
-    exploreStore.recordRecentSearch(folder.slug)
-    await router.push({ name: "folder", params: { slug: folder.slug } })
-  }
-
-  function describeFolder(folder: FolderSummary): string {
-    const location = folder.breadcrumb ?? folder.folderPath
-    const postLabel = `${folder.imageCount} post${folder.imageCount === 1 ? "" : "s"}`
-
-    return `${location} • ${postLabel}`
-  }
-
-  async function loadMore() {
-    await exploreStore.loadMore()
-  }
-
-  function handleWindowKeydown(event: KeyboardEvent) {
-    if (event.key !== "Escape" || !isSearchActive.value) {
-      return
+    const nextTab = hasRouteQuery ? parseSearchTab(routeTab) : 'media';
+    if (nextTab !== activeSearchTab.value) {
+      activeSearchTab.value = nextTab;
     }
 
-    void handleEscape()
+    if (hasRouteQuery) {
+      isSearchActive.value = true;
+    }
+  },
+  { immediate: true }
+);
+
+watch([trimmedSearchQuery, activeSearchTab], ([query, tab]) => {
+  const currentQuery = readRouteQueryValue(route.query.q).trim();
+  const currentTab =
+    currentQuery.length > 0 ? parseSearchTab(route.query.tab) : 'media';
+  const nextTab = query.length > 0 ? tab : 'media';
+
+  if (currentQuery === query && currentTab === nextTab) {
+    return;
   }
 
-  onMounted(async () => {
-    exploreStore.initializeRecentSearches()
+  const nextRouteQuery = {
+    ...route.query
+  };
 
-    const tasks: Array<Promise<unknown>> = []
-    if (foldersStore.items.length === 0) {
-      tasks.push(foldersStore.fetchFolders())
+  if (query.length > 0) {
+    nextRouteQuery.q = query;
+    if (tab === 'folders') {
+      nextRouteQuery.tab = 'folders';
+    } else {
+      delete nextRouteQuery.tab;
+    }
+  } else {
+    delete nextRouteQuery.q;
+    delete nextRouteQuery.tab;
+  }
+
+  void router.replace({
+    name: 'explore',
+    query: nextRouteQuery
+  });
+});
+
+watch(
+  trimmedSearchQuery,
+  (query, previousQuery) => {
+    const previousValue = previousQuery ?? '';
+
+    if (searchDebounceTimer !== null) {
+      window.clearTimeout(searchDebounceTimer);
+      searchDebounceTimer = null;
     }
 
-    if (!appStore.isLibraryUnavailable) {
-      tasks.push(exploreStore.loadInitial())
+    if (query.length === 0) {
+      exploreStore.resetSearch();
+      activeSearchTab.value = 'media';
+
+      if (previousValue.length > 0) {
+        isSearchActive.value = recentSearchQueries.value.length > 0;
+      }
+
+      return;
     }
 
-    window.addEventListener("keydown", handleWindowKeydown)
-    await Promise.all(tasks)
-  })
+    isSearchActive.value = true;
+    searchDebounceTimer = window.setTimeout(() => {
+      void exploreStore.loadSearch(query, true);
+    }, SEARCH_DEBOUNCE_MS);
+  },
+  { immediate: true }
+);
 
-  onUnmounted(() => {
-    window.removeEventListener("keydown", handleWindowKeydown)
-  })
+function activateSearch() {
+  isSearchActive.value = true;
+}
+
+function commitSearch(query = trimmedSearchQuery.value) {
+  exploreStore.recordRecentSearch(query);
+}
+
+async function applyRecentSearch(query: string) {
+  commitSearch(query);
+  activeSearchTab.value = 'media';
+  isSearchActive.value = true;
+  searchQuery.value = query;
+
+  await nextTick();
+  searchInput.value?.focus();
+  searchInput.value?.setSelectionRange(query.length, query.length);
+}
+
+async function clearRecentSearches() {
+  exploreStore.clearRecentSearches();
+
+  if (!hasActiveQuery.value) {
+    isSearchActive.value = false;
+  }
+
+  await nextTick();
+  searchInput.value?.focus();
+}
+
+async function closeSearch() {
+  if (searchDebounceTimer !== null) {
+    window.clearTimeout(searchDebounceTimer);
+    searchDebounceTimer = null;
+  }
+
+  searchQuery.value = '';
+  activeSearchTab.value = 'media';
+  isSearchActive.value = false;
+  exploreStore.resetSearch();
+
+  await nextTick();
+  searchInput.value?.blur();
+}
+
+async function clearSearch() {
+  if (searchDebounceTimer !== null) {
+    window.clearTimeout(searchDebounceTimer);
+    searchDebounceTimer = null;
+  }
+
+  searchQuery.value = '';
+  activeSearchTab.value = 'media';
+  exploreStore.resetSearch();
+
+  await nextTick();
+  isSearchActive.value = recentSearchQueries.value.length > 0;
+  searchInput.value?.focus();
+}
+
+async function handleEscape() {
+  if (hasActiveQuery.value || showRecentSearches.value) {
+    await closeSearch();
+    return;
+  }
+
+  searchInput.value?.blur();
+}
+
+function selectSearchTab(tab: SearchTab) {
+  activeSearchTab.value = tab;
+}
+
+async function openFolder(folder: FolderSummary) {
+  commitSearch();
+  await router.push({ name: 'folder', params: { slug: folder.slug } });
+}
+
+function handleSearchMediaOpen() {
+  commitSearch();
+}
+
+function describeFolder(folder: FolderSummary): string {
+  const location = folder.breadcrumb ?? folder.folderPath;
+  const postLabel = `${folder.imageCount} post${folder.imageCount === 1 ? '' : 's'}`;
+
+  return `${location} • ${postLabel}`;
+}
+
+async function loadMore() {
+  await exploreStore.loadMore();
+}
+
+async function loadMoreSearch() {
+  if (activeSearchTab.value !== 'media') {
+    return;
+  }
+
+  await exploreStore.loadMoreSearch();
+}
+
+function handleWindowKeydown(event: KeyboardEvent) {
+  if (event.key !== 'Escape' || !showSearchChrome.value) {
+    return;
+  }
+
+  void handleEscape();
+}
+
+onMounted(async () => {
+  exploreStore.initializeRecentSearches();
+
+  const tasks: Array<Promise<unknown>> = [];
+  if (foldersStore.items.length === 0) {
+    tasks.push(foldersStore.fetchFolders());
+  }
+
+  if (!appStore.isLibraryUnavailable) {
+    tasks.push(exploreStore.loadInitial());
+  }
+
+  window.addEventListener('keydown', handleWindowKeydown);
+  await Promise.all(tasks);
+});
+
+onUnmounted(() => {
+  if (searchDebounceTimer !== null) {
+    window.clearTimeout(searchDebounceTimer);
+  }
+
+  window.removeEventListener('keydown', handleWindowKeydown);
+});
+
+function readRouteQueryValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return typeof value[0] === 'string' ? value[0] : '';
+  }
+
+  return '';
+}
+
+function parseSearchTab(value: unknown): SearchTab {
+  return readRouteQueryValue(value) === 'folders' ? 'folders' : 'media';
+}
 </script>
 
 <style scoped>
-  .explore-view__search {
-    box-shadow: inset 0 1px 0 var(--border);
-  }
+.explore-view__search {
+  box-shadow: inset 0 1px 0 var(--border);
+}
 
-  .explore-view__result {
-    display: flex;
-    align-items: center;
-    gap: 0.9rem;
-    width: 100%;
-    padding: 0.65rem 0.3rem;
-    border: 0;
-    background: transparent;
-    cursor: pointer;
-    color: inherit;
-    transition: background-color 0.15s ease;
-  }
+.explore-view__tabs {
+  align-items: center;
+}
 
-  .explore-view__result:hover {
-    background: var(--surface-hover);
-  }
+.explore-view__tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.6rem;
+  padding: 0.62rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease,
+    transform 0.15s ease;
+}
 
-  .explore-view__message-card {
-    display: grid;
-    gap: 0.6rem;
-    padding: 1.35rem 1.45rem;
-    border: 1px solid var(--border);
-    border-radius: 1rem;
-    background: var(--surface);
-  }
+.explore-view__tab:hover {
+  border-color: color-mix(in srgb, var(--border) 52%, var(--accent) 48%);
+  color: var(--text);
+  transform: translateY(-1px);
+}
 
+.explore-view__tab--active {
+  border-color: transparent;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--accent) 88%, white 12%),
+    color-mix(in srgb, var(--accent-strong) 84%, white 16%)
+  );
+  color: #ffffff;
+  box-shadow: 0 14px 28px rgba(0, 149, 246, 0.18);
+}
+
+.explore-view__recent-clear {
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.15s ease;
+}
+
+.explore-view__recent-clear:hover {
+  color: var(--text);
+}
+
+.explore-view__recent-query {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  width: 100%;
+  padding: 0.72rem 0.3rem;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.explore-view__recent-query:hover {
+  background: var(--surface-hover);
+}
+
+.explore-view__recent-query-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.explore-view__result {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  width: 100%;
+  padding: 0.65rem 0.3rem;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  color: inherit;
+  transition: background-color 0.15s ease;
+}
+
+.explore-view__result:hover {
+  background: var(--surface-hover);
+}
+
+.explore-view__message-card {
+  display: grid;
+  gap: 0.6rem;
+  padding: 1.35rem 1.45rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: var(--surface);
+}
+
+.explore-view__skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-auto-flow: dense;
+  gap: 0.2rem;
+}
+
+.explore-view__skeleton {
+  aspect-ratio: 1 / 1;
+  background: var(--surface-alt);
+  animation: pulse 1.3s ease-in-out infinite;
+}
+
+@media (min-width: 1080px) {
   .explore-view__skeleton-grid {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    grid-auto-flow: dense;
-    gap: 0.2rem;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
-  .explore-view__skeleton {
-    aspect-ratio: 1 / 1;
-    background: var(--surface-alt);
-    animation: pulse 1.3s ease-in-out infinite;
+  .explore-view__skeleton--feature {
+    grid-column: span 2;
+    grid-row: span 2;
   }
-
-  @media (min-width: 1080px) {
-    .explore-view__skeleton-grid {
-      grid-template-columns: repeat(4, minmax(0, 1fr));
-    }
-
-    .explore-view__skeleton--feature {
-      grid-column: span 2;
-      grid-row: span 2;
-    }
-  }
+}
 </style>

--- a/server/src/db/repositories.ts
+++ b/server/src/db/repositories.ts
@@ -23,6 +23,25 @@ const COVER_FILENAMES = ['cover.jpg', 'cover.jpeg', 'cover.png', 'cover.webp', '
 const COVER_FILENAME_SQL = COVER_FILENAMES.map((name) => `'${name}'`).join(', ');
 const VISIBLE_IMAGE_WHERE_SQL = `images.is_deleted = 0 AND images.is_trashed = 0 AND LOWER(images.filename) NOT IN (${COVER_FILENAME_SQL})`;
 const VISIBLE_IMAGE_WHERE_UNSCOPED_SQL = `is_deleted = 0 AND is_trashed = 0 AND LOWER(filename) NOT IN (${COVER_FILENAME_SQL})`;
+const IMAGE_FILENAME_SEARCH_SQL = 'LOWER(images.filename)';
+const FOLDER_NAME_SEARCH_SQL = 'LOWER(folders.name)';
+const FOLDER_SLUG_SEARCH_SQL = 'LOWER(folders.slug)';
+const FOLDER_PATH_SEARCH_SQL = 'LOWER(folders.folder_path)';
+const EXIF_CAMERA_MAKE_SEARCH_SQL =
+  "LOWER(COALESCE(CASE WHEN json_valid(images.exif_json) THEN json_extract(images.exif_json, '$.cameraMake') END, ''))";
+const EXIF_CAMERA_MODEL_SEARCH_SQL =
+  "LOWER(COALESCE(CASE WHEN json_valid(images.exif_json) THEN json_extract(images.exif_json, '$.cameraModel') END, ''))";
+const EXIF_LENS_MODEL_SEARCH_SQL =
+  "LOWER(COALESCE(CASE WHEN json_valid(images.exif_json) THEN json_extract(images.exif_json, '$.lensModel') END, ''))";
+const MEDIA_SEARCH_FIELD_SQL = [
+  IMAGE_FILENAME_SEARCH_SQL,
+  FOLDER_NAME_SEARCH_SQL,
+  FOLDER_SLUG_SEARCH_SQL,
+  FOLDER_PATH_SEARCH_SQL,
+  EXIF_CAMERA_MAKE_SEARCH_SQL,
+  EXIF_CAMERA_MODEL_SEARCH_SQL,
+  EXIF_LENS_MODEL_SEARCH_SQL
+] as const;
 const FEED_IMAGE_SELECT_SQL = `
   SELECT
     images.id,
@@ -45,12 +64,112 @@ const FEED_IMAGE_SELECT_SQL = `
   INNER JOIN folders ON folders.id = images.folder_id
 `;
 
+interface MediaSearchSql {
+  whereSql: string;
+  whereParams: string[];
+  rankSql: string;
+  rankParams: string[];
+}
+
 function nowIso(): string {
   return new Date().toISOString();
 }
 
 function serializeAnimatedFlag(isAnimated: boolean | null | undefined): number {
   return isAnimated ? 1 : 0;
+}
+
+function normalizeSearchQuery(query: string): string {
+  return query.trim().toLocaleLowerCase().replace(/\s+/g, ' ');
+}
+
+function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, '\\$&');
+}
+
+function buildMediaSearchSql(query: string): MediaSearchSql | null {
+  const normalizedQuery = normalizeSearchQuery(query);
+  if (normalizedQuery.length === 0) {
+    return null;
+  }
+
+  const normalizedTokens = [...new Set(normalizedQuery.split(' ').filter(Boolean))];
+  const tokenClauseSql = `(${MEDIA_SEARCH_FIELD_SQL.map((fieldSql) => `${fieldSql} LIKE ? ESCAPE '\\'`).join(' OR ')})`;
+  const whereSql = normalizedTokens.map(() => tokenClauseSql).join(' AND ');
+  const whereParams = normalizedTokens.flatMap((token) =>
+    MEDIA_SEARCH_FIELD_SQL.map(() => `%${escapeLikePattern(token)}%`)
+  );
+  const queryContainsPattern = `%${escapeLikePattern(normalizedQuery)}%`;
+  const queryPrefixPattern = `${escapeLikePattern(normalizedQuery)}%`;
+
+  const rankSqlParts = [
+    `CASE
+      WHEN ${IMAGE_FILENAME_SEARCH_SQL} = ? THEN 240
+      WHEN ${IMAGE_FILENAME_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 180
+      WHEN ${IMAGE_FILENAME_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 140
+      ELSE 0
+    END`,
+    `CASE
+      WHEN ${FOLDER_NAME_SEARCH_SQL} = ? THEN 120
+      WHEN ${FOLDER_NAME_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 84
+      WHEN ${FOLDER_NAME_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 56
+      ELSE 0
+    END`,
+    `CASE
+      WHEN ${FOLDER_SLUG_SEARCH_SQL} = ? THEN 76
+      WHEN ${FOLDER_SLUG_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 52
+      WHEN ${FOLDER_SLUG_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 36
+      ELSE 0
+    END`,
+    `CASE WHEN ${FOLDER_PATH_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 32 ELSE 0 END`,
+    `CASE WHEN ${EXIF_CAMERA_MAKE_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 20 ELSE 0 END`,
+    `CASE WHEN ${EXIF_CAMERA_MODEL_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 20 ELSE 0 END`,
+    `CASE WHEN ${EXIF_LENS_MODEL_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 18 ELSE 0 END`
+  ];
+  const rankParams: string[] = [
+    normalizedQuery,
+    queryPrefixPattern,
+    queryContainsPattern,
+    normalizedQuery,
+    queryPrefixPattern,
+    queryContainsPattern,
+    normalizedQuery,
+    queryPrefixPattern,
+    queryContainsPattern,
+    queryContainsPattern,
+    queryContainsPattern,
+    queryContainsPattern,
+    queryContainsPattern
+  ];
+
+  for (const token of normalizedTokens) {
+    const tokenPattern = `%${escapeLikePattern(token)}%`;
+    rankSqlParts.push(
+      `CASE WHEN ${IMAGE_FILENAME_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 18 ELSE 0 END`,
+      `CASE WHEN ${FOLDER_NAME_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 12 ELSE 0 END`,
+      `CASE WHEN ${FOLDER_SLUG_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 8 ELSE 0 END`,
+      `CASE WHEN ${FOLDER_PATH_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 8 ELSE 0 END`,
+      `CASE WHEN ${EXIF_CAMERA_MAKE_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 6 ELSE 0 END`,
+      `CASE WHEN ${EXIF_CAMERA_MODEL_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 6 ELSE 0 END`,
+      `CASE WHEN ${EXIF_LENS_MODEL_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 6 ELSE 0 END`
+    );
+    rankParams.push(
+      tokenPattern,
+      tokenPattern,
+      tokenPattern,
+      tokenPattern,
+      tokenPattern,
+      tokenPattern,
+      tokenPattern
+    );
+  }
+
+  return {
+    whereSql,
+    whereParams,
+    rankSql: rankSqlParts.join(' + '),
+    rankParams
+  };
 }
 
 export interface UpsertFolderInput {
@@ -514,6 +633,28 @@ export const imageRepository = {
     );
   },
 
+  countVisibleSearch(query: string): number {
+    const mediaSearch = buildMediaSearchSql(query);
+    if (!mediaSearch) {
+      return 0;
+    }
+
+    return Number(
+      (
+        database
+          .prepare(
+            `
+            SELECT COUNT(*) AS count
+            FROM images
+            INNER JOIN folders ON folders.id = images.folder_id
+            WHERE ${VISIBLE_IMAGE_WHERE_SQL} AND ${mediaSearch.whereSql}
+            `
+          )
+          .get(...mediaSearch.whereParams) as { count: number }
+      ).count
+    );
+  },
+
   listRecentCandidates(offset: number, limit: number): FeedImage[] {
     return database.prepare(
       `
@@ -561,6 +702,61 @@ export const imageRepository = {
       LIMIT ? OFFSET ?
       `
     ).all(seed, limit, offset) as unknown as FeedImage[];
+  },
+
+  listVisibleSearch(query: string, page: number, limit: number): FeedImage[] {
+    const mediaSearch = buildMediaSearchSql(query);
+    if (!mediaSearch) {
+      return [];
+    }
+
+    const offset = (page - 1) * limit;
+    return database.prepare(
+      `
+      SELECT
+        search_results.id,
+        search_results.folderId,
+        search_results.folderSlug,
+        search_results.folderName,
+        search_results.folderPath,
+        search_results.filename,
+        search_results.width,
+        search_results.height,
+        search_results.mediaType,
+        search_results.durationMs,
+        search_results.isAnimated,
+        search_results.thumbnailUrl,
+        search_results.previewUrl,
+        search_results.playbackStrategy,
+        search_results.sortTimestamp,
+        search_results.takenAt
+      FROM (
+        SELECT
+          images.id,
+          images.folder_id AS folderId,
+          folders.slug AS folderSlug,
+          folders.name AS folderName,
+          folders.folder_path AS folderPath,
+          images.filename,
+          images.width,
+          images.height,
+          images.media_type AS mediaType,
+          images.duration_ms AS durationMs,
+          images.is_animated AS isAnimated,
+          images.thumbnail_path AS thumbnailUrl,
+          images.preview_path AS previewUrl,
+          images.playback_strategy AS playbackStrategy,
+          images.sort_timestamp AS sortTimestamp,
+          images.taken_at AS takenAt,
+          (${mediaSearch.rankSql}) AS searchRank
+        FROM images
+        INNER JOIN folders ON folders.id = images.folder_id
+        WHERE ${VISIBLE_IMAGE_WHERE_SQL} AND ${mediaSearch.whereSql}
+      ) AS search_results
+      ORDER BY search_results.searchRank DESC, search_results.sortTimestamp DESC, search_results.id DESC
+      LIMIT ? OFFSET ?
+      `
+    ).all(...mediaSearch.rankParams, ...mediaSearch.whereParams, limit, offset) as unknown as FeedImage[];
   },
 
   countByMonthDayKeys(monthDayKeys: string[], maxYearExclusive: number): number {

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -39,6 +39,9 @@ const feedQuerySchema = paginationQuerySchema.extend({
   mode: z.enum(['recent', 'rediscover', 'random']).default('random'),
   seed: z.coerce.number().int().nonnegative().optional()
 });
+const mediaSearchQuerySchema = paginationQuerySchema.extend({
+  q: z.string().trim().min(1).max(160)
+});
 const homeFeedDefaultBodySchema = z.object({
   defaultMode: z.enum(['recent', 'rediscover', 'random'])
 });
@@ -277,6 +280,11 @@ router.put('/auth/viewer-access', authRateLimiter, (request, response) => {
 router.get('/feed', (request, response) => {
   const query = feedQuerySchema.parse(request.query);
   response.json(galleryService.getFeed(query.page, query.limit, query.mode, query.seed));
+});
+
+router.get('/feed/search', (request, response) => {
+  const query = mediaSearchQuerySchema.parse(request.query);
+  response.json(galleryService.searchMedia(query.q, query.page, query.limit));
 });
 
 router.get('/status', (_request, response) => {

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -660,6 +660,34 @@ export const galleryService = {
     };
   },
 
+  searchMedia(query: string, page: number, limit: number) {
+    if (!storageService.getState().libraryAvailable) {
+      return {
+        items: [],
+        page,
+        limit,
+        total: 0,
+        hasMore: false
+      };
+    }
+
+    const normalizedQuery = query.trim();
+    if (normalizedQuery.length === 0) {
+      return {
+        items: [],
+        page,
+        limit,
+        total: 0,
+        hasMore: false
+      };
+    }
+
+    const total = imageRepository.countVisibleSearch(normalizedQuery);
+    const items = total > 0 ? imageRepository.listVisibleSearch(normalizedQuery, page, limit) : [];
+
+    return buildPaginatedPayload(mapFeedItems(items), page, limit, total);
+  },
+
   listMoments() {
     if (!storageService.getState().libraryAvailable) {
       return {

--- a/server/test/media-search.test.ts
+++ b/server/test/media-search.test.ts
@@ -1,0 +1,183 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createFingerprint,
+  getMediaTypeFromExtension,
+  getMimeTypeFromExtension,
+  getPreviewRelativePath,
+  getThumbnailRelativePath
+} from '../src/utils/image-utils.js';
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type GalleryServiceModule = typeof import('../src/services/gallery-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type ModelsModule = typeof import('../src/types/models.js');
+
+type ImageRecord = ModelsModule['ImageRecord'];
+type MediaType = ModelsModule['MediaType'];
+
+describe.sequential('media search', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let galleryService: GalleryServiceModule['galleryService'];
+  let folderRepository: RepositoriesModule['folderRepository'];
+  let imageRepository: RepositoriesModule['imageRepository'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-media-search-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.resetModules();
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ galleryService } = await import('../src/services/gallery-service.js'));
+    ({ folderRepository, imageRepository } = await import('../src/db/repositories.js'));
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('matches filename substrings case-insensitively and paginates mixed media results', async () => {
+    const redPandaPhoto = await createIndexedMedia('animals/red-pandas', 'redpanda.JPG', 1_777_000_000_000);
+    const redPandaVideo = await createIndexedMedia('animals/red-pandas', 'RED_PANDA.mp4', 1_777_000_000_500);
+    await createIndexedMedia('animals/alpacas', 'alpaca.jpg', 1_777_000_001_000);
+
+    const firstPage = galleryService.searchMedia('PANDA', 1, 1);
+    const secondPage = galleryService.searchMedia('PANDA', 2, 1);
+
+    expect(firstPage.total).toBe(2);
+    expect(firstPage.hasMore).toBe(true);
+    expect(secondPage.hasMore).toBe(false);
+
+    const resultIds = new Set([...firstPage.items, ...secondPage.items].map((item) => item.id));
+    expect(resultIds).toEqual(new Set([redPandaPhoto.id, redPandaVideo.id]));
+    expect(firstPage.items[0]?.mediaType).toBe('video');
+  });
+
+  it('matches partial multi-token queries across compact and underscore filenames', async () => {
+    const compact = await createIndexedMedia('wildlife', 'redpanda.jpg', 1_777_100_000_000);
+    const underscored = await createIndexedMedia('wildlife', 'red_panda.mp4', 1_777_100_000_500);
+
+    const payload = galleryService.searchMedia('red panda', 1, 20);
+
+    expect(payload.total).toBe(2);
+    expect(new Set(payload.items.map((item) => item.id))).toEqual(new Set([compact.id, underscored.id]));
+  });
+
+  it('excludes deleted, trashed, and hidden cover media from search results', async () => {
+    const visible = await createIndexedMedia('travel/sunrise', 'sunrise-visible.jpg', 1_777_200_000_000);
+    const deleted = await createIndexedMedia('travel/sunrise', 'sunrise-deleted.jpg', 1_777_200_000_500);
+    const trashed = await createIndexedMedia('travel/sunrise', 'sunrise-trashed.jpg', 1_777_200_001_000);
+    await createIndexedMedia('travel/sunrise', 'cover.jpg', 1_777_200_001_500);
+
+    imageRepository.markDeleted(deleted.relative_path);
+    expect(imageRepository.moveToTrash(trashed.id)).toBe(true);
+
+    const sunriseResults = galleryService.searchMedia('sunrise', 1, 20);
+    const coverResults = galleryService.searchMedia('cover', 1, 20);
+
+    expect(sunriseResults.total).toBe(1);
+    expect(sunriseResults.items.map((item) => item.id)).toEqual([visible.id]);
+    expect(coverResults.total).toBe(0);
+    expect(coverResults.items).toEqual([]);
+  });
+
+  it('searches selected exif text fields without relying on raw json matching', async () => {
+    const cameraMatch = await createIndexedMedia(
+      'gear/fuji',
+      'street-shot.jpg',
+      1_777_300_000_000,
+      JSON.stringify({
+        cameraMake: 'Fujifilm',
+        cameraModel: 'X100VI',
+        lensModel: 'Summilux 28'
+      })
+    );
+    await createIndexedMedia(
+      'gear/other',
+      'different-shot.jpg',
+      1_777_300_000_500,
+      JSON.stringify({
+        cameraMake: 'Canon',
+        cameraModel: 'R6',
+        lensModel: 'RF 35mm'
+      })
+    );
+
+    expect(galleryService.searchMedia('fujifilm', 1, 20).items.map((item) => item.id)).toEqual([cameraMatch.id]);
+    expect(galleryService.searchMedia('x100vi', 1, 20).items.map((item) => item.id)).toEqual([cameraMatch.id]);
+    expect(galleryService.searchMedia('summilux', 1, 20).items.map((item) => item.id)).toEqual([cameraMatch.id]);
+  });
+
+  async function createIndexedMedia(
+    folderPath: string,
+    filename: string,
+    timestamp: number,
+    exifJson = '{}'
+  ): Promise<ImageRecord> {
+    const folderName = path.posix.basename(folderPath);
+    const folder = folderRepository.upsert({
+      slug: folderPath.replaceAll('/', '-'),
+      name: folderName,
+      folderPath
+    });
+    const relativePath = `${folderPath}/${filename}`;
+    const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+    const extension = path.extname(filename).toLowerCase();
+    const mediaType = getMediaTypeFromExtension(extension);
+    const thumbnailPath = getThumbnailRelativePath(relativePath);
+    const previewPath = getPreviewRelativePath(relativePath, mediaType);
+
+    return imageRepository.upsert({
+      folderId: folder.id,
+      filename,
+      extension,
+      relativePath,
+      absolutePath,
+      fileSize: 2_048,
+      width: mediaType === 'video' ? 1080 : 1600,
+      height: mediaType === 'video' ? 1920 : 1200,
+      mediaType,
+      mimeType: getMimeTypeFromExtension(extension),
+      durationMs: getDurationForMediaType(mediaType),
+      isAnimated: false,
+      fingerprint: createFingerprint(relativePath, 2_048, timestamp),
+      mtimeMs: timestamp,
+      firstSeenAt: new Date(timestamp).toISOString(),
+      sortTimestamp: timestamp,
+      takenAt: timestamp,
+      takenAtSource: 'mtime',
+      exifJson,
+      thumbnailPath,
+      previewPath
+    });
+  }
+
+  function getDurationForMediaType(mediaType: MediaType): number | null {
+    return mediaType === 'video' ? 12_000 : null;
+  }
+});


### PR DESCRIPTION
Closes #15 

This PR adds tabbed search to /explore, with paginated media results and folder results while keeping the existing default explore grid unchanged when the query is empty. It also adds committed recent-search history in localStorage, improves the search flow so partial typed queries are not saved as separate entries, and removes the duplicate native clear icon so the custom search clear control is the only one shown.