### PR TITLE
Adds original media download controls to the main viewing surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 Foldergram is a self-hosted web application that turns your local folders into a beautiful, instagram-style feed and profile. It turns your local folder to app folders (profiles), and serves a lightning-fast Progressive Web App (PWA).
 
-Foldergram indexes supported media from a configured `GALLERY_ROOT`, stores metadata in SQLite, generates thumbnails and previews, and serves a fast feed-style web app for local browsing. Derivatives can be generated during scans or lazily on first request, and image detail pages can be configured to use generated previews or originals. The current app includes Home, Reels, Explore, Library, Likes, Moments or Highlights, App Folder pages, post detail views, delete actions, scan controls, and rebuild tools.
+Foldergram indexes supported media from a configured `GALLERY_ROOT`, stores metadata in SQLite, generates thumbnails and previews, and serves a fast feed-style web app for local browsing. Derivatives can be generated during scans or lazily on first request, and image detail pages can be configured to use generated previews or originals. The current app includes Home, Reels, Explore, Library, Likes, Moments or Highlights, App Folder pages, post detail views, original-media download controls, delete actions, scan controls, and rebuild tools.
 
 ## Features
 
@@ -40,6 +40,7 @@ Foldergram indexes supported media from a configured `GALLERY_ROOT`, stores meta
 - App Folder pages with a posts grid and a folder-specific `Reels` tab when videos exist.
 - Shared likes in SQLite for signed-in admin/viewer sessions, plus browser-local favorites in public mode.
 - Image and video support with configurable eager or lazy derivative generation for fast browsing.
+- Original-media download controls on home feed cards, post detail, and stories, alongside open-original actions.
 - Optional role-based local access with admin, viewer, and public browse modes.
 - Settings actions for Home/Reels default modes, manual scan, thumbnail rebuild, and library-index rebuild.
 - A web app manifest plus production service worker registration.

--- a/client/src/components/FeedCard.test.ts
+++ b/client/src/components/FeedCard.test.ts
@@ -274,6 +274,11 @@ describe('FeedCard', () => {
     expect(postRouteLink?.attributes('data-to')).toContain('"id":"807"');
     expect(wrapper.get('a[aria-label="Open folder"]').attributes('title')).toBe('Open folder');
 
+    const downloadLink = wrapper.get('a[aria-label="Download original file"]');
+
+    expect(downloadLink.attributes('href')).toBe('/api/originals/807?download=1');
+    expect(downloadLink.attributes('title')).toBe('Download original file');
+
     const originalLink = wrapper.get('a[aria-label="Open original file"]');
 
     expect(originalLink.attributes('href')).toBe('/api/originals/807');

--- a/client/src/components/FeedCard.vue
+++ b/client/src/components/FeedCard.vue
@@ -238,25 +238,46 @@
             <span class="i-fluent-folder-16-regular w-[1.30rem] h-[1.30rem]" aria-hidden="true" />
           </RouterLink>
         </div>
-        <a
-          class="inline-flex items-center justify-center w-8 h-8 border-0 bg-transparent cursor-pointer color-inherit transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px"
-          :href="originalMediaUrl"
-          target="_blank"
-          rel="noreferrer"
-          aria-label="Open original file"
-          title="Open original file"
-        >
-          <svg class="w-[1.45rem] h-[1.45rem]" viewBox="0 0 24 24" role="presentation">
-            <path
-              d="M14 5h5v5m0-5-7.5 7.5M10 7H7.5A2.5 2.5 0 0 0 5 9.5v7A2.5 2.5 0 0 0 7.5 19h7a2.5 2.5 0 0 0 2.5-2.5V14"
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1.8"
-            />
-          </svg>
-        </a>
+        <div class="flex items-center gap-[0.65rem]">
+          <a
+            v-if="isHomeContext"
+            class="inline-flex items-center justify-center w-8 h-8 border-0 bg-transparent cursor-pointer color-inherit transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px"
+            :href="downloadOriginalMediaUrl"
+            download
+            aria-label="Download original file"
+            title="Download original file"
+          >
+            <svg class="w-[1.45rem] h-[1.45rem]" viewBox="0 0 24 24" role="presentation">
+              <path
+                d="M12 4.75v9.5m0 0 3.5-3.5M12 14.25l-3.5-3.5M5.75 16.75v1.5A1.75 1.75 0 0 0 7.5 20h9a1.75 1.75 0 0 0 1.75-1.75v-1.5"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.8"
+              />
+            </svg>
+          </a>
+          <a
+            class="inline-flex items-center justify-center w-8 h-8 border-0 bg-transparent cursor-pointer color-inherit transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px"
+            :href="originalMediaUrl"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Open original file"
+            title="Open original file"
+          >
+            <svg class="w-[1.45rem] h-[1.45rem]" viewBox="0 0 24 24" role="presentation">
+              <path
+                d="M14 5h5v5m0-5-7.5 7.5M10 7H7.5A2.5 2.5 0 0 0 5 9.5v7A2.5 2.5 0 0 0 7.5 19h7a2.5 2.5 0 0 0 2.5-2.5V14"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.8"
+              />
+            </svg>
+          </a>
+        </div>
       </div>
 
       <p class="m-0 text-[0.88rem]">
@@ -382,6 +403,7 @@ import { useMomentsStore } from '../stores/moments';
 import type { FeedItem } from '../types/api';
 import { formatMediaDuration } from '../utils/media';
 import { resolveFeedAspectRatio } from '../utils/media-layout';
+import { getOriginalMediaDownloadUrl, getOriginalMediaUrl } from '../utils/original-media';
 import Avatar from './Avatar.vue';
 import ConfirmDialog from './ConfirmDialog.vue';
 import ResilientImage from './ResilientImage.vue';
@@ -469,7 +491,8 @@ const formattedDuration = computed(() => formatMediaDuration(props.item.duration
 const mediaAspectRatio = computed(() => resolveFeedAspectRatio(props.item.width, props.item.height));
 const homeVideoAspectRatio = computed(() => loadedHomeVideoAspectRatio.value ?? mediaAspectRatio.value);
 const homeImageSrc = computed(() => (props.item.isAnimated ? props.item.previewUrl : props.item.thumbnailUrl));
-const originalMediaUrl = computed(() => `/api/originals/${props.item.id}`);
+const originalMediaUrl = computed(() => getOriginalMediaUrl(props.item.id));
+const downloadOriginalMediaUrl = computed(() => getOriginalMediaDownloadUrl(props.item.id));
 const homeVideoSource = computed<PlayerSrc>(() => ({
   src: props.item.previewUrl,
   type: 'video/mp4'
@@ -791,7 +814,7 @@ function bindHomePlayerEventListeners(player: MediaPlayerElement | null) {
 
 function openOriginal() {
   menuOpen.value = false;
-  window.open(`/api/originals/${props.item.id}`, '_blank', 'noopener,noreferrer');
+  window.open(getOriginalMediaUrl(props.item.id), '_blank', 'noopener,noreferrer');
 }
 
 function handleDelete() {

--- a/client/src/components/PostViewer.test.ts
+++ b/client/src/components/PostViewer.test.ts
@@ -225,6 +225,29 @@ describe('PostViewer', () => {
     expect(setFolderCoverSpy).toHaveBeenCalledWith('animal-planet', 21);
   });
 
+  it('renders a download-original control beside the open-original action', () => {
+    const wrapper = mount(PostViewer, {
+      props: {
+        image: createImageDetail(18, {
+          previousImageId: null,
+          nextImageId: null
+        }),
+        isModal: true
+      },
+      global: {
+        stubs: globalStubs
+      }
+    });
+
+    const downloadLink = wrapper.get('a[aria-label="Download original file"]');
+    const originalLink = wrapper.get('a[aria-label="Open original file"]');
+
+    expect(downloadLink.attributes('href')).toBe('/api/originals/18?download=1');
+    expect(downloadLink.attributes('title')).toBe('Download original file');
+    expect(originalLink.attributes('href')).toBe('/api/originals/18');
+    expect(originalLink.attributes('title')).toBe('Open original file');
+  });
+
   it('toggles video playback from stage clicks and shows the paused indicator', async () => {
     const wrapper = mount(PostViewer, {
       props: {

--- a/client/src/components/PostViewer.vue
+++ b/client/src/components/PostViewer.vue
@@ -436,10 +436,33 @@
             >
               <span :class="[isCurrentCover ? 'i-fluent-folder-add-20-filled text-accent' : 'i-fluent-folder-add-20-regular', 'w-[1.5rem] h-[1.5rem]']" aria-hidden="true" />
             </button>
+            <!-- Download original -->
+            <a
+              class="viewer__sidebar-action inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer text-text transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px"
+              :href="downloadOriginalMediaUrl"
+              download
+              aria-label="Download original file"
+              title="Download original file"
+            >
+              <svg
+                class="w-[1.55rem] h-[1.55rem]"
+                viewBox="0 0 24 24"
+                role="presentation"
+              >
+                <path
+                  d="M12 4.75v9.5m0 0 3.5-3.5M12 14.25l-3.5-3.5M5.75 16.75v1.5A1.75 1.75 0 0 0 7.5 20h9a1.75 1.75 0 0 0 1.75-1.75v-1.5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.4"
+                />
+              </svg>
+            </a>
             <!-- Open original -->
             <a
               class="viewer__sidebar-action inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer text-text transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px"
-              :href="image.originalUrl"
+              :href="originalMediaUrl"
               target="_blank"
               rel="noreferrer"
               aria-label="Open original file"
@@ -520,6 +543,7 @@
   import { useAuthStore } from "../stores/auth"
   import { useLikesStore } from "../stores/likes"
   import { useFoldersStore } from "../stores/folders"
+  import { getOriginalMediaDownloadUrl, getOriginalMediaUrl } from "../utils/original-media"
   import Avatar from "./Avatar.vue"
   import ResilientImage from "./ResilientImage.vue"
   import { formatMediaDuration, videoPreviewWouldDownscale } from "../utils/media"
@@ -558,6 +582,8 @@
 
   const WHEEL_NAVIGATION_THRESHOLD = 72
   const NAVIGATION_COOLDOWN_MS = 320
+  const originalMediaUrl = computed(() => (props.image ? getOriginalMediaUrl(props.image.id) : ""))
+  const downloadOriginalMediaUrl = computed(() => (props.image ? getOriginalMediaDownloadUrl(props.image.id) : ""))
   const MODAL_SIDEBAR_COLLAPSE_BREAKPOINT = 960
   const SHEET_SWIPE_MIN_DISTANCE = 56
   const SHEET_SWIPE_MAX_HORIZONTAL_DISTANCE = 96

--- a/client/src/components/ReelActionRail.test.ts
+++ b/client/src/components/ReelActionRail.test.ts
@@ -87,4 +87,34 @@ describe('ReelActionRail', () => {
     expect(wrapper.get('[data-test="parent-count"]').text()).toBe('0');
     expect(likesStore.isLiked(item.id)).toBe(true);
   });
+
+  it('renders the download control between the info toggle and folder link', () => {
+    const item = createFeedItem(22);
+
+    const wrapper = mount(ReelActionRail, {
+      props: {
+        item
+      },
+      global: {
+        stubs: {
+          RouterLink: {
+            props: ['to'],
+            template: '<a data-test="folder-link"><slot /></a>'
+          }
+        }
+      }
+    });
+
+    const controls = wrapper.findAll('.reel-action-rail > *');
+
+    expect(controls).toHaveLength(4);
+    expect(controls[1]?.find('button[aria-label="Show reel details"]').exists()).toBe(true);
+
+    const downloadLink = controls[2];
+
+    expect(downloadLink?.attributes('aria-label')).toBe('Download original file');
+    expect(downloadLink?.attributes('href')).toBe('/api/originals/22?download=1');
+    expect(downloadLink?.attributes('title')).toBe('Download original file');
+    expect(controls[3]?.attributes('data-test')).toBe('folder-link');
+  });
 });

--- a/client/src/components/ReelActionRail.vue
+++ b/client/src/components/ReelActionRail.vue
@@ -36,6 +36,16 @@
       </div>
     </div>
 
+    <a
+      class="reel-action-rail__button"
+      :href="downloadOriginalMediaUrl"
+      download
+      aria-label="Download original file"
+      title="Download original file"
+    >
+      <span class="reel-action-rail__icon i-fluent-arrow-download-20-regular" aria-hidden="true" />
+    </a>
+
     <RouterLink
       class="reel-action-rail__button"
       :to="{ name: 'folder', params: { slug: item.folderSlug } }"
@@ -53,6 +63,7 @@ import { RouterLink } from 'vue-router';
 import { useAuthStore } from '../stores/auth';
 import { useLikesStore } from '../stores/likes';
 import type { FeedItem } from '../types/api';
+import { getOriginalMediaDownloadUrl } from '../utils/original-media';
 
 const props = defineProps<{
   item: FeedItem;
@@ -66,6 +77,7 @@ defineEmits<{
 const authStore = useAuthStore();
 const likesStore = useLikesStore();
 const isLiked = computed(() => likesStore.isLiked(props.item.id));
+const downloadOriginalMediaUrl = computed(() => getOriginalMediaDownloadUrl(props.item.id));
 
 async function handleLike() {
   if (!authStore.canUseSavedItems) {

--- a/client/src/components/ReelPlayerCard.vue
+++ b/client/src/components/ReelPlayerCard.vue
@@ -106,6 +106,7 @@ import type { MediaPlayerElement } from 'vidstack/elements';
 
 import { useAppStore } from '../stores/app';
 import type { FeedItem, FolderSummary } from '../types/api';
+import { getOriginalMediaUrl } from '../utils/original-media';
 import Avatar from './Avatar.vue';
 
 const props = defineProps<{
@@ -119,7 +120,7 @@ const playerElement = ref<MediaPlayerElement | null>(null);
 const isPaused = ref(false);
 const isUsingOriginalFallback = ref(false);
 const playerLoadMode = computed(() => (props.active ? 'eager' : 'visible'));
-const currentVideoSrc = computed(() => (isUsingOriginalFallback.value ? `/api/originals/${props.item.id}` : props.item.previewUrl));
+const currentVideoSrc = computed(() => (isUsingOriginalFallback.value ? getOriginalMediaUrl(props.item.id) : props.item.previewUrl));
 const videoSource = computed<PlayerSrc>(() => ({
   src: currentVideoSrc.value,
   type: 'video/mp4'

--- a/client/src/components/StoriesModal.test.ts
+++ b/client/src/components/StoriesModal.test.ts
@@ -104,6 +104,45 @@ describe('StoriesModal', () => {
     expect(wrapper.find('img[data-test="resilient-image"]').exists()).toBe(false);
   });
 
+  it('renders a download-original control and updates it when the active capsule changes', async () => {
+    const firstItem = createVideoItem(451);
+    const secondItem = createVideoItem(452);
+    const firstCapsule = createCapsule('capsule-download-one', 'Download One', firstItem);
+    const secondCapsule = createCapsule('capsule-download-two', 'Download Two', secondItem);
+    const store = createStore([firstCapsule, secondCapsule], {
+      [firstCapsule.id]: [firstItem],
+      [secondCapsule.id]: [secondItem]
+    });
+
+    const wrapper = mount(StoriesModal, {
+      props: {
+        items: [firstCapsule, secondCapsule],
+        initialId: firstCapsule.id,
+        railSingularLabel: 'Story',
+        store
+      },
+      global: {
+        stubs: {
+          Avatar: {
+            template: '<div data-test="avatar" />'
+          },
+          ResilientImage: {
+            template: '<img data-test="resilient-image" />'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    expect(wrapper.get('a[aria-label="Download original file"]').attributes('href')).toBe('/api/originals/451?download=1');
+
+    await wrapper.get('.story-stage__pager--right').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.get('a[aria-label="Download original file"]').attributes('href')).toBe('/api/originals/452?download=1');
+  });
+
   it('keeps the next arrow enabled on the last item when another capsule exists and advances into it', async () => {
     const firstItem = createVideoItem(501);
     const secondItem = createVideoItem(502);

--- a/client/src/components/StoriesModal.vue
+++ b/client/src/components/StoriesModal.vue
@@ -101,6 +101,26 @@
             </div>
 
             <div class="story-stage__controls">
+              <a
+                v-if="downloadOriginalMediaUrl"
+                class="story-stage__control-button"
+                :href="downloadOriginalMediaUrl"
+                download
+                aria-label="Download original file"
+                title="Download original file"
+                data-swipe-ignore="true"
+              >
+                <svg class="h-4 w-4" viewBox="0 0 24 24" role="presentation">
+                  <path
+                    d="M12 4.75v9.5m0 0 3.5-3.5M12 14.25l-3.5-3.5M5.75 16.75v1.5A1.75 1.75 0 0 0 7.5 20h9a1.75 1.75 0 0 0 1.75-1.75v-1.5"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.8"
+                  />
+                </svg>
+              </a>
               <button
                 class="story-stage__control-button"
                 type="button"
@@ -236,6 +256,7 @@ import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useHorizontalSwipe } from '../composables/useHorizontalSwipe';
 import type { FeedItem, RailCapsule, RailViewerStoreContract } from '../types/api';
 import { useAppStore } from '../stores/app';
+import { getOriginalMediaDownloadUrl } from '../utils/original-media';
 import Avatar from './Avatar.vue';
 import ResilientImage from './ResilientImage.vue';
 
@@ -280,6 +301,9 @@ const activeImages = computed(() =>
   props.store.currentCapsule?.id === activeCapsuleId.value ? props.store.currentImages : []
 );
 const displayImage = computed<FeedItem | null>(() => activeImages.value[activeImageIndex.value] ?? activeCapsule.value?.coverImage ?? null);
+const downloadOriginalMediaUrl = computed(() =>
+  displayImage.value ? getOriginalMediaDownloadUrl(displayImage.value.id) : null
+);
 const totalImageCount = computed(() => Math.max(activeCapsule.value?.imageCount ?? activeImages.value.length, 1));
 const previousCapsule = computed(() => {
   const index = activeCapsuleIndex.value;

--- a/client/src/utils/original-media.ts
+++ b/client/src/utils/original-media.ts
@@ -1,0 +1,7 @@
+export function getOriginalMediaUrl(id: number): string {
+  return `/api/originals/${id}`;
+}
+
+export function getOriginalMediaDownloadUrl(id: number): string {
+  return `${getOriginalMediaUrl(id)}?download=1`;
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -420,11 +420,19 @@ Errors:
 
 Serves the original file from disk by image ID only.
 
+Query parameters:
+
+| Param | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `download` | `1` | unset | When set to `1`, the server responds with an attachment using the indexed original filename. |
+
 Rules:
 
 - the indexed path must still exist
 - the resolved path must stay within `GALLERY_ROOT`
 - deleted posts do not resolve
+- without `download=1`, the route streams the original inline/open behavior
+- with `download=1`, the route serves the same file as a download attachment
 
 Errors:
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -17,6 +17,7 @@ It includes:
 - a top Moments or Highlights section
 - feed-card avatar rings that can open an App Folder's avatar story in place when that folder has stories
 - an active home-feed video player that promotes one visible video card at a time and gives that card play, mute, and fullscreen controls
+- feed-card actions for downloading the original media file and opening the original in a new tab
 - a startup scan state when the first index is still being built
 - a rebuild notice when the configured gallery root changed
 - desktop recommendations for folders based on recency, likes, and recent navigation
@@ -116,6 +117,7 @@ In the default reserved-stories mode:
 - the folder header avatar opens the avatar story when one exists
 - Home feed cards can open the same avatar story from the folder avatar ring
 - the shared stories modal is used for both the home-feed entry point and the folder-page entry points
+- the shared stories modal header includes original-media download plus playback controls for the active story item
 
 If the reserved root has no direct media but highlight capsules do exist,
 Foldergram can synthesize the avatar story from recent highlight media so the
@@ -141,6 +143,7 @@ The detail view includes:
 - folder link and breadcrumb context
 - size, dimensions, MIME type, and duration metadata
 - like toggle
+- original-media download control
 - original-file link
 - an admin-only "Set as Cover" action to customize the folder avatar, which highlights dynamically if the image is already the cover
 - delete action with confirmation for admin sessions only

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -18,6 +18,23 @@ const paginationQuerySchema = z.object({
 const mediaTypeQuerySchema = z.object({
   mediaType: z.enum(['image', 'video']).optional()
 });
+const originalMediaQuerySchema = z.object({
+  download: z.preprocess((value) => {
+    if (value === undefined) {
+      return false;
+    }
+
+    if (value === true || value === 1 || value === '1' || value === 'true') {
+      return true;
+    }
+
+    if (value === false || value === 0 || value === '0' || value === 'false') {
+      return false;
+    }
+
+    return value;
+  }, z.boolean())
+});
 const deleteFolderQuerySchema = z.object({
   deleteSourceFolder: z.preprocess((value) => {
     if (value === undefined) {
@@ -575,14 +592,20 @@ router.delete('/images/:id', requireCapability('canDeleteMedia', 'Admin access i
 
 router.get('/originals/:id', (request, response) => {
   const params = imageIdSchema.parse(request.params);
-  const originalPath = galleryService.getOriginalImagePath(params.id);
+  const query = originalMediaQuerySchema.parse(request.query);
+  const originalMedia = galleryService.getOriginalMediaFile(params.id);
 
-  if (!originalPath) {
+  if (!originalMedia) {
     response.status(404).json({ message: 'Original media not found' });
     return;
   }
 
-  response.sendFile(originalPath);
+  if (query.download) {
+    response.download(originalMedia.path, originalMedia.filename);
+    return;
+  }
+
+  response.sendFile(originalMedia.path);
 });
 
 const adminMutationRateLimiter = createRateLimiter({

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -166,6 +166,27 @@ function buildPreviewUrl(
   return toPublicMediaUrl('/previews', image.previewUrl, version);
 }
 
+function resolveOriginalMediaFile(id: number): { path: string; filename: string } | null {
+  if (!storageService.getState().libraryAvailable) {
+    return null;
+  }
+
+  const detail = imageRepository.getById(id);
+  if (!detail || detail.is_deleted || detail.is_trashed) {
+    return null;
+  }
+
+  const resolvedPath = resolveWithinRoot(appConfig.galleryRoot, detail.absolute_path);
+  if (!resolvedPath || !fs.existsSync(resolvedPath)) {
+    return null;
+  }
+
+  return {
+    path: resolvedPath,
+    filename: detail.filename
+  };
+}
+
 function resolveWithinRoot(rootPath: string, targetPath: string): string | null {
   const resolved = path.resolve(targetPath);
   const relative = path.relative(path.resolve(rootPath), resolved);
@@ -1361,22 +1382,12 @@ export const galleryService = {
     };
   },
 
+  getOriginalMediaFile(id: number): { path: string; filename: string } | null {
+    return resolveOriginalMediaFile(id);
+  },
+
   getOriginalImagePath(id: number): string | null {
-    if (!storageService.getState().libraryAvailable) {
-      return null;
-    }
-
-    const detail = imageRepository.getById(id);
-    if (!detail || detail.is_deleted || detail.is_trashed) {
-      return null;
-    }
-
-    const resolved = resolveWithinRoot(appConfig.galleryRoot, detail.absolute_path);
-    if (!resolved || !fs.existsSync(resolved)) {
-      return null;
-    }
-
-    return resolved;
+    return resolveOriginalMediaFile(id)?.path ?? null;
   },
 
   async deleteImage(id: number) {

--- a/server/test/original-media-download.test.ts
+++ b/server/test/original-media-download.test.ts
@@ -1,0 +1,208 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import type express from 'express';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createFingerprint,
+  getMediaTypeFromExtension,
+  getMimeTypeFromExtension,
+  getPreviewRelativePath,
+  getThumbnailRelativePath
+} from '../src/utils/image-utils.js';
+
+type ApiModule = typeof import('../src/routes/api.js');
+type EnvModule = typeof import('../src/config/env.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type ModelsModule = typeof import('../src/types/models.js');
+
+type FolderRecord = ModelsModule['FolderRecord'];
+type PlaybackStrategy = ModelsModule['PlaybackStrategy'];
+
+interface MockResponse {
+  status: ReturnType<typeof vi.fn>;
+  json: ReturnType<typeof vi.fn>;
+  sendFile: ReturnType<typeof vi.fn>;
+  download: ReturnType<typeof vi.fn>;
+}
+
+interface RouteLayer {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: express.RequestHandler }>;
+  };
+}
+
+describe.sequential('original media route download behavior', () => {
+  let tempRoot = '';
+  let apiRouter: ApiModule['apiRouter'];
+  let appConfig: EnvModule['appConfig'];
+  let folderRepository: RepositoriesModule['folderRepository'];
+  let imageRepository: RepositoriesModule['imageRepository'];
+  let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-original-media-download-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.resetModules();
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ apiRouter } = await import('../src/routes/api.js'));
+    ({ folderRepository, imageRepository, maintenanceRepository } = await import('../src/db/repositories.js'));
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.dbDir, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+
+    maintenanceRepository.resetLibraryIndex();
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('streams the original file inline when download is not requested', async () => {
+    const folder = folderRepository.upsert({ slug: 'album', name: 'Album', folderPath: 'album' });
+    const image = await createIndexedMedia(folder, 'photo.jpg', 1_000, 'preview');
+    const handler = getRouteHandler('/originals/:id', 'get');
+    const response = createResponse();
+
+    handler(
+      {
+        params: { id: String(image.id) },
+        query: {}
+      } as unknown as express.Request,
+      response as unknown as express.Response,
+      vi.fn()
+    );
+
+    expect(response.sendFile).toHaveBeenCalledWith(image.absolute_path);
+    expect(response.download).not.toHaveBeenCalled();
+    expect(response.status).not.toHaveBeenCalled();
+  });
+
+  it('downloads the original file as an attachment when download=1 is provided', async () => {
+    const folder = folderRepository.upsert({ slug: 'album-download', name: 'Album Download', folderPath: 'album-download' });
+    const image = await createIndexedMedia(folder, 'snow day.jpg', 2_000, 'preview');
+    const handler = getRouteHandler('/originals/:id', 'get');
+    const response = createResponse();
+
+    handler(
+      {
+        params: { id: String(image.id) },
+        query: { download: '1' }
+      } as unknown as express.Request,
+      response as unknown as express.Response,
+      vi.fn()
+    );
+
+    expect(response.download).toHaveBeenCalledWith(image.absolute_path, 'snow day.jpg');
+    expect(response.sendFile).not.toHaveBeenCalled();
+    expect(response.status).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the original file is no longer available on disk', async () => {
+    const folder = folderRepository.upsert({ slug: 'album-missing', name: 'Album Missing', folderPath: 'album-missing' });
+    const image = await createIndexedMedia(folder, 'missing.jpg', 3_000, 'preview');
+    const handler = getRouteHandler('/originals/:id', 'get');
+    const response = createResponse();
+
+    await fs.rm(image.absolute_path, { force: true });
+
+    handler(
+      {
+        params: { id: String(image.id) },
+        query: {}
+      } as unknown as express.Request,
+      response as unknown as express.Response,
+      vi.fn()
+    );
+
+    expect(response.status).toHaveBeenCalledWith(404);
+    expect(response.json).toHaveBeenCalledWith({ message: 'Original media not found' });
+    expect(response.sendFile).not.toHaveBeenCalled();
+    expect(response.download).not.toHaveBeenCalled();
+  });
+
+  function createResponse(): MockResponse {
+    return {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+      sendFile: vi.fn().mockReturnThis(),
+      download: vi.fn().mockReturnThis()
+    };
+  }
+
+  function getRouteHandler(routePath: string, method: 'get'): express.RequestHandler {
+    const routerLayers = (apiRouter as unknown as { stack: RouteLayer[] }).stack;
+    const layer = routerLayers.find((entry) => entry.route?.path === routePath && entry.route.methods[method]);
+
+    if (!layer?.route) {
+      throw new Error(`Route ${method.toUpperCase()} ${routePath} was not found`);
+    }
+
+    return layer.route.stack.at(-1)!.handle;
+  }
+
+  async function createIndexedMedia(
+    folder: FolderRecord,
+    filename: string,
+    mtimeMs: number,
+    playbackStrategy: PlaybackStrategy,
+    durationMs: number | null = null
+  ) {
+    const relativePath = `${folder.folder_path}/${filename}`;
+    const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+    const extension = path.extname(filename).toLowerCase();
+    const mediaType = getMediaTypeFromExtension(extension);
+    const previewRelativePath = getPreviewRelativePath(relativePath, mediaType);
+    const thumbnailRelativePath = getThumbnailRelativePath(relativePath);
+    const fileSize = 2_048 + mtimeMs;
+
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, `original:${filename}`);
+
+    return imageRepository.upsert({
+      folderId: folder.id,
+      filename,
+      extension,
+      relativePath,
+      absolutePath,
+      fileSize,
+      width: 1280,
+      height: 960,
+      mediaType,
+      mimeType: getMimeTypeFromExtension(extension),
+      durationMs,
+      fingerprint: createFingerprint(relativePath, fileSize, mtimeMs),
+      mtimeMs,
+      firstSeenAt: '2026-01-01T00:00:00.000Z',
+      sortTimestamp: mtimeMs,
+      takenAt: mtimeMs,
+      takenAtSource: 'mtime',
+      exifJson: mediaType === 'image' ? '{}' : null,
+      thumbnailPath: thumbnailRelativePath,
+      previewPath: previewRelativePath,
+      playbackStrategy
+    });
+  }
+});


### PR DESCRIPTION
Closes #37 

## What changed
- adds a download action to home feed posts
- adds a download action to the post viewer
- adds a download action to the stories viewer
- adds a download action to the reels viewer

## Notes
- download always targets the original source media
- includes test coverage for the new UI actions and original route behavior