### PR TITLE
Fix ImageModal navigation on likes page and add fallback for missing image previews

### DIFF
--- a/client/src/components/ImageModal.test.ts
+++ b/client/src/components/ImageModal.test.ts
@@ -1,0 +1,112 @@
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { FeedItem, ImageDetail } from '../types/api';
+import { useAppStore } from '../stores/app';
+import { useLikesStore } from '../stores/likes';
+import ImageModal from './ImageModal.vue';
+
+const mockRouterResolve = vi.fn();
+
+vi.mock('vidstack/bundle', () => ({}));
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router');
+
+  return {
+    ...actual,
+    useRoute: () => ({
+      query: {}
+    }),
+    useRouter: () => ({
+      push: vi.fn(),
+      resolve: mockRouterResolve
+    })
+  };
+});
+
+function createFeedItem(id: number): FeedItem {
+  return {
+    id,
+    folderId: 7,
+    folderSlug: 'animal-planet',
+    folderName: 'AnimalPlanet',
+    folderPath: 'animal-planet',
+    folderBreadcrumb: null,
+    filename: `post-${id}.jpg`,
+    width: 1200,
+    height: 1500,
+    mediaType: 'image',
+    durationMs: null,
+    isAnimated: false,
+    thumbnailUrl: `/thumbnails/${id}.webp`,
+    previewUrl: `/previews/${id}.webp`,
+    sortTimestamp: 1_777_000_000_000 + id,
+    takenAt: 1_777_000_000_000 + id
+  };
+}
+
+function createImageDetail(id: number, options: { previousImageId: number | null; nextImageId: number | null }): ImageDetail {
+  const item = createFeedItem(id);
+
+  return {
+    ...item,
+    folderAvatarImageId: null,
+    relativePath: `${item.folderSlug}/${item.filename}`,
+    mimeType: 'image/jpeg',
+    fileSize: 123_456,
+    exif: null,
+    originalUrl: `/api/originals/${id}`,
+    playbackStrategy: null,
+    previousImageId: options.previousImageId,
+    nextImageId: options.nextImageId
+  };
+}
+
+const globalStubs = {
+  Avatar: {
+    template: '<div data-test="avatar" />'
+  },
+  ResilientImage: {
+    template: '<img data-test="resilient-image" />'
+  },
+  RouterLink: {
+    inheritAttrs: false,
+    props: ['to'],
+    template: '<a v-bind="$attrs" :data-to="JSON.stringify(to)"><slot /></a>'
+  }
+};
+
+describe('ImageModal', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockRouterResolve.mockReset();
+    mockRouterResolve.mockImplementation((path: string) => ({
+      name: path === '/likes/posts' ? 'likes' : 'folder'
+    }));
+  });
+
+  it('uses likes-page neighbors instead of folder neighbors when opened from likes', () => {
+    const appStore = useAppStore();
+    const likesStore = useLikesStore();
+
+    appStore.setImageModalBackground('/likes/posts');
+    likesStore.syncFromItems([createFeedItem(11), createFeedItem(12), createFeedItem(13)], 'shared');
+
+    const wrapper = mount(ImageModal, {
+      props: {
+        image: createImageDetail(12, {
+          previousImageId: null,
+          nextImageId: 99
+        }),
+        isModal: true
+      },
+      global: {
+        stubs: globalStubs
+      }
+    });
+
+    expect(wrapper.get('a[aria-label="Previous post"]').attributes('data-to')).toContain('"id":"11"');
+    expect(wrapper.get('a[aria-label="Next post"]').attributes('data-to')).toContain('"id":"13"');
+  });
+});

--- a/client/src/components/ImageModal.vue
+++ b/client/src/components/ImageModal.vue
@@ -30,7 +30,7 @@
 
     <!-- Previous nav -->
     <RouterLink
-      v-if="image.previousImageId"
+      v-if="previousNavigationImageId"
       :class="[
         'inline-flex items-center justify-center w-[2.2rem] h-[2.2rem] rounded-full text-[#111] bg-white/88 shadow-[0_8px_20px_rgba(0,0,0,0.18)]',
         isModal
@@ -39,7 +39,7 @@
       ]"
       :to="{
         name: 'image',
-        params: { id: String(image.previousImageId) },
+        params: { id: String(previousNavigationImageId) },
         query: route.query,
       }"
       aria-label="Previous post"
@@ -58,7 +58,7 @@
 
     <!-- Next nav -->
     <RouterLink
-      v-if="image.nextImageId"
+      v-if="nextNavigationImageId"
       :class="[
         'inline-flex items-center justify-center w-[2.2rem] h-[2.2rem] rounded-full text-[#111] bg-white/88 shadow-[0_8px_20px_rgba(0,0,0,0.18)]',
         isModal
@@ -67,7 +67,7 @@
       ]"
       :to="{
         name: 'image',
-        params: { id: String(image.nextImageId) },
+        params: { id: String(nextNavigationImageId) },
         query: route.query,
       }"
       aria-label="Next post"
@@ -236,6 +236,7 @@
           <ResilientImage
             class="viewer__media-image"
             :src="image.previewUrl"
+            :fallback-src="image.originalUrl"
             :alt="image.filename"
             :width="image.width"
             :height="image.height"
@@ -733,6 +734,36 @@
   })
   const isModalSidebarCollapsible = computed(
     () => props.isModal === true && isSidebarCollapsible.value,
+  )
+  const isLikesNavigationContext = computed(() => {
+    if (props.isModal !== true || !appStore.imageModalBackgroundPath) {
+      return false
+    }
+
+    return router.resolve(appStore.imageModalBackgroundPath).name === "likes"
+  })
+  const likesNavigationIds = computed(() => {
+    if (!props.image || !isLikesNavigationContext.value) {
+      return null
+    }
+
+    const currentIndex = likesStore.items.findIndex(
+      item => item.id === props.image?.id,
+    )
+    if (currentIndex === -1) {
+      return null
+    }
+
+    return {
+      previousImageId: likesStore.items[currentIndex - 1]?.id ?? null,
+      nextImageId: likesStore.items[currentIndex + 1]?.id ?? null,
+    }
+  })
+  const previousNavigationImageId = computed(
+    () => likesNavigationIds.value?.previousImageId ?? props.image?.previousImageId ?? null,
+  )
+  const nextNavigationImageId = computed(
+    () => likesNavigationIds.value?.nextImageId ?? props.image?.nextImageId ?? null,
   )
   const isModalSidebarOverlayVisible = computed(
     () => isModalSidebarCollapsible.value && isSidebarExpanded.value,
@@ -1316,14 +1347,10 @@
   )
 
   async function navigateByDirection(direction: "previous" | "next") {
-    if (!props.image) {
-      return
-    }
-
     const targetId =
       direction === "next"
-        ? props.image.nextImageId
-        : props.image.previousImageId
+        ? nextNavigationImageId.value
+        : previousNavigationImageId.value
     if (!targetId) {
       return
     }

--- a/client/src/components/ResilientImage.test.ts
+++ b/client/src/components/ResilientImage.test.ts
@@ -1,0 +1,25 @@
+import { nextTick } from 'vue';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import ResilientImage from './ResilientImage.vue';
+
+describe('ResilientImage', () => {
+  it('falls back to the original source when the preview source fails', async () => {
+    const wrapper = mount(ResilientImage, {
+      props: {
+        src: '/previews/NaturePlanet/pexels-photo-2770371.webp',
+        fallbackSrc: '/api/originals/2770371',
+        alt: 'NaturePlanet preview',
+        loading: 'eager'
+      }
+    });
+
+    expect(wrapper.get('img').attributes('src')).toContain('/previews/NaturePlanet/pexels-photo-2770371.webp');
+
+    await wrapper.get('img').trigger('error');
+    await nextTick();
+
+    expect(wrapper.get('img').attributes('src')).toContain('/api/originals/2770371');
+  });
+});

--- a/client/src/components/ResilientImage.vue
+++ b/client/src/components/ResilientImage.vue
@@ -18,6 +18,7 @@ import { computed, onBeforeUnmount, ref, watch } from 'vue';
 const props = withDefaults(
   defineProps<{
     src: string | null;
+    fallbackSrc?: string | null;
     alt: string;
     width?: number;
     height?: number;
@@ -28,6 +29,7 @@ const props = withDefaults(
   }>(),
   {
     src: null,
+    fallbackSrc: null,
     loading: 'lazy',
     retryWhile: false,
     maxRetries: 8,
@@ -38,19 +40,28 @@ const props = withDefaults(
 const attempt = ref(0);
 const loaded = ref(false);
 const hiddenUntilRetry = ref(false);
+const usingFallback = ref(false);
 let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
+const activeSrc = computed(() => {
+  if (usingFallback.value && props.fallbackSrc && props.fallbackSrc !== props.src) {
+    return props.fallbackSrc;
+  }
+
+  return props.src;
+});
+
 const resolvedSrc = computed(() => {
-  if (!props.src || hiddenUntilRetry.value) {
+  if (!activeSrc.value || hiddenUntilRetry.value) {
     return null;
   }
 
   if (attempt.value === 0) {
-    return props.src;
+    return activeSrc.value;
   }
 
-  const separator = props.src.includes('?') ? '&' : '?';
-  return `${props.src}${separator}retry=${attempt.value}`;
+  const separator = activeSrc.value.includes('?') ? '&' : '?';
+  return `${activeSrc.value}${separator}retry=${attempt.value}`;
 });
 
 function clearRetryTimer() {
@@ -65,6 +76,7 @@ function resetState() {
   attempt.value = 0;
   loaded.value = false;
   hiddenUntilRetry.value = false;
+  usingFallback.value = false;
 }
 
 function scheduleRetry() {
@@ -92,6 +104,14 @@ function handleLoad() {
 function handleError() {
   loaded.value = false;
 
+  if (!usingFallback.value && props.fallbackSrc && props.fallbackSrc !== props.src) {
+    clearRetryTimer();
+    attempt.value = 0;
+    hiddenUntilRetry.value = false;
+    usingFallback.value = true;
+    return;
+  }
+
   const canRetry = props.retryWhile || attempt.value < props.maxRetries;
   if (!canRetry) {
     hiddenUntilRetry.value = true;
@@ -102,7 +122,7 @@ function handleError() {
   scheduleRetry();
 }
 
-watch(() => props.src, resetState);
+watch(() => [props.src, props.fallbackSrc] as const, resetState);
 watch(
   () => props.retryWhile,
   (retryWhile) => {


### PR DESCRIPTION
Fixes #33 

Two ImageModal issues affecting posts opened from `/likes/posts`.

Changes:
- Use the likes collection to determine previous/next navigation when the modal is opened from the likes page.
- Preserve existing folder-based navigation as the fallback for other modal entry points.
- Add an image fallback so the modal loads the original file when the preview asset is missing or fails to load.
- Add tests covering likes-page modal navigation and preview-to-original fallback behavior.

Result:
- Liked posts now rotate correctly within the likes page.
- Images with missing previews no longer render as a blank modal.
