### PR TITLE
Fix rotated feed videos and home feed playback interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,20 @@
 
 Foldergram is a self-hosted web application that turns your local folders into a beautiful, instagram-style feed and profile. It turns your local folder to app folders (profiles), and serves a lightning-fast Progressive Web App (PWA).
 
-Foldergram indexes supported media from a configured `GALLERY_ROOT`, stores metadata in SQLite, generates thumbnails and previews, and serves a fast feed-style web app for local browsing. Derivatives can be generated during scans or lazily on first request, and image detail pages can be configured to use generated previews or originals. The current app includes Home, Explore, Library, Likes, Moments or Highlights, App Folder pages, post detail views, delete actions, scan controls, and rebuild tools.
+Foldergram indexes supported media from a configured `GALLERY_ROOT`, stores metadata in SQLite, generates thumbnails and previews, and serves a fast feed-style web app for local browsing. Derivatives can be generated during scans or lazily on first request, and image detail pages can be configured to use generated previews or originals. The current app includes Home, Reels, Explore, Library, Likes, Moments or Highlights, App Folder pages, post detail views, delete actions, scan controls, and rebuild tools.
 
 ## Features
 
 - **Instagram-Inspired UI:** Enjoy a familiar feed layout, dedicated app folders (profiles), and a media viewer.
 - Home feed with `Recent`, `Rediscover`, and `Random` modes.
+- A dedicated `/reels` route with a video-only queue. Settings can default it to `Recommended`, `Recent`, or `Random`.
 - A top rail that shows `Moments` when capture-date coverage is strong, or `Highlights` when it is not.
 - Library browsing with App Folder search, sorting, and delete actions.
-- App Folder pages with a posts grid and a `Reels` tab when videos exist.
+- App Folder pages with a posts grid and a folder-specific `Reels` tab when videos exist.
 - Shared likes in SQLite for signed-in admin/viewer sessions, plus browser-local favorites in public mode.
 - Image and video support with configurable eager or lazy derivative generation for fast browsing.
 - Optional role-based local access with admin, viewer, and public browse modes.
-- Settings actions for manual scan, thumbnail rebuild, and library-index rebuild.
+- Settings actions for Home/Reels default modes, manual scan, thumbnail rebuild, and library-index rebuild.
 - A web app manifest plus production service worker registration.
 - A debounced filesystem watcher in development mode only.
 - No multi-user accounts, cloud sync, uploads, comments, messaging, notifications, or remote APIs.

--- a/client/src/components/FeedCard.test.ts
+++ b/client/src/components/FeedCard.test.ts
@@ -1,0 +1,202 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { FeedItem } from '../types/api';
+import FeedCard from './FeedCard.vue';
+
+vi.mock('vidstack/bundle', () => ({}));
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router');
+
+  return {
+    ...actual,
+    useRoute: () => ({
+      fullPath: '/'
+    })
+  };
+});
+
+class FakeMediaPlayerElement extends HTMLElement {
+  muted = true;
+  paused = true;
+  playCallCount = 0;
+  pauseCallCount = 0;
+
+  async play() {
+    this.playCallCount += 1;
+    this.paused = false;
+  }
+
+  async pause() {
+    this.pauseCallCount += 1;
+    this.paused = true;
+  }
+}
+
+class FakeMediaProviderElement extends HTMLElement {}
+class FakeMediaPosterElement extends HTMLElement {}
+class FakeMediaControlsElement extends HTMLElement {}
+class FakeMediaControlsGroupElement extends HTMLElement {}
+class FakeMediaPlayButtonElement extends HTMLElement {}
+class FakeMediaMuteButtonElement extends HTMLElement {}
+class FakeMediaFullscreenButtonElement extends HTMLElement {}
+
+if (!customElements.get('media-player')) {
+  customElements.define('media-player', FakeMediaPlayerElement);
+}
+
+if (!customElements.get('media-provider')) {
+  customElements.define('media-provider', FakeMediaProviderElement);
+}
+
+if (!customElements.get('media-poster')) {
+  customElements.define('media-poster', FakeMediaPosterElement);
+}
+
+if (!customElements.get('media-controls')) {
+  customElements.define('media-controls', FakeMediaControlsElement);
+}
+
+if (!customElements.get('media-controls-group')) {
+  customElements.define('media-controls-group', FakeMediaControlsGroupElement);
+}
+
+if (!customElements.get('media-play-button')) {
+  customElements.define('media-play-button', FakeMediaPlayButtonElement);
+}
+
+if (!customElements.get('media-mute-button')) {
+  customElements.define('media-mute-button', FakeMediaMuteButtonElement);
+}
+
+if (!customElements.get('media-fullscreen-button')) {
+  customElements.define('media-fullscreen-button', FakeMediaFullscreenButtonElement);
+}
+
+function createVideoItem(id: number): FeedItem {
+  return {
+    id,
+    folderId: 15,
+    folderSlug: 'phone-clips',
+    folderName: 'Phone Clips',
+    folderPath: 'phone-clips',
+    folderBreadcrumb: null,
+    filename: `clip-${id}.mp4`,
+    width: 1920,
+    height: 1080,
+    mediaType: 'video',
+    durationMs: 31_000,
+    thumbnailUrl: `/thumbs/${id}.webp`,
+    previewUrl: `/previews/${id}.mp4`,
+    sortTimestamp: 1_777_000_000_000 + id,
+    takenAt: 1_777_000_000_000 + id
+  };
+}
+
+const globalStubs = {
+  Avatar: {
+    template: '<div data-test="avatar" />'
+  },
+  ConfirmDialog: {
+    template: '<div data-test="confirm-dialog" />'
+  },
+  ResilientImage: {
+    template: '<img data-test="resilient-image" />'
+  },
+  RouterLink: {
+    props: ['custom'],
+    template: `
+      <template v-if="custom">
+        <slot href="#" :navigate="() => {}" />
+      </template>
+      <a v-else><slot /></a>
+    `
+  }
+};
+
+describe('FeedCard', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        observe() {}
+        disconnect() {}
+        unobserve() {}
+      }
+    );
+  });
+
+  it('updates the home video aspect ratio from the loaded video element when metadata disagrees with indexed dimensions', async () => {
+    const wrapper = mount(FeedCard, {
+      props: {
+        item: createVideoItem(804),
+        avatarUrl: null,
+        context: 'home',
+        isActiveVideo: false
+      },
+      global: {
+        stubs: globalStubs
+      }
+    });
+
+    await flushPromises();
+
+    const player = wrapper.get('media-player').element as FakeMediaPlayerElement;
+    const container = player.parentElement as HTMLElement;
+
+    expect(container.style.aspectRatio).toBe('1920 / 1080');
+
+    const video = document.createElement('video');
+    Object.defineProperty(video, 'videoWidth', {
+      configurable: true,
+      value: 1080
+    });
+    Object.defineProperty(video, 'videoHeight', {
+      configurable: true,
+      value: 1920
+    });
+    player.appendChild(video);
+    player.dispatchEvent(new Event('loaded-metadata'));
+
+    await flushPromises();
+
+    expect(container.style.aspectRatio).toBe('1080 / 1920');
+  });
+
+  it('toggles playback from home-feed video clicks and shows the paused indicator', async () => {
+    const wrapper = mount(FeedCard, {
+      props: {
+        item: createVideoItem(805),
+        avatarUrl: null,
+        context: 'home',
+        isActiveVideo: true
+      },
+      global: {
+        stubs: globalStubs
+      }
+    });
+
+    await flushPromises();
+
+    const player = wrapper.get('media-player').element as FakeMediaPlayerElement;
+    expect(player.playCallCount).toBeGreaterThanOrEqual(1);
+    expect(player.paused).toBe(false);
+    expect(wrapper.find('.feed-card__pause-indicator').exists()).toBe(false);
+
+    await wrapper.get('.feed-card__video-shell').trigger('click');
+    await flushPromises();
+
+    expect(player.pauseCallCount).toBe(1);
+    expect(player.paused).toBe(true);
+    expect(wrapper.find('.feed-card__pause-indicator').exists()).toBe(true);
+
+    await wrapper.get('.feed-card__video-shell').trigger('click');
+    await flushPromises();
+
+    expect(player.playCallCount).toBeGreaterThanOrEqual(2);
+    expect(player.paused).toBe(false);
+    expect(wrapper.find('.feed-card__pause-indicator').exists()).toBe(false);
+  });
+});

--- a/client/src/components/FeedCard.vue
+++ b/client/src/components/FeedCard.vue
@@ -67,8 +67,14 @@
     <div
       v-else
       ref="homeVideoTarget"
-      class="relative block overflow-hidden rounded-[0.5rem] border border-border bg-surface-alt"
-      :style="{ aspectRatio: mediaAspectRatio }"
+      class="feed-card__video-shell relative block overflow-hidden rounded-[0.5rem] border border-border bg-surface-alt"
+      :class="{ 'feed-card__video-shell--interactive': showHomeVideoSurfaceControls }"
+      :style="{ aspectRatio: homeVideoAspectRatio }"
+      :aria-label="showHomeVideoSurfaceControls ? 'Toggle playback' : undefined"
+      :role="showHomeVideoSurfaceControls ? 'button' : undefined"
+      :tabindex="showHomeVideoSurfaceControls ? 0 : -1"
+      @click="handleHomeVideoSurfaceClick"
+      @keydown="handleHomeVideoSurfaceKeydown"
     >
       <media-player
         ref="homePlayerElement"
@@ -91,6 +97,8 @@
         <media-controls
           v-if="showHomeVideoControls"
           class="feed-card__player-controls"
+          @click.stop
+          @keydown.stop
         >
           <media-controls-group class="feed-card__player-controls-group">
             <media-play-button
@@ -138,6 +146,13 @@
           </media-controls-group>
         </media-controls>
       </media-player>
+      <div
+        v-if="showHomeVideoPausedIndicator"
+        class="feed-card__pause-indicator"
+        aria-hidden="true"
+      >
+        <span class="feed-card__pause-icon i-fluent-play-20-filled" />
+      </div>
       <div
         class="absolute inset-x-0 top-0 flex items-center justify-between gap-3 px-4 py-3 text-white pointer-events-none bg-[linear-gradient(180deg,rgba(10,14,24,0.82)_0%,rgba(10,14,24,0)_100%)]"
       >
@@ -382,6 +397,8 @@ const deleteOriginalFromDisk = ref(false);
 const deleteError = ref<string | null>(null);
 const homeVideoTarget = ref<HTMLElement | null>(null);
 const homePlayerElement = ref<MediaPlayerElement | null>(null);
+const loadedHomeVideoAspectRatio = ref<string | null>(null);
+const isHomeVideoPaused = ref(false);
 const isHomeVideoFullscreen = ref(false);
 const lastHomeImageTapAt = ref(0);
 
@@ -409,12 +426,15 @@ const formattedDate = computed(() =>
 );
 const formattedDuration = computed(() => formatMediaDuration(props.item.durationMs));
 const mediaAspectRatio = computed(() => resolveFeedAspectRatio(props.item.width, props.item.height));
+const homeVideoAspectRatio = computed(() => loadedHomeVideoAspectRatio.value ?? mediaAspectRatio.value);
 const homeImageSrc = computed(() => (props.item.isAnimated ? props.item.previewUrl : props.item.thumbnailUrl));
 const homeVideoSource = computed<PlayerSrc>(() => ({
   src: props.item.previewUrl,
   type: 'video/mp4'
 }));
 const showHomeVideoControls = computed(() => props.isActiveVideo || isHomeVideoFullscreen.value);
+const showHomeVideoSurfaceControls = computed(() => props.isActiveVideo || isHomeVideoFullscreen.value);
+const showHomeVideoPausedIndicator = computed(() => showHomeVideoSurfaceControls.value && isHomeVideoPaused.value);
 const deleteDialogMessage = computed(() =>
   deleteOriginalFromDisk.value
     ? 'This will permanently delete the post from the app and remove original media from disk.'
@@ -424,6 +444,12 @@ const deleteDialogConfirmLabel = computed(() => (deleteOriginalFromDisk.value ? 
 
 function isPrimaryPlainClick(event: MouseEvent) {
   return !event.defaultPrevented && event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;
+}
+
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLElement && Boolean(
+    target.closest('a, button, input, textarea, select, media-play-button, media-mute-button, media-fullscreen-button, media-controls')
+  );
 }
 
 function clearHomeImageTapResetTimer() {
@@ -492,6 +518,29 @@ function emitHomeVideoVisibility(ratio: number, centerOffset = Number.POSITIVE_I
   });
 }
 
+function getHomeVideoElement(player: MediaPlayerElement | null): HTMLVideoElement | null {
+  if (!player) {
+    return null;
+  }
+
+  const directVideo = player.querySelector('video');
+  if (directVideo instanceof HTMLVideoElement) {
+    return directVideo;
+  }
+
+  const shadowVideo = player.shadowRoot?.querySelector('video');
+  return shadowVideo instanceof HTMLVideoElement ? shadowVideo : null;
+}
+
+function syncHomeVideoAspectRatio(player: MediaPlayerElement | null = homePlayerElement.value) {
+  const video = getHomeVideoElement(player);
+  if (!video || video.videoWidth <= 0 || video.videoHeight <= 0) {
+    return;
+  }
+
+  loadedHomeVideoAspectRatio.value = resolveFeedAspectRatio(video.videoWidth, video.videoHeight);
+}
+
 function stopHomeVideoObserver(options: { clearVisibility?: boolean } = {}) {
   if (homeVideoObserver) {
     homeVideoObserver.disconnect();
@@ -548,6 +597,7 @@ async function syncHomeVideoPlayback() {
   }
 
   if (!props.isActiveVideo && !isHomeVideoFullscreen.value) {
+    isHomeVideoPaused.value = false;
     void player.pause().catch(() => {
       // Ignore pause rejections before the provider is ready.
     });
@@ -559,6 +609,7 @@ async function syncHomeVideoPlayback() {
 
   try {
     await player.play();
+    isHomeVideoPaused.value = false;
     return;
   } catch {
     if (appStore.videoMuted) {
@@ -577,11 +628,51 @@ async function syncHomeVideoPlayback() {
 }
 
 function handleHomeVideoPlay() {
+  isHomeVideoPaused.value = false;
+
   if (!props.isActiveVideo && !isHomeVideoFullscreen.value) {
     void homePlayerElement.value?.pause().catch(() => {
       // Ignore pause rejections before the provider is ready.
     });
   }
+}
+
+function handleHomeVideoPause() {
+  isHomeVideoPaused.value = showHomeVideoSurfaceControls.value;
+}
+
+async function handleHomeVideoSurfaceClick(event: MouseEvent) {
+  if (!showHomeVideoSurfaceControls.value || !isPrimaryPlainClick(event) || isInteractiveTarget(event.target)) {
+    return;
+  }
+
+  const player = homePlayerElement.value;
+  if (!player) {
+    return;
+  }
+
+  if (player.paused) {
+    await syncHomeVideoPlayback();
+    return;
+  }
+
+  isHomeVideoPaused.value = true;
+  void player.pause().catch(() => {
+    // Ignore pause rejections before the provider is ready.
+  });
+}
+
+function handleHomeVideoSurfaceKeydown(event: KeyboardEvent) {
+  if (isInteractiveTarget(event.target)) {
+    return;
+  }
+
+  if (event.key !== 'Enter' && event.key !== ' ') {
+    return;
+  }
+
+  event.preventDefault();
+  void handleHomeVideoSurfaceClick(new MouseEvent('click', { button: 0 }));
 }
 
 function handleHomeVideoFullscreenChange(event: Event) {
@@ -623,6 +714,7 @@ function bindHomePlayerEventListeners(player: MediaPlayerElement | null) {
   }
 
   const handleReady = () => {
+    syncHomeVideoAspectRatio(player);
     void syncHomeVideoPlayback();
   };
   const handleVolume = () => {
@@ -631,20 +723,26 @@ function bindHomePlayerEventListeners(player: MediaPlayerElement | null) {
   const handlePlay = () => {
     handleHomeVideoPlay();
   };
+  const handlePause = () => {
+    handleHomeVideoPause();
+  };
 
   player.addEventListener('loaded-metadata', handleReady);
   player.addEventListener('can-play', handleReady);
   player.addEventListener('volume-change', handleVolume);
   player.addEventListener('play', handlePlay);
+  player.addEventListener('pause', handlePause);
 
   removeHomePlayerEventListeners = () => {
     player.removeEventListener('loaded-metadata', handleReady);
     player.removeEventListener('can-play', handleReady);
     player.removeEventListener('volume-change', handleVolume);
     player.removeEventListener('play', handlePlay);
+    player.removeEventListener('pause', handlePause);
   };
 
   if (player.hasAttribute('data-can-play')) {
+    syncHomeVideoAspectRatio(player);
     void syncHomeVideoPlayback();
   }
 }
@@ -706,6 +804,14 @@ watch(
 );
 
 watch(
+  () => props.item.id,
+  () => {
+    loadedHomeVideoAspectRatio.value = null;
+    isHomeVideoPaused.value = false;
+  }
+);
+
+watch(
   () => props.isActiveVideo,
   () => {
     void syncHomeVideoPlayback();
@@ -729,6 +835,8 @@ watch(
 );
 
 watch(homePlayerElement, (player) => {
+  loadedHomeVideoAspectRatio.value = null;
+  isHomeVideoPaused.value = false;
   bindHomePlayerEventListeners(player);
 });
 
@@ -744,6 +852,7 @@ watch(
     }
 
     stopHomeVideoObserver();
+    isHomeVideoPaused.value = false;
     void homePlayerElement.value?.pause().catch(() => {
       // Ignore pause rejections before the provider is ready.
     });
@@ -760,6 +869,7 @@ onMounted(() => {
 onBeforeUnmount(() => {
   clearHomeImageTapResetTimer();
   stopHomeVideoObserver();
+  isHomeVideoPaused.value = false;
   removeHomePlayerEventListeners?.();
   removeHomePlayerEventListeners = null;
   void homePlayerElement.value?.pause().catch(() => {

--- a/client/src/stores/feed.test.ts
+++ b/client/src/stores/feed.test.ts
@@ -1,0 +1,82 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as galleryApi from '../api/gallery';
+import type { FeedItem } from '../types/api';
+import { useFeedStore } from './feed';
+
+function createFeedItem(id: number): FeedItem {
+  return {
+    id,
+    folderId: 1,
+    folderSlug: 'alpha',
+    folderName: 'Alpha',
+    folderPath: 'albums/alpha',
+    folderBreadcrumb: null,
+    filename: `image-${id}.jpg`,
+    width: 1200,
+    height: 1500,
+    mediaType: 'image',
+    durationMs: null,
+    thumbnailUrl: `/thumbnails/${id}.webp`,
+    previewUrl: `/previews/${id}.webp`,
+    sortTimestamp: 1_778_400_000_000 + id,
+    takenAt: 1_778_400_000_000 + id
+  };
+}
+
+describe('feed store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.restoreAllMocks();
+  });
+
+  it('loads the recent feed without a random seed', async () => {
+    const fetchFeedSpy = vi.spyOn(galleryApi, 'fetchFeed').mockResolvedValue({
+      mode: 'recent',
+      items: [createFeedItem(7)],
+      page: 1,
+      limit: 18,
+      total: 1,
+      hasMore: false
+    });
+
+    const feedStore = useFeedStore();
+    feedStore.initializeMode('recent');
+    await feedStore.loadInitial();
+
+    expect(feedStore.mode).toBe('recent');
+    expect(fetchFeedSpy).toHaveBeenCalledWith(1, 18, 'recent', undefined);
+    expect(feedStore.loadedMode).toBe('recent');
+    expect(feedStore.items.map((item) => item.id)).toEqual([7]);
+  });
+
+  it('reloads initialized items when the active mode changed since the last fetch', async () => {
+    const fetchFeedSpy = vi.spyOn(galleryApi, 'fetchFeed').mockResolvedValue({
+      mode: 'recent',
+      items: [createFeedItem(21)],
+      page: 1,
+      limit: 18,
+      total: 1,
+      hasMore: false
+    });
+
+    const feedStore = useFeedStore();
+    feedStore.$patch({
+      mode: 'random',
+      loadedMode: 'random',
+      items: [createFeedItem(5)],
+      page: 2,
+      hasMore: true,
+      initialized: true,
+      randomSeed: 12345
+    });
+
+    feedStore.initializeMode('recent');
+    await feedStore.loadInitial();
+
+    expect(fetchFeedSpy).toHaveBeenCalledWith(1, 18, 'recent', undefined);
+    expect(feedStore.loadedMode).toBe('recent');
+    expect(feedStore.items.map((item) => item.id)).toEqual([21]);
+  });
+});

--- a/client/src/stores/feed.ts
+++ b/client/src/stores/feed.ts
@@ -5,6 +5,7 @@ import type { FeedItem, FeedMode } from '../types/api';
 
 interface FeedState {
   mode: FeedMode;
+  loadedMode: FeedMode | null;
   items: FeedItem[];
   page: number;
   limit: number;
@@ -27,6 +28,7 @@ function createRandomSeed(): number {
 export const useFeedStore = defineStore('feed', {
   state: (): FeedState => ({
     mode: 'random',
+    loadedMode: null,
     items: [],
     page: 1,
     limit: 18,
@@ -39,7 +41,10 @@ export const useFeedStore = defineStore('feed', {
   actions: {
     initializeMode(mode: FeedMode = 'random') {
       this.mode = mode;
-      this.randomSeed = null;
+
+      if (mode !== 'random') {
+        this.randomSeed = null;
+      }
     },
 
     ensureRandomSeed() {
@@ -70,6 +75,7 @@ export const useFeedStore = defineStore('feed', {
     },
 
     resetForRebuild() {
+      this.loadedMode = null;
       this.items = [];
       this.page = 1;
       this.hasMore = true;
@@ -83,11 +89,15 @@ export const useFeedStore = defineStore('feed', {
         return;
       }
 
-      if (this.initialized && !force) {
+      const queueRequiresSeed = this.mode === 'random';
+      const queueMatchesMode = this.loadedMode === this.mode && (!queueRequiresSeed || this.randomSeed !== null);
+
+      if (this.initialized && !force && queueMatchesMode) {
         return;
       }
 
       this.items = [];
+      this.loadedMode = null;
       this.page = 1;
       this.hasMore = true;
       this.initialized = false;
@@ -106,6 +116,7 @@ export const useFeedStore = defineStore('feed', {
         const seed = this.mode === 'random' ? this.ensureRandomSeed() : undefined;
         const payload = await fetchFeed(this.page, this.limit, this.mode, seed);
         this.items.push(...payload.items);
+        this.loadedMode = payload.mode ?? this.mode;
         this.page += 1;
         this.hasMore = payload.hasMore;
         this.initialized = true;

--- a/client/src/styles/base.css
+++ b/client/src/styles/base.css
@@ -574,6 +574,31 @@ img[data-loaded="true"] {
   object-fit: contain;
 }
 
+.feed-card__video-shell--interactive {
+  cursor: pointer;
+}
+
+.feed-card__pause-indicator {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 4.25rem;
+  height: 4.25rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.48);
+  color: #fff;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+}
+
+.feed-card__pause-icon {
+  width: 1.45rem;
+  height: 1.45rem;
+}
+
 .feed-card__player-controls {
   position: absolute;
   inset-inline: 0;
@@ -664,6 +689,11 @@ img[data-loaded="true"] {
 }
 
 @media (max-width: 768px) {
+  .feed-card__pause-indicator {
+    width: 3.9rem;
+    height: 3.9rem;
+  }
+
   .viewer__player-controls {
     padding: 0.48rem 0.55rem 0.6rem;
   }

--- a/docs/api.md
+++ b/docs/api.md
@@ -115,7 +115,7 @@ Query parameters:
 | --- | --- | --- | --- |
 | `page` | integer | `1` | Minimum `1`. |
 | `limit` | integer | `24` | Minimum `1`, maximum `60`. |
-| `mode` | `recent | rediscover | random` | `recent` | Home feed mode. |
+| `mode` | `recent | rediscover | random` | `random` | Home feed mode. |
 | `seed` | integer | unset | Optional random seed for `random` mode. |
 
 Response shape:
@@ -136,6 +136,39 @@ Notes:
 - `items` contain both images and videos.
 - `thumbnailUrl` points to `/thumbnails/...`.
 - `previewUrl` points to `/previews/...`.
+
+### `GET /api/reels`
+
+Query parameters:
+
+| Param | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `page` | integer | `1` | Minimum `1`. |
+| `limit` | integer | `24` | Minimum `1`, maximum `60`. The current client helper requests `6` per page. |
+| `mode` | `recommended | recent | random` | `recommended` | Reels queue mode. |
+| `seed` | integer | unset | Optional seed used to keep `recommended` and `random` queues stable while paging. |
+| `lastFolder` | string | unset | Optional recent-navigation hint used by `recommended`. |
+| `recentFolders` | comma-separated string | unset | Optional recent-navigation hints used by `recommended`. |
+
+Response shape:
+
+```json
+{
+  "mode": "recommended",
+  "items": [],
+  "page": 1,
+  "limit": 6,
+  "total": 0,
+  "hasMore": false
+}
+```
+
+Notes:
+
+- `items` contain videos only.
+- `recommended` uses `lastFolder` and `recentFolders` to bias the queue toward folders you recently opened.
+- `recent` ignores recommendation hints and returns newest indexed videos first.
+- `random` and `recommended` stay stable across pages when the same `seed` is reused.
 
 ### `GET /api/feed/moments`
 
@@ -325,6 +358,8 @@ Notable fields:
 | `scan` | Live scan progress snapshot. `currentFolder` is redacted and `lastCompletedScan.error_text` is always `null`. |
 | `storage` | Availability with a generic unavailable message only. |
 | `libraryIndex` | Rebuild requirement plus ignored root-media count. Gallery-root paths are omitted. |
+| `preferences.defaultHomeFeedMode` | Current app-wide default home feed mode. |
+| `preferences.defaultReelsFeedMode` | Current app-wide default reels mode used when `/reels` opens. |
 
 ### `GET /api/admin/stats`
 
@@ -517,6 +552,58 @@ Notes:
 - changing viewer access invalidates older sessions
 - `mode=public` enables anonymous browsing immediately
 - anonymous public sessions use local browser favorites instead of shared `/api/likes`
+
+### `PUT /api/admin/settings/home-feed-default`
+
+Sets the default mode used when Home opens.
+
+Body:
+
+```json
+{
+  "defaultMode": "recent"
+}
+```
+
+Allowed values:
+
+- `recent`
+- `rediscover`
+- `random`
+
+Success:
+
+```json
+{
+  "defaultMode": "recent"
+}
+```
+
+### `PUT /api/admin/settings/reels-feed-default`
+
+Sets the app-wide default mode used when `/reels` opens.
+
+Body:
+
+```json
+{
+  "defaultMode": "recommended"
+}
+```
+
+Allowed values:
+
+- `recommended`
+- `recent`
+- `random`
+
+Success:
+
+```json
+{
+  "defaultMode": "recommended"
+}
+```
 
 ### `POST /api/images/:id/like`
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -29,6 +29,28 @@ It includes:
 | Rediscover | "Older posts resurface when they are worth another look." |
 | Random | "A fresh shuffle that stays steady while you browse." |
 
+## Reels
+
+The dedicated reels view is available at `/reels`.
+
+It includes:
+
+- a video-only queue sourced from indexed library posts
+- a full-height scroll-snap deck
+- wheel, arrow-key, and page-up/page-down navigation in addition to direct scrolling
+- infinite loading with prefetch as you approach the end of the current queue
+- a desktop action rail for like/favorite toggle, details sidebar, folder shortcut, and original-video link
+- loading, empty, and error states
+- an app-wide default mode from Settings; the page itself does not expose an inline mode switch
+
+### Queue behavior
+
+| Mode | What it does |
+| --- | --- |
+| Recommended | "Affinity-ranked mix." It scores videos using freshness, likes, recent folder affinity, portrait fit, duration fit, and a deterministic seed, then reduces immediate repeats from the same folder when alternatives exist. |
+| Recent | "Newest videos first." |
+| Random | "Stable session shuffle." |
+
 ## Explore
 
 Explore is a dedicated full-screen shell with a darker visual treatment.
@@ -134,6 +156,7 @@ It exposes:
 
 - admin-password controls
 - viewer password and public access controls
+- home and reels default feed-mode controls
 - live scan status
 - storage and index status
 - last completed scan details

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -130,6 +130,20 @@ The home feed supports three modes:
 | `rediscover` | Surfaces posts older than 180 days and prioritizes liked items within that older pool. |
 | `random` | Uses a deterministic seeded shuffle so a browsing session stays stable while paging. |
 
+## Reels behavior
+
+The `/reels` route reads only indexed video candidates from SQLite. It does not
+scan the filesystem on request.
+
+The page opens with the app-wide default configured in Settings and does not
+provide an inline mode switch of its own.
+
+| Mode | Behavior |
+| --- | --- |
+| `recommended` | Builds a seeded queue from indexed videos using freshness, likes, folder-affinity signals from recent navigation, portrait fit, duration fit, and a small deterministic jitter. It also penalizes immediate repeats from the same folder when alternatives exist. |
+| `recent` | Uses newest indexed videos first. |
+| `random` | Uses a deterministic seeded shuffle so the queue stays stable while paging. |
+
 ## Moments and highlights
 
 `GET /api/feed/moments` can return either a Moments rail or a Highlights rail.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ features:
     details: Foldergram indexes supported image and video formats, generates thumbnails, creates previews eagerly or lazily, and can expose compatible original MP4 playback in the detail player.
   - icon: 🎯
     title: Honest scope
-    details: The current app includes feed browsing, explore, library, likes and favorites, moments, optional admin/viewer/public access control, and admin-only maintenance controls without cloud sync or social features.
+    details: The current app includes home feed browsing, a dedicated reels route, explore, library, likes and favorites, moments, optional admin/viewer/public access control, and admin-only maintenance controls without cloud sync or social features.
 ---
 
 ## Foldergram at a Glance
@@ -40,7 +40,7 @@ features:
 
 <div class="cs-feature">
 <h3>🚀 What ships today</h3>
-<p>The current repository includes Home, Explore, Library, Likes and Favorites, Moments, Settings, folder pages, a post detail view and modal flow, shared SQLite likes, browser-local favorites in public mode, delete actions, optional admin/viewer/public access control, and local scan/rebuild tooling.</p>
+<p>The current repository includes Home, Reels, Explore, Library, Likes and Favorites, Moments, Settings, folder pages, a post detail view and modal flow, shared SQLite likes, browser-local favorites in public mode, delete actions, optional admin/viewer/public access control, and local scan/rebuild tooling.</p>
 </div>
 
 <div class="cs-feature">

--- a/server/src/services/derivative-service.ts
+++ b/server/src/services/derivative-service.ts
@@ -31,7 +31,11 @@ interface FfprobeStream {
   pix_fmt?: string;
   tags?: {
     creation_time?: string;
+    rotate?: string;
   };
+  side_data_list?: Array<{
+    rotation?: number;
+  }>;
 }
 
 interface FfprobeFormat {
@@ -100,7 +104,7 @@ async function readVideoProbe(sourcePath: string): Promise<FfprobePayload> {
       '-v',
       'error',
       '-show_entries',
-      'format=duration,format_name:format_tags=creation_time:stream=codec_type,codec_name,width,height,pix_fmt:stream_tags=creation_time',
+      'format=duration,format_name:format_tags=creation_time:stream=codec_type,codec_name,width,height,pix_fmt:stream_tags=creation_time,rotate:stream_side_data=rotation',
       '-of',
       'json',
       sourcePath
@@ -111,6 +115,40 @@ async function readVideoProbe(sourcePath: string): Promise<FfprobePayload> {
   );
 
   return JSON.parse(stdout) as FfprobePayload;
+}
+
+function normalizeVideoRotation(rotation: number | string | null | undefined): number {
+  if (rotation === null || rotation === undefined || rotation === '') {
+    return 0;
+  }
+
+  const parsedRotation = typeof rotation === 'number' ? rotation : Number.parseFloat(rotation);
+  if (!Number.isFinite(parsedRotation)) {
+    return 0;
+  }
+
+  return ((Math.round(parsedRotation) % 360) + 360) % 360;
+}
+
+function resolveVideoDisplayDimensions(videoStream: FfprobeStream | undefined): Pick<MediaMetadata, 'width' | 'height'> {
+  const width = videoStream?.width ?? THUMBNAIL_SIZE;
+  const height = videoStream?.height ?? THUMBNAIL_SIZE;
+  const rotation =
+    videoStream?.side_data_list?.find((sideData) => typeof sideData.rotation === 'number')?.rotation
+    ?? videoStream?.tags?.rotate;
+  const normalizedRotation = normalizeVideoRotation(rotation);
+
+  if (normalizedRotation % 180 === 90) {
+    return {
+      width: height,
+      height: width
+    };
+  }
+
+  return {
+    width,
+    height
+  };
 }
 
 async function readImageMetadata(sourcePath: string): Promise<MediaMetadata> {
@@ -166,11 +204,11 @@ async function readVideoMetadata(sourcePath: string, options: ReadMediaMetadataO
   const durationSeconds = payload.format?.duration ? Number.parseFloat(payload.format.duration) : Number.NaN;
   const durationMs = Number.isFinite(durationSeconds) ? Math.round(durationSeconds * 1000) : null;
   const takenAt = normalizeTakenAtValue(videoStream?.tags?.creation_time ?? payload.format?.tags?.creation_time ?? null);
-  const width = videoStream?.width ?? THUMBNAIL_SIZE;
+  const displayDimensions = resolveVideoDisplayDimensions(videoStream);
 
   return {
-    width,
-    height: videoStream?.height ?? THUMBNAIL_SIZE,
+    width: displayDimensions.width,
+    height: displayDimensions.height,
     takenAt,
     exif: null,
     durationMs,

--- a/server/test/video-derivative-strategy.test.ts
+++ b/server/test/video-derivative-strategy.test.ts
@@ -115,6 +115,40 @@ describe.sequential('video derivative strategy', () => {
     expect(ffmpegCalls[1]?.[1]).toContain('libx264');
     expect(ffmpegCalls[1]?.[1]).toContain(expectedVideoScaleFilter());
   });
+
+  it('normalizes rotated source dimensions to display dimensions before returning metadata', async () => {
+    execFileAsyncMock.mockImplementation(createExecFileAsyncMock({
+      format: {
+        duration: '4.0',
+        format_name: 'mov,mp4,m4a,3gp,3g2,mj2'
+      },
+      streams: [
+        {
+          codec_type: 'video',
+          codec_name: 'h264',
+          width: 1920,
+          height: 1080,
+          pix_fmt: 'yuv420p',
+          side_data_list: [
+            {
+              rotation: -90
+            }
+          ]
+        },
+        { codec_type: 'audio', codec_name: 'aac' }
+      ]
+    }));
+
+    const sourcePath = path.join(appConfig.galleryRoot, 'clips', 'reel-rotated.mp4');
+
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, Buffer.alloc(1024 * 1024));
+
+    const result = await generateDerivatives(sourcePath, 'clips/reel-rotated.mp4', true);
+
+    expect(result.width).toBe(1080);
+    expect(result.height).toBe(1920);
+  });
 });
 
 function expectedVideoScaleFilter(): string {


### PR DESCRIPTION
Fixes #20 

Corrects portrait video rendering in the home feed for rotated phone recordings and aligns click-to-pause behavior with the reels player. Fix home feed mode sync and document the reels route

- reload the Home feed when the active mode no longer matches the cached queue
- add feed store regression coverage for recent/random mode transitions
- document the dedicated /reels page, its queue modes, settings defaults, and API surface
