### PR TITLE
Implements reserved AppFolder/stories support

### DIFF
--- a/client/src/api/gallery.ts
+++ b/client/src/api/gallery.ts
@@ -3,8 +3,11 @@ import type {
   AppStats,
   AuthMutationResult,
   AuthStatus,
+  FolderStoriesPayload,
+  FolderStoryFeedPayload,
   HomeFeedDefaultSetting,
   ReelsFeedDefaultSetting,
+  StoriesModeSetting,
   ViewerAccessMode,
   DeleteImageResult,
   DeleteFolderResult,
@@ -111,6 +114,16 @@ export function fetchFolderImages(slug: string, page = 1, limit = 24, mediaType?
   }
 
   return requestJson<FolderImagesPayload>(`/api/folders/${encodeURIComponent(slug)}/images?${params.toString()}`);
+}
+
+export function fetchFolderStories(slug: string) {
+  return requestJson<FolderStoriesPayload>(`/api/folders/${encodeURIComponent(slug)}/stories`);
+}
+
+export function fetchFolderStoryFeed(slug: string, storyId: string, page = 1, limit = 24) {
+  return requestJson<FolderStoryFeedPayload>(
+    `/api/folders/${encodeURIComponent(slug)}/stories/${encodeURIComponent(storyId)}?page=${page}&limit=${limit}`
+  );
 }
 
 export function updateFolderProfile(slug: string, name: string, description: string | null) {
@@ -301,5 +314,13 @@ export function updateReelsFeedDefault(defaultMode: ReelsFeedMode) {
     method: 'PUT',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ defaultMode })
+  });
+}
+
+export function updateStoriesMode(treatStoriesAsFolders: boolean) {
+  return requestJson<StoriesModeSetting>('/api/admin/settings/stories-mode', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ treatStoriesAsFolders })
   });
 }

--- a/client/src/components/FeedCard.test.ts
+++ b/client/src/components/FeedCard.test.ts
@@ -199,4 +199,28 @@ describe('FeedCard', () => {
     expect(player.paused).toBe(false);
     expect(wrapper.find('.feed-card__pause-indicator').exists()).toBe(false);
   });
+
+  it('renders a story ring on the home avatar and emits an in-place story open event', async () => {
+    const wrapper = mount(FeedCard, {
+      props: {
+        item: createVideoItem(806),
+        avatarUrl: null,
+        hasAvatarStory: true,
+        context: 'home',
+        isActiveVideo: false
+      },
+      global: {
+        stubs: globalStubs
+      }
+    });
+
+    await flushPromises();
+
+    const avatarButton = wrapper.get('button[aria-label="Open Phone Clips stories"]');
+    expect(avatarButton.exists()).toBe(true);
+
+    await avatarButton.trigger('click');
+
+    expect(wrapper.emitted('openFolderStory')).toEqual([['phone-clips']]);
+  });
 });

--- a/client/src/components/FeedCard.vue
+++ b/client/src/components/FeedCard.vue
@@ -1,14 +1,36 @@
 <template>
   <article class="bg-transparent">
     <div class="flex items-center justify-between gap-4 px-4 py-[0.55rem]">
-      <RouterLink class="feed-card__folder flex items-center gap-[0.72rem] min-w-0" :to="{ name: 'folder', params: { slug: item.folderSlug } }">
-        <Avatar class="w-8 h-8" :name="item.folderName" :src="avatarUrl" />
-        <div class="min-w-0">
-          <h3 class="m-0 text-[0.88rem] font-semibold truncate">
-            {{ item.folderName }}
-          </h3>
-        </div>
-      </RouterLink>
+      <div class="feed-card__folder flex items-center gap-[0.72rem] min-w-0">
+        <button
+          v-if="showHomeStoryAvatar"
+          class="block rounded-full border-0 bg-transparent p-0 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text/55 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          type="button"
+          :aria-label="`Open ${item.folderName} stories`"
+          @click="emit('openFolderStory', item.folderSlug)"
+        >
+          <div class="rounded-full p-[0.1rem] shadow-[0_10px_22px_rgba(246,106,61,0.16)]" style="background: var(--story-ring);">
+            <div class="rounded-full bg-bg p-[0.1rem]">
+              <Avatar class="w-8 h-8" :name="item.folderName" :src="avatarUrl" />
+            </div>
+          </div>
+        </button>
+        <RouterLink
+          v-else
+          class="block rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text/55 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          :to="{ name: 'folder', params: { slug: item.folderSlug } }"
+          :aria-label="`Open ${item.folderName}`"
+        >
+          <Avatar class="w-8 h-8" :name="item.folderName" :src="avatarUrl" />
+        </RouterLink>
+        <RouterLink class="min-w-0 text-inherit no-underline" :to="{ name: 'folder', params: { slug: item.folderSlug } }">
+          <div class="min-w-0">
+            <h3 class="m-0 text-[0.88rem] font-semibold truncate">
+              {{ item.folderName }}
+            </h3>
+          </div>
+        </RouterLink>
+      </div>
       <button
         class="inline-flex items-center justify-center w-8 h-8 p-0 border-0 text-muted bg-transparent cursor-pointer"
         type="button"
@@ -370,16 +392,19 @@ const props = withDefaults(
   defineProps<{
     item: FeedItem;
     avatarUrl: string | null;
+    hasAvatarStory?: boolean;
     context?: 'default' | 'home';
     isActiveVideo?: boolean;
   }>(),
   {
+    hasAvatarStory: false,
     context: 'default',
     isActiveVideo: false
   }
 );
 
 const emit = defineEmits<{
+  openFolderStory: [folderSlug: string];
   videoVisibilityChange: [payload: HomeVideoVisibilityChange];
 }>();
 
@@ -409,6 +434,7 @@ let removeHomePlayerEventListeners: (() => void) | null = null;
 
 const imageRoute = computed(() => `/image/${props.item.id}`);
 const isHomeContext = computed(() => props.context === 'home');
+const showHomeStoryAvatar = computed(() => isHomeContext.value && props.hasAvatarStory);
 const shouldOpenPostInModal = computed(() => props.context !== 'home');
 const caption = computed(() =>
   props.item.filename

--- a/client/src/components/FeedList.vue
+++ b/client/src/components/FeedList.vue
@@ -6,8 +6,10 @@
       :key="item.id"
       :item="item"
       :context="context"
+      :has-avatar-story="folderLookup.get(item.folderSlug)?.hasAvatarStory ?? false"
       :avatar-url="folderLookup.get(item.folderSlug)?.avatarUrl ?? null"
       :is-active-video="context === 'home' && item.id === activeVideoId"
+      @open-folder-story="emit('openFolderStory', $event)"
       @video-visibility-change="handleVideoVisibilityChange"
     />
   </section>
@@ -39,6 +41,10 @@ const props = withDefaults(
     context: 'default'
   }
 );
+
+const emit = defineEmits<{
+  openFolderStory: [folderSlug: string];
+}>();
 
 const foldersStore = useFoldersStore();
 const folderLookup = computed(() => new Map(foldersStore.items.map((folder) => [folder.slug, folder])));

--- a/client/src/components/FolderHeader.vue
+++ b/client/src/components/FolderHeader.vue
@@ -1,21 +1,34 @@
 <template>
   <section class="grid grid-cols-[10.75rem_minmax(0,1fr)] items-start gap-x-[2.65rem] pt-[0.6rem] pb-[2.4rem] max-md:grid-cols-[9rem_minmax(0,1fr)] max-md:gap-x-[2rem] max-sm:grid-cols-1 max-sm:gap-y-[1.35rem] max-sm:pb-[1.85rem] max-sm:text-center">
     <div class="grid place-items-center">
-      <RouterLink v-if="folder.avatarImageId" custom :to="buildAvatarRoute(folder.avatarImageId)" v-slot="{ href, navigate }">
+      <button
+        v-if="hasAvatarStory"
+        type="button"
+        class="block border-0 bg-transparent p-0 rounded-full cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text/55 focus-visible:ring-offset-4 focus-visible:ring-offset-bg"
+        aria-label="Open folder stories"
+        @click="emit('openAvatarStory')"
+      >
+        <div class="rounded-full p-[0.22rem] shadow-[0_16px_34px_rgba(246,106,61,0.12)] transition-transform duration-[180ms] hover:scale-[1.02]" style="background: var(--story-ring);">
+          <div class="rounded-full bg-bg p-[0.22rem]">
+            <Avatar class="w-[9.35rem] h-[9.35rem] max-md:w-[7.75rem] max-md:h-[7.75rem]" :name="folder.name" :src="folder.avatarUrl" />
+          </div>
+        </div>
+      </button>
+      <RouterLink v-else-if="folder.avatarImageId" custom :to="buildAvatarRoute(folder.avatarImageId)" v-slot="{ href, navigate }">
         <a
           :href="href"
           class="block rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text/55 focus-visible:ring-offset-4 focus-visible:ring-offset-bg"
           aria-label="Open folder avatar"
           @click="handleAvatarNavigation($event, navigate)"
         >
-          <div class="rounded-full p-[0.22rem] shadow-[0_16px_34px_rgba(246,106,61,0.12)] transition-transform duration-[180ms] hover:scale-[1.02]" style="background: var(--story-ring);">
+          <div class="rounded-full p-[0.22rem] shadow-[0_12px_24px_rgba(99,115,129,0.12)] transition-transform duration-[180ms] hover:scale-[1.02]" style="background: rgba(43, 48, 54, 0.8);">
             <div class="rounded-full bg-bg p-[0.22rem]">
               <Avatar class="w-[9.35rem] h-[9.35rem] max-md:w-[7.75rem] max-md:h-[7.75rem]" :name="folder.name" :src="folder.avatarUrl" />
             </div>
           </div>
         </a>
       </RouterLink>
-      <div v-else class="rounded-full p-[0.22rem] shadow-[0_16px_34px_rgba(246,106,61,0.12)]" style="background: var(--story-ring);">
+      <div v-else class="rounded-full p-[0.22rem] shadow-[0_12px_24px_rgba(99,115,129,0.12)]" style="background: rgba(43, 48, 54, 0.8);">
         <div class="rounded-full bg-bg p-[0.22rem]">
           <Avatar class="w-[9.35rem] h-[9.35rem] max-md:w-[7.75rem] max-md:h-[7.75rem]" :name="folder.name" :src="folder.avatarUrl" />
         </div>
@@ -74,6 +87,11 @@ import { useFoldersStore } from '../stores/folders';
 
 const props = defineProps<{
   folder: FolderSummary;
+  hasAvatarStory?: boolean;
+}>();
+
+const emit = defineEmits<{
+  openAvatarStory: [];
 }>();
 
 const appStore = useAppStore();

--- a/client/src/components/StoriesModal.test.ts
+++ b/client/src/components/StoriesModal.test.ts
@@ -1,0 +1,247 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { reactive } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { FeedItem, RailCapsule, RailViewerStoreContract } from '../types/api';
+import { useAppStore } from '../stores/app';
+import StoriesModal from './StoriesModal.vue';
+
+function createVideoItem(id: number): FeedItem {
+  return {
+    id,
+    folderId: 91,
+    folderSlug: 'animal-planet',
+    folderName: 'Animal Planet',
+    folderPath: 'animal-planet',
+    folderBreadcrumb: null,
+    filename: `story-${id}.mp4`,
+    width: 1080,
+    height: 1920,
+    mediaType: 'video',
+    durationMs: 12_000,
+    thumbnailUrl: `/thumbs/${id}.webp`,
+    previewUrl: `/previews/${id}.mp4`,
+    sortTimestamp: 1_777_000_000_000 + id,
+    takenAt: 1_777_000_000_000 + id
+  };
+}
+
+function createCapsule(id: string, title: string, item: FeedItem): RailCapsule {
+  return {
+    id,
+    title,
+    subtitle: 'Recent story set',
+    dateContext: 'Latest Mar 28, 2026',
+    imageCount: 1,
+    coverImage: item
+  };
+}
+
+function createStore(capsules: RailCapsule[], imagesByCapsuleId: Record<string, FeedItem[]>) {
+  return reactive<RailViewerStoreContract>({
+    currentCapsule: null,
+    currentImages: [],
+    currentHasMore: false,
+    async loadCapsule(id: string) {
+      const capsule = capsules.find((entry) => entry.id === id) ?? null;
+      if (!capsule) {
+        return;
+      }
+
+      this.currentCapsule = capsule;
+      this.currentImages = imagesByCapsuleId[id] ?? [];
+      this.currentHasMore = false;
+    }
+  });
+}
+
+describe('StoriesModal', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    setActivePinia(createPinia());
+    const appStore = useAppStore();
+    appStore.$patch({
+      videoMuted: true,
+      stats: null
+    });
+
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+  });
+
+  it('renders an actual video element for video story items in the shared rail viewer', async () => {
+    const videoItem = createVideoItem(401);
+    const capsule = createCapsule('home-stories', 'Home Stories', videoItem);
+    const store = createStore([capsule], {
+      [capsule.id]: [videoItem]
+    });
+
+    const wrapper = mount(StoriesModal, {
+      props: {
+        items: [capsule],
+        initialId: capsule.id,
+        railSingularLabel: 'Story',
+        store
+      },
+      global: {
+        stubs: {
+          Avatar: {
+            template: '<div data-test="avatar" />'
+          },
+          ResilientImage: {
+            template: '<img data-test="resilient-image" />'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    const video = wrapper.get('video.story-stage__video');
+    expect(video.attributes('src')).toBe(videoItem.previewUrl);
+    expect(video.attributes('poster')).toBe(videoItem.thumbnailUrl);
+    expect(wrapper.find('img[data-test="resilient-image"]').exists()).toBe(false);
+  });
+
+  it('keeps the next arrow enabled on the last item when another capsule exists and advances into it', async () => {
+    const firstItem = createVideoItem(501);
+    const secondItem = createVideoItem(502);
+    const firstCapsule = createCapsule('capsule-one', 'First Stories', firstItem);
+    const secondCapsule = createCapsule('capsule-two', 'Second Stories', secondItem);
+    const store = createStore([firstCapsule, secondCapsule], {
+      [firstCapsule.id]: [firstItem],
+      [secondCapsule.id]: [secondItem]
+    });
+
+    const wrapper = mount(StoriesModal, {
+      props: {
+        items: [firstCapsule, secondCapsule],
+        initialId: firstCapsule.id,
+        railSingularLabel: 'Story',
+        store
+      },
+      global: {
+        stubs: {
+          Avatar: {
+            template: '<div data-test="avatar" />'
+          },
+          ResilientImage: {
+            template: '<img data-test="resilient-image" />'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    const nextButton = wrapper.get('.story-stage__pager--right');
+    expect(nextButton.attributes('disabled')).toBeUndefined();
+
+    await nextButton.trigger('click');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Second Stories');
+    expect(wrapper.get('video.story-stage__video').attributes('src')).toBe(secondItem.previewUrl);
+  });
+
+  it('autoplay advances into the next capsule when the current capsule finishes', async () => {
+    vi.useFakeTimers();
+
+    let autoplayNow = 0;
+    vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback) =>
+      window.setTimeout(() => {
+        autoplayNow += 5_000;
+        callback(autoplayNow);
+      }, 0)
+    );
+
+    const firstItem = createVideoItem(601);
+    const secondItem = createVideoItem(602);
+    const firstCapsule = createCapsule('capsule-autoplay-one', 'Autoplay One', firstItem);
+    const secondCapsule = createCapsule('capsule-autoplay-two', 'Autoplay Two', secondItem);
+    const store = createStore([firstCapsule, secondCapsule], {
+      [firstCapsule.id]: [firstItem],
+      [secondCapsule.id]: [secondItem]
+    });
+
+    const wrapper = mount(StoriesModal, {
+      props: {
+        items: [firstCapsule, secondCapsule],
+        initialId: firstCapsule.id,
+        railSingularLabel: 'Story',
+        store
+      },
+      global: {
+        stubs: {
+          Avatar: {
+            template: '<div data-test="avatar" />'
+          },
+          ResilientImage: {
+            template: '<img data-test="resilient-image" />'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+    await vi.runAllTimersAsync();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Autoplay Two');
+    expect(wrapper.get('video.story-stage__video').attributes('src')).toBe(secondItem.previewUrl);
+
+    vi.useRealTimers();
+  });
+
+  it('shows capsule load errors in the viewer and retries the active capsule', async () => {
+    const videoItem = createVideoItem(701);
+    const capsule = createCapsule('capsule-error', 'Error Stories', videoItem);
+    const loadCapsule = vi.fn();
+    let shouldFail = true;
+    const store = reactive<RailViewerStoreContract>({
+      currentCapsule: null,
+      currentImages: [],
+      currentHasMore: false,
+      currentError: null,
+      async loadCapsule(id: string) {
+        loadCapsule(id);
+        this.currentCapsule = capsule;
+        this.currentImages = [videoItem];
+        this.currentHasMore = false;
+        this.currentError = shouldFail ? 'Unable to load this story capsule' : null;
+        shouldFail = false;
+      }
+    });
+
+    const wrapper = mount(StoriesModal, {
+      props: {
+        items: [capsule],
+        initialId: capsule.id,
+        railSingularLabel: 'Story',
+        store
+      },
+      global: {
+        stubs: {
+          Avatar: {
+            template: '<div data-test="avatar" />'
+          },
+          ResilientImage: {
+            template: '<img data-test="resilient-image" />'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Unable to load this story capsule');
+
+    await wrapper.get('button.story-stage__error-button').trigger('click');
+    await flushPromises();
+
+    expect(loadCapsule).toHaveBeenCalledTimes(2);
+    expect(loadCapsule).toHaveBeenLastCalledWith(capsule.id);
+    expect(wrapper.text()).not.toContain('Unable to load this story capsule');
+  });
+});

--- a/client/src/components/StoriesModal.vue
+++ b/client/src/components/StoriesModal.vue
@@ -39,7 +39,7 @@
             <div class="story-side-card__shade" />
             <div class="story-side-card__meta">
               <strong class="block truncate text-[0.92rem]">{{ previousCapsule.title }}</strong>
-              <span class="block truncate text-[0.78rem] text-white/68">{{ previousCapsule.imageCount }} posts</span>
+              <span class="block truncate text-[0.78rem] text-white/68">{{ previousCapsule.imageCount }} items</span>
             </div>
           </article>
         </button>
@@ -135,10 +135,24 @@
           />
 
           <div class="story-stage__surface" :style="activeStageTransitionStyle">
+            <video
+              v-if="displayImage?.mediaType === 'video'"
+              :key="`video-${displayImage.id}`"
+              ref="videoElement"
+              class="story-stage__video"
+              :src="displayImage.previewUrl"
+              :poster="displayImage.thumbnailUrl"
+              :muted="appStore.videoMuted"
+              autoplay
+              loop
+              playsinline
+              preload="metadata"
+            />
             <ResilientImage
-              v-if="displayImage"
+              v-else-if="displayImage"
+              :key="`image-${displayImage.id}`"
               class="story-stage__image"
-              :src="displayImage.mediaType === 'video' ? displayImage.thumbnailUrl : displayImage.previewUrl"
+              :src="displayImage.previewUrl"
               :alt="displayImage.filename"
               loading="eager"
               :retry-while="appStore.isScanning"
@@ -149,8 +163,19 @@
           </div>
 
           <footer class="story-stage__footer">
+            <div v-if="currentError" class="story-stage__error" role="alert">
+              <span>{{ currentError }}</span>
+              <button
+                class="story-stage__error-button"
+                type="button"
+                data-swipe-ignore="true"
+                @click="retryCurrentCapsule"
+              >
+                Retry
+              </button>
+            </div>
             <div class="grid gap-[0.18rem]">
-              <strong class="text-[0.92rem]">{{ displayImage?.folderName ?? activeCapsule?.title }}</strong>
+              <strong class="text-[0.92rem]">{{ activeCapsule?.title ?? displayImage?.folderName }}</strong>
               <p class="m-0 text-[0.8rem] text-white/70">{{ footerMeta }}</p>
             </div>
           </footer>
@@ -196,7 +221,7 @@
             <div class="story-side-card__shade" />
             <div class="story-side-card__meta">
               <strong class="block truncate text-[0.9rem]">{{ capsule.title }}</strong>
-              <span class="block truncate text-[0.76rem] text-white/68">{{ capsule.imageCount }} posts</span>
+              <span class="block truncate text-[0.76rem] text-white/68">{{ capsule.imageCount }} items</span>
             </div>
           </article>
         </button>
@@ -209,9 +234,8 @@
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 
 import { useHorizontalSwipe } from '../composables/useHorizontalSwipe';
-import type { FeedItem, MomentCapsule } from '../types/api';
+import type { FeedItem, RailCapsule, RailViewerStoreContract } from '../types/api';
 import { useAppStore } from '../stores/app';
-import { useMomentsStore } from '../stores/moments';
 import Avatar from './Avatar.vue';
 import ResilientImage from './ResilientImage.vue';
 
@@ -220,9 +244,10 @@ const CAPSULE_SWITCH_ANIMATION_MS = 360;
 const CAPSULE_VIEW_TRANSITION_NAME = 'rail-highlight-stage';
 
 const props = defineProps<{
-  items: MomentCapsule[];
+  items: RailCapsule[];
   initialId: string;
   railSingularLabel: string;
+  store: RailViewerStoreContract;
 }>();
 
 const emit = defineEmits<{
@@ -230,7 +255,6 @@ const emit = defineEmits<{
 }>();
 
 const appStore = useAppStore();
-const momentsStore = useMomentsStore();
 const activeCapsuleId = ref(props.initialId);
 const activeImageIndex = ref(0);
 const autoplayProgress = ref(0);
@@ -238,6 +262,7 @@ const isPaused = ref(false);
 const activeCapsuleTransitionId = ref<string | null>(null);
 const transitionPending = ref(false);
 const isCapsuleSwitching = ref(false);
+const videoElement = ref<HTMLVideoElement | null>(null);
 
 let previousBodyOverflow = '';
 let animationFrameId = 0;
@@ -245,20 +270,24 @@ let autoplayStartedAt = 0;
 
 const activeCapsuleIndex = computed(() => props.items.findIndex((item) => item.id === activeCapsuleId.value));
 const activeCapsule = computed(() => {
-  if (momentsStore.currentMoment?.id === activeCapsuleId.value) {
-    return momentsStore.currentMoment;
+  if (props.store.currentCapsule?.id === activeCapsuleId.value) {
+    return props.store.currentCapsule;
   }
 
   return props.items.find((item) => item.id === activeCapsuleId.value) ?? null;
 });
 const activeImages = computed(() =>
-  momentsStore.currentMoment?.id === activeCapsuleId.value ? momentsStore.currentImages : []
+  props.store.currentCapsule?.id === activeCapsuleId.value ? props.store.currentImages : []
 );
 const displayImage = computed<FeedItem | null>(() => activeImages.value[activeImageIndex.value] ?? activeCapsule.value?.coverImage ?? null);
 const totalImageCount = computed(() => Math.max(activeCapsule.value?.imageCount ?? activeImages.value.length, 1));
 const previousCapsule = computed(() => {
   const index = activeCapsuleIndex.value;
   return index > 0 ? props.items[index - 1] : null;
+});
+const nextCapsule = computed(() => {
+  const index = activeCapsuleIndex.value;
+  return index >= 0 ? props.items[index + 1] ?? null : null;
 });
 const nextCapsules = computed(() => {
   const index = activeCapsuleIndex.value;
@@ -276,8 +305,9 @@ const activeCapsuleMeta = computed(() => {
     return '';
   }
 
-  return `${activeCapsule.value.imageCount} posts · ${activeCapsule.value.dateContext}`;
+  return `${activeCapsule.value.imageCount} items · ${activeCapsule.value.dateContext}`;
 });
+const currentError = computed(() => props.store.currentError ?? null);
 const footerMeta = computed(() => {
   if (!displayImage.value) {
     return '';
@@ -294,7 +324,7 @@ const canGoNextImage = computed(
   () =>
     !transitionPending.value &&
     activeImages.value.length > 0 &&
-    (activeImageIndex.value < activeImages.value.length - 1 || momentsStore.currentHasMore)
+    (activeImageIndex.value < activeImages.value.length - 1 || props.store.currentHasMore || nextCapsule.value !== null)
 );
 const swipeNavigation = useHorizontalSwipe({
   canStart: canStartStageSwipe,
@@ -318,6 +348,9 @@ watch(
   () => [displayImage.value?.id ?? null, activeCapsuleId.value] as const,
   () => {
     syncAutoplayForCurrentImage();
+    void nextTick(() => {
+      syncMediaPlayback();
+    });
   }
 );
 
@@ -392,10 +425,12 @@ function togglePaused() {
 
   if (isPaused.value) {
     stopAutoplay();
+    syncMediaPlayback();
     return;
   }
 
   startAutoplay();
+  syncMediaPlayback();
 }
 
 function canStartStageSwipe(event: PointerEvent) {
@@ -436,7 +471,7 @@ async function loadCapsuleData(id: string, reset = true) {
   transitionPending.value = true;
 
   try {
-    await momentsStore.loadMoment(id, reset);
+    await props.store.loadCapsule(id, reset);
   } finally {
     transitionPending.value = false;
   }
@@ -511,13 +546,13 @@ async function showNextImageInternal(fromAutoplay: boolean) {
     return;
   }
 
-  if (momentsStore.currentHasMore) {
+  if (props.store.currentHasMore) {
     transitionPending.value = true;
     stopAutoplay();
     const previousLength = activeImages.value.length;
 
     try {
-      await momentsStore.loadMoment(activeCapsuleId.value, false);
+      await props.store.loadCapsule(activeCapsuleId.value, false);
     } finally {
       transitionPending.value = false;
     }
@@ -526,6 +561,11 @@ async function showNextImageInternal(fromAutoplay: boolean) {
       activeImageIndex.value = previousLength;
       return;
     }
+  }
+
+  if (nextCapsule.value) {
+    await openCapsule(nextCapsule.value.id, { fromPreview: true });
+    return;
   }
 
   if (fromAutoplay) {
@@ -541,6 +581,14 @@ async function showPreviousImage() {
   if (activeImageIndex.value > 0) {
     activeImageIndex.value -= 1;
   }
+}
+
+async function retryCurrentCapsule() {
+  if (transitionPending.value) {
+    return;
+  }
+
+  await loadCapsuleData(activeCapsuleId.value, activeImages.value.length === 0);
 }
 
 async function handleKeydown(event: KeyboardEvent) {
@@ -568,6 +616,24 @@ async function handleKeydown(event: KeyboardEvent) {
   }
 }
 
+function syncMediaPlayback() {
+  const player = videoElement.value;
+  if (!player || displayImage.value?.mediaType !== 'video') {
+    return;
+  }
+
+  player.muted = appStore.videoMuted;
+
+  if (isPaused.value) {
+    player.pause();
+    return;
+  }
+
+  void player.play().catch(() => {
+    // Ignore autoplay rejections so the viewer can continue advancing.
+  });
+}
+
 function lockBodyScroll() {
   previousBodyOverflow = document.body.style.overflow;
   document.body.style.overflow = 'hidden';
@@ -581,6 +647,9 @@ onMounted(async () => {
   lockBodyScroll();
   window.addEventListener('keydown', handleKeydown);
   await ensureCapsuleLoaded(props.initialId, true);
+  await nextTick();
+  syncAutoplayForCurrentImage();
+  syncMediaPlayback();
 });
 
 onUnmounted(() => {
@@ -758,6 +827,12 @@ onUnmounted(() => {
   object-fit: contain;
 }
 
+.story-stage__video {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
 .story-stage__empty {
   color: rgba(255, 255, 255, 0.62);
 }
@@ -882,6 +957,38 @@ onUnmounted(() => {
   z-index: 3;
   padding: 5rem 1rem 1rem;
   background: linear-gradient(180deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.8) 44%, rgba(0, 0, 0, 0.96));
+}
+
+.story-stage__error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.85rem;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid rgba(255, 122, 122, 0.3);
+  border-radius: 0.9rem;
+  background: rgba(133, 20, 20, 0.34);
+  color: rgba(255, 235, 235, 0.96);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.story-stage__error-button {
+  flex-shrink: 0;
+  border: 0;
+  border-radius: 999px;
+  padding: 0.45rem 0.8rem;
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background-color 150ms ease;
+}
+
+.story-stage__error-button:hover {
+  background: rgba(255, 255, 255, 0.22);
 }
 
 @media (max-width: 768px) {

--- a/client/src/stores/app.ts
+++ b/client/src/stores/app.ts
@@ -65,7 +65,8 @@ export const useAppStore = defineStore('app', {
     hasCompletedScan: (state) => state.stats?.scan.lastCompletedScan !== null,
     isInitialScan: (state) => state.stats?.scan.isScanning === true && state.stats?.scan.lastCompletedScan === null,
     defaultHomeFeedMode: (state): FeedMode => state.stats?.preferences.defaultHomeFeedMode ?? 'random',
-    defaultReelsFeedMode: (state): ReelsFeedMode => state.stats?.preferences.defaultReelsFeedMode ?? 'random'
+    defaultReelsFeedMode: (state): ReelsFeedMode => state.stats?.preferences.defaultReelsFeedMode ?? 'random',
+    treatStoriesAsFolders: (state) => state.stats?.preferences.treatStoriesAsFolders === true
   },
   actions: {
     persistOpenedFolderState() {

--- a/client/src/stores/folder-stories.test.ts
+++ b/client/src/stores/folder-stories.test.ts
@@ -1,0 +1,78 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as galleryApi from '../api/gallery';
+import type { FeedItem, FolderStoriesPayload } from '../types/api';
+import { useFolderStoriesStore } from './folder-stories';
+
+function createFeedItem(id: number): FeedItem {
+  return {
+    id,
+    folderId: 14,
+    folderSlug: 'beach-club',
+    folderName: 'Beach Club',
+    folderPath: 'albums/beach-club',
+    folderBreadcrumb: null,
+    filename: `story-${id}.jpg`,
+    width: 1080,
+    height: 1920,
+    mediaType: 'image',
+    durationMs: null,
+    thumbnailUrl: `/thumbnails/${id}.webp`,
+    previewUrl: `/previews/${id}.webp`,
+    sortTimestamp: 1_778_400_000_000 + id,
+    takenAt: 1_778_400_000_000 + id
+  };
+}
+
+function createStoriesPayload(): FolderStoriesPayload {
+  const coverImage = createFeedItem(31);
+
+  return {
+    railKind: 'stories',
+    railTitle: 'Stories',
+    railDescription: 'Stories and highlights for Beach Club.',
+    railSingularLabel: 'Story',
+    hasAvatarStory: true,
+    avatarStoryId: 'beach-club-story',
+    items: [
+      {
+        id: 'beach-club-story',
+        title: 'Beach Club',
+        subtitle: 'Beach Club story set',
+        dateContext: 'Latest Mar 28, 2026',
+        imageCount: 1,
+        presentation: 'avatar',
+        coverImage
+      }
+    ],
+    highlights: []
+  };
+}
+
+describe('folder stories store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.restoreAllMocks();
+  });
+
+  it('retries the same folder after a previous fetch failure', async () => {
+    const fetchFolderStoriesSpy = vi
+      .spyOn(galleryApi, 'fetchFolderStories')
+      .mockRejectedValueOnce(new Error('Temporary stories failure'))
+      .mockResolvedValueOnce(createStoriesPayload());
+
+    const store = useFolderStoriesStore();
+
+    await store.fetchStories('beach-club');
+    expect(store.listError).toBe('Temporary stories failure');
+    expect(store.items).toHaveLength(0);
+
+    await store.fetchStories('beach-club');
+
+    expect(fetchFolderStoriesSpy).toHaveBeenCalledTimes(2);
+    expect(store.listError).toBeNull();
+    expect(store.items).toHaveLength(1);
+    expect(store.avatarStoryId).toBe('beach-club-story');
+  });
+});

--- a/client/src/stores/folder-stories.ts
+++ b/client/src/stores/folder-stories.ts
@@ -1,0 +1,143 @@
+import { defineStore } from 'pinia';
+
+import { fetchFolderStories, fetchFolderStoryFeed } from '../api/gallery';
+import type { FeedItem, FolderStoriesPayload, RailCapsule } from '../types/api';
+
+interface FolderStoriesState {
+  currentFolderSlug: string | null;
+  railTitle: string;
+  railDescription: string;
+  railSingularLabel: string;
+  hasAvatarStory: boolean;
+  avatarStoryId: string | null;
+  items: RailCapsule[];
+  highlights: RailCapsule[];
+  loadingList: boolean;
+  listError: string | null;
+  currentStory: RailCapsule | null;
+  currentImages: FeedItem[];
+  currentPage: number;
+  currentLimit: number;
+  currentHasMore: boolean;
+  loadingStory: boolean;
+  storyError: string | null;
+}
+
+function createEmptyStoryRail(): Pick<
+  FolderStoriesState,
+  'railTitle' | 'railDescription' | 'railSingularLabel' | 'hasAvatarStory' | 'avatarStoryId' | 'items' | 'highlights'
+> {
+  return {
+    railTitle: 'Stories',
+    railDescription: 'Profile stories and highlights.',
+    railSingularLabel: 'Story',
+    hasAvatarStory: false,
+    avatarStoryId: null,
+    items: [],
+    highlights: []
+  };
+}
+
+function applyStoryRailPayload(state: FolderStoriesState, payload: FolderStoriesPayload) {
+  state.railTitle = payload.railTitle;
+  state.railDescription = payload.railDescription;
+  state.railSingularLabel = payload.railSingularLabel;
+  state.hasAvatarStory = payload.hasAvatarStory;
+  state.avatarStoryId = payload.avatarStoryId;
+  state.items = payload.items;
+  state.highlights = payload.highlights;
+}
+
+function resetCurrentStoryState(state: FolderStoriesState) {
+  state.currentStory = null;
+  state.currentImages = [];
+  state.currentPage = 1;
+  state.currentHasMore = true;
+  state.loadingStory = false;
+  state.storyError = null;
+}
+
+export const useFolderStoriesStore = defineStore('folderStories', {
+  state: (): FolderStoriesState => ({
+    currentFolderSlug: null,
+    ...createEmptyStoryRail(),
+    loadingList: false,
+    listError: null,
+    currentStory: null,
+    currentImages: [],
+    currentPage: 1,
+    currentLimit: 18,
+    currentHasMore: true,
+    loadingStory: false,
+    storyError: null
+  }),
+  getters: {
+    currentCapsule: (state) => state.currentStory,
+    currentError: (state) => state.storyError
+  },
+  actions: {
+    reset() {
+      this.currentFolderSlug = null;
+      Object.assign(this, createEmptyStoryRail());
+      this.loadingList = false;
+      this.listError = null;
+      resetCurrentStoryState(this);
+    },
+
+    async fetchStories(slug: string, force = false) {
+      if (this.loadingList) {
+        return;
+      }
+
+      if (!force && this.currentFolderSlug === slug && this.items.length > 0 && this.listError === null) {
+        return;
+      }
+
+      this.currentFolderSlug = slug;
+      resetCurrentStoryState(this);
+      this.loadingList = true;
+      this.listError = null;
+
+      try {
+        const payload = await fetchFolderStories(slug);
+        applyStoryRailPayload(this, payload);
+      } catch (error) {
+        Object.assign(this, createEmptyStoryRail());
+        this.listError = error instanceof Error ? error.message : 'Unable to load folder stories';
+      } finally {
+        this.loadingList = false;
+      }
+    },
+
+    async loadCapsule(id: string, reset = true) {
+      if (this.loadingStory || !this.currentFolderSlug) {
+        return;
+      }
+
+      if (reset) {
+        this.currentStory = null;
+        this.currentImages = [];
+        this.currentPage = 1;
+        this.currentHasMore = true;
+      }
+
+      this.loadingStory = true;
+      this.storyError = null;
+
+      try {
+        const payload = await fetchFolderStoryFeed(this.currentFolderSlug, id, this.currentPage, this.currentLimit);
+        this.railTitle = payload.railTitle;
+        this.railDescription = payload.railDescription;
+        this.railSingularLabel = payload.railSingularLabel;
+        this.currentStory = payload.story;
+        this.currentImages.push(...payload.items);
+        this.currentPage += 1;
+        this.currentHasMore = payload.hasMore;
+      } catch (error) {
+        this.storyError = error instanceof Error ? error.message : 'Unable to load this story capsule';
+      } finally {
+        this.loadingStory = false;
+      }
+    }
+  }
+});

--- a/client/src/stores/moments.ts
+++ b/client/src/stores/moments.ts
@@ -37,6 +37,10 @@ export const useMomentsStore = defineStore('moments', {
     loadingMoment: false,
     momentError: null
   }),
+  getters: {
+    currentCapsule: (state) => state.currentMoment,
+    currentError: (state) => state.momentError
+  },
   actions: {
     removeImage(imageId: number) {
       if (this.currentMoment) {
@@ -124,6 +128,10 @@ export const useMomentsStore = defineStore('moments', {
       } finally {
         this.loadingMoment = false;
       }
+    },
+
+    async loadCapsule(id: string, reset = true) {
+      await this.loadMoment(id, reset);
     }
   }
 });

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -1,6 +1,7 @@
 export type FeedMode = 'recent' | 'rediscover' | 'random';
 export type ReelsFeedMode = 'recommended' | 'recent' | 'random';
 export type FeedRailKind = 'moments' | 'highlights';
+export type StoryCapsulePresentation = 'avatar' | 'highlight';
 
 export interface HomeFeedDefaultSetting {
   defaultMode: FeedMode;
@@ -8,6 +9,10 @@ export interface HomeFeedDefaultSetting {
 
 export interface ReelsFeedDefaultSetting {
   defaultMode: ReelsFeedMode;
+}
+
+export interface StoriesModeSetting {
+  treatStoriesAsFolders: boolean;
 }
 
 export interface FeedItem {
@@ -39,6 +44,7 @@ export interface FolderSummary {
   imageCount: number;
   videoCount: number;
   latestImageMtimeMs: number | null;
+  hasAvatarStory?: boolean;
   avatarImageId: number | null;
   avatarUrl: string | null;
 }
@@ -75,14 +81,17 @@ export interface PaginatedReels {
   hasMore: boolean;
 }
 
-export interface MomentCapsule {
+export interface RailCapsule {
   id: string;
   title: string;
   subtitle: string;
   dateContext: string;
   imageCount: number;
   coverImage: FeedItem;
+  presentation?: StoryCapsulePresentation;
 }
+
+export type MomentCapsule = RailCapsule;
 
 export interface MomentsPayload {
   railKind: FeedRailKind;
@@ -97,7 +106,26 @@ export interface MomentFeedPayload extends PaginatedFeed {
   railTitle: string;
   railDescription: string;
   railSingularLabel: string;
-  moment: MomentCapsule;
+  moment: RailCapsule;
+}
+
+export interface FolderStoriesPayload {
+  railKind: 'stories';
+  railTitle: string;
+  railDescription: string;
+  railSingularLabel: string;
+  hasAvatarStory: boolean;
+  avatarStoryId: string | null;
+  items: RailCapsule[];
+  highlights: RailCapsule[];
+}
+
+export interface FolderStoryFeedPayload extends PaginatedFeed {
+  railKind: 'stories';
+  railTitle: string;
+  railDescription: string;
+  railSingularLabel: string;
+  story: RailCapsule;
 }
 
 export interface FolderImagesPayload extends PaginatedFeed {
@@ -215,6 +243,11 @@ export interface AppStatus {
   preferences: {
     defaultHomeFeedMode: FeedMode;
     defaultReelsFeedMode: ReelsFeedMode;
+    treatStoriesAsFolders: boolean;
+  };
+  storiesMigration: {
+    hasLegacyStoriesCandidates: boolean;
+    decisionPending: boolean;
   };
 }
 
@@ -257,4 +290,12 @@ export interface AuthStatus {
 export interface AuthMutationResult {
   ok: boolean;
   auth: AuthStatus;
+}
+
+export interface RailViewerStoreContract {
+  currentCapsule: RailCapsule | null;
+  currentImages: FeedItem[];
+  currentHasMore: boolean;
+  currentError?: string | null;
+  loadCapsule(id: string, reset?: boolean): Promise<void>;
 }

--- a/client/src/views/FolderView.vue
+++ b/client/src/views/FolderView.vue
@@ -24,7 +24,27 @@
     <template v-else-if="foldersStore.currentFolder">
       <div class="mx-auto grid w-full max-w-[69rem] gap-[0.15rem]">
         <div class="mx-auto w-[min(100%,54rem)]">
-          <FolderHeader :folder="foldersStore.currentFolder" />
+          <FolderHeader
+            :folder="foldersStore.currentFolder"
+            :has-avatar-story="folderStoriesStore.hasAvatarStory"
+            @open-avatar-story="openAvatarStory"
+          />
+        </div>
+        <div
+          v-if="folderStoriesStore.listError"
+          class="mx-auto mb-5 grid w-[min(100%,66.5625rem)] gap-[0.75rem] rounded-[1rem] border border-[rgba(214,48,49,0.24)] bg-[rgba(214,48,49,0.08)] px-4 py-[0.95rem] text-[#c0392b]"
+          role="alert"
+        >
+          <p class="m-0 text-[0.92rem]">{{ folderStoriesStore.listError }}</p>
+          <div>
+            <button
+              class="inline-flex min-h-9 items-center justify-center rounded-[0.8rem] border border-[rgba(192,57,43,0.18)] bg-white/65 px-3 text-[0.82rem] font-semibold text-[#a93226] transition-colors duration-180 hover:bg-white"
+              type="button"
+              @click="retryFolderStories"
+            >
+              Retry Stories
+            </button>
+          </div>
         </div>
         <EmptyState
           v-if="
@@ -45,6 +65,32 @@
         />
         <template v-else>
           <section class="mx-auto w-[min(100%,66.5625rem)]">
+            <div
+              v-if="folderStoriesStore.highlights.length"
+              class="mb-5 overflow-x-auto pb-3 pt-[0.12rem] [scrollbar-width:none]"
+              aria-label="Folder stories"
+            >
+              <div class="mx-auto flex w-max min-w-full justify-center gap-[0.95rem] px-1">
+                <button
+                  v-for="story in folderStoriesStore.highlights"
+                  :key="story.id"
+                  class="flex flex-col items-center gap-[0.48rem] min-w-[5.85rem] border-0 bg-transparent p-0 text-muted text-[0.74rem] text-center cursor-pointer transition-transform duration-180 hover:-translate-y-[1px]"
+                  :title="`${story.title} · ${story.subtitle}`"
+                  type="button"
+                  @click="openStoryViewer(story.id)"
+                >
+                  <div
+                    class="rounded-full p-[0.2rem] shadow-[0_14px_30px_rgba(246,106,61,0.18)]"
+                    style="background: var(--story-ring);"
+                  >
+                    <div class="rounded-full bg-bg p-[0.2rem]">
+                      <Avatar class="w-[4.625rem] h-[4.625rem]" :name="story.title" :src="story.coverImage.thumbnailUrl" />
+                    </div>
+                  </div>
+                  <span class="max-w-[5.75rem] overflow-hidden text-ellipsis whitespace-nowrap font-semibold leading-tight text-text">{{ story.title }}</span>
+                </button>
+              </div>
+            </div>
             <div class="flex justify-center border-b border-border" aria-label="Folder sections">
               <div class="flex items-center gap-40 pt-[0.2rem] max-sm:gap-[2.9rem] max-sm:pt-[0.12rem]">
                 <button
@@ -114,6 +160,15 @@
           </section>
         </template>
       </div>
+
+      <StoriesModal
+        v-if="activeStoryViewerId && folderStoriesStore.items.length"
+        :items="folderStoriesStore.items"
+        :initial-id="activeStoryViewerId"
+        :rail-singular-label="folderStoriesStore.railSingularLabel"
+        :store="folderStoriesStore"
+        @close="closeStoryViewer"
+      />
     </template>
     <EmptyState
       v-else-if="hasLoadedOnce && !foldersStore.loadingFolder"
@@ -133,7 +188,10 @@
   import InfiniteLoader from "../components/InfiniteLoader.vue"
   import FolderGrid from "../components/FolderGrid.vue"
   import FolderHeader from "../components/FolderHeader.vue"
+  import Avatar from "../components/Avatar.vue"
+  import StoriesModal from "../components/StoriesModal.vue"
   import { useAppStore } from "../stores/app"
+  import { useFolderStoriesStore } from "../stores/folder-stories"
   import { useFoldersStore } from "../stores/folders"
 
   const props = defineProps<{
@@ -141,10 +199,12 @@
   }>()
 
   const appStore = useAppStore()
+  const folderStoriesStore = useFolderStoriesStore()
   const foldersStore = useFoldersStore()
   const route = useRoute()
   const router = useRouter()
   const hasLoadedOnce = ref(false)
+  const activeStoryViewerId = ref<string | null>(null)
   const activeTab = computed(() =>
     route.query.tab === "reels" ? "reels" : "posts",
   )
@@ -158,11 +218,14 @@
       return
     }
 
-    await foldersStore.loadFolder(
-      props.slug,
-      true,
-      activeTab.value === "reels" ? "video" : undefined,
-    )
+    await Promise.all([
+      foldersStore.loadFolder(
+        props.slug,
+        true,
+        activeTab.value === "reels" ? "video" : undefined,
+      ),
+      folderStoriesStore.fetchStories(props.slug, folderStoriesStore.currentFolderSlug !== props.slug),
+    ])
 
     if (activeTab.value === "reels" && !hasReelsTab.value) {
       await router.replace({
@@ -207,11 +270,32 @@
     })
   }
 
+  function openAvatarStory() {
+    if (!folderStoriesStore.hasAvatarStory || !folderStoriesStore.avatarStoryId) {
+      return
+    }
+
+    activeStoryViewerId.value = folderStoriesStore.avatarStoryId
+  }
+
+  function openStoryViewer(id: string) {
+    activeStoryViewerId.value = id
+  }
+
+  function closeStoryViewer() {
+    activeStoryViewerId.value = null
+  }
+
+  async function retryFolderStories() {
+    await folderStoriesStore.fetchStories(props.slug, true)
+  }
+
   onMounted(loadFolder)
   watch(
     () => [props.slug, activeTab.value] as const,
     async () => {
       hasLoadedOnce.value = false
+      activeStoryViewerId.value = null
       await loadFolder()
     },
   )

--- a/client/src/views/HomeView.vue
+++ b/client/src/views/HomeView.vue
@@ -50,7 +50,7 @@
               @click="openRailViewer(moment.id)"
             >
               <div
-                class="rounded-full p-[0.26rem] shadow-[0_14px_30px_rgba(246,106,61,0.18)]"
+                class="rounded-full p-[0.2rem] shadow-[0_14px_30px_rgba(246,106,61,0.18)]"
                 style="background: var(--story-ring);"
               >
                 <div class="rounded-full bg-bg p-[0.2rem]">
@@ -159,21 +159,53 @@
       </section>
       <EmptyState v-else-if="feedStore.initialized && feedStore.items.length === 0" title="No posts indexed yet" description="Add folders under the gallery root and the feed will populate after the next scan." />
       <template v-else>
+        <div
+          v-if="feedStoryError"
+          class="mx-auto mb-[1.1rem] grid w-full max-w-[29.375rem] gap-[0.75rem] rounded-[1rem] border border-[rgba(214,48,49,0.24)] bg-[rgba(214,48,49,0.08)] px-4 py-[0.95rem] text-[#c0392b]"
+          role="alert"
+        >
+          <p class="m-0 text-[0.92rem]">{{ feedStoryError }}</p>
+          <div>
+            <button
+              class="inline-flex min-h-9 items-center justify-center rounded-[0.8rem] border border-[rgba(192,57,43,0.18)] bg-white/65 px-3 text-[0.82rem] font-semibold text-[#a93226] transition-colors duration-180 hover:bg-white"
+              type="button"
+              :disabled="!feedStoryRetrySlug"
+              @click="retryFeedFolderStory"
+            >
+              Retry Story
+            </button>
+          </div>
+        </div>
+
         <!-- Feed cards in home-layout context: transparent card, no shadow -->
         <div class="w-full max-w-[29.375rem] mx-auto flex flex-col gap-[1.2rem]">
-          <FeedList :items="feedStore.items" context="home" :show-skeleton="!feedStore.initialized && feedStore.loading" />
+          <FeedList
+            :items="feedStore.items"
+            context="home"
+            :show-skeleton="!feedStore.initialized && feedStore.loading"
+            @open-folder-story="openFeedFolderStory"
+          />
         </div>
         <div class="w-full max-w-[29.375rem] mx-auto">
           <InfiniteLoader :loading="feedStore.loading" :has-more="feedStore.hasMore" @load-more="feedStore.loadMore" />
         </div>
       </template>
 
-      <RailViewerModal
+      <StoriesModal
         v-if="activeRailViewerId && momentsStore.items.length"
         :items="momentsStore.items"
         :initial-id="activeRailViewerId"
         :rail-singular-label="momentsStore.railSingularLabel"
+        :store="momentsStore"
         @close="closeRailViewer"
+      />
+      <StoriesModal
+        v-if="activeFeedStoryId && folderStoriesStore.items.length"
+        :items="folderStoriesStore.items"
+        :initial-id="activeFeedStoryId"
+        :rail-singular-label="folderStoriesStore.railSingularLabel"
+        :store="folderStoriesStore"
+        @close="closeFeedFolderStory"
       />
     </div>
 
@@ -242,10 +274,11 @@ import EmptyState from '../components/EmptyState.vue';
 import ErrorState from '../components/ErrorState.vue';
 import FeedList from '../components/FeedList.vue';
 import InfiniteLoader from '../components/InfiniteLoader.vue';
-import RailViewerModal from '../components/RailViewerModal.vue';
+import StoriesModal from '../components/StoriesModal.vue';
 import { useAppStore } from '../stores/app';
 import { useAuthStore } from '../stores/auth';
 import { useFeedStore } from '../stores/feed';
+import { useFolderStoriesStore } from '../stores/folder-stories';
 import { useLikesStore } from '../stores/likes';
 import { useFoldersStore } from '../stores/folders';
 import { useMomentsStore } from '../stores/moments';
@@ -255,6 +288,7 @@ import { buildLikedCountByFolder, selectHomeRecommendations } from '../utils/hom
 const appStore = useAppStore();
 const authStore = useAuthStore();
 const feedStore = useFeedStore();
+const folderStoriesStore = useFolderStoriesStore();
 const likesStore = useLikesStore();
 const foldersStore = useFoldersStore();
 const momentsStore = useMomentsStore();
@@ -265,10 +299,13 @@ const homeRecommendations = computed(() =>
 const homeSummaryFolder = computed(() => homeRecommendations.value.homeSummaryFolder);
 const recommendedFolders = computed(() => homeRecommendations.value.recommendedFolders);
 const activeRailViewerId = ref<string | null>(null);
+const activeFeedStoryId = ref<string | null>(null);
+const feedStoryRetrySlug = ref<string | null>(null);
 const homeLayoutElement = ref<HTMLElement | null>(null);
 const isCompactHomeLayout = ref(false);
 const requestingHomeScan = ref(false);
 const homeScanError = ref<string | null>(null);
+const feedStoryError = ref<string | null>(null);
 
 const HOME_RIGHT_RAIL_BREAKPOINT = 960;
 let homeLayoutResizeObserver: ResizeObserver | null = null;
@@ -418,11 +455,57 @@ async function selectMode(mode: FeedMode) {
 }
 
 function openRailViewer(id: string) {
+  activeFeedStoryId.value = null;
   activeRailViewerId.value = id;
 }
 
 function closeRailViewer() {
   activeRailViewerId.value = null;
+}
+
+async function openFeedFolderStory(slug: string) {
+  if (appStore.isLibraryUnavailable) {
+    return;
+  }
+
+  activeRailViewerId.value = null;
+  activeFeedStoryId.value = null;
+  feedStoryRetrySlug.value = slug;
+  feedStoryError.value = null;
+
+  await folderStoriesStore.fetchStories(slug, folderStoriesStore.currentFolderSlug !== slug);
+  if (folderStoriesStore.listError) {
+    feedStoryError.value = folderStoriesStore.listError;
+    return;
+  }
+
+  if (!folderStoriesStore.hasAvatarStory || !folderStoriesStore.avatarStoryId) {
+    return;
+  }
+
+  activeFeedStoryId.value = folderStoriesStore.avatarStoryId;
+}
+
+function closeFeedFolderStory() {
+  activeFeedStoryId.value = null;
+}
+
+async function retryFeedFolderStory() {
+  if (!feedStoryRetrySlug.value) {
+    return;
+  }
+
+  await folderStoriesStore.fetchStories(feedStoryRetrySlug.value, true);
+  if (folderStoriesStore.listError) {
+    feedStoryError.value = folderStoriesStore.listError;
+    return;
+  }
+
+  feedStoryError.value = null;
+
+  if (folderStoriesStore.hasAvatarStory && folderStoriesStore.avatarStoryId) {
+    activeFeedStoryId.value = folderStoriesStore.avatarStoryId;
+  }
 }
 
 function updateHomeLayout() {
@@ -517,6 +600,17 @@ watch(
   (ids) => {
     if (activeRailViewerId.value && !ids.includes(activeRailViewerId.value)) {
       activeRailViewerId.value = ids[0] ?? null;
+    }
+  }
+);
+
+watch(
+  () => folderStoriesStore.items.map((item) => item.id),
+  (ids) => {
+    if (activeFeedStoryId.value && !ids.includes(activeFeedStoryId.value)) {
+      activeFeedStoryId.value = folderStoriesStore.avatarStoryId && ids.includes(folderStoriesStore.avatarStoryId)
+        ? folderStoriesStore.avatarStoryId
+        : null;
     }
   }
 );

--- a/client/src/views/SettingsView.test.ts
+++ b/client/src/views/SettingsView.test.ts
@@ -49,7 +49,12 @@ function createAppStatus(
     },
     preferences: {
       defaultHomeFeedMode,
-      defaultReelsFeedMode
+      defaultReelsFeedMode,
+      treatStoriesAsFolders: false
+    },
+    storiesMigration: {
+      hasLegacyStoriesCandidates: false,
+      decisionPending: false
     }
   };
 }
@@ -115,8 +120,6 @@ describe('SettingsView', () => {
 
     expect(saveButton).toBeDefined();
     expect(saveButton!.attributes('disabled')).toBeDefined();
-    expect(saveButton!.attributes('style')).toContain('cursor: not-allowed');
-    expect(saveButton!.attributes('style')).not.toContain('wait');
   });
 
   it('hydrates the saved feed defaults correctly when app status finishes loading after mount', async () => {
@@ -153,7 +156,6 @@ describe('SettingsView', () => {
 
     expect(saveButton).toBeDefined();
     expect(saveButton!.attributes('disabled')).toBeDefined();
-    expect(saveButton!.attributes('style')).toContain('cursor: not-allowed');
   });
 
   it('saves the reels default from the feed defaults card', async () => {

--- a/client/src/views/SettingsView.vue
+++ b/client/src/views/SettingsView.vue
@@ -351,6 +351,138 @@
 
         <!-- CATEGORY: LIBRARY -->
         <template v-if="currentCategory === 'library'">
+          <section
+            v-if="showStoriesMigrationNotice"
+            class="card grid gap-[1rem] p-6 border-[color-mix(in_srgb,#d2a133_42%,var(--border)_58%)]"
+            style="background: radial-gradient(circle at top right, rgba(210,161,51,0.18), transparent 40%), linear-gradient(180deg, color-mix(in srgb, var(--surface) 94%, #fff3cf 6%) 0%, color-mix(in srgb, var(--surface) 88%, #ffe6a6 12%) 100%);"
+          >
+            <div class="flex items-start justify-between gap-4">
+              <div class="grid gap-[0.3rem]">
+                <span class="eyebrow text-[#9f6a00]">Stories Migration</span>
+                <h2 class="m-0 text-[1.1rem]">This library may already use folders named stories</h2>
+                <p class="m-0 text-muted">
+                  Foldergram can now treat <code>stories/</code> as profile stories and highlights by default. Choose whether to keep legacy folder behavior or switch to the new reserved stories mode, then rescan the library.
+                </p>
+              </div>
+              <button
+                class="inline-flex h-9 w-9 items-center justify-center rounded-full border-0 bg-[rgba(159,106,0,0.08)] text-[#9f6a00] cursor-pointer transition-colors duration-180 hover:bg-[rgba(159,106,0,0.14)]"
+                type="button"
+                aria-label="Dismiss stories migration notice"
+                @click="dismissStoriesMigrationNotice"
+              >
+                <span class="i-fluent-dismiss-20-filled h-5 w-5" aria-hidden="true" />
+              </button>
+            </div>
+
+            <div class="flex flex-col md:flex-row items-center gap-3 max-sm:items-stretch">
+              <button class="btn-primary min-w-[13rem]" type="button" :disabled="storiesModeActionBusy || !authStore.canManageLibrary" @click="openStoriesModeConfirm(false)">
+                Use Stories Feature
+              </button>
+              <button
+                class="inline-flex min-h-11 items-center justify-center rounded-[0.95rem] border border-border bg-transparent px-4 text-[0.92rem] font-semibold text-text transition-colors duration-180 hover:bg-surface-alt disabled:cursor-not-allowed disabled:opacity-60"
+                type="button"
+                :disabled="storiesModeActionBusy || !authStore.canManageLibrary"
+                @click="openStoriesModeConfirm(true)"
+              >
+                Keep Legacy Behavior
+              </button>
+            </div>
+            <p class="m-0 text-muted">{{ storiesModeActionHelper }}</p>
+          </section>
+
+          <section
+            v-else-if="showStoriesAnnouncementCard"
+            class="card grid gap-[1rem] border-[color-mix(in_srgb,var(--border)_84%,#8cc8ff_16%)] p-6"
+            style="background: linear-gradient(135deg, color-mix(in srgb, var(--surface) 97%, #f7fbff 3%) 0%, color-mix(in srgb, var(--surface) 93%, #e6f3ff 7%) 100%);"
+          >
+            <div class="flex items-start justify-between gap-4">
+              <div class="grid gap-[0.3rem]">
+                <div class="flex items-center gap-2">
+                  <h2 class="m-0 text-xl">Stories</h2>
+                  <span class="eyebrow inline-flex w-fit self-start text-xs">New Feature</span>
+                </div>
+                <p class="m-0 text-[0.95rem] font-medium text-text">Reserved <code>stories/</code> folders can power App Folder stories</p>
+                <p class="m-0 text-muted">
+                  Drop direct media into <code>AppFolder/stories</code> for the avatar story set, and use direct child folders for highlight circles. Nested folders stay inside the same highlight capsule.
+                  <button
+                    class="ml-1 inline-flex border-0 bg-transparent p-0 text-[0.92em] font-semibold text-accent-strong underline underline-offset-[0.18em] cursor-pointer transition-opacity duration-180 hover:opacity-80"
+                    type="button"
+                    :aria-expanded="showStoriesAnnouncementStructure"
+                    @click="toggleStoriesAnnouncementStructure"
+                  >
+                    {{ showStoriesAnnouncementStructure ? 'Hide directory structure' : 'See directory structure' }}
+                  </button>
+                </p>
+              </div>
+              <button
+                class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-0 bg-[rgba(24,119,242,0.08)] text-accent-strong cursor-pointer transition-colors duration-180 hover:bg-[rgba(24,119,242,0.14)]"
+                type="button"
+                aria-label="Dismiss stories announcement"
+                @click="dismissStoriesAnnouncement"
+              >
+                <span class="i-fluent-dismiss-20-filled h-5 w-5" aria-hidden="true" />
+              </button>
+            </div>
+
+            <pre v-if="showStoriesAnnouncementStructure" class="m-0 overflow-x-auto rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_82%,transparent_18%)] p-4 text-[0.78rem] leading-[1.55] text-muted"><code>gallery/
+└─ AnimalPlanet/
+   ├─ cover.jpg
+   ├─ post-1.jpg
+   └─ stories/
+      ├─ story-1.mp4
+      ├─ story-2.jpg
+      ├─ Lions/
+      │  ├─ clip-1.mp4
+      │  └─ nested-1/
+      │     └─ clip-2.jpg
+      └─ Tigers/
+         └─ tiger-1.jpg</code></pre>
+          </section>
+
+          <section class="card grid gap-[1.15rem] p-6">
+            <div class="flex items-start justify-between gap-4 max-sm:flex-col max-sm:items-start">
+              <div>
+                <h2 class="m-0 text-[1.18rem]">Stories folders</h2>
+                <p class="m-0 mt-[0.25rem] text-muted">
+                  {{ storiesModeDescription }}
+                </p>
+              </div>
+              <span class="inline-flex items-center justify-center min-h-8 px-[0.7rem] py-[0.35rem] rounded-full text-[0.76rem] font-bold whitespace-nowrap text-accent-strong bg-[color-mix(in_srgb,var(--accent-soft)_78%,transparent_22%)]">
+                {{ storiesMode ? 'Legacy folders' : 'Reserved stories' }}
+              </span>
+            </div>
+
+            <label class="flex items-start gap-3 rounded-[0.95rem] border border-border px-4 py-3 cursor-pointer">
+              <input
+                v-model="storiesMode"
+                class="mt-[0.2rem]"
+                type="checkbox"
+                :disabled="storiesModeActionBusy || waitingForInitialStatus"
+              />
+              <span class="grid gap-[0.15rem]">
+                <span class="text-[0.92rem] font-semibold text-text">Treat stories folders as normal app folders</span>
+                <span class="text-[0.84rem] text-muted">{{ storiesModeLabelDescription }}</span>
+              </span>
+            </label>
+
+            <div v-if="storiesModeFeedback" class="rounded-[0.95rem] px-4 py-3 text-[0.9rem]" :class="storiesModeFeedback.tone === 'error' ? 'border border-[rgba(214,48,49,0.24)] text-[#c0392b] bg-[rgba(214,48,49,0.08)]' : 'border border-[rgba(24,119,242,0.2)] text-accent-strong bg-[rgba(24,119,242,0.08)]'">
+              {{ storiesModeFeedback.message }}
+            </div>
+
+            <div class="flex flex-col md:flex-row items-center gap-3 max-sm:items-stretch">
+              <p class="m-0 flex-1 text-muted">{{ storiesModeActionNote }}</p>
+              <button
+                class="btn-primary min-w-[13rem]"
+                type="button"
+                :disabled="storiesModeActionDisabled"
+                :style="{ cursor: storiesModeActionBusy ? 'wait' : storiesModeActionDisabled ? 'not-allowed' : undefined }"
+                @click="openStoriesModeConfirm(storiesMode)"
+              >
+                {{ storiesModeButtonLabel }}
+              </button>
+            </div>
+          </section>
+
           <section class="card grid gap-[1.15rem] p-6">
             <div class="flex items-start justify-between gap-4 max-sm:flex-col max-sm:items-start">
               <div>
@@ -607,6 +739,16 @@
       @cancel="confirmThumbnailRebuildOpen = false"
       @confirm="runThumbnailRebuild"
     />
+    <ConfirmDialog
+      v-if="confirmStoriesModeOpen"
+      :title="storiesModeConfirmTitle"
+      :message="storiesModeConfirmMessage"
+      confirm-label="Save and Rescan"
+      loading-label="Saving..."
+      :loading="savingStoriesMode"
+      @cancel="confirmStoriesModeOpen = false"
+      @confirm="runStoriesModeSave"
+    />
   </section>
 </template>
 <script setup lang="ts">
@@ -614,7 +756,7 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 
 import ConfirmDialog from '../components/ConfirmDialog.vue';
-import { fetchAdminStats, triggerLibraryRebuild, triggerManualScan, triggerThumbnailRebuild, updateHomeFeedDefault, updateReelsFeedDefault } from '../api/gallery';
+import { fetchAdminStats, triggerLibraryRebuild, triggerManualScan, triggerThumbnailRebuild, updateHomeFeedDefault, updateReelsFeedDefault, updateStoriesMode } from '../api/gallery';
 import { useAppStore } from '../stores/app';
 import { useAuthStore } from '../stores/auth';
 import { useFeedStore } from '../stores/feed';
@@ -639,12 +781,15 @@ const thumbnailRebuildError = ref<string | null>(null);
 const requestingScan = ref(false);
 const rebuilding = ref(false);
 const rebuildingThumbnails = ref(false);
+const savingStoriesMode = ref(false);
 const savingFeedDefaults = ref(false);
 const confirmRebuildOpen = ref(false);
 const confirmThumbnailRebuildOpen = ref(false);
+const confirmStoriesModeOpen = ref(false);
 const authFeedback = ref<{ tone: 'success' | 'error'; message: string } | null>(null);
 const viewerFeedback = ref<{ tone: 'success' | 'error'; message: string } | null>(null);
 const feedDefaultsFeedback = ref<{ tone: 'success' | 'error'; message: string } | null>(null);
+const storiesModeFeedback = ref<{ tone: 'success' | 'error'; message: string } | null>(null);
 const adminStats = ref<AppStats | null>(null);
 const showChangePasswordForm = ref(false);
 const showDisablePasswordForm = ref(false);
@@ -656,7 +801,11 @@ const nextPasswordConfirmation = ref('');
 const disablePassword = ref('');
 const homeFeedDefaultMode = ref<FeedMode>('random');
 const reelsFeedDefaultMode = ref<ReelsFeedMode>('random');
+const storiesMode = ref(false);
 const feedDefaultsHydrated = ref(false);
+const storiesModeHydrated = ref(false);
+const pendingStoriesModeValue = ref<boolean | null>(null);
+const showStoriesAnnouncementStructure = ref(false);
 const viewerAccessMode = ref<ViewerAccessMode>(authStore.accessMode);
 const viewerPassword = ref('');
 const viewerPasswordConfirmation = ref('');
@@ -666,6 +815,8 @@ const NOTICE_DISMISS_MS = 7 * 24 * 60 * 60 * 1000;
 const MIN_PASSWORD_LENGTH = 8;
 const HOME_FEED_DEFAULT_GROUP_NAME = 'home-feed-default';
 const REELS_FEED_DEFAULT_GROUP_NAME = 'reels-feed-default';
+const STORIES_MIGRATION_NOTICE_STORAGE_KEY = 'foldergram-stories-migration-dismissed';
+const STORIES_ANNOUNCEMENT_STORAGE_KEY = 'foldergram-stories-announcement-dismissed';
 
 function loadDismissedScanErrorNotice(): { scanId: number; dismissedUntil: number } | null {
   if (typeof window === 'undefined') {
@@ -699,6 +850,8 @@ function loadDismissedScanErrorNotice(): { scanId: number; dismissedUntil: numbe
 
 const dismissedScanErrorNotice = ref(loadDismissedScanErrorNotice());
 const dismissedIgnoredRootMediaNotice = ref(loadDismissedIgnoredRootMediaNotice());
+const dismissedStoriesMigrationNotice = ref(loadDismissedStoriesNotice(STORIES_MIGRATION_NOTICE_STORAGE_KEY));
+const dismissedStoriesAnnouncement = ref(loadDismissedStoriesNotice(STORIES_ANNOUNCEMENT_STORAGE_KEY));
 
 function wait(milliseconds: number) {
   return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
@@ -731,6 +884,10 @@ function clearViewerFeedback() {
 
 function clearFeedDefaultsFeedback() {
   feedDefaultsFeedback.value = null;
+}
+
+function clearStoriesModeFeedback() {
+  storiesModeFeedback.value = null;
 }
 
 function setAuthError(message: string) {
@@ -814,6 +971,11 @@ function syncFeedDefaultsFromSaved() {
   feedDefaultsHydrated.value = true;
 }
 
+function syncStoriesModeFromSaved() {
+  storiesMode.value = appStore.treatStoriesAsFolders;
+  storiesModeHydrated.value = true;
+}
+
 const scan = computed(() => appStore.stats?.scan ?? null);
 const lastCompletedScan = computed(() => scan.value?.lastCompletedScan ?? adminStats.value?.lastScan ?? null);
 const activeScanReason = computed(() => scan.value?.scanReason ?? null);
@@ -863,6 +1025,8 @@ const highlightRebuildAction = computed(() => route.query.action === 'rebuild');
 const waitingForInitialStatus = computed(() => !appStore.stats || appStore.loadingStats);
 const savedHomeFeedDefaultMode = computed(() => appStore.defaultHomeFeedMode);
 const savedReelsFeedDefaultMode = computed(() => appStore.defaultReelsFeedMode);
+const savedStoriesMode = computed(() => appStore.treatStoriesAsFolders);
+const storiesModeRequiresDecision = computed(() => appStore.stats?.storiesMigration.decisionPending === true);
 const savedHomeFeedDefaultModeLabel = computed(
   () => homeFeedDefaultOptions.find((mode) => mode.id === savedHomeFeedDefaultMode.value)?.label ?? 'Random'
 );
@@ -876,8 +1040,19 @@ const reelsFeedDefaultDirty = computed(
   () => feedDefaultsHydrated.value && reelsFeedDefaultMode.value !== savedReelsFeedDefaultMode.value
 );
 const feedDefaultsDirty = computed(() => homeFeedDefaultDirty.value || reelsFeedDefaultDirty.value);
+const storiesModeDirty = computed(() => storiesModeHydrated.value && storiesMode.value !== savedStoriesMode.value);
 const feedDefaultsSaveDisabled = computed(
   () => waitingForInitialStatus.value || savingFeedDefaults.value || !feedDefaultsDirty.value
+);
+const storiesModeActionBusy = computed(
+  () => savingStoriesMode.value || requestingScan.value || rebuilding.value || rebuildingThumbnails.value || appStore.isScanning
+);
+const storiesModeActionDisabled = computed(
+  () =>
+    waitingForInitialStatus.value ||
+    appStore.isLibraryUnavailable ||
+    storiesModeActionBusy.value ||
+    (!storiesModeDirty.value && !storiesModeRequiresDecision.value)
 );
 const feedDefaultsButtonLabel = computed(() => {
   if (savingFeedDefaults.value) {
@@ -885,6 +1060,17 @@ const feedDefaultsButtonLabel = computed(() => {
   }
 
   return feedDefaultsDirty.value ? 'Save Feed Defaults' : 'Saved';
+});
+const storiesModeButtonLabel = computed(() => {
+  if (savingStoriesMode.value) {
+    return 'Saving...';
+  }
+
+  if (storiesModeDirty.value || storiesModeRequiresDecision.value) {
+    return 'Save and Rescan';
+  }
+
+  return 'Saved';
 });
 const feedDefaultsButtonStyle = computed(() =>
   feedDefaultsSaveDisabled.value ? { cursor: savingFeedDefaults.value ? 'wait' : 'not-allowed' } : undefined
@@ -908,6 +1094,73 @@ const feedDefaultsActionNote = computed(() => {
 
   return 'These are the current app-wide defaults for Home and Reels.';
 });
+const storiesModeDescription = computed(() =>
+  storiesMode.value
+    ? 'Folders named stories behave like ordinary app folders across the app.'
+    : 'Folders named stories become profile stories/highlights instead of standalone app folders.'
+);
+const storiesModeLabelDescription = computed(() =>
+  storiesMode.value
+    ? 'Legacy mode is enabled. stories folders remain ordinary app folders everywhere.'
+    : 'Reserved stories mode is enabled. AppFolder/stories powers avatar stories and highlight circles.'
+);
+const storiesModeActionNote = computed(() => {
+  if (waitingForInitialStatus.value) {
+    return 'Loading the current stories folders mode...';
+  }
+
+  if (appStore.isLibraryUnavailable) {
+    return appStore.libraryUnavailableReason;
+  }
+
+  if (storiesModeActionBusy.value) {
+    return 'Wait for the current library task to finish first.';
+  }
+
+  if (storiesModeRequiresDecision.value) {
+    return 'Save your choice and rescan so the indexed folder structure matches the stories mode.';
+  }
+
+  if (storiesModeDirty.value) {
+    return 'Changing this setting requires a rescan because stories paths are reinterpreted.';
+  }
+
+  return 'Reserved stories mode is the default. Enable legacy mode only if you rely on normal app folders literally named stories.';
+});
+const storiesModeActionHelper = computed(() => {
+  if (!authStore.canManageLibrary) {
+    return 'An admin session needs to confirm the stories folder mode and run the rescan.';
+  }
+
+  if (storiesModeActionBusy.value) {
+    return 'Wait for the current library task to finish first.';
+  }
+
+  return 'This saves the setting immediately and starts a full rescan so the library reflects the chosen mode.';
+});
+const showStoriesMigrationNotice = computed(
+  () =>
+    appStore.stats?.storiesMigration.hasLegacyStoriesCandidates === true &&
+    appStore.stats?.storiesMigration.decisionPending === true &&
+    !dismissedStoriesMigrationNotice.value
+);
+const showStoriesAnnouncementCard = computed(
+  () =>
+    appStore.stats?.storiesMigration.hasLegacyStoriesCandidates === false &&
+    appStore.stats?.storiesMigration.decisionPending === true &&
+    !dismissedStoriesAnnouncement.value
+);
+const storiesModeConfirmTarget = computed(() => pendingStoriesModeValue.value ?? storiesMode.value);
+const storiesModeConfirmTitle = computed(() =>
+  storiesModeConfirmTarget.value
+    ? 'Treat stories folders as normal app folders?'
+    : 'Enable reserved stories folders?'
+);
+const storiesModeConfirmMessage = computed(() =>
+  storiesModeConfirmTarget.value
+    ? 'This will keep folders named stories behaving like normal app folders everywhere in the app. A rescan will start immediately because the indexed folder structure may change.'
+    : 'This will reserve AppFolder/stories for avatar stories and highlight capsules by default. A rescan will start immediately because the indexed folder structure may change.'
+);
 const scanActionDisabled = computed(
   () =>
     waitingForInitialStatus.value ||
@@ -1302,6 +1555,33 @@ function dismissIgnoredRootMediaNotice() {
   }
 }
 
+function loadDismissedStoriesNotice(storageKey: string): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return window.localStorage.getItem(storageKey) === '1';
+}
+
+function dismissStoriesMigrationNotice() {
+  dismissedStoriesMigrationNotice.value = true;
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(STORIES_MIGRATION_NOTICE_STORAGE_KEY, '1');
+  }
+}
+
+function dismissStoriesAnnouncement() {
+  dismissedStoriesAnnouncement.value = true;
+  showStoriesAnnouncementStructure.value = false;
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(STORIES_ANNOUNCEMENT_STORAGE_KEY, '1');
+  }
+}
+
+function toggleStoriesAnnouncementStructure() {
+  showStoriesAnnouncementStructure.value = !showStoriesAnnouncementStructure.value;
+}
+
 async function enableAccessProtection() {
   if (authStore.loading) {
     return;
@@ -1480,6 +1760,17 @@ async function saveFeedDefaults() {
   }
 }
 
+function openStoriesModeConfirm(value: boolean) {
+  if (!authStore.canManageLibrary) {
+    return;
+  }
+
+  clearStoriesModeFeedback();
+  storiesMode.value = value;
+  pendingStoriesModeValue.value = value;
+  confirmStoriesModeOpen.value = true;
+}
+
 async function warmScanStatus() {
   for (let attempt = 0; attempt < 12; attempt += 1) {
     await wait(attempt === 0 ? 150 : 250);
@@ -1498,6 +1789,65 @@ async function warmScanStatus() {
 
 async function loadAdminStats() {
   adminStats.value = await fetchAdminStats();
+}
+
+async function runStoriesModeSave() {
+  if (!authStore.canManageLibrary || appStore.isLibraryUnavailable) {
+    return;
+  }
+
+  const targetValue = pendingStoriesModeValue.value ?? storiesMode.value;
+  let savedSetting = false;
+
+  savingStoriesMode.value = true;
+  clearStoriesModeFeedback();
+  confirmStoriesModeOpen.value = false;
+
+  try {
+    const payload = await updateStoriesMode(targetValue);
+    savedSetting = true;
+    storiesMode.value = payload.treatStoriesAsFolders;
+
+    if (appStore.stats) {
+      appStore.stats.preferences.treatStoriesAsFolders = payload.treatStoriesAsFolders;
+      appStore.stats.storiesMigration.decisionPending = false;
+    }
+
+    const request = triggerManualScan();
+    void warmScanStatus();
+    await request;
+    await appStore.fetchStats({ background: true });
+    await loadAdminStats().catch(() => {});
+    await Promise.all([
+      foldersStore.fetchFolders(true),
+      feedStore.loadInitial(true),
+      likesStore.initialize(true),
+      momentsStore.fetchMoments(true)
+    ]);
+
+    storiesModeFeedback.value = {
+      tone: 'success',
+      message: targetValue
+        ? 'stories folders now behave like normal app folders. The library was rescanned.'
+        : 'Reserved stories folders are now active. The library was rescanned.'
+    };
+  } catch (error) {
+    await appStore.fetchStats({ background: true }).catch(() => {});
+    await loadAdminStats().catch(() => {});
+    storiesModeFeedback.value = {
+      tone: 'error',
+      message: savedSetting
+        ? error instanceof Error
+          ? `The stories folders setting was saved, but the rescan failed: ${error.message}`
+          : 'The stories folders setting was saved, but the rescan failed.'
+        : error instanceof Error
+          ? error.message
+          : 'Unable to update the stories folders setting.'
+    };
+  } finally {
+    pendingStoriesModeValue.value = null;
+    savingStoriesMode.value = false;
+  }
 }
 
 async function runManualScan() {
@@ -1595,12 +1945,13 @@ onMounted(async () => {
 
   if (appStore.stats) {
     syncFeedDefaultsFromSaved();
+    syncStoriesModeFromSaved();
   }
   await loadAdminStats().catch(() => {});
 });
 
 watch(
-  () => [appStore.stats, appStore.loadingStats, savedHomeFeedDefaultMode.value, savedReelsFeedDefaultMode.value] as const,
+  () => [appStore.stats, appStore.loadingStats, savedHomeFeedDefaultMode.value, savedReelsFeedDefaultMode.value, savedStoriesMode.value] as const,
   ([stats, loadingStats]) => {
     if (!stats || loadingStats) {
       return;
@@ -1608,6 +1959,10 @@ watch(
 
     if (!feedDefaultsHydrated.value || savingFeedDefaults.value || !feedDefaultsDirty.value) {
       syncFeedDefaultsFromSaved();
+    }
+
+    if (!storiesModeHydrated.value || savingStoriesMode.value || !storiesModeDirty.value) {
+      syncStoriesModeFromSaved();
     }
   },
   {

--- a/docs/api.md
+++ b/docs/api.md
@@ -172,9 +172,9 @@ Notes:
 
 ### `GET /api/feed/moments`
 
-Returns the current home rail definition.
+Returns the current Home Moments or Highlights definition.
 
-The rail can be:
+The response can be:
 
 - `moments`
 - `highlights`
@@ -207,7 +207,7 @@ Query parameters:
 | `limit` | integer | `24` |
 
 Returns `404` with `{"message":"Feed capsule not found"}` when the ID does not
-exist in the currently selected rail.
+exist in the currently selected set.
 
 ### `GET /api/folders`
 
@@ -224,16 +224,23 @@ Each item is a folder summary with:
 - `id`
 - `slug`
 - `name`
+- `description`
 - `folderPath`
 - `breadcrumb`
 - `imageCount`
 - `videoCount`
 - `latestImageMtimeMs`
+- `hasAvatarStory`
+- `avatarImageId`
 - `avatarUrl`
 
 ### `GET /api/folders/:slug`
 
 Returns one folder summary.
+
+The response uses the same shape as folder items from `GET /api/folders`,
+including `hasAvatarStory` so the client can decide whether the folder avatar
+should open a story entry point.
 
 Errors:
 
@@ -257,11 +264,14 @@ Response shape:
     "id": 1,
     "slug": "oslo",
     "name": "oslo",
+    "description": null,
     "folderPath": "trips/oslo",
     "breadcrumb": "trips",
     "imageCount": 12,
     "videoCount": 3,
     "latestImageMtimeMs": 1700000000000,
+    "hasAvatarStory": false,
+    "avatarImageId": 42,
     "avatarUrl": "/thumbnails/trips/oslo/IMG_0001.webp?v=4"
   },
   "items": [],
@@ -275,6 +285,87 @@ Response shape:
 Errors:
 
 - `404` with `{"message":"Folder not found"}`
+
+### `GET /api/folders/:slug/stories`
+
+Returns the stories payload for one folder.
+
+Response shape:
+
+```json
+{
+  "railKind": "stories",
+  "railTitle": "Stories",
+  "railDescription": "Stories and highlights for AnimalPlanet.",
+  "railSingularLabel": "Story",
+  "hasAvatarStory": true,
+  "avatarStoryId": "animalplanet-stories",
+  "items": [],
+  "highlights": []
+}
+```
+
+Notes:
+
+- `items` contains the avatar story first when one exists, followed by highlight capsules.
+- `highlights` contains only highlight capsules.
+- each capsule item includes `id`, `title`, `subtitle`, `dateContext`, `imageCount`, `coverImage`, and `presentation`
+- `presentation` is `avatar` or `highlight`
+- `avatarStoryId` can be a synthetic fallback id when the folder has highlight media but no direct avatar-story files
+
+Errors:
+
+- `404` with `{"message":"Folder not found"}`
+
+### `GET /api/folders/:slug/stories/:id`
+
+Path parameters:
+
+| Param | Type |
+| --- | --- |
+| `slug` | string |
+| `id` | string |
+
+Query parameters:
+
+| Param | Type | Default |
+| --- | --- | --- |
+| `page` | integer | `1` |
+| `limit` | integer | `24` |
+
+Response shape:
+
+```json
+{
+  "railKind": "stories",
+  "railTitle": "Stories",
+  "railDescription": "Stories and highlights for AnimalPlanet.",
+  "railSingularLabel": "Story",
+  "story": {
+    "id": "animalplanet-stories",
+    "title": "AnimalPlanet",
+    "subtitle": "AnimalPlanet story set",
+    "dateContext": "Today",
+    "imageCount": 8,
+    "presentation": "avatar",
+    "coverImage": {}
+  },
+  "items": [],
+  "page": 1,
+  "limit": 24,
+  "total": 8,
+  "hasMore": false
+}
+```
+
+Notes:
+
+- the paginated `items` array contains normal feed-item payloads
+- if the requested avatar story is a fallback capsule, the server returns recent highlight media for that synthetic capsule
+
+Errors:
+
+- `404` with `{"message":"Story capsule not found"}`
 
 ### `GET /api/likes`
 
@@ -360,6 +451,8 @@ Notable fields:
 | `libraryIndex` | Rebuild requirement plus ignored root-media count. Gallery-root paths are omitted. |
 | `preferences.defaultHomeFeedMode` | Current app-wide default home feed mode. |
 | `preferences.defaultReelsFeedMode` | Current app-wide default reels mode used when `/reels` opens. |
+| `preferences.treatStoriesAsFolders` | Whether folders literally named `stories` are treated as ordinary app folders instead of reserved story sources. |
+| `storiesMigration` | Migration hint with `hasLegacyStoriesCandidates` and `decisionPending`. |
 
 ### `GET /api/admin/stats`
 
@@ -378,6 +471,9 @@ additional fields below:
 | `libraryIndex.previousGalleryRoot` | Prior configured gallery root when the root changed. |
 | `libraryIndex.lastSuccessfulGalleryRoot` | Gallery root from the last completed successful scan. |
 | `lastScan` | Last completed scan run. |
+
+The same `preferences.treatStoriesAsFolders` and `storiesMigration` fields from
+`GET /api/status` are also present here.
 
 ## Mutating endpoints
 
@@ -604,6 +700,32 @@ Success:
   "defaultMode": "recommended"
 }
 ```
+
+### `PUT /api/admin/settings/stories-mode`
+
+Sets how folders literally named `stories` are interpreted.
+
+Body:
+
+```json
+{
+  "treatStoriesAsFolders": false
+}
+```
+
+Success:
+
+```json
+{
+  "treatStoriesAsFolders": false
+}
+```
+
+Notes:
+
+- `false` enables the default reserved-stories mode
+- `true` keeps `stories/` folders behaving like ordinary app folders
+- the Settings UI immediately follows this write with `POST /api/admin/rescan`, but this endpoint itself only saves the setting
 
 ### `POST /api/images/:id/like`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,19 @@ Instead:
 The built-in auth model is a small role-based password gate for one app
 instance, not a multi-user account system.
 
+## Stories folders mode
+
+Reserved stories behavior is **not** configured in `.env`.
+
+Instead:
+
+- Foldergram stores the current stories-folders mode in SQLite `app_settings`
+- the Settings page exposes the toggle `Treat stories folders as normal app folders`
+- the default mode is reserved stories, where `AppFolder/stories` powers avatar stories and highlight capsules
+- turning the toggle on enables legacy behavior, where folders literally named `stories` remain ordinary app folders
+- changing this setting requires a rescan because the indexed folder structure changes
+- if the existing library already contains candidate `stories/` folders, Settings can show a migration decision card until you choose a mode
+
 ## Path resolution rules
 
 - `DATA_ROOT` is the common fallback parent for the app's storage directories.
@@ -165,6 +178,25 @@ gallery/
     berlin/
       notes.txt          # not indexed
 ```
+
+In the default reserved-stories mode, Foldergram also treats
+`AppFolder/stories` specially:
+
+```text
+gallery/
+  AnimalPlanet/
+    post-1.jpg          # indexed owner folder media
+    stories/
+      story-1.mp4       # avatar story set
+      Lions/
+        clip-1.mp4      # highlight capsule
+        nested-1/
+          clip-2.jpg    # still part of Lions
+```
+
+If you want folders literally named `stories` to remain ordinary app folders,
+enable `Treat stories folders as normal app folders` in Settings and rescan the
+library.
 
 ## Gallery root changes
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -34,6 +34,20 @@ If no explicit cover file is found, it falls back to the most recent (newest) su
 Admins can also use the "Set as Cover" action from the detail view of any image to set it as the cover without renaming files.
 Any explicit `cover.*` files, or any files manually set as the cover via the UI, are hidden from the normal folder grid so they don't appear as duplicate posts.
 
+## How do reserved stories folders work?
+
+In the default mode, `AppFolder/stories` is treated as a story source for that
+folder:
+
+- direct media inside `stories/` becomes the avatar story set
+- each direct child folder becomes one highlight capsule
+- nested folders stay inside that same highlight capsule
+- story media is hidden from normal folder, feed, and reels surfaces while this mode is active
+
+If you already rely on folders literally named `stories` as normal app folders,
+open Settings, enable `Treat stories folders as normal app folders`, and rescan
+the library.
+
 ## Are likes shared with other users?
 
 Admin and viewer sessions share SQLite likes for the current library.

--- a/docs/features.md
+++ b/docs/features.md
@@ -14,7 +14,8 @@ The home view is the primary feed surface.
 It includes:
 
 - three feed modes: Recent, Rediscover, and Random
-- a top rail that can show Moments or Highlights
+- a top Moments or Highlights section
+- feed-card avatar rings that can open an App Folder's avatar story in place when that folder has stories
 - an active home-feed video player that promotes one visible video card at a time and gives that card play, mute, and fullscreen controls
 - a startup scan state when the first index is still being built
 - a rebuild notice when the configured gallery root changed
@@ -39,7 +40,7 @@ It includes:
 - a full-height scroll-snap deck
 - wheel, arrow-key, and page-up/page-down navigation in addition to direct scrolling
 - infinite loading with prefetch as you approach the end of the current queue
-- a desktop action rail for like/favorite toggle, details sidebar, folder shortcut, and original-video link
+- a desktop action bar for like/favorite toggle, details sidebar, folder shortcut, and original-video link
 - loading, empty, and error states
 - an app-wide default mode from Settings; the page itself does not expose an inline mode switch
 
@@ -91,14 +92,34 @@ A folder page is available at:
 
 Folder pages include:
 
-- a folder header with avatar, posts counts, and descriptions
+- a folder header with avatar, posts counts, descriptions, and optional avatar-story opening
 - editable folder name and description via an admin "Edit App Folder" flow
 - a posts grid
+- highlight circles above the posts and reels tabs when the folder has story capsules
 - a reels tab when the folder contains videos
 - infinite loading
 
 The reels tab is a filtered view backed by the same folder endpoint using
 `mediaType=video`.
+
+## Folder stories and highlights
+
+Foldergram can reserve `AppFolder/stories` as a story-style source for that
+folder.
+
+In the default reserved-stories mode:
+
+- direct media inside `AppFolder/stories` becomes the folder's avatar story set
+- each direct child folder inside `AppFolder/stories` becomes one highlight capsule
+- nested folders below a highlight are folded into that same capsule instead of becoming separate app folders
+- story media is hidden from normal folder, feed, search, and reels surfaces
+- the folder header avatar opens the avatar story when one exists
+- Home feed cards can open the same avatar story from the folder avatar ring
+- the shared stories modal is used for both the home-feed entry point and the folder-page entry points
+
+If the reserved root has no direct media but highlight capsules do exist,
+Foldergram can synthesize the avatar story from recent highlight media so the
+folder still has an avatar-story entry point.
 
 ## Post detail and modal flow
 
@@ -140,13 +161,16 @@ There is no shared social layer behind either mode.
 
 ## Moments
 
-The home rail and `/moments/:id` view expose either:
+Home and `/moments/:id` expose either:
 
 - date-driven Moments
 - fallback Highlights
 
-The selected rail depends on timestamp coverage in the current library. The UI
+The selected set depends on timestamp coverage in the current library. The UI
 uses the same route name for both and adapts to the returned payload labels.
+
+This is separate from folder stories and folder highlights sourced
+from reserved `stories/` folders.
 
 ## Settings
 
@@ -157,6 +181,7 @@ It exposes:
 - admin-password controls
 - viewer password and public access controls
 - home and reels default feed-mode controls
+- stories-folders mode controls, migration notices, and a save-and-rescan flow
 - live scan status
 - storage and index status
 - last completed scan details

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -23,6 +23,24 @@ Foldergram recursively walks `GALLERY_ROOT` and applies these rules:
 - Any non-hidden folder that directly contains supported media becomes an indexed album.
 - Files directly in `GALLERY_ROOT` are ignored.
 - Nested folders are treated separately from their parent folders.
+- In the default reserved-stories mode, a child `stories/` folder beneath an indexed owner folder is withheld from normal album discovery and scanned separately as story data.
+
+## Reserved stories folders
+
+By default, Foldergram treats `AppFolder/stories` as a reserved subtree for
+that app folder.
+
+The scan model is:
+
+- direct media inside `AppFolder/stories` becomes a `story_root` folder used for the avatar story set
+- each direct child directory under `AppFolder/stories` becomes one `story_capsule`
+- nested media below that direct child directory is collected recursively into the same capsule
+- reserved story folders do not become normal app folders while this mode is enabled
+- if the reserved root has no direct media but highlight capsules exist, Foldergram synthesizes an avatar-story entry from recent highlight media
+
+This behavior is controlled by the Settings toggle `Treat stories folders as
+normal app folders`. When that legacy mode is enabled, `stories/` folders are
+discovered like ordinary app folders again.
 
 ## Storage layout
 
@@ -104,10 +122,11 @@ During a full scan, Foldergram:
 1. Walks the gallery tree to discover source folders.
 2. Stats supported files in those folders.
 3. Resolves folder records and stable slugs.
-4. Reads or refreshes media metadata.
-5. Marks missing indexed rows as deleted.
-6. Queues derivative work for changed or missing outputs.
-7. Writes scan status to `scan_runs`.
+4. Scans reserved `stories/` subtrees for owner folders when reserved-stories mode is active.
+5. Reads or refreshes media metadata.
+6. Marks missing indexed rows as deleted.
+7. Queues derivative work for changed or missing outputs.
+8. Writes scan status to `scan_runs`.
 
 ## Incremental scans and watching
 
@@ -146,9 +165,9 @@ provide an inline mode switch of its own.
 
 ## Moments and highlights
 
-`GET /api/feed/moments` can return either a Moments rail or a Highlights rail.
+`GET /api/feed/moments` can return either Moments or Highlights.
 
-### Moments rail
+### Moments
 
 Foldergram prefers date-based moments when the library has enough EXIF-backed
 timestamps:
@@ -163,7 +182,7 @@ The current date-driven capsules are:
 - This Week
 - Last Year Around Now
 
-### Highlights rail
+### Highlights
 
 When date coverage is too sparse, Foldergram falls back to curated sets:
 
@@ -171,6 +190,15 @@ When date coverage is too sparse, Foldergram falls back to curated sets:
 - Forgotten Favorites
 - Deep Cuts
 - Lucky Dip
+
+## Folder stories
+
+Folder stories use separate SQLite-backed queries from `GET /api/feed/moments`.
+
+- folder summaries expose whether a folder currently has an avatar-story entry point
+- `GET /api/folders/:slug/stories` returns the folder's avatar story and highlight capsules
+- `GET /api/folders/:slug/stories/:id` pages through the media for one story capsule
+- neither route walks the filesystem on request
 
 ## Folder rebuild requirement
 
@@ -186,6 +214,6 @@ Once data is indexed:
 - folder pages read from SQLite
 - feed pages read from SQLite
 - likes read from SQLite
-- moments and highlights read from SQLite
+- moments, highlights, and folder stories read from SQLite
 - thumbnails and previews are served as static files
 - originals are served by image ID only

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ features:
     details: Foldergram indexes supported image and video formats, generates thumbnails, creates previews eagerly or lazily, and can expose compatible original MP4 playback in the detail player.
   - icon: 🎯
     title: Honest scope
-    details: The current app includes home feed browsing, a dedicated reels route, explore, library, likes and favorites, moments, optional admin/viewer/public access control, and admin-only maintenance controls without cloud sync or social features.
+    details: The current app includes home feed browsing, folder stories and highlights, a dedicated reels route, explore, library, likes and favorites, moments, optional admin/viewer/public access control, and admin-only maintenance controls without cloud sync or social features.
 ---
 
 ## Foldergram at a Glance
@@ -40,7 +40,7 @@ features:
 
 <div class="cs-feature">
 <h3>🚀 What ships today</h3>
-<p>The current repository includes Home, Reels, Explore, Library, Likes and Favorites, Moments, Settings, folder pages, a post detail view and modal flow, shared SQLite likes, browser-local favorites in public mode, delete actions, optional admin/viewer/public access control, and local scan/rebuild tooling.</p>
+<p>The current repository includes Home, Reels, Explore, Library, Likes and Favorites, Moments, folder stories and highlights, Settings, folder pages, a post detail view and modal flow, shared SQLite likes, browser-local favorites in public mode, delete actions, optional admin/viewer/public access control, and local scan/rebuild tooling.</p>
 </div>
 
 <div class="cs-feature">
@@ -81,12 +81,12 @@ features:
 
 <div class="cs-feature">
 <h3>4. Serve fast reads</h3>
-<p>Feed, folders, likes, moments, and explore read from SQLite and derivative URLs instead of scanning the filesystem on request.</p>
+<p>Feed, folders, folder stories, likes, moments, and explore read from SQLite and derivative URLs instead of scanning the filesystem on request.</p>
 </div>
 
 <div class="cs-feature">
-<h3>5. Build moments and highlights</h3>
-<p>The home rail can surface date-based Moments when the library has enough EXIF-backed timestamps, or fall back to Highlights when capture-date coverage is sparse.</p>
+<h3>5. Build Moments, Highlights, and Stories</h3>
+<p>Home can surface date-based Moments when the library has enough EXIF-backed timestamps, or fall back to Highlights when capture-date coverage is sparse. Reserved <code>AppFolder/stories</code> folders can also power avatar stories and folder highlight circles.</p>
 </div>
 
 <div class="cs-feature">

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -44,6 +44,32 @@ The important rule is simple:
 - A non-hidden folder becomes an indexed album only when it directly contains supported media.
 - Nested folders become separate albums if they directly contain media.
 
+Optional: add folder stories and highlights with a reserved `stories/` folder:
+
+```text
+data/
+  gallery/
+    AnimalPlanet/
+      post-1.jpg
+      stories/
+        story-1.mp4
+        story-2.jpg
+        Lions/
+          clip-1.mp4
+          nested-1/
+            clip-2.jpg
+```
+
+In the default mode:
+
+- direct media inside `AppFolder/stories` powers the folder avatar story
+- each direct child folder under `stories/` becomes one highlight circle
+- nested folders stay inside that same highlight capsule
+
+If you need folders literally named `stories` to behave like normal app
+folders, enable `Treat stories folders as normal app folders` in Settings and
+run a rescan.
+
 ## 3. Start the container
 
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -74,6 +74,19 @@ Foldergram switches to Highlights unless it has:
 - at least `18` EXIF-backed posts
 - at least `30%` EXIF coverage
 
+## A folder named `stories` stopped appearing as a normal album
+
+That is expected when Foldergram is using the default reserved-stories mode.
+
+In that mode, `AppFolder/stories` is reinterpreted as folder-story data instead
+of a standalone app folder.
+
+If you want folders literally named `stories` to remain ordinary app folders:
+
+1. open Settings
+2. enable `Treat stories folders as normal app folders`
+3. save the change and let the library rescan
+
 ## Videos fail to index or generate previews
 
 Check that both tools are installed and available on `PATH`:

--- a/server/src/constants/app-setting-keys.ts
+++ b/server/src/constants/app-setting-keys.ts
@@ -1,6 +1,8 @@
 export const LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY = 'scanner.last_successful_gallery_root';
 export const LIBRARY_REBUILD_REQUIRED_SETTING_KEY = 'scanner.library_rebuild_required';
 export const PREVIOUS_GALLERY_ROOT_SETTING_KEY = 'scanner.previous_gallery_root';
+export const TREAT_STORIES_AS_FOLDERS_SETTING_KEY = 'library.treat_stories_as_folders';
+export const STORIES_MIGRATION_DECISION_SETTING_KEY = 'library.stories_migration_decision';
 export const HOME_FEED_DEFAULT_MODE_SETTING_KEY = 'feed.default_home_mode';
 export const REELS_FEED_DEFAULT_MODE_SETTING_KEY = 'feed.default_reels_mode';
 export const AUTH_PASSWORD_HASH_SETTING_KEY = 'auth.password_hash';

--- a/server/src/db/database.ts
+++ b/server/src/db/database.ts
@@ -55,6 +55,14 @@ class DatabaseManager {
       this.database.exec("ALTER TABLE folders ADD COLUMN avatar_source TEXT NOT NULL DEFAULT 'auto'");
     }
 
+    if (this.tableExists('folders') && !this.tableHasColumn('folders', 'role')) {
+      this.database.exec("ALTER TABLE folders ADD COLUMN role TEXT NOT NULL DEFAULT 'normal'");
+    }
+
+    if (this.tableExists('folders') && !this.tableHasColumn('folders', 'story_owner_folder_id')) {
+      this.database.exec('ALTER TABLE folders ADD COLUMN story_owner_folder_id INTEGER NULL');
+    }
+
     if (this.tableExists('images') && !this.tableHasColumn('images', 'media_type')) {
       this.database.exec("ALTER TABLE images ADD COLUMN media_type TEXT NOT NULL DEFAULT 'image'");
     }
@@ -105,6 +113,8 @@ class DatabaseManager {
   }
 
   private applyCompatIndexes(): void {
+    this.database.exec("CREATE INDEX IF NOT EXISTS idx_folders_role ON folders(role)");
+    this.database.exec('CREATE INDEX IF NOT EXISTS idx_folders_story_owner_role ON folders(story_owner_folder_id, role, folder_path COLLATE NOCASE)');
     this.database.exec('CREATE INDEX IF NOT EXISTS idx_images_taken_at ON images(taken_at DESC)');
     this.database.exec('CREATE INDEX IF NOT EXISTS idx_images_taken_at_source ON images(is_deleted, taken_at_source)');
     this.database.exec('CREATE INDEX IF NOT EXISTS idx_images_media_type ON images(media_type, is_deleted, sort_timestamp DESC)');

--- a/server/src/db/repositories.ts
+++ b/server/src/db/repositories.ts
@@ -4,6 +4,7 @@ import type {
   AppSettingRecord,
   FeedImage,
   FolderAvatarSource,
+  FolderRole,
   FolderScanStateRecord,
   ImageDetail,
   ImageRecord,
@@ -22,8 +23,26 @@ const database = databaseManager.connection;
 const EFFECTIVE_FEED_TIME_SQL = 'COALESCE(images.taken_at, images.sort_timestamp)';
 const COVER_FILENAMES = ['cover.jpg', 'cover.jpeg', 'cover.png', 'cover.webp', 'cover.gif'] as const;
 const COVER_FILENAME_SQL = COVER_FILENAMES.map((name) => `'${name}'`).join(', ');
-const VISIBLE_IMAGE_WHERE_SQL = `images.is_deleted = 0 AND images.is_trashed = 0 AND LOWER(images.filename) NOT IN (${COVER_FILENAME_SQL})`;
-const VISIBLE_IMAGE_WHERE_UNSCOPED_SQL = `is_deleted = 0 AND is_trashed = 0 AND LOWER(filename) NOT IN (${COVER_FILENAME_SQL})`;
+const NORMAL_FOLDER_ROLE_SQL = "folders.role = 'normal'";
+const NORMAL_FOLDER_ID_SUBQUERY_SQL = "SELECT id FROM folders WHERE role = 'normal'";
+const VISIBLE_IMAGE_WHERE_SQL =
+  `images.is_deleted = 0 AND images.is_trashed = 0 AND LOWER(images.filename) NOT IN (${COVER_FILENAME_SQL}) AND ${NORMAL_FOLDER_ROLE_SQL}`;
+const VISIBLE_IMAGE_WHERE_UNSCOPED_SQL =
+  `is_deleted = 0 AND is_trashed = 0 AND LOWER(filename) NOT IN (${COVER_FILENAME_SQL}) AND folder_id IN (${NORMAL_FOLDER_ID_SUBQUERY_SQL})`;
+const STORY_IMAGE_WHERE_SQL = 'images.is_deleted = 0 AND images.is_trashed = 0';
+const STORY_IMAGE_WHERE_UNSCOPED_SQL = 'is_deleted = 0 AND is_trashed = 0';
+const HAS_AVATAR_STORY_SQL = `
+  EXISTS (
+    SELECT 1
+    FROM folders AS story_folders
+    INNER JOIN images AS story_images ON story_images.folder_id = story_folders.id
+    WHERE story_folders.story_owner_folder_id = folders.id
+      AND story_folders.role IN ('story_root', 'story_capsule')
+      AND story_images.is_deleted = 0
+      AND story_images.is_trashed = 0
+    LIMIT 1
+  )
+`;
 const IMAGE_FILENAME_SEARCH_SQL = 'LOWER(images.filename)';
 const FOLDER_NAME_SEARCH_SQL = 'LOWER(folders.name)';
 const FOLDER_SLUG_SEARCH_SQL = 'LOWER(folders.slug)';
@@ -177,6 +196,8 @@ export interface UpsertFolderInput {
   slug: string;
   name: string;
   folderPath: string;
+  role?: FolderRole;
+  storyOwnerFolderId?: number | null;
 }
 
 export interface SaveFolderResult {
@@ -245,6 +266,10 @@ export const folderRepository = {
     return database.prepare('SELECT * FROM folders ORDER BY folder_path COLLATE NOCASE ASC').all() as unknown as FolderRecord[];
   },
 
+  getNormalBySlug(slug: string): FolderRecord | undefined {
+    return database.prepare("SELECT * FROM folders WHERE slug = ? AND role = 'normal'").get(slug) as FolderRecord | undefined;
+  },
+
   getAllSummaries(): FolderSummaryRecord[] {
     return database
       .prepare(
@@ -253,9 +278,11 @@ export const folderRepository = {
           folders.*,
           COUNT(images.id) AS image_count,
           SUM(CASE WHEN images.media_type = 'video' THEN 1 ELSE 0 END) AS video_count,
-          MAX(images.mtime_ms) AS latest_image_mtime_ms
+          MAX(images.mtime_ms) AS latest_image_mtime_ms,
+          CASE WHEN ${HAS_AVATAR_STORY_SQL} THEN 1 ELSE 0 END AS has_avatar_story
         FROM folders
         INNER JOIN images ON images.folder_id = folders.id AND ${VISIBLE_IMAGE_WHERE_SQL}
+        WHERE folders.role = 'normal'
         GROUP BY folders.id
         ORDER BY latest_image_mtime_ms DESC, folders.name COLLATE NOCASE ASC, folders.folder_path COLLATE NOCASE ASC
         `
@@ -285,10 +312,11 @@ export const folderRepository = {
           folders.*,
           COUNT(images.id) AS image_count,
           SUM(CASE WHEN images.media_type = 'video' THEN 1 ELSE 0 END) AS video_count,
-          MAX(images.mtime_ms) AS latest_image_mtime_ms
+          MAX(images.mtime_ms) AS latest_image_mtime_ms,
+          CASE WHEN ${HAS_AVATAR_STORY_SQL} THEN 1 ELSE 0 END AS has_avatar_story
         FROM folders
         INNER JOIN images ON images.folder_id = folders.id AND ${VISIBLE_IMAGE_WHERE_SQL}
-        WHERE folders.slug = ?
+        WHERE folders.slug = ? AND folders.role = 'normal'
         GROUP BY folders.id
         `
       )
@@ -297,16 +325,20 @@ export const folderRepository = {
 
   upsert(input: UpsertFolderInput): FolderRecord {
     const normalizedFolderPath = normalizePath(input.folderPath);
+    const role = input.role ?? 'normal';
+    const storyOwnerFolderId = input.storyOwnerFolderId ?? null;
     database.prepare(
       `
-      INSERT INTO folders (slug, name, folder_path, updated_at)
-      VALUES (?, ?, ?, ?)
+      INSERT INTO folders (slug, name, folder_path, role, story_owner_folder_id, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?)
       ON CONFLICT(folder_path) DO UPDATE SET
         slug = excluded.slug,
         name = excluded.name,
+        role = excluded.role,
+        story_owner_folder_id = excluded.story_owner_folder_id,
         updated_at = excluded.updated_at
       `
-    ).run(input.slug, input.name, normalizedFolderPath, nowIso());
+    ).run(input.slug, input.name, normalizedFolderPath, role, storyOwnerFolderId, nowIso());
 
     return this.getByFolderPath(normalizedFolderPath) as FolderRecord;
   },
@@ -314,7 +346,15 @@ export const folderRepository = {
   save(input: UpsertFolderInput): SaveFolderResult {
     const normalizedFolderPath = normalizePath(input.folderPath);
     const existing = this.getByFolderPath(normalizedFolderPath);
-    if (existing && existing.slug === input.slug) {
+    const role = input.role ?? 'normal';
+    const storyOwnerFolderId = input.storyOwnerFolderId ?? null;
+
+    if (
+      existing &&
+      existing.slug === input.slug &&
+      existing.role === role &&
+      existing.story_owner_folder_id === storyOwnerFolderId
+    ) {
       return {
         folder: existing,
         wrote: false
@@ -322,7 +362,9 @@ export const folderRepository = {
     }
 
     if (existing) {
-      database.prepare('UPDATE folders SET slug = ?, updated_at = ? WHERE id = ?').run(input.slug, nowIso(), existing.id);
+      database
+        .prepare('UPDATE folders SET slug = ?, role = ?, story_owner_folder_id = ?, updated_at = ? WHERE id = ?')
+        .run(input.slug, role, storyOwnerFolderId, nowIso(), existing.id);
 
       return {
         folder: this.getById(existing.id) as FolderRecord,
@@ -347,11 +389,12 @@ export const folderRepository = {
             `
             SELECT COUNT(*) AS count
             FROM folders
-            WHERE EXISTS (
-              SELECT 1
-              FROM images
-              WHERE images.folder_id = folders.id AND images.is_deleted = 0 AND images.is_trashed = 0
-            )
+            WHERE folders.role = 'normal'
+              AND EXISTS (
+                SELECT 1
+                FROM images
+                WHERE images.folder_id = folders.id AND ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL}
+              )
             `
           )
           .get() as { count: number }
@@ -373,13 +416,13 @@ export const folderRepository = {
   },
 
   updateMetadata(slug: string, name: string, description: string | null): FolderRecord | undefined {
-    database.prepare('UPDATE folders SET name = ?, description = ?, updated_at = ? WHERE slug = ?').run(
+    database.prepare("UPDATE folders SET name = ?, description = ?, updated_at = ? WHERE slug = ? AND role = 'normal'").run(
       name,
       description,
       nowIso(),
       slug
     );
-    return this.getBySlug(slug);
+    return this.getNormalBySlug(slug);
   },
 
   delete(id: number): void {
@@ -429,6 +472,59 @@ export const folderRepository = {
     }
 
     this.setAvatar(folderId, nextSelection.imageId, nextSelection.source);
+  },
+
+  listOwnedStoryFolders(ownerFolderId: number): FolderRecord[] {
+    return database
+      .prepare(
+        `
+        SELECT *
+        FROM folders
+        WHERE story_owner_folder_id = ?
+          AND role IN ('story_root', 'story_capsule')
+        ORDER BY
+          CASE role
+            WHEN 'story_root' THEN 0
+            ELSE 1
+          END,
+          name COLLATE NOCASE ASC,
+          folder_path COLLATE NOCASE ASC
+        `
+      )
+      .all(ownerFolderId) as unknown as FolderRecord[];
+  },
+
+  getOwnedStoryFolderBySlug(ownerFolderId: number, slug: string): FolderRecord | undefined {
+    return database
+      .prepare(
+        `
+        SELECT *
+        FROM folders
+        WHERE story_owner_folder_id = ?
+          AND slug = ?
+          AND role IN ('story_root', 'story_capsule')
+        `
+      )
+      .get(ownerFolderId, slug) as FolderRecord | undefined;
+  },
+
+  hasLegacyStoriesCandidates(): boolean {
+    const row = database
+      .prepare(
+        `
+        SELECT 1 AS found
+        FROM folders
+        WHERE
+          LOWER(folder_path) = 'stories'
+          OR LOWER(folder_path) LIKE '%/stories'
+          OR LOWER(folder_path) LIKE 'stories/%'
+          OR LOWER(folder_path) LIKE '%/stories/%'
+        LIMIT 1
+        `
+      )
+      .get() as { found: number } | undefined;
+
+    return row?.found === 1;
   }
 };
 
@@ -803,7 +899,7 @@ export const imageRepository = {
             `
             SELECT COUNT(*) AS count
             FROM images
-            WHERE ${VISIBLE_IMAGE_WHERE_SQL}
+            WHERE ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL}
               AND strftime('%m-%d', ${EFFECTIVE_FEED_TIME_SQL} / 1000, 'unixepoch', 'localtime') IN (${placeholders})
               AND CAST(strftime('%Y', ${EFFECTIVE_FEED_TIME_SQL} / 1000, 'unixepoch', 'localtime') AS INTEGER) < ?
             `
@@ -841,7 +937,7 @@ export const imageRepository = {
             `
             SELECT COUNT(*) AS count
             FROM images
-            WHERE ${VISIBLE_IMAGE_WHERE_SQL}
+            WHERE ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL}
               AND ${EFFECTIVE_FEED_TIME_SQL} BETWEEN ? AND ?
             `
           )
@@ -875,6 +971,34 @@ export const imageRepository = {
       LIMIT ? OFFSET ?
       `
     ).all(...(mediaType ? [folderId, mediaType, limit, offset] : [folderId, limit, offset])) as unknown as FeedImage[];
+  },
+
+  listStoryFolderImages(folderId: number, page: number, limit: number, mediaType?: MediaType): FeedImage[] {
+    const offset = (page - 1) * limit;
+    const mediaTypeClause = mediaType ? ' AND images.media_type = ?' : '';
+    return database.prepare(
+      `
+      ${FEED_IMAGE_SELECT_SQL}
+      WHERE images.folder_id = ? AND ${STORY_IMAGE_WHERE_SQL}${mediaTypeClause}
+      ORDER BY images.sort_timestamp DESC, images.id DESC
+      LIMIT ? OFFSET ?
+      `
+    ).all(...(mediaType ? [folderId, mediaType, limit, offset] : [folderId, limit, offset])) as unknown as FeedImage[];
+  },
+
+  listStoryCapsuleImagesByOwnerFolder(ownerFolderId: number, page: number, limit: number, mediaType?: MediaType): FeedImage[] {
+    const offset = (page - 1) * limit;
+    const mediaTypeClause = mediaType ? ' AND images.media_type = ?' : '';
+    return database.prepare(
+      `
+      ${FEED_IMAGE_SELECT_SQL}
+      WHERE folders.story_owner_folder_id = ?
+        AND folders.role = 'story_capsule'
+        AND ${STORY_IMAGE_WHERE_SQL}${mediaTypeClause}
+      ORDER BY ${EFFECTIVE_FEED_TIME_SQL} DESC, images.sort_timestamp DESC, images.id DESC
+      LIMIT ? OFFSET ?
+      `
+    ).all(...(mediaType ? [ownerFolderId, mediaType, limit, offset] : [ownerFolderId, limit, offset])) as unknown as FeedImage[];
   },
 
   listTrashed(page: number, limit: number): TrashImage[] {
@@ -936,6 +1060,37 @@ export const imageRepository = {
     );
   },
 
+  countStoryMediaByFolder(folderId: number, mediaType?: MediaType): number {
+    const mediaTypeClause = mediaType ? ' AND media_type = ?' : '';
+    return Number(
+      (
+        database
+          .prepare(`SELECT COUNT(*) AS count FROM images WHERE folder_id = ? AND ${STORY_IMAGE_WHERE_UNSCOPED_SQL}${mediaTypeClause}`)
+          .get(...(mediaType ? [folderId, mediaType] : [folderId])) as { count: number }
+      ).count
+    );
+  },
+
+  countStoryCapsuleMediaByOwnerFolder(ownerFolderId: number, mediaType?: MediaType): number {
+    const mediaTypeClause = mediaType ? ' AND images.media_type = ?' : '';
+    return Number(
+      (
+        database
+          .prepare(
+            `
+            SELECT COUNT(*) AS count
+            FROM images
+            INNER JOIN folders ON folders.id = images.folder_id
+            WHERE folders.story_owner_folder_id = ?
+              AND folders.role = 'story_capsule'
+              AND ${STORY_IMAGE_WHERE_SQL}${mediaTypeClause}
+            `
+          )
+          .get(...(mediaType ? [ownerFolderId, mediaType] : [ownerFolderId])) as { count: number }
+      ).count
+    );
+  },
+
   listActiveByFolder(folderId: number): ImageRecord[] {
     return database
       .prepare('SELECT * FROM images WHERE folder_id = ? AND is_deleted = 0 ORDER BY id ASC')
@@ -987,6 +1142,20 @@ export const imageRepository = {
       `SELECT id FROM images WHERE folder_id = ? AND ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL} ORDER BY sort_timestamp DESC, id DESC LIMIT 1`
     ).get(folderId) as { id: number } | undefined;
     return row?.id ?? null;
+  },
+
+  getLatestStoryImageId(folderId: number): number | null {
+    const row = database.prepare(
+      `SELECT id FROM images WHERE folder_id = ? AND ${STORY_IMAGE_WHERE_UNSCOPED_SQL} ORDER BY sort_timestamp DESC, id DESC LIMIT 1`
+    ).get(folderId) as { id: number } | undefined;
+    return row?.id ?? null;
+  },
+
+  getLatestEffectiveTimestampByFolder(folderId: number): number | null {
+    const row = database.prepare(
+      `SELECT MAX(COALESCE(taken_at, sort_timestamp)) AS latestTimestamp FROM images WHERE folder_id = ? AND ${STORY_IMAGE_WHERE_UNSCOPED_SQL}`
+    ).get(folderId) as { latestTimestamp: number | null } | undefined;
+    return row?.latestTimestamp ?? null;
   },
 
   getExplicitCoverImageId(folderId: number): number | null {
@@ -1175,6 +1344,7 @@ export const likeRepository = {
             SELECT COUNT(*) AS count
             FROM likes
             INNER JOIN images ON images.id = likes.image_id
+            INNER JOIN folders ON folders.id = images.folder_id
             WHERE ${VISIBLE_IMAGE_WHERE_SQL} AND ${EFFECTIVE_FEED_TIME_SQL} <= ?
             `
           )

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -6,12 +6,15 @@ CREATE TABLE IF NOT EXISTS folders (
   slug TEXT NOT NULL UNIQUE,
   name TEXT NOT NULL,
   folder_path TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'normal',
+  story_owner_folder_id INTEGER NULL,
   description TEXT NULL,
   avatar_image_id INTEGER NULL,
   avatar_source TEXT NOT NULL DEFAULT 'auto',
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (avatar_image_id) REFERENCES images(id)
+  FOREIGN KEY (avatar_image_id) REFERENCES images(id),
+  FOREIGN KEY (story_owner_folder_id) REFERENCES folders(id) ON DELETE SET NULL
 );
 
 CREATE TABLE IF NOT EXISTS images (
@@ -80,6 +83,8 @@ CREATE TABLE IF NOT EXISTS likes (
 
 CREATE INDEX IF NOT EXISTS idx_folders_slug ON folders(slug);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_folders_folder_path ON folders(folder_path);
+CREATE INDEX IF NOT EXISTS idx_folders_role ON folders(role);
+CREATE INDEX IF NOT EXISTS idx_folders_story_owner_role ON folders(story_owner_folder_id, role, folder_path COLLATE NOCASE);
 CREATE INDEX IF NOT EXISTS idx_images_folder_id ON images(folder_id);
 CREATE INDEX IF NOT EXISTS idx_images_sort_timestamp ON images(sort_timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_images_taken_at ON images(taken_at DESC);

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -54,12 +54,18 @@ const homeFeedDefaultBodySchema = z.object({
 const reelsFeedDefaultBodySchema = z.object({
   defaultMode: z.enum(['recommended', 'recent', 'random'])
 });
+const storiesModeBodySchema = z.object({
+  treatStoriesAsFolders: z.boolean()
+});
 
 const slugSchema = z.object({
   slug: z.string().min(1).max(240)
 });
 const momentIdSchema = z.object({
   id: z.string().min(1).max(120)
+});
+const storyIdSchema = z.object({
+  id: z.string().min(1).max(240)
 });
 
 const imageIdSchema = z.object({
@@ -126,7 +132,15 @@ export const authRequestBodySchemas = {
 
 export const settingsRequestBodySchemas = {
   homeFeedDefault: homeFeedDefaultBodySchema,
-  reelsFeedDefault: reelsFeedDefaultBodySchema
+  reelsFeedDefault: reelsFeedDefaultBodySchema,
+  storiesMode: storiesModeBodySchema
+};
+
+export const routeParamSchemas = {
+  slug: slugSchema,
+  momentId: momentIdSchema,
+  storyId: storyIdSchema,
+  imageId: imageIdSchema
 };
 
 const authRateLimiter = createRateLimiter({
@@ -336,6 +350,15 @@ router.put(
   }
 );
 
+router.put(
+  '/admin/settings/stories-mode',
+  requireCapability('canAccessSettings', 'Admin access is required.'),
+  (request, response) => {
+    const body = storiesModeBodySchema.parse(request.body);
+    response.json(galleryService.setTreatStoriesAsFolders(body.treatStoriesAsFolders));
+  }
+);
+
 router.get('/feed/moments', (_request, response) => {
   response.json(galleryService.listMoments());
 });
@@ -422,6 +445,31 @@ router.get('/folders/:slug/images', (request, response) => {
 
   if (!payload) {
     response.status(404).json({ message: 'Folder not found' });
+    return;
+  }
+
+  response.json(payload);
+});
+
+router.get('/folders/:slug/stories', (request, response) => {
+  const params = slugSchema.parse(request.params);
+  const payload = galleryService.getFolderStories(params.slug);
+
+  if (!payload) {
+    response.status(404).json({ message: 'Folder not found' });
+    return;
+  }
+
+  response.json(payload);
+});
+
+router.get('/folders/:slug/stories/:id', (request, response) => {
+  const params = slugSchema.merge(storyIdSchema).parse(request.params);
+  const query = paginationQuerySchema.parse(request.query);
+  const payload = galleryService.getFolderStoryFeed(params.slug, params.id, query.page, query.limit);
+
+  if (!payload) {
+    response.status(404).json({ message: 'Story capsule not found' });
     return;
   }
 

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -7,17 +7,20 @@ import {
   LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY,
   LIBRARY_REBUILD_REQUIRED_SETTING_KEY,
   PREVIOUS_GALLERY_ROOT_SETTING_KEY,
-  REELS_FEED_DEFAULT_MODE_SETTING_KEY
+  REELS_FEED_DEFAULT_MODE_SETTING_KEY,
+  STORIES_MIGRATION_DECISION_SETTING_KEY,
+  TREAT_STORIES_AS_FOLDERS_SETTING_KEY
 } from '../constants/app-setting-keys.js';
 import { appConfig } from '../config/env.js';
 import { appSettingsRepository, folderRepository, folderScanStateRepository, imageRepository, likeRepository, scanRunRepository } from '../db/repositories.js';
-import type { FeedImage, ImageDetail, FolderSummaryRecord, MediaType, PlaybackStrategy, TrashImage } from '../types/models.js';
+import type { FeedImage, FolderRecord, FolderSummaryRecord, ImageDetail, MediaType, PlaybackStrategy, TrashImage } from '../types/models.js';
 import { deserializeImageExifData } from '../utils/exif-utils.js';
 import { buildMonthDayKey, countFeedBursts, diversifyFeedCandidates, groupFeedBursts, listMonthDayKeysAroundDate } from '../utils/feed-utils.js';
 import { shouldPreferMomentRail, type FeedRailKind } from '../utils/feed-rail-utils.js';
 import { countSupportedRootMediaFiles } from '../utils/gallery-root-utils.js';
 import { getPathBreadcrumb } from '../utils/path-utils.js';
 import { buildReelQueue, shuffleReelCandidates, type ReelAffinitySignals } from '../utils/reels-utils.js';
+import { parseTreatStoriesAsFoldersSetting, serializeTreatStoriesAsFoldersSetting } from '../utils/stories-utils.js';
 import { scannerService } from './scanner-service.js';
 import { storageService } from './storage-service.js';
 
@@ -46,6 +49,28 @@ interface DeleteFolderOptions {
   deleteSourceFolder?: boolean;
 }
 
+interface StoryRailCapsule {
+  id: string;
+  title: string;
+  subtitle: string;
+  dateContext: string;
+  imageCount: number;
+  coverImage: FeedImage;
+  presentation: 'avatar' | 'highlight';
+  latestActivityTimestamp: number;
+}
+
+interface StoryRailPayload {
+  railKind: 'stories';
+  railTitle: string;
+  railDescription: string;
+  railSingularLabel: string;
+  hasAvatarStory: boolean;
+  avatarStoryId: string | null;
+  items: StoryRailCapsule[];
+  highlights: StoryRailCapsule[];
+}
+
 const REDISCOVER_MIN_AGE_MS = 1000 * 60 * 60 * 24 * 180;
 const DIVERSIFIED_FETCH_BATCH_SIZE = 72;
 const MAX_DIVERSIFIED_CANDIDATES = 2400;
@@ -57,6 +82,8 @@ const HIGHLIGHT_CAPSULE_MAX_ITEMS = 30;
 // Keep the rail visually distinct from the first home-feed screen when enough alternatives exist.
 const HIGHLIGHT_FEED_OVERLAP_WINDOW = 18;
 const RAIL_COVER_CANDIDATE_LIMIT = 12;
+const FALLBACK_AVATAR_STORY_LIMIT = 10;
+const FALLBACK_AVATAR_STORY_ID = '__story-avatar-fallback__';
 
 type IndexedFeedImage = FeedImage & { playbackStrategy?: PlaybackStrategy | null };
 type IndexedImageDetail = ImageDetail & { playbackStrategy?: PlaybackStrategy | null; exifJson?: string | null };
@@ -92,6 +119,17 @@ function parseReelsFeedMode(value: string | null): ReelsFeedMode {
 
 function getDefaultReelsFeedMode(): ReelsFeedMode {
   return parseReelsFeedMode(appSettingsRepository.get(REELS_FEED_DEFAULT_MODE_SETTING_KEY));
+}
+
+function getTreatStoriesAsFolders(): boolean {
+  return parseTreatStoriesAsFoldersSetting(appSettingsRepository.get(TREAT_STORIES_AS_FOLDERS_SETTING_KEY));
+}
+
+function getStoriesMigrationStatus() {
+  return {
+    hasLegacyStoriesCandidates: folderRepository.hasLegacyStoriesCandidates(),
+    decisionPending: appSettingsRepository.get(STORIES_MIGRATION_DECISION_SETTING_KEY) === null
+  };
 }
 
 function getDerivativeAssetVersion(): string | null {
@@ -286,9 +324,37 @@ function buildFolderSummary(folder: FolderSummaryRecord) {
     imageCount: folder.image_count,
     videoCount: folder.video_count,
     latestImageMtimeMs: folder.latest_image_mtime_ms,
+    hasAvatarStory: Boolean(folder.has_avatar_story),
     avatarImageId: avatar?.id ?? null,
     avatarUrl: avatar ? mapImageDetail(avatar, derivativeVersion).thumbnailUrl : null
   };
+}
+
+function mapFeedImageForOwnerFolder(
+  image: IndexedFeedImage,
+  ownerFolder: ReturnType<typeof buildFolderSummary>,
+  derivativeVersion = getDerivativeAssetVersion()
+): FeedImage {
+  return {
+    ...mapFeedImage(image, derivativeVersion),
+    folderId: ownerFolder.id,
+    folderSlug: ownerFolder.slug,
+    folderName: ownerFolder.name,
+    folderPath: ownerFolder.folderPath,
+    folderBreadcrumb: ownerFolder.breadcrumb
+  };
+}
+
+function formatStoryDateContext(timestamp: number | null): string {
+  if (timestamp === null) {
+    return 'No recent activity';
+  }
+
+  return `Latest ${new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  }).format(new Date(timestamp))}`;
 }
 
 function formatMonthDay(date: Date): string {
@@ -519,9 +585,9 @@ function buildHighlightRailDefinition(now = new Date()): FeedRailDefinition {
 
   return {
     kind: 'highlights',
-    title: 'Highlights',
-    description: 'Curated sets from your library when capture dates are sparse or synthetic.',
-    singularLabel: 'Highlight',
+    title: 'Stories',
+    description: 'Curated story-style sets from your library when capture dates are sparse or synthetic.',
+    singularLabel: 'Story',
     capsules: [
       buildStaticCapsuleDefinition(
         {
@@ -617,6 +683,119 @@ function getSelectedFeedRail(now = new Date()) {
   }
 
   return momentRail.capsules.length > 0 ? momentRail : highlightRail;
+}
+
+function buildFolderStoryRail(folder: FolderSummaryRecord): StoryRailPayload {
+  const ownerFolder = buildFolderSummary(folder);
+  const derivativeVersion = getDerivativeAssetVersion();
+  const storyFolders = folderRepository.listOwnedStoryFolders(folder.id);
+  const rootStoryFolder = storyFolders.find((entry) => entry.role === 'story_root') ?? null;
+  const highlightStoryFolders = storyFolders.filter((entry) => entry.role === 'story_capsule');
+
+  const rootStoryCapsule = rootStoryFolder ? buildStoryRailCapsule(rootStoryFolder, ownerFolder, derivativeVersion) : null;
+  const highlightCapsules = highlightStoryFolders
+    .map((storyFolder) => buildStoryRailCapsule(storyFolder, ownerFolder, derivativeVersion))
+    .filter((capsule): capsule is StoryRailCapsule => capsule !== null)
+    .sort((left, right) => {
+      if (left.latestActivityTimestamp !== right.latestActivityTimestamp) {
+        return right.latestActivityTimestamp - left.latestActivityTimestamp;
+      }
+
+      return left.title.localeCompare(right.title, undefined, { sensitivity: 'base' });
+    });
+  const avatarStoryCapsule = rootStoryCapsule ?? buildFallbackAvatarStoryCapsule(ownerFolder, derivativeVersion);
+  const items = avatarStoryCapsule ? [avatarStoryCapsule, ...highlightCapsules] : highlightCapsules;
+
+  return {
+    railKind: 'stories',
+    railTitle: 'Stories',
+    railDescription: `Stories and highlights for ${folder.name}.`,
+    railSingularLabel: 'Story',
+    hasAvatarStory: avatarStoryCapsule !== null,
+    avatarStoryId: avatarStoryCapsule?.id ?? null,
+    items,
+    highlights: highlightCapsules
+  };
+}
+
+function buildStoryRailCapsule(
+  storyFolder: FolderRecord,
+  ownerFolder: ReturnType<typeof buildFolderSummary>,
+  derivativeVersion: string | null
+): StoryRailCapsule | null {
+  const imageCount = imageRepository.countStoryMediaByFolder(storyFolder.id);
+  if (imageCount === 0) {
+    return null;
+  }
+
+  const coverImage = imageRepository.listStoryFolderImages(storyFolder.id, 1, 1)[0];
+  if (!coverImage) {
+    return null;
+  }
+
+  const latestActivityTimestamp = imageRepository.getLatestEffectiveTimestampByFolder(storyFolder.id) ?? 0;
+  const presentation = storyFolder.role === 'story_root' ? 'avatar' as const : 'highlight' as const;
+
+  return {
+    id: storyFolder.slug,
+    title: presentation === 'avatar' ? ownerFolder.name : storyFolder.name,
+    subtitle: presentation === 'avatar' ? `${ownerFolder.name} story set` : 'Profile highlight',
+    dateContext: formatStoryDateContext(latestActivityTimestamp),
+    imageCount,
+    coverImage: mapFeedImageForOwnerFolder(coverImage, ownerFolder, derivativeVersion),
+    presentation,
+    latestActivityTimestamp
+  };
+}
+
+function buildFallbackAvatarStoryCapsule(
+  ownerFolder: ReturnType<typeof buildFolderSummary>,
+  derivativeVersion: string | null
+): StoryRailCapsule | null {
+  const imageCount = Math.min(imageRepository.countStoryCapsuleMediaByOwnerFolder(ownerFolder.id), FALLBACK_AVATAR_STORY_LIMIT);
+  if (imageCount === 0) {
+    return null;
+  }
+
+  const coverImage = imageRepository.listStoryCapsuleImagesByOwnerFolder(ownerFolder.id, 1, 1)[0];
+  if (!coverImage) {
+    return null;
+  }
+
+  const latestActivityTimestamp = coverImage.takenAt ?? coverImage.sortTimestamp;
+
+  return {
+    id: FALLBACK_AVATAR_STORY_ID,
+    title: ownerFolder.name,
+    subtitle: 'Latest from highlights',
+    dateContext: formatStoryDateContext(latestActivityTimestamp),
+    imageCount,
+    coverImage: mapFeedImageForOwnerFolder(coverImage, ownerFolder, derivativeVersion),
+    presentation: 'avatar',
+    latestActivityTimestamp
+  };
+}
+
+function listFallbackAvatarStoryItems(
+  ownerFolder: ReturnType<typeof buildFolderSummary>,
+  page: number,
+  limit: number,
+  derivativeVersion = getDerivativeAssetVersion()
+) {
+  const total = Math.min(imageRepository.countStoryCapsuleMediaByOwnerFolder(ownerFolder.id), FALLBACK_AVATAR_STORY_LIMIT);
+  const offset = (page - 1) * limit;
+  const remaining = Math.max(total - offset, 0);
+  const items =
+    remaining > 0
+      ? imageRepository
+          .listStoryCapsuleImagesByOwnerFolder(ownerFolder.id, page, Math.min(limit, remaining))
+          .map((image) => mapFeedImageForOwnerFolder(image, ownerFolder, derivativeVersion))
+      : [];
+
+  return {
+    total,
+    items
+  };
 }
 
 export const galleryService = {
@@ -836,7 +1015,7 @@ export const galleryService = {
       return null;
     }
 
-    const folder = folderRepository.getBySlug(slug);
+    const folder = folderRepository.getNormalBySlug(slug);
     if (!folder) {
       return null;
     }
@@ -848,6 +1027,70 @@ export const galleryService = {
 
     folderRepository.setAvatar(folder.id, imageId, 'manual');
     return true;
+  },
+
+  getFolderStories(slug: string) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const folder = folderRepository.getSummaryBySlug(slug);
+    if (!folder) {
+      return null;
+    }
+
+    return buildFolderStoryRail(folder);
+  },
+
+  getFolderStoryFeed(slug: string, storyId: string, page: number, limit: number) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const folder = folderRepository.getSummaryBySlug(slug);
+    if (!folder) {
+      return null;
+    }
+
+    const rail = buildFolderStoryRail(folder);
+    const capsule = rail.items.find((entry) => entry.id === storyId);
+    if (!capsule) {
+      return null;
+    }
+
+    const ownerFolder = buildFolderSummary(folder);
+    if (storyId === FALLBACK_AVATAR_STORY_ID) {
+      const fallbackFeed = listFallbackAvatarStoryItems(ownerFolder, page, limit);
+
+      return {
+        railKind: 'stories' as const,
+        railTitle: rail.railTitle,
+        railDescription: rail.railDescription,
+        railSingularLabel: rail.railSingularLabel,
+        story: capsule,
+        ...buildPaginatedPayload(fallbackFeed.items, page, limit, fallbackFeed.total)
+      };
+    }
+
+    const storyFolder = folderRepository.getOwnedStoryFolderBySlug(folder.id, storyId);
+    if (!storyFolder) {
+      return null;
+    }
+
+    const derivativeVersion = getDerivativeAssetVersion();
+    const total = imageRepository.countStoryMediaByFolder(storyFolder.id);
+    const items = imageRepository
+      .listStoryFolderImages(storyFolder.id, page, limit)
+      .map((image) => mapFeedImageForOwnerFolder(image, ownerFolder, derivativeVersion));
+
+    return {
+      railKind: 'stories' as const,
+      railTitle: rail.railTitle,
+      railDescription: rail.railDescription,
+      railSingularLabel: rail.railSingularLabel,
+      story: capsule,
+      ...buildPaginatedPayload(items, page, limit, total)
+    };
   },
 
   getFolderImages(slug: string, page: number, limit: number, mediaType?: MediaType) {
@@ -1016,6 +1259,8 @@ export const galleryService = {
     const rebuildRequired = appSettingsRepository.get(LIBRARY_REBUILD_REQUIRED_SETTING_KEY) === '1';
     const defaultHomeFeedMode = getDefaultHomeFeedMode();
     const defaultReelsFeedMode = getDefaultReelsFeedMode();
+    const treatStoriesAsFolders = getTreatStoriesAsFolders();
+    const storiesMigration = getStoriesMigrationStatus();
 
     return {
       folders: storageState.libraryAvailable ? folderRepository.count() : 0,
@@ -1037,8 +1282,10 @@ export const galleryService = {
       },
       preferences: {
         defaultHomeFeedMode,
-        defaultReelsFeedMode
-      }
+        defaultReelsFeedMode,
+        treatStoriesAsFolders
+      },
+      storiesMigration
     };
   },
 
@@ -1052,6 +1299,8 @@ export const galleryService = {
     const lastSuccessfulGalleryRoot = appSettingsRepository.get(LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY);
     const defaultHomeFeedMode = getDefaultHomeFeedMode();
     const defaultReelsFeedMode = getDefaultReelsFeedMode();
+    const treatStoriesAsFolders = getTreatStoriesAsFolders();
+    const storiesMigration = getStoriesMigrationStatus();
 
     return {
       folders: storageState.libraryAvailable ? folderRepository.count() : 0,
@@ -1080,8 +1329,10 @@ export const galleryService = {
       },
       preferences: {
         defaultHomeFeedMode,
-        defaultReelsFeedMode
-      }
+        defaultReelsFeedMode,
+        treatStoriesAsFolders
+      },
+      storiesMigration
     };
   },
 
@@ -1098,6 +1349,15 @@ export const galleryService = {
 
     return {
       defaultMode: mode
+    };
+  },
+
+  setTreatStoriesAsFolders(treatStoriesAsFolders: boolean) {
+    appSettingsRepository.set(TREAT_STORIES_AS_FOLDERS_SETTING_KEY, serializeTreatStoriesAsFoldersSetting(treatStoriesAsFolders));
+    appSettingsRepository.set(STORIES_MIGRATION_DECISION_SETTING_KEY, treatStoriesAsFolders ? 'legacy' : 'stories');
+
+    return {
+      treatStoriesAsFolders
     };
   },
 

--- a/server/src/services/scanner-service.ts
+++ b/server/src/services/scanner-service.ts
@@ -8,7 +8,8 @@ import pLimit from 'p-limit';
 import {
   LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY,
   LIBRARY_REBUILD_REQUIRED_SETTING_KEY,
-  PREVIOUS_GALLERY_ROOT_SETTING_KEY
+  PREVIOUS_GALLERY_ROOT_SETTING_KEY,
+  TREAT_STORIES_AS_FOLDERS_SETTING_KEY
 } from '../constants/app-setting-keys.js';
 import { appConfig } from '../config/env.js';
 import {
@@ -41,6 +42,11 @@ import {
   normalizePath
 } from '../utils/path-utils.js';
 import {
+  findReservedStoriesOwnerPath,
+  isStoriesFolderName,
+  parseTreatStoriesAsFoldersSetting
+} from '../utils/stories-utils.js';
+import {
   createFolderScanSignature,
   resolveFullScanOptions,
   shouldQueueDerivativeJobForStatus,
@@ -50,7 +56,7 @@ import {
   type IndexedFileStatus
 } from '../utils/scan-utils.js';
 import { resolveUniqueSlug, slugifyFolderPath } from '../utils/slug.js';
-import type { FolderRecord, FolderScanStateRecord, ScanRunRecord } from '../types/models.js';
+import type { FolderRecord, FolderRole, FolderScanStateRecord, ScanRunRecord } from '../types/models.js';
 
 interface ScanSummary {
   status: string;
@@ -89,6 +95,40 @@ interface SourceFolderCandidate {
 interface ResolvedFolderResult {
   folder: FolderRecord;
   wroteFolder: boolean;
+}
+
+interface ResolvedFolderOptions {
+  role?: FolderRole;
+  storyOwnerFolderId?: number | null;
+}
+
+interface IndexedFolderScanOptions {
+  folderPath: string;
+  scannedFileCount: number;
+  activeRelativePaths: string[];
+  discoveredFiles: IndexedFileCandidate[];
+  existingFolders: FolderRecord[];
+  usedSlugs: Set<string>;
+  folderScanStates: Map<string, FolderScanStateRecord>;
+  derivativeJobs: Map<string, DerivativeJob>;
+  errors: string[];
+  options: FullScanOptions;
+  context: ImageProcessingContext;
+  logLabel: string;
+  role?: FolderRole;
+  storyOwnerFolderId?: number | null;
+  folderHadErrors?: boolean;
+}
+
+interface IndexedFileReference {
+  absolutePath: string;
+  relativePath: string;
+}
+
+interface StatIndexedFilesResult {
+  activeRelativePaths: string[];
+  discoveredFiles: IndexedFileCandidate[];
+  folderHadErrors: boolean;
 }
 
 interface SourceFolderScanResult {
@@ -475,10 +515,15 @@ class ScannerService {
     return matchesRelativeRoot(relativePath, appConfig.managedGalleryRelativeIgnores);
   }
 
+  private shouldTreatStoriesAsFolders(): boolean {
+    return parseTreatStoriesAsFoldersSetting(appSettingsRepository.get(TREAT_STORIES_AS_FOLDERS_SETTING_KEY));
+  }
+
   private async walkMediaSourceFolders(
     currentAbsolutePath: string,
     onSourceFolder: (sourceFolder: SourceFolderCandidate) => Promise<void>,
-    currentRelativePath: string | null = null
+    currentRelativePath: string | null = null,
+    treatStoriesAsFolders = this.shouldTreatStoriesAsFolders()
   ): Promise<void> {
     this.setProgress({
       currentFolder: currentRelativePath ? normalizePath(currentRelativePath) : ROOT_DISCOVERY_LABEL
@@ -538,11 +583,15 @@ class ScannerService {
     }
 
     for (const childDirectory of childDirectories) {
-      await this.walkMediaSourceFolders(childDirectory.absolutePath, onSourceFolder, childDirectory.relativePath);
+      if (!treatStoriesAsFolders && currentRelativePath && hasDirectImages && isStoriesFolderName(path.basename(childDirectory.relativePath))) {
+        continue;
+      }
+
+      await this.walkMediaSourceFolders(childDirectory.absolutePath, onSourceFolder, childDirectory.relativePath, treatStoriesAsFolders);
     }
   }
 
-  private clearIndexedSourceFolder(sourceFolderPath: string, existingFolders: FolderRecord[]): SourceFolderScanResult {
+  private clearIndexedFolder(sourceFolderPath: string, existingFolders: FolderRecord[]): SourceFolderScanResult {
     const existingFolder = existingFolders.find(
       (folder) => normalizePath(folder.folder_path) === normalizePath(sourceFolderPath)
     );
@@ -594,7 +643,7 @@ class ScannerService {
       });
 
     if (!entries) {
-      return this.clearIndexedSourceFolder(sourceFolderPath, existingFolders);
+      return this.clearIndexedFolder(sourceFolderPath, existingFolders);
     }
 
     const imageFiles = entries.filter(
@@ -602,7 +651,7 @@ class ScannerService {
     );
 
     if (imageFiles.length === 0) {
-      return this.clearIndexedSourceFolder(sourceFolderPath, existingFolders);
+      return this.clearIndexedFolder(sourceFolderPath, existingFolders);
     }
 
     this.setProgress({
@@ -610,45 +659,348 @@ class ScannerService {
       discoveredImages: this.progress.discoveredImages + imageFiles.length
     });
 
+    const statResult = await this.statIndexedFiles(
+      imageFiles.map((entry) => {
+        const absolutePath = path.join(sourceFolder.absolutePath, entry.name);
+        return {
+          absolutePath,
+          relativePath: getRelativeGalleryPath(appConfig.galleryRoot, absolutePath)
+        };
+      }),
+      errors
+    );
+
+    const result = await this.scanIndexedFolderFiles({
+      folderPath: sourceFolderPath,
+      scannedFileCount: imageFiles.length,
+      activeRelativePaths: statResult.activeRelativePaths,
+      discoveredFiles: statResult.discoveredFiles,
+      existingFolders,
+      usedSlugs,
+      folderScanStates,
+      derivativeJobs,
+      errors,
+      options,
+      context,
+      logLabel: 'App folder indexed',
+      folderHadErrors: statResult.folderHadErrors
+    });
+
+    log.info(
+      joinLogParts([
+        'App folder indexed',
+        sourceFolderPath,
+        formatStep('scanned', imageFiles.length),
+        formatStep('new', result.newFiles),
+        formatStep('updated', result.updatedFiles),
+        formatStep('removed', result.removedFiles),
+        formatStep('unchanged', result.unchangedFiles),
+        formatStep('duration', formatDuration(elapsedMilliseconds(folderStartedAt)))
+      ])
+    );
+
+    return result;
+  }
+
+  private async statIndexedFiles(files: IndexedFileReference[], errors: string[]): Promise<StatIndexedFilesResult> {
+    const activeRelativePaths: string[] = [];
+    const discoveredFiles: IndexedFileCandidate[] = [];
+    let folderHadErrors = false;
+
+    await Promise.all(
+      files.map((file) =>
+        discoveryLimit(async () => {
+          activeRelativePaths.push(file.relativePath);
+
+          try {
+            const stats = await fs.stat(file.absolutePath);
+            discoveredFiles.push({
+              absolutePath: file.absolutePath,
+              relativePath: file.relativePath,
+              stats
+            });
+          } catch (error) {
+            folderHadErrors = true;
+            const message = error instanceof Error ? error.message : String(error);
+            errors.push(`${file.relativePath}: ${message}`);
+            this.setProgress({
+              processedImages: this.progress.processedImages + 1
+            });
+            log.error(joinLogParts(['Failed to stat media during discovery', formatStep('file', file.relativePath), message]));
+          }
+        })
+      )
+    );
+
+    return {
+      activeRelativePaths,
+      discoveredFiles,
+      folderHadErrors
+    };
+  }
+
+  private async collectRecursiveMediaFiles(currentAbsolutePath: string, currentRelativePath: string): Promise<IndexedFileReference[]> {
+    const entries = await fs
+      .readdir(currentAbsolutePath, { withFileTypes: true })
+      .catch((error: unknown) => {
+        const filesystemError = error as NodeJS.ErrnoException;
+        if (filesystemError.code === 'ENOENT') {
+          return null;
+        }
+
+        throw error;
+      });
+
+    if (!entries) {
+      return [];
+    }
+
+    const files: IndexedFileReference[] = [];
+
+    for (const entry of entries) {
+      const relativeEntryPath = normalizePath(`${currentRelativePath}/${entry.name}`);
+      if (isHiddenPath(relativeEntryPath)) {
+        continue;
+      }
+
+      if (entry.isDirectory()) {
+        if (this.isManagedGalleryPath(relativeEntryPath)) {
+          continue;
+        }
+
+        files.push(...await this.collectRecursiveMediaFiles(path.join(currentAbsolutePath, entry.name), relativeEntryPath));
+        continue;
+      }
+
+      if (entry.isFile() && isSupportedMediaFile(entry.name)) {
+        files.push({
+          absolutePath: path.join(currentAbsolutePath, entry.name),
+          relativePath: relativeEntryPath
+        });
+      }
+    }
+
+    return files;
+  }
+
+  private async scanStoryFoldersForOwnerFolder(
+    ownerFolder: FolderRecord,
+    sourceFolder: SourceFolderCandidate,
+    existingFolders: FolderRecord[],
+    usedSlugs: Set<string>,
+    folderScanStates: Map<string, FolderScanStateRecord>,
+    derivativeJobs: Map<string, DerivativeJob>,
+    errors: string[],
+    options: FullScanOptions,
+    context: ImageProcessingContext
+  ): Promise<SourceFolderScanResult[]> {
+    const ownerEntries = await fs
+      .readdir(sourceFolder.absolutePath, { withFileTypes: true })
+      .catch((error: unknown) => {
+        const filesystemError = error as NodeJS.ErrnoException;
+        if (filesystemError.code === 'ENOENT') {
+          return null;
+        }
+
+        throw error;
+      });
+
+    if (!ownerEntries) {
+      return [];
+    }
+
+    const storiesDirectory = ownerEntries.find((entry) => {
+      if (!entry.isDirectory()) {
+        return false;
+      }
+
+      const relativeEntryPath = normalizePath(`${sourceFolder.relativePath}/${entry.name}`);
+      return !isHiddenPath(relativeEntryPath) && !this.isManagedGalleryPath(relativeEntryPath) && isStoriesFolderName(entry.name);
+    });
+
+    if (!storiesDirectory) {
+      return [];
+    }
+
+    const storiesAbsolutePath = path.join(sourceFolder.absolutePath, storiesDirectory.name);
+    const storiesRelativePath = normalizePath(`${sourceFolder.relativePath}/${storiesDirectory.name}`);
+    const storiesEntries = await fs
+      .readdir(storiesAbsolutePath, { withFileTypes: true })
+      .catch((error: unknown) => {
+        const filesystemError = error as NodeJS.ErrnoException;
+        if (filesystemError.code === 'ENOENT') {
+          return null;
+        }
+
+        throw error;
+      });
+
+    if (!storiesEntries) {
+      return [];
+    }
+
+    const storyResults: SourceFolderScanResult[] = [];
+    const directStoryFiles = storiesEntries
+      .filter((entry) => entry.isFile() && isSupportedMediaFile(entry.name) && !entry.name.startsWith('.'))
+      .map((entry) => ({
+        absolutePath: path.join(storiesAbsolutePath, entry.name),
+        relativePath: normalizePath(`${storiesRelativePath}/${entry.name}`)
+      }));
+
+    if (directStoryFiles.length > 0) {
+      const startedAt = performance.now();
+      this.setProgress({
+        currentFolder: storiesRelativePath,
+        discoveredImages: this.progress.discoveredImages + directStoryFiles.length
+      });
+      const statResult = await this.statIndexedFiles(directStoryFiles, errors);
+      const result = await this.scanIndexedFolderFiles({
+        folderPath: storiesRelativePath,
+        scannedFileCount: directStoryFiles.length,
+        activeRelativePaths: statResult.activeRelativePaths,
+        discoveredFiles: statResult.discoveredFiles,
+        existingFolders,
+        usedSlugs,
+        folderScanStates,
+        derivativeJobs,
+        errors,
+        options,
+        context,
+        logLabel: 'Story root indexed',
+        role: 'story_root',
+        storyOwnerFolderId: ownerFolder.id,
+        folderHadErrors: statResult.folderHadErrors
+      });
+
+      log.info(
+        joinLogParts([
+          'Story root indexed',
+          storiesRelativePath,
+          formatStep('scanned', directStoryFiles.length),
+          formatStep('new', result.newFiles),
+          formatStep('updated', result.updatedFiles),
+          formatStep('removed', result.removedFiles),
+          formatStep('unchanged', result.unchangedFiles),
+          formatStep('duration', formatDuration(elapsedMilliseconds(startedAt)))
+        ])
+      );
+
+      storyResults.push(result);
+    }
+
+    for (const entry of storiesEntries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const capsuleRelativePath = normalizePath(`${storiesRelativePath}/${entry.name}`);
+      if (isHiddenPath(capsuleRelativePath) || this.isManagedGalleryPath(capsuleRelativePath)) {
+        continue;
+      }
+
+      const startedAt = performance.now();
+      const nestedFiles = await this.collectRecursiveMediaFiles(path.join(storiesAbsolutePath, entry.name), capsuleRelativePath);
+      if (nestedFiles.length === 0) {
+        continue;
+      }
+
+      this.setProgress({
+        currentFolder: capsuleRelativePath,
+        discoveredImages: this.progress.discoveredImages + nestedFiles.length
+      });
+      const statResult = await this.statIndexedFiles(nestedFiles, errors);
+      const result = await this.scanIndexedFolderFiles({
+        folderPath: capsuleRelativePath,
+        scannedFileCount: nestedFiles.length,
+        activeRelativePaths: statResult.activeRelativePaths,
+        discoveredFiles: statResult.discoveredFiles,
+        existingFolders,
+        usedSlugs,
+        folderScanStates,
+        derivativeJobs,
+        errors,
+        options,
+        context,
+        logLabel: 'Story capsule indexed',
+        role: 'story_capsule',
+        storyOwnerFolderId: ownerFolder.id,
+        folderHadErrors: statResult.folderHadErrors
+      });
+
+      log.info(
+        joinLogParts([
+          'Story capsule indexed',
+          capsuleRelativePath,
+          formatStep('scanned', nestedFiles.length),
+          formatStep('new', result.newFiles),
+          formatStep('updated', result.updatedFiles),
+          formatStep('removed', result.removedFiles),
+          formatStep('unchanged', result.unchangedFiles),
+          formatStep('duration', formatDuration(elapsedMilliseconds(startedAt)))
+        ])
+      );
+
+      storyResults.push(result);
+    }
+
+    return storyResults;
+  }
+
+  private async scanIndexedFolderFiles({
+    folderPath,
+    scannedFileCount,
+    activeRelativePaths,
+    discoveredFiles,
+    existingFolders,
+    usedSlugs,
+    folderScanStates,
+    derivativeJobs,
+    errors,
+    options,
+    context,
+    role = 'normal',
+    storyOwnerFolderId = null,
+    folderHadErrors = false
+  }: IndexedFolderScanOptions): Promise<SourceFolderScanResult> {
+    const normalizedFolderPath = normalizePath(folderPath);
+
+    if (discoveredFiles.length === 0) {
+      if (activeRelativePaths.length > 0) {
+        const resolvedFolder = this.resolveFolder(existingFolders, usedSlugs, normalizedFolderPath, {
+          role,
+          storyOwnerFolderId
+        });
+
+        return {
+          folder: resolvedFolder.folder,
+          sourceFolderPath: normalizedFolderPath,
+          discoveredDirectImages: true,
+          wroteFolder: resolvedFolder.wroteFolder,
+          scannedFiles: scannedFileCount,
+          newFiles: 0,
+          updatedFiles: 0,
+          removedFiles: 0,
+          unchangedFiles: 0,
+          refreshedUnchangedRows: 0,
+          skippedUnchangedRows: 0,
+          usedFolderShortcut: false
+        };
+      }
+
+      return this.clearIndexedFolder(normalizedFolderPath, existingFolders);
+    }
+
+    const resolvedFolder = this.resolveFolder(existingFolders, usedSlugs, normalizedFolderPath, {
+      role,
+      storyOwnerFolderId
+    });
+    const folder = resolvedFolder.folder;
     let unchangedFiles = 0;
     let newFiles = 0;
     let updatedFiles = 0;
     let refreshedUnchangedRows = 0;
     let skippedUnchangedRows = 0;
     let usedFolderShortcut = false;
-    let folderHadErrors = false;
-
-    const resolvedFolder = this.resolveFolder(existingFolders, usedSlugs, sourceFolderPath);
-    const folder = resolvedFolder.folder;
-    const activeRelativePaths: string[] = [];
-    const discoveredFiles: IndexedFileCandidate[] = [];
-
-    await Promise.all(
-      imageFiles.map((entry) =>
-        discoveryLimit(async () => {
-          const absolutePath = path.join(sourceFolder.absolutePath, entry.name);
-          const relativePath = getRelativeGalleryPath(appConfig.galleryRoot, absolutePath);
-          activeRelativePaths.push(relativePath);
-
-          try {
-            const stats = await fs.stat(absolutePath);
-            discoveredFiles.push({
-              absolutePath,
-              relativePath,
-              stats
-            });
-          } catch (error) {
-            folderHadErrors = true;
-            const message = error instanceof Error ? error.message : String(error);
-            errors.push(`${relativePath}: ${message}`);
-            this.setProgress({
-              processedImages: this.progress.processedImages + 1
-            });
-            log.error(joinLogParts(['Failed to stat media during discovery', formatStep('file', relativePath), message]));
-          }
-        })
-      )
-    );
 
     const folderSignature = createFolderScanSignature(
       discoveredFiles.map((file) => ({
@@ -657,7 +1009,7 @@ class ScannerService {
         mtimeMs: file.stats.mtimeMs
       }))
     );
-    const storedFolderState = folderScanStates.get(sourceFolderPath);
+    const storedFolderState = folderScanStates.get(normalizedFolderPath);
     const hasCompleteTakenAtMetadata = imageRepository.countMissingTimestampMetadataByFolder(folder.id) === 0;
     const hasCompletePlaybackStrategyMetadata = imageRepository.countMissingPlaybackStrategyByFolder(folder.id) === 0;
     const hasMatchingIndexedFiles =
@@ -688,10 +1040,10 @@ class ScannerService {
 
       return {
         folder,
-        sourceFolderPath,
+        sourceFolderPath: normalizedFolderPath,
         discoveredDirectImages: true,
         wroteFolder: resolvedFolder.wroteFolder,
-        scannedFiles: imageFiles.length,
+        scannedFiles: scannedFileCount,
         newFiles: 0,
         updatedFiles: 0,
         removedFiles: 0,
@@ -747,14 +1099,14 @@ class ScannerService {
 
     if (!folderHadErrors) {
       folderScanStateRepository.upsert({
-        folderPath: sourceFolderPath,
+        folderPath: normalizedFolderPath,
         signature: folderSignature.signature,
         fileCount: folderSignature.fileCount,
         maxMtimeMs: folderSignature.maxMtimeMs,
         totalSize: folderSignature.totalSize
       });
-      folderScanStates.set(sourceFolderPath, {
-        folder_path: sourceFolderPath,
+      folderScanStates.set(normalizedFolderPath, {
+        folder_path: normalizedFolderPath,
         signature: folderSignature.signature,
         file_count: folderSignature.fileCount,
         max_mtime_ms: folderSignature.maxMtimeMs,
@@ -763,25 +1115,12 @@ class ScannerService {
       });
     }
 
-    log.info(
-      joinLogParts([
-        'App folder indexed',
-        sourceFolderPath,
-        formatStep('scanned', imageFiles.length),
-        formatStep('new', newFiles),
-        formatStep('updated', updatedFiles),
-        formatStep('removed', removedFiles),
-        formatStep('unchanged', unchangedFiles),
-        formatStep('duration', formatDuration(elapsedMilliseconds(folderStartedAt)))
-      ])
-    );
-
     return {
       folder,
-      sourceFolderPath,
+      sourceFolderPath: normalizedFolderPath,
       discoveredDirectImages: true,
       wroteFolder: resolvedFolder.wroteFolder,
-      scannedFiles: imageFiles.length,
+      scannedFiles: scannedFileCount,
       newFiles,
       updatedFiles,
       removedFiles,
@@ -941,6 +1280,7 @@ class ScannerService {
       galleryRootChanged,
       hasStoredGalleryRoot
     };
+    const treatStoriesAsFolders = this.shouldTreatStoriesAsFolders();
 
     if (!storageService.refreshAvailability().libraryAvailable) {
       return this.finishUnavailableRun(runId, reason);
@@ -953,6 +1293,7 @@ class ScannerService {
         formatStep('repair-derivatives', formatToggle(options.repairUnchangedDerivatives)),
         formatStep('root-changed', formatToggle(galleryRootChanged)),
         formatStep('stored-root', formatToggle(hasStoredGalleryRoot)),
+        formatStep('stories-as-folders', formatToggle(treatStoriesAsFolders)),
         appConfig.managedGalleryRelativeIgnores.length > 0
           ? formatStep('ignored-managed-paths', appConfig.managedGalleryRelativeIgnores.join(','))
           : null,
@@ -982,19 +1323,7 @@ class ScannerService {
       const discoveryStartedAt = performance.now();
       let discoveredSourceFolders = 0;
 
-      await this.walkMediaSourceFolders(appConfig.galleryRoot, async (sourceFolder) => {
-        discoveredSourceFolders += 1;
-        const result = await this.scanSourceFolder(
-          sourceFolder,
-          existingFolders,
-          usedSlugs,
-          folderScanStates,
-          derivativeJobs,
-          errors,
-          options,
-          imageProcessingContext
-        );
-
+      const applyScanResult = (result: SourceFolderScanResult) => {
         summary.scanned_files += result.scannedFiles;
         summary.new_files += result.newFiles;
         summary.updated_files += result.updatedFiles;
@@ -1033,12 +1362,46 @@ class ScannerService {
             metrics.unchangedFilesSkippedDerivativeVerification += result.unchangedFiles;
           }
         }
+      };
+
+      await this.walkMediaSourceFolders(appConfig.galleryRoot, async (sourceFolder) => {
+        discoveredSourceFolders += 1;
+        const result = await this.scanSourceFolder(
+          sourceFolder,
+          existingFolders,
+          usedSlugs,
+          folderScanStates,
+          derivativeJobs,
+          errors,
+          options,
+          imageProcessingContext
+        );
+
+        applyScanResult(result);
+
+        if (!treatStoriesAsFolders && result.folder && result.discoveredDirectImages) {
+          const storyResults = await this.scanStoryFoldersForOwnerFolder(
+            result.folder,
+            sourceFolder,
+            existingFolders,
+            usedSlugs,
+            folderScanStates,
+            derivativeJobs,
+            errors,
+            options,
+            imageProcessingContext
+          );
+
+          for (const storyResult of storyResults) {
+            applyScanResult(storyResult);
+          }
+        }
 
         this.setProgress({
           processedFolders: this.progress.processedFolders + 1
         });
         this.logProgress('folder');
-      });
+      }, null, treatStoriesAsFolders);
 
       for (const folder of existingFolders) {
         if (!discoveredFolderIds.has(folder.id)) {
@@ -1110,6 +1473,7 @@ class ScannerService {
 
     const normalizedPaths = [...new Set(relativePaths.map((value) => normalizePath(value)).filter(Boolean))];
     const impactedSourceFolders = new Set<string>();
+    const treatStoriesAsFolders = this.shouldTreatStoriesAsFolders();
 
     for (const relativePath of normalizedPaths) {
       if (isHiddenPath(relativePath)) {
@@ -1122,6 +1486,11 @@ class ScannerService {
 
       if (!isSupportedMediaFile(path.basename(relativePath))) {
         continue;
+      }
+
+      if (!treatStoriesAsFolders && findReservedStoriesOwnerPath(relativePath)) {
+        fallbackReason = `${reason}:fallback`;
+        break;
       }
 
       const sourceFolderPath = getSourceFolderPathFromRelativePath(relativePath);
@@ -1331,12 +1700,19 @@ class ScannerService {
     return summary;
   }
 
-  private resolveFolder(existingFolders: FolderRecord[], usedSlugs: Set<string>, sourceFolderPath: string): ResolvedFolderResult {
+  private resolveFolder(
+    existingFolders: FolderRecord[],
+    usedSlugs: Set<string>,
+    sourceFolderPath: string,
+    options: ResolvedFolderOptions = {}
+  ): ResolvedFolderResult {
     const normalizedFolderPath = normalizePath(sourceFolderPath);
     const existingByFolder = existingFolders.find(
       (folder) => normalizePath(folder.folder_path) === normalizedFolderPath
     );
     const folderName = getFolderDisplayInfo(normalizedFolderPath).name;
+    const role = options.role ?? 'normal';
+    const storyOwnerFolderId = options.storyOwnerFolderId ?? null;
 
     if (existingByFolder) {
       usedSlugs.delete(existingByFolder.slug);
@@ -1346,7 +1722,9 @@ class ScannerService {
     const saved = folderRepository.save({
       slug,
       name: folderName,
-      folderPath: normalizedFolderPath
+      folderPath: normalizedFolderPath,
+      role,
+      storyOwnerFolderId
     });
     this.rememberFolder(existingFolders, saved.folder);
     return {

--- a/server/src/types/models.ts
+++ b/server/src/types/models.ts
@@ -2,6 +2,7 @@ export type MediaType = 'image' | 'video';
 export type TakenAtSource = 'exif' | 'mtime' | 'first_seen' | 'sort_timestamp';
 export type PlaybackStrategy = 'preview' | 'original';
 export type FolderAvatarSource = 'auto' | 'manual' | 'cover';
+export type FolderRole = 'normal' | 'story_root' | 'story_capsule';
 
 export interface ImageExifData {
   cameraMake?: string;
@@ -22,6 +23,8 @@ export interface FolderRecord {
   slug: string;
   name: string;
   folder_path: string;
+  role: FolderRole;
+  story_owner_folder_id: number | null;
   description: string | null;
   avatar_image_id: number | null;
   avatar_source: FolderAvatarSource;
@@ -33,6 +36,7 @@ export interface FolderSummaryRecord extends FolderRecord {
   image_count: number;
   video_count: number;
   latest_image_mtime_ms: number | null;
+  has_avatar_story?: number | null;
 }
 
 export interface ImageRecord {

--- a/server/src/utils/stories-utils.ts
+++ b/server/src/utils/stories-utils.ts
@@ -1,0 +1,35 @@
+import { normalizePath, splitPathSegments } from './path-utils.js';
+
+export const RESERVED_STORIES_FOLDER_NAME = 'stories';
+
+export function isStoriesFolderName(value: string): boolean {
+  return value.trim().toLocaleLowerCase() === RESERVED_STORIES_FOLDER_NAME;
+}
+
+export function parseTreatStoriesAsFoldersSetting(value: string | null): boolean {
+  return value === '1';
+}
+
+export function serializeTreatStoriesAsFoldersSetting(value: boolean): string {
+  return value ? '1' : '0';
+}
+
+export function getReservedStoriesFolderPath(ownerFolderPath: string): string {
+  return `${normalizePath(ownerFolderPath)}/${RESERVED_STORIES_FOLDER_NAME}`;
+}
+
+export function findReservedStoriesOwnerPath(relativePath: string): string | null {
+  const segments = splitPathSegments(relativePath);
+
+  for (let index = 1; index < segments.length; index += 1) {
+    if (isStoriesFolderName(segments[index] ?? '')) {
+      return segments.slice(0, index).join('/');
+    }
+  }
+
+  return null;
+}
+
+export function isWithinReservedStoriesSubtree(relativePath: string): boolean {
+  return findReservedStoriesOwnerPath(relativePath) !== null;
+}

--- a/server/test/auth-route-validation.test.ts
+++ b/server/test/auth-route-validation.test.ts
@@ -10,6 +10,7 @@ describe.sequential('auth route validation', () => {
   let tempRoot = '';
   let authRequestBodySchemas: ApiModule['authRequestBodySchemas'];
   let settingsRequestBodySchemas: ApiModule['settingsRequestBodySchemas'];
+  let routeParamSchemas: ApiModule['routeParamSchemas'];
 
   beforeAll(async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-auth-route-validation-'));
@@ -27,7 +28,7 @@ describe.sequential('auth route validation', () => {
     await fs.mkdir(tempRoot, { recursive: true });
 
     vi.resetModules();
-    ({ authRequestBodySchemas, settingsRequestBodySchemas } = await import('../src/routes/api.js'));
+    ({ authRequestBodySchemas, settingsRequestBodySchemas, routeParamSchemas } = await import('../src/routes/api.js'));
   });
 
   afterAll(async () => {
@@ -113,6 +114,16 @@ describe.sequential('auth route validation', () => {
       })
     ).toEqual({
       defaultMode: 'recommended'
+    });
+  });
+
+  it('accepts long story ids up to the folder-slug route limit', () => {
+    expect(
+      routeParamSchemas.storyId.parse({
+        id: 'story-'.repeat(40)
+      })
+    ).toEqual({
+      id: 'story-'.repeat(40)
     });
   });
 });

--- a/server/test/stories-feature.test.ts
+++ b/server/test/stories-feature.test.ts
@@ -1,0 +1,268 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getMediaTypeFromExtension,
+  getPreviewRelativePath,
+  getThumbnailRelativePath
+} from '../src/utils/image-utils.js';
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type AppSettingKeysModule = typeof import('../src/constants/app-setting-keys.js');
+type GalleryServiceModule = typeof import('../src/services/gallery-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type ScannerServiceModule = typeof import('../src/services/scanner-service.js');
+
+const generateThumbnailDerivativeMock = vi.fn();
+const generateDerivativesMock = vi.fn();
+const readMediaMetadataMock = vi.fn();
+
+describe.sequential('stories feature', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let galleryService: GalleryServiceModule['galleryService'];
+  let scannerService: ScannerServiceModule['scannerService'];
+  let appSettingsRepository: RepositoriesModule['appSettingsRepository'];
+  let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+  let STORIES_MIGRATION_DECISION_SETTING_KEY: AppSettingKeysModule['STORIES_MIGRATION_DECISION_SETTING_KEY'];
+  let TREAT_STORIES_AS_FOLDERS_SETTING_KEY: AppSettingKeysModule['TREAT_STORIES_AS_FOLDERS_SETTING_KEY'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-stories-feature-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    generateThumbnailDerivativeMock.mockReset();
+    generateDerivativesMock.mockReset();
+    readMediaMetadataMock.mockReset();
+
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.resetModules();
+    vi.doMock('../src/services/derivative-service.js', () => ({
+      generateDerivatives: generateDerivativesMock,
+      generateThumbnailDerivative: generateThumbnailDerivativeMock,
+      readMediaMetadata: readMediaMetadataMock
+    }));
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ galleryService } = await import('../src/services/gallery-service.js'));
+    ({ scannerService } = await import('../src/services/scanner-service.js'));
+    ({ appSettingsRepository, maintenanceRepository } = await import('../src/db/repositories.js'));
+    ({ STORIES_MIGRATION_DECISION_SETTING_KEY, TREAT_STORIES_AS_FOLDERS_SETTING_KEY } = await import(
+      '../src/constants/app-setting-keys.js'
+    ));
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+
+    readMediaMetadataMock.mockImplementation(async (absolutePath: string) => {
+      const extension = path.extname(absolutePath).toLowerCase();
+      const mediaType = getMediaTypeFromExtension(extension);
+
+      return {
+        width: mediaType === 'video' ? 1080 : 1440,
+        height: mediaType === 'video' ? 1920 : 960,
+        takenAt: null,
+        durationMs: mediaType === 'video' ? 4_000 : null,
+        mediaType,
+        playbackStrategy: 'preview',
+        isAnimated: false
+      };
+    });
+
+    generateDerivativesMock.mockImplementation(async (_sourcePath: string, relativePath: string) => {
+      const extension = path.extname(relativePath).toLowerCase();
+      const mediaType = getMediaTypeFromExtension(extension);
+
+      return {
+        width: mediaType === 'video' ? 1080 : 1440,
+        height: mediaType === 'video' ? 1920 : 960,
+        takenAt: null,
+        durationMs: mediaType === 'video' ? 4_000 : null,
+        mediaType,
+        playbackStrategy: 'preview',
+        isAnimated: false,
+        thumbnailPath: getThumbnailRelativePath(relativePath),
+        previewPath: getPreviewRelativePath(relativePath, mediaType),
+        generatedThumbnail: true,
+        generatedPreview: true
+      };
+    });
+
+    maintenanceRepository.resetLibraryIndex();
+    appSettingsRepository.remove(TREAT_STORIES_AS_FOLDERS_SETTING_KEY);
+    appSettingsRepository.remove(STORIES_MIGRATION_DECISION_SETTING_KEY);
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('keeps reserved stories hidden from normal surfaces and exposes them through folder story rails', async () => {
+    await createSourceFile('albums/beach/photo-main.jpg', 8_000);
+    await createSourceFile('albums/beach/stories/avatar-1.jpg', 6_000);
+    await createSourceFile('albums/beach/stories/avatar-2.mp4', 5_000);
+    await createSourceFile('albums/beach/stories/highlights/day-1.jpg', 4_000);
+    await createSourceFile('albums/beach/stories/highlights/deeper/day-2.jpg', 3_000);
+
+    await scannerService.scanAll('manual');
+
+    const folders = galleryService.listFolders();
+    expect(folders).toHaveLength(1);
+    expect(folders[0]?.folderPath).toBe('albums/beach');
+    expect(folders[0]?.hasAvatarStory).toBe(true);
+
+    const folder = folders[0]!;
+    expect(galleryService.getFeed(1, 20, 'recent').total).toBe(1);
+    expect(galleryService.searchMedia('avatar', 1, 20).total).toBe(0);
+    expect(galleryService.searchMedia('day-1', 1, 20).total).toBe(0);
+
+    const stories = galleryService.getFolderStories(folder.slug);
+    expect(stories).not.toBeNull();
+    expect(stories?.hasAvatarStory).toBe(true);
+    expect(stories?.avatarStoryId).toBeTruthy();
+    expect(stories?.items).toHaveLength(2);
+    expect(stories?.highlights).toHaveLength(1);
+    expect(stories?.items[0]?.presentation).toBe('avatar');
+    expect(stories?.highlights[0]?.presentation).toBe('highlight');
+
+    const avatarFeed = galleryService.getFolderStoryFeed(folder.slug, stories!.avatarStoryId!, 1, 20);
+    expect(avatarFeed).not.toBeNull();
+    expect(avatarFeed?.story.presentation).toBe('avatar');
+    expect(avatarFeed?.items.map((item) => item.mediaType)).toEqual(['video', 'image']);
+    expect(avatarFeed?.items.every((item) => item.folderSlug === folder.slug)).toBe(true);
+    expect(avatarFeed?.items.every((item) => item.folderPath === folder.folderPath)).toBe(true);
+
+    const highlightFeed = galleryService.getFolderStoryFeed(folder.slug, stories!.highlights[0]!.id, 1, 20);
+    expect(highlightFeed).not.toBeNull();
+    expect(highlightFeed?.story.presentation).toBe('highlight');
+    expect(highlightFeed?.total).toBe(2);
+    expect(highlightFeed?.items.every((item) => item.folderSlug === folder.slug)).toBe(true);
+
+    expect(galleryService.getStatus().storiesMigration).toEqual({
+      hasLegacyStoriesCandidates: true,
+      decisionPending: true
+    });
+  });
+
+  it('restores legacy stories folders when the setting is enabled before scanning', async () => {
+    galleryService.setTreatStoriesAsFolders(true);
+
+    await createSourceFile('albums/beach/photo-main.jpg', 8_000);
+    await createSourceFile('albums/beach/stories/avatar-1.jpg', 6_000);
+    await createSourceFile('albums/beach/stories/highlights/day-1.jpg', 4_000);
+
+    await scannerService.scanAll('manual');
+
+    const folders = galleryService
+      .listFolders()
+      .map((folder) => folder.folderPath)
+      .sort();
+
+    expect(folders).toEqual([
+      'albums/beach',
+      'albums/beach/stories',
+      'albums/beach/stories/highlights'
+    ]);
+
+    const ownerFolder = galleryService.listFolders().find((folder) => folder.folderPath === 'albums/beach');
+    expect(ownerFolder).toBeDefined();
+    expect(ownerFolder?.hasAvatarStory).toBe(false);
+    expect(galleryService.getFolderStories(ownerFolder!.slug)).toEqual({
+      railKind: 'stories',
+      railTitle: 'Stories',
+      railDescription: `Stories and highlights for ${ownerFolder!.name}.`,
+      railSingularLabel: 'Story',
+      hasAvatarStory: false,
+      avatarStoryId: null,
+      items: [],
+      highlights: []
+    });
+
+    expect(galleryService.searchMedia('avatar', 1, 20).total).toBe(1);
+    expect(galleryService.getStatus().preferences.treatStoriesAsFolders).toBe(true);
+    expect(galleryService.getStatus().storiesMigration).toEqual({
+      hasLegacyStoriesCandidates: true,
+      decisionPending: false
+    });
+  });
+
+  it('uses the latest nested highlight media as the avatar story when the root stories folder has no direct media', async () => {
+    await createSourceFile('albums/beach/photo-main.jpg', 20_000);
+    await createSourceFile('albums/beach/stories/city/city-01.jpg', 12_000);
+    await createSourceFile('albums/beach/stories/city/city-02.jpg', 11_000);
+    await createSourceFile('albums/beach/stories/city/city-03.jpg', 10_000);
+    await createSourceFile('albums/beach/stories/city/city-04.jpg', 9_000);
+    await createSourceFile('albums/beach/stories/city/city-05.jpg', 8_000);
+    await createSourceFile('albums/beach/stories/city/city-06.jpg', 7_000);
+    await createSourceFile('albums/beach/stories/food/food-07.jpg', 6_000);
+    await createSourceFile('albums/beach/stories/food/food-08.jpg', 5_000);
+    await createSourceFile('albums/beach/stories/food/food-09.jpg', 4_000);
+    await createSourceFile('albums/beach/stories/food/food-10.jpg', 3_000);
+    await createSourceFile('albums/beach/stories/food/food-11.jpg', 2_000);
+    await createSourceFile('albums/beach/stories/food/food-12.mp4', 1_000);
+
+    await scannerService.scanAll('manual');
+
+    const folder = galleryService.listFolders()[0]!;
+    expect(folder.hasAvatarStory).toBe(true);
+    const stories = galleryService.getFolderStories(folder.slug);
+    expect(stories).not.toBeNull();
+    expect(stories?.hasAvatarStory).toBe(true);
+    expect(stories?.avatarStoryId).toBeTruthy();
+    expect(stories?.items).toHaveLength(3);
+    expect(stories?.highlights).toHaveLength(2);
+    expect(stories?.items[0]?.id).toBe(stories?.avatarStoryId);
+    expect(stories?.items[0]?.presentation).toBe('avatar');
+    expect(stories?.items[0]?.imageCount).toBe(10);
+
+    const avatarFeed = galleryService.getFolderStoryFeed(folder.slug, stories!.avatarStoryId!, 1, 20);
+    expect(avatarFeed).not.toBeNull();
+    expect(avatarFeed?.story.presentation).toBe('avatar');
+    expect(avatarFeed?.total).toBe(10);
+    expect(avatarFeed?.hasMore).toBe(false);
+    expect(avatarFeed?.items.map((item) => item.filename)).toEqual([
+      'food-12.mp4',
+      'food-11.jpg',
+      'food-10.jpg',
+      'food-09.jpg',
+      'food-08.jpg',
+      'food-07.jpg',
+      'city-06.jpg',
+      'city-05.jpg',
+      'city-04.jpg',
+      'city-03.jpg'
+    ]);
+    expect(avatarFeed?.items.every((item) => item.folderSlug === folder.slug)).toBe(true);
+    expect(avatarFeed?.items.every((item) => item.folderPath === folder.folderPath)).toBe(true);
+  });
+
+  async function createSourceFile(relativePath: string, mtimeOffsetMs = 0): Promise<void> {
+    const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, `source:${relativePath}`);
+
+    if (mtimeOffsetMs > 0) {
+      const now = new Date();
+      now.setMilliseconds(now.getMilliseconds() - mtimeOffsetMs);
+      await fs.utimes(absolutePath, now, now);
+    }
+  }
+});

--- a/server/test/viewer-status.test.ts
+++ b/server/test/viewer-status.test.ts
@@ -115,7 +115,8 @@ describe.sequential('viewer-safe status payload', () => {
 
     expect(status.preferences).toEqual({
       defaultHomeFeedMode: 'random',
-      defaultReelsFeedMode: 'random'
+      defaultReelsFeedMode: 'random',
+      treatStoriesAsFolders: false
     });
   });
 
@@ -127,7 +128,8 @@ describe.sequential('viewer-safe status payload', () => {
 
     expect(status.preferences).toEqual({
       defaultHomeFeedMode: 'rediscover',
-      defaultReelsFeedMode: 'recommended'
+      defaultReelsFeedMode: 'recommended',
+      treatStoriesAsFolders: false
     });
   });
 });


### PR DESCRIPTION
Closes #27 
Fixes #24 
Implements reserved `AppFolder/stories` support end to end. Adds scanner/DB/API support for avatar stories and highlight capsules, wires the shared Stories modal into Home and folder pages, adds the Settings toggle for legacy `stories`-as-folders mode with migration/rescan handling, and includes the follow-up fixes for story id validation, retry/error states, tests, and docs.