### PR TITLE
Add configurable excluded folders for gallery discovery and rescans

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ DB_DIR=./data/db
 THUMBNAILS_DIR=./data/thumbnails
 PREVIEWS_DIR=./data/previews
 
+# Optional: comma-separated folder rules by name or exact relative path, for example @eaDir,thumbnails,Archive/cache
+GALLERY_EXCLUDED_FOLDERS=
+
 # Media behavior
 # Controls what the image detail page loads: 'preview' (default) or 'original'
 IMAGE_DETAIL_SOURCE=preview

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Foldergram indexes supported media from a configured `GALLERY_ROOT`, stores meta
 - Image and video support with configurable eager or lazy derivative generation for fast browsing.
 - Original-media download controls on home feed cards, post detail, and stories, alongside open-original actions.
 - Optional role-based local access with admin, viewer, and public browse modes.
-- Settings actions for Home/Reels default modes, manual scan, thumbnail rebuild, and library-index rebuild.
+- Settings split into `General Settings` for Home/Reels defaults, stories mode, and excluded folders, plus `Scan & Library` for scan and rebuild actions.
 - A web app manifest plus production service worker registration.
 - A debounced filesystem watcher in development mode only.
 - No multi-user accounts, cloud sync, uploads, comments, messaging, notifications, or remote APIs.
@@ -112,6 +112,13 @@ The shipped Compose file includes `IMAGE_DETAIL_SOURCE: preview` and
 
 If you want lazy derivatives or original-backed image detail pages in Docker,
 edit those values in `docker-compose.yml` before starting the container.
+
+If you want Docker to skip unwanted source folders from the first scan, add
+`GALLERY_EXCLUDED_FOLDERS` under the Compose `environment:` block. For example:
+
+```yaml
+GALLERY_EXCLUDED_FOLDERS: "@eaDir,thumbnails,Archive/cache"
+```
 
 For an optional read-only public demo in Docker, add `PUBLIC_DEMO_MODE: "1"`
 under the Compose `environment:` block. If the browser-visible origin differs
@@ -219,6 +226,7 @@ data/
 | `DEV_CLIENT_PORT`             | `4141`              | Base Vite client port during `pnpm dev`. The client may use up to `4144`. |
 | `DATA_ROOT`                   | `./data`            | Root directory for app-managed storage.                                   |
 | `GALLERY_ROOT`                | `./data/gallery`    | Root directory scanned for App Folders.                                   |
+| `GALLERY_EXCLUDED_FOLDERS`    | empty               | Comma-separated folder exclusion rules such as `@eaDir,Archive/cache`.    |
 | `DB_DIR`                      | `./data/db`         | SQLite database directory.                                                |
 | `THUMBNAILS_DIR`              | `./data/thumbnails` | Generated thumbnail output directory.                                     |
 | `PREVIEWS_DIR`                | `./data/previews`   | Generated preview output directory.                                       |
@@ -243,6 +251,15 @@ image.
 For the default Docker Compose setup, runtime variables are defined in
 [`docker-compose.yml`](docker-compose.yml). The source-install `.env` file is
 not read directly by the container.
+
+### Excluded Folders
+
+- Use `GALLERY_EXCLUDED_FOLDERS` to skip unwanted source folders during discovery and rescans.
+- Rules without a slash match a folder name anywhere in the gallery tree, such as `@eaDir` or `thumbnails`.
+- Rules with a slash match one exact relative folder path beneath `GALLERY_ROOT`, such as `Archive/cache`.
+- The Settings sidebar now separates app-wide preferences into `General Settings`. That section includes the stories-folders toggle, Home/Reels defaults, and the excluded-folder editor.
+- `General Settings` can add or remove custom exclusion rules at runtime. Env-backed rules stay read-only there and still require a restart to change.
+- After changing excluded folders or stories mode in `General Settings`, run a full library scan from `Scan & Library` so previously indexed folders are soft-removed or reclassified correctly.
 
 ### Detail Media and Derivative Timing
 

--- a/client/src/api/gallery.ts
+++ b/client/src/api/gallery.ts
@@ -6,6 +6,7 @@ import type {
   FolderStoriesPayload,
   FolderStoryFeedPayload,
   HomeFeedDefaultSetting,
+  UpdateExcludedFoldersSettingResult,
   ReelsFeedDefaultSetting,
   StoriesModeSetting,
   ViewerAccessMode,
@@ -322,5 +323,13 @@ export function updateStoriesMode(treatStoriesAsFolders: boolean) {
     method: 'PUT',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ treatStoriesAsFolders })
+  });
+}
+
+export function updateExcludedFolders(rules: string[]) {
+  return requestJson<UpdateExcludedFoldersSettingResult>('/api/admin/settings/excluded-folders', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ rules })
   });
 }

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -15,6 +15,16 @@ export interface StoriesModeSetting {
   treatStoriesAsFolders: boolean;
 }
 
+export interface ExcludedFoldersSettings {
+  envExcludedFolders: string[];
+  customExcludedFolders: string[];
+  effectiveExcludedFolders: string[];
+}
+
+export interface UpdateExcludedFoldersSettingResult extends ExcludedFoldersSettings {
+  requiresScan: boolean;
+}
+
 export interface FeedItem {
   id: number;
   folderId: number;
@@ -255,6 +265,7 @@ export interface AppStats extends AppStatus {
   deletedImages: number;
   thumbnailCount: number;
   previewCount: number;
+  excludedFolders: ExcludedFoldersSettings;
   storage: AppStatus['storage'] & {
     usingInMemoryDatabase: boolean;
   };

--- a/client/src/views/SettingsView.test.ts
+++ b/client/src/views/SettingsView.test.ts
@@ -65,6 +65,11 @@ function createAppStats(): AppStats {
     deletedImages: 0,
     thumbnailCount: 18,
     previewCount: 6,
+    excludedFolders: {
+      envExcludedFolders: [],
+      customExcludedFolders: [],
+      effectiveExcludedFolders: []
+    },
     storage: {
       available: true,
       reason: null,
@@ -82,6 +87,27 @@ function createAppStats(): AppStats {
   };
 }
 
+function mountSettingsView() {
+  return mount(SettingsView, {
+    global: {
+      stubs: {
+        ConfirmDialog: true
+      }
+    }
+  });
+}
+
+async function openGeneralSettingsSidebarTab(wrapper: ReturnType<typeof mountSettingsView>) {
+  const generalSettingsButton = wrapper
+    .findAll('button')
+    .find((button) => button.text().includes('General Settings'));
+
+  expect(generalSettingsButton).toBeDefined();
+
+  await generalSettingsButton!.trigger('click');
+  await flushPromises();
+}
+
 describe('SettingsView', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
@@ -95,24 +121,23 @@ describe('SettingsView', () => {
       stats: createAppStatus()
     });
 
-    const wrapper = mount(SettingsView, {
-      global: {
-        stubs: {
-          ConfirmDialog: true
-        }
-      }
-    });
+    const wrapper = mountSettingsView();
 
     await flushPromises();
 
-    expect(wrapper.text()).toContain('Feed Defaults');
-    expect(wrapper.text()).toContain('Home feed default');
-    expect(wrapper.text()).toContain('Reels feed default');
-    expect(wrapper.findAll('input[type="radio"]')).toHaveLength(6);
-    expect(wrapper.text()).not.toContain('Save Home Feed Default');
-    expect(wrapper.text()).not.toContain('Save Reels Feed Default');
-    expect((wrapper.get('input[name="home-feed-default"][value="rediscover"]').element as HTMLInputElement).checked).toBe(true);
-    expect((wrapper.get('input[name="reels-feed-default"][value="random"]').element as HTMLInputElement).checked).toBe(true);
+    expect(wrapper.text()).toContain('Scan & Library');
+    expect(wrapper.text()).toContain('General Settings');
+    expect(wrapper.text()).not.toContain('Home feed sort order');
+
+    await openGeneralSettingsSidebarTab(wrapper);
+
+    expect(wrapper.text()).toContain('Home feed sort order');
+    expect(wrapper.text()).toContain('Reels feed sort order');
+    expect(wrapper.text()).toContain('Excluded source folders');
+
+    const [homeButton, reelsButton] = wrapper.findAll('button[aria-expanded]');
+    expect(homeButton?.text()).toContain('Rediscover');
+    expect(reelsButton?.text()).toContain('Random');
 
     const saveButton = wrapper
       .findAll('button')
@@ -129,15 +154,11 @@ describe('SettingsView', () => {
       loadingStats: true
     });
 
-    const wrapper = mount(SettingsView, {
-      global: {
-        stubs: {
-          ConfirmDialog: true
-        }
-      }
-    });
+    const wrapper = mountSettingsView();
 
     await flushPromises();
+
+    await openGeneralSettingsSidebarTab(wrapper);
 
     appStore.$patch({
       loadingStats: false,
@@ -146,9 +167,9 @@ describe('SettingsView', () => {
 
     await flushPromises();
 
-    expect((wrapper.get('input[name="home-feed-default"][value="recent"]').element as HTMLInputElement).checked).toBe(true);
-    expect((wrapper.get('input[name="home-feed-default"][value="random"]').element as HTMLInputElement).checked).toBe(false);
-    expect((wrapper.get('input[name="reels-feed-default"][value="random"]').element as HTMLInputElement).checked).toBe(true);
+    const [homeButton, reelsButton] = wrapper.findAll('button[aria-expanded]');
+    expect(homeButton?.text()).toContain('Recent');
+    expect(reelsButton?.text()).toContain('Random');
 
     const saveButton = wrapper
       .findAll('button')
@@ -158,7 +179,7 @@ describe('SettingsView', () => {
     expect(saveButton!.attributes('disabled')).toBeDefined();
   });
 
-  it('saves the reels default from the feed defaults card', async () => {
+  it('saves the reels default from the general settings card', async () => {
     const appStore = useAppStore();
     appStore.$patch({
       stats: createAppStatus()
@@ -169,23 +190,26 @@ describe('SettingsView', () => {
       defaultMode: 'recommended'
     });
 
-    const wrapper = mount(SettingsView, {
-      global: {
-        stubs: {
-          ConfirmDialog: true
-        }
-      }
-    });
+    const wrapper = mountSettingsView();
 
     await flushPromises();
+    await openGeneralSettingsSidebarTab(wrapper);
 
-    await wrapper.get('input[value="recommended"]').setValue(true);
+    const [, reelsButton] = wrapper.findAll('button[aria-expanded]');
+    expect(reelsButton).toBeDefined();
+
+    await reelsButton!.trigger('click');
+    await flushPromises();
+    const recommendedOption = wrapper.findAll('button').find((button) => button.text().includes('Recommended'));
+    expect(recommendedOption).toBeDefined();
+    await recommendedOption!.trigger('click');
     await flushPromises();
 
     const updateHomeFeedDefaultSpy = vi.spyOn(galleryApi, 'updateHomeFeedDefault');
+    const updateExcludedFoldersSpy = vi.spyOn(galleryApi, 'updateExcludedFolders');
     const saveButton = wrapper
       .findAll('button')
-      .find((button) => button.text() === 'Save Feed Defaults');
+      .find((button) => button.text() === 'Save changes');
 
     expect(saveButton).toBeDefined();
 
@@ -194,7 +218,42 @@ describe('SettingsView', () => {
 
     expect(updateReelsFeedDefaultSpy).toHaveBeenCalledWith('recommended');
     expect(updateHomeFeedDefaultSpy).not.toHaveBeenCalled();
+    expect(updateExcludedFoldersSpy).not.toHaveBeenCalled();
     expect(appStore.stats?.preferences.defaultReelsFeedMode).toBe('recommended');
     expect(wrapper.text()).toContain('Reels now opens with Recommended.');
+  });
+
+  it('saves custom excluded folder rules from the settings textarea', async () => {
+    const appStore = useAppStore();
+    appStore.$patch({
+      stats: createAppStatus()
+    });
+
+    vi.spyOn(appStore, 'fetchStats').mockResolvedValue();
+    const updateExcludedFoldersSpy = vi.spyOn(galleryApi, 'updateExcludedFolders').mockResolvedValue({
+      envExcludedFolders: ['@eaDir'],
+      customExcludedFolders: ['Archive/cache', 'thumbnails'],
+      effectiveExcludedFolders: ['@eaDir', 'Archive/cache', 'thumbnails'],
+      requiresScan: true
+    });
+
+    const wrapper = mountSettingsView();
+    await flushPromises();
+    await openGeneralSettingsSidebarTab(wrapper);
+
+    await wrapper.get('textarea').setValue('Archive/cache\nthumbnails');
+    await flushPromises();
+
+    const saveButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'Save changes');
+
+    expect(saveButton).toBeDefined();
+
+    await saveButton!.trigger('click');
+    await flushPromises();
+
+    expect(updateExcludedFoldersSpy).toHaveBeenCalledWith(['Archive/cache', 'thumbnails']);
+    expect(wrapper.text()).toContain('Excluded folders were saved. Run a library scan to apply them.');
   });
 });

--- a/client/src/views/SettingsView.vue
+++ b/client/src/views/SettingsView.vue
@@ -4,7 +4,7 @@
       <div>
         <span class="eyebrow">Settings</span>
         <h1 class="mt-[0.15rem] mb-0 text-[clamp(1.55rem,2.4vw,2rem)] font-medium tracking-[-0.04em]">Library Controls</h1>
-        <p class="m-0 text-muted">Manage feed defaults, access, scans, and the library index.</p>
+        <p class="m-0 text-muted">Manage scans, app defaults, access, and the library index.</p>
       </div>
     </header>
 
@@ -66,7 +66,19 @@
           <span class="w-[1.25rem] h-[1.25rem] shrink-0 mt-[0.1rem]" :class="currentCategory === 'library' ? 'i-fluent-folder-sync-20-filled' : 'i-fluent-folder-sync-20-regular'" aria-hidden="true"></span>
           <span class="flex flex-col gap-[0.1rem]">
             <span>Scan & Library</span>
-            <span class="text-[0.75rem] font-normal text-muted">Index media, rebuild derivatives, and set feed defaults</span>
+            <span class="text-[0.75rem] font-normal text-muted">Index media, rebuild thumbnails, and maintain the library index</span>
+          </span>
+        </button>
+        <button
+          @click="currentCategory = 'general'"
+          class="flex items-start gap-3 px-4 py-[0.85rem] rounded-[0.85rem] border-0 text-left transition-colors duration-150 cursor-pointer"
+          :class="currentCategory === 'general' ? 'bg-surface-alt font-bold text-text' : 'bg-transparent text-muted hover:bg-surface-hover hover:text-text'"
+        >
+          <span class="w-[1.25rem] h-[1.25rem] shrink-0 mt-[0.1rem]" :class="currentCategory === 'general' ? 'i-fluent-settings-20-filled' : 'i-fluent-settings-20-regular'" aria-hidden="true"></span>
+          <span class="flex flex-col gap-[0.1rem] min-w-0">
+
+              <span class="truncate">General Settings</span>
+            <span class="text-[0.75rem] font-normal text-muted">Stories mode, excluded folders, and feed defaults</span>
           </span>
         </button>
         <button
@@ -349,8 +361,8 @@
           </div>
         </template>
 
-        <!-- CATEGORY: LIBRARY -->
-        <template v-if="currentCategory === 'library'">
+        <!-- CATEGORY: GENERAL -->
+        <template v-if="currentCategory === 'general'">
           <section
             v-if="showStoriesMigrationNotice"
             class="card grid gap-[1rem] p-6 border-[color-mix(in_srgb,#d2a133_42%,var(--border)_58%)]"
@@ -448,7 +460,7 @@
             <div class="border-b border-border px-6 py-5">
               <div>
                 <h2 class="m-0 text-[1.18rem]">General Settings</h2>
-                <p class="m-0 mt-[0.25rem] text-muted">App-wide defaults for stories folders, Home, and Reels.</p>
+                <p class="m-0 mt-[0.25rem] text-muted">App-wide defaults for stories folders, excluded folders, Home, and Reels.</p>
               </div>
             </div>
 
@@ -465,6 +477,9 @@
                 <div class="min-w-0">
                   <div class="flex flex-wrap items-center gap-2">
                     <p class="m-0 text-[0.96rem] font-semibold text-text">Treat stories folders as normal app folders</p>
+                    <span class="inline-flex items-center rounded-full bg-surface-alt px-2 py-[0.2rem] text-[0.72rem] font-semibold uppercase tracking-[0.08em] text-muted">
+                      Scan required
+                    </span>
                     <div class="group relative inline-flex">
                       <button
                         class="inline-flex h-6 w-6 items-center justify-center rounded-full border-0 bg-transparent p-0 text-muted cursor-help transition-colors duration-150 hover:text-text focus-visible:text-text"
@@ -500,6 +515,65 @@
                     />
                   </span>
                 </button>
+              </div>
+
+              <div class="grid gap-4 px-6 py-4">
+                <div class="min-w-0">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <p class="m-0 text-[0.96rem] font-semibold text-text">Excluded source folders</p>
+                    <span class="inline-flex items-center rounded-full bg-surface-alt px-2 py-[0.2rem] text-[0.72rem] font-semibold uppercase tracking-[0.08em] text-muted">
+                      Scan required
+                    </span>
+                  </div>
+                  <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">
+                    Skip matching folders anywhere by name or by exact relative path under the gallery root. Hidden paths and app-managed storage stay excluded automatically.
+                  </p>
+                </div>
+
+                <label class="grid gap-[0.45rem]">
+                  <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">Custom rules</span>
+                  <textarea
+                    v-model="customExcludedFoldersDraft"
+                    class="min-h-[10rem] rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 py-3 text-[0.95rem] leading-[1.55] text-text outline-none transition-[border-color,box-shadow] duration-180 placeholder:text-muted focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
+                    :disabled="savingGeneralSettings || adminStats === null"
+                    rows="5"
+                    placeholder="@eaDir&#10;thumbnails&#10;Archive/cache"
+                    spellcheck="false"
+                    @input="clearGeneralSettingsFeedback"
+                  />
+                </label>
+
+                <div class="grid gap-3 lg:grid-cols-2">
+                  <div class="rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_78%,transparent_22%)] px-4 py-4">
+                    <p class="m-0 text-[0.82rem] font-semibold uppercase tracking-[0.08em] text-muted">Read-only env rules</p>
+                    <p class="m-0 mt-[0.35rem] text-[0.82rem] text-muted">Change <code>GALLERY_EXCLUDED_FOLDERS</code> in <code>.env</code> or Docker and restart the app to update these.</p>
+                    <div v-if="envExcludedFolders.length > 0" class="mt-3 flex flex-wrap gap-2">
+                      <span
+                        v-for="rule in envExcludedFolders"
+                        :key="`env-${rule}`"
+                        class="inline-flex items-center rounded-full bg-[rgba(24,119,242,0.08)] px-3 py-[0.35rem] text-[0.78rem] font-medium text-accent-strong"
+                      >
+                        {{ rule }}
+                      </span>
+                    </div>
+                    <p v-else class="m-0 mt-3 text-[0.84rem] text-muted">No env-backed folder exclusions are configured.</p>
+                  </div>
+
+                  <div class="rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_78%,transparent_22%)] px-4 py-4">
+                    <p class="m-0 text-[0.82rem] font-semibold uppercase tracking-[0.08em] text-muted">Currently active saved rules</p>
+                    <p class="m-0 mt-[0.35rem] text-[0.82rem] text-muted">This combines the saved textarea rules with any env-backed entries. New textarea edits appear here after you save them.</p>
+                    <div v-if="effectiveExcludedFolders.length > 0" class="mt-3 flex flex-wrap gap-2">
+                      <span
+                        v-for="rule in effectiveExcludedFolders"
+                        :key="`effective-${rule}`"
+                        class="inline-flex items-center rounded-full bg-surface px-3 py-[0.35rem] text-[0.78rem] font-medium text-text"
+                      >
+                        {{ rule }}
+                      </span>
+                    </div>
+                    <p v-else class="m-0 mt-3 text-[0.84rem] text-muted">No saved custom or env-backed folder exclusions are active.</p>
+                  </div>
+                </div>
               </div>
 
               <div class="grid gap-3 px-6 py-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
@@ -626,12 +700,12 @@
 
             </div>
 
-            <div class="border-t border-border bg-[color-mix(in_srgb,var(--surface)_96%,var(--accent-soft)_4%)] px-6 py-5">
+            <div class="rounded-b-[1.05rem] border-t border-border bg-[color-mix(in_srgb,var(--surface)_96%,var(--accent-soft)_4%)] px-6 py-5">
               <div
-                v-if="showStoriesRescanNotice"
+                v-if="showGeneralSettingsRescanNotice"
                 class="mb-4 rounded-[0.95rem] border border-[rgba(210,161,51,0.28)] bg-[rgba(210,161,51,0.08)] px-4 py-3 text-[0.88rem] text-[#9f6a00]"
               >
-                Save this change, then run a library scan before expecting stories folders, avatar stories, or highlights to update.
+                {{ generalSettingsRescanNotice }}
               </div>
 
               <div class="flex items-center justify-between gap-3 max-sm:flex-col max-sm:items-stretch">
@@ -649,6 +723,10 @@
             </div>
           </section>
 
+        </template>
+
+        <!-- CATEGORY: LIBRARY -->
+        <template v-if="currentCategory === 'library'">
           <section class="card grid gap-[1.15rem] p-8">
             <div class="flex items-start justify-between gap-4 max-sm:flex-col max-sm:items-start">
               <div>
@@ -827,7 +905,16 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 
 import ConfirmDialog from '../components/ConfirmDialog.vue';
-import { fetchAdminStats, triggerLibraryRebuild, triggerManualScan, triggerThumbnailRebuild, updateHomeFeedDefault, updateReelsFeedDefault, updateStoriesMode } from '../api/gallery';
+import {
+  fetchAdminStats,
+  triggerLibraryRebuild,
+  triggerManualScan,
+  triggerThumbnailRebuild,
+  updateExcludedFolders,
+  updateHomeFeedDefault,
+  updateReelsFeedDefault,
+  updateStoriesMode
+} from '../api/gallery';
 import { useAppStore } from '../stores/app';
 import { useAuthStore } from '../stores/auth';
 import { useFeedStore } from '../stores/feed';
@@ -845,7 +932,7 @@ const likesStore = useLikesStore();
 const momentsStore = useMomentsStore();
 const viewerStore = useViewerStore();
 const route = useRoute();
-const currentCategory = ref<'library' | 'access' | 'status'>('library');
+const currentCategory = ref<'library' | 'general' | 'access' | 'status'>('library');
 const scanError = ref<string | null>(null);
 const rebuildError = ref<string | null>(null);
 const thumbnailRebuildError = ref<string | null>(null);
@@ -877,12 +964,61 @@ const showStoriesAnnouncementStructure = ref(false);
 const viewerAccessMode = ref<ViewerAccessMode>(authStore.accessMode);
 const viewerPassword = ref('');
 const viewerPasswordConfirmation = ref('');
+const customExcludedFoldersDraft = ref('');
 const SCAN_ERROR_NOTICE_STORAGE_KEY = 'foldergram-scan-error-notice-dismissal';
 const IGNORED_ROOT_MEDIA_NOTICE_STORAGE_KEY = 'foldergram-ignored-root-media-notice-dismissal';
 const NOTICE_DISMISS_MS = 7 * 24 * 60 * 60 * 1000;
 const MIN_PASSWORD_LENGTH = 8;
 const STORIES_MIGRATION_NOTICE_STORAGE_KEY = 'foldergram-stories-migration-dismissed';
 const STORIES_ANNOUNCEMENT_STORAGE_KEY = 'foldergram-stories-announcement-dismissed';
+const EXCLUDED_FOLDER_EDGE_SLASH_PATTERN = /^\/+|\/+$/g;
+const EXCLUDED_FOLDER_UNSUPPORTED_PATTERN = /[*?]/;
+const excludedFoldersHydrated = ref(false);
+
+function normalizeExcludedFolderRuleInput(rule: string): string {
+  const segments = rule
+    .replace(/\\/g, '/')
+    .trim()
+    .replace(EXCLUDED_FOLDER_EDGE_SLASH_PATTERN, '')
+    .split('/')
+    .filter(Boolean);
+
+  if (segments.length === 0) {
+    throw new Error('Excluded folder rules cannot be empty.');
+  }
+
+  if (segments.some((segment) => segment === '.' || segment === '..')) {
+    throw new Error(`Invalid excluded folder rule: ${rule}`);
+  }
+
+  if (segments.some((segment) => EXCLUDED_FOLDER_UNSUPPORTED_PATTERN.test(segment))) {
+    throw new Error(`Unsupported excluded folder rule: ${rule}`);
+  }
+
+  return segments.join('/');
+}
+
+function parseExcludedFolderRulesDraft(value: string): string[] {
+  const normalized: string[] = [];
+
+  for (const entry of value.split(/\r?\n/u)) {
+    const trimmedEntry = entry.trim();
+    if (trimmedEntry.length === 0) {
+      continue;
+    }
+
+    const normalizedEntry = normalizeExcludedFolderRuleInput(trimmedEntry);
+    if (!normalized.includes(normalizedEntry)) {
+      normalized.push(normalizedEntry);
+    }
+  }
+
+  return normalized;
+}
+
+function formatExcludedFolderRules(rules: string[]): string {
+  return rules.join('\n');
+}
 
 function loadDismissedScanErrorNotice(): { scanId: number; dismissedUntil: number } | null {
   if (typeof window === 'undefined') {
@@ -1038,6 +1174,11 @@ function syncStoriesModeFromSaved() {
   storiesModeHydrated.value = true;
 }
 
+function syncExcludedFoldersFromSaved() {
+  customExcludedFoldersDraft.value = formatExcludedFolderRules(adminStats.value?.excludedFolders.customExcludedFolders ?? []);
+  excludedFoldersHydrated.value = true;
+}
+
 const scan = computed(() => appStore.stats?.scan ?? null);
 const lastCompletedScan = computed(() => scan.value?.lastCompletedScan ?? adminStats.value?.lastScan ?? null);
 const activeScanReason = computed(() => scan.value?.scanReason ?? null);
@@ -1088,6 +1229,9 @@ const waitingForInitialStatus = computed(() => !appStore.stats || appStore.loadi
 const savedHomeFeedDefaultMode = computed(() => appStore.defaultHomeFeedMode);
 const savedReelsFeedDefaultMode = computed(() => appStore.defaultReelsFeedMode);
 const savedStoriesMode = computed(() => appStore.treatStoriesAsFolders);
+const savedCustomExcludedFolders = computed(() => adminStats.value?.excludedFolders.customExcludedFolders ?? []);
+const envExcludedFolders = computed(() => adminStats.value?.excludedFolders.envExcludedFolders ?? []);
+const effectiveExcludedFolders = computed(() => adminStats.value?.excludedFolders.effectiveExcludedFolders ?? []);
 const storiesModeRequiresDecision = computed(() => appStore.stats?.storiesMigration.decisionPending === true);
 const savedHomeFeedDefaultModeLabel = computed(
   () => homeFeedDefaultOptions.find((mode) => mode.id === savedHomeFeedDefaultMode.value)?.label ?? 'Random'
@@ -1109,10 +1253,24 @@ const reelsFeedDefaultDirty = computed(
 );
 const feedDefaultsDirty = computed(() => homeFeedDefaultDirty.value || reelsFeedDefaultDirty.value);
 const storiesModeDirty = computed(() => storiesModeHydrated.value && storiesMode.value !== savedStoriesMode.value);
+const excludedFoldersDirty = computed(() => {
+  if (!excludedFoldersHydrated.value) {
+    return false;
+  }
+
+  try {
+    const currentRules = parseExcludedFolderRulesDraft(customExcludedFoldersDraft.value);
+    return JSON.stringify(currentRules) !== JSON.stringify(savedCustomExcludedFolders.value);
+  } catch {
+    return true;
+  }
+});
 const generalSettingsDirty = computed(
-  () => feedDefaultsDirty.value || storiesModeDirty.value || storiesModeRequiresDecision.value
+  () => feedDefaultsDirty.value || storiesModeDirty.value || excludedFoldersDirty.value || storiesModeRequiresDecision.value
 );
-const showStoriesRescanNotice = computed(() => storiesModeDirty.value || storiesModeRequiresDecision.value);
+const showGeneralSettingsRescanNotice = computed(
+  () => storiesModeDirty.value || storiesModeRequiresDecision.value || excludedFoldersDirty.value
+);
 const generalSettingsSaveDisabled = computed(
   () => waitingForInitialStatus.value || savingGeneralSettings.value || !generalSettingsDirty.value
 );
@@ -1129,6 +1287,14 @@ const generalSettingsButtonStyle = computed(() =>
 const generalSettingsActionNote = computed(() => {
   if (waitingForInitialStatus.value) {
     return 'Loading the current app preferences...';
+  }
+
+  if (excludedFoldersDirty.value && (storiesModeDirty.value || storiesModeRequiresDecision.value || feedDefaultsDirty.value)) {
+    return 'Save the folder exclusion rules with the other app-wide changes. Run a library scan afterward so stories and excluded folders reindex correctly.';
+  }
+
+  if (excludedFoldersDirty.value) {
+    return 'This saves the custom excluded folders only. Run a library scan afterward so those folders disappear from the index.';
   }
 
   if (storiesModeDirty.value && feedDefaultsDirty.value) {
@@ -1151,7 +1317,18 @@ const generalSettingsActionNote = computed(() => {
     return 'This updates the queue style used when Reels opens for this app. Visitors cannot switch modes from the reels page.';
   }
 
-  return 'These are the current app-wide defaults for Home, Reels, and stories folders.';
+  return 'These are the current app-wide defaults for Home, Reels, stories folders, and excluded folders.';
+});
+const generalSettingsRescanNotice = computed(() => {
+  if (excludedFoldersDirty.value && (storiesModeDirty.value || storiesModeRequiresDecision.value)) {
+    return 'Save these changes, then run a library scan before expecting stories folders and excluded folders to update.';
+  }
+
+  if (excludedFoldersDirty.value) {
+    return 'Save this change, then run a library scan before excluded folders disappear from the index.';
+  }
+
+  return 'Save this change, then run a library scan before expecting stories folders, avatar stories, or highlights to update.';
 });
 const storiesModeLabelDescription = computed(() =>
   storiesMode.value
@@ -1761,16 +1938,44 @@ async function saveGeneralSettings() {
     return;
   }
 
+  const shouldSaveExcludedFolders = excludedFoldersDirty.value;
   const shouldSaveStories = storiesModeDirty.value || storiesModeRequiresDecision.value;
   const shouldSaveHome = homeFeedDefaultDirty.value;
   const shouldSaveReels = reelsFeedDefaultDirty.value;
   const savedParts: string[] = [];
+  let nextExcludedFolders: string[] = [];
+
+  if (shouldSaveExcludedFolders) {
+    try {
+      nextExcludedFolders = parseExcludedFolderRulesDraft(customExcludedFoldersDraft.value);
+    } catch (error) {
+      setGeneralSettingsFeedback('error', error instanceof Error ? error.message : 'Unable to validate the excluded folder rules.');
+      return;
+    }
+  }
 
   savingGeneralSettings.value = true;
   closeGeneralSettingsMenu();
   clearGeneralSettingsFeedback();
 
   try {
+    if (shouldSaveExcludedFolders) {
+      const payload = await updateExcludedFolders(nextExcludedFolders);
+      savedParts.push('excluded folders');
+      customExcludedFoldersDraft.value = formatExcludedFolderRules(payload.customExcludedFolders);
+
+      if (adminStats.value) {
+        adminStats.value = {
+          ...adminStats.value,
+          excludedFolders: {
+            envExcludedFolders: payload.envExcludedFolders,
+            customExcludedFolders: payload.customExcludedFolders,
+            effectiveExcludedFolders: payload.effectiveExcludedFolders
+          }
+        };
+      }
+    }
+
     if (shouldSaveStories) {
       const payload = await updateStoriesMode(storiesMode.value);
       savedParts.push('stories folder handling');
@@ -1802,11 +2007,17 @@ async function saveGeneralSettings() {
 
     await appStore.fetchStats({ background: true });
 
-    if (shouldSaveStories) {
+    if (shouldSaveStories || shouldSaveExcludedFolders) {
       await loadAdminStats().catch(() => {});
     }
 
-    if (shouldSaveStories && (shouldSaveHome || shouldSaveReels)) {
+    if ((shouldSaveStories || shouldSaveExcludedFolders) && (shouldSaveHome || shouldSaveReels)) {
+      setGeneralSettingsFeedback('success', 'Settings were saved. Run a library scan to apply the folder rule changes.');
+    } else if (shouldSaveExcludedFolders && shouldSaveStories) {
+      setGeneralSettingsFeedback('success', 'Folder exclusion rules and stories folder behavior were saved. Run a library scan to apply them.');
+    } else if (shouldSaveExcludedFolders) {
+      setGeneralSettingsFeedback('success', 'Excluded folders were saved. Run a library scan to apply them.');
+    } else if (shouldSaveStories && (shouldSaveHome || shouldSaveReels)) {
       setGeneralSettingsFeedback('success', 'Settings were saved. Run a library scan to apply the stories folder change.');
     } else if (shouldSaveStories) {
       setGeneralSettingsFeedback('success', 'Stories folder behavior was saved. Run a library scan to apply it.');
@@ -1825,7 +2036,7 @@ async function saveGeneralSettings() {
     }
   } catch (error) {
     await appStore.fetchStats({ background: true }).catch(() => {});
-    if (shouldSaveStories) {
+    if (shouldSaveStories || shouldSaveExcludedFolders) {
       await loadAdminStats().catch(() => {});
     }
 
@@ -1861,6 +2072,10 @@ async function warmScanStatus() {
 
 async function loadAdminStats() {
   adminStats.value = await fetchAdminStats();
+
+  if (!excludedFoldersHydrated.value || savingGeneralSettings.value || !excludedFoldersDirty.value) {
+    syncExcludedFoldersFromSaved();
+  }
 }
 
 async function runManualScan() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     environment:
       IMAGE_DETAIL_SOURCE: preview
       DERIVATIVE_MODE: eager
+      # Optional: skip specific source folders by name or by exact relative path.
+      # GALLERY_EXCLUDED_FOLDERS: "@eaDir,thumbnails,Archive/cache"
       # Optional: enable read-only public demo behavior.
       # PUBLIC_DEMO_MODE: "1"
       # Optional when the browser-visible origin differs from the upstream Node host.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Environment variables, path rules, and scan concurrency controls in Foldergram.
+description: Environment variables, excluded-folder rules, path behavior, and scan controls in Foldergram.
 ---
 
 # Configuration
@@ -24,6 +24,7 @@ yourself.
 | `DATA_ROOT` | `./data` | Base directory for app-managed storage. Other storage paths default under it unless overridden. |
 | `DATA_DIR` | unset | Optional alias that falls back into `DATA_ROOT` resolution when `DATA_ROOT` is absent. |
 | `GALLERY_ROOT` | `./data/gallery` | Source media root. Foldergram scans below this path. |
+| `GALLERY_EXCLUDED_FOLDERS` | unset | Comma-separated folder exclusion rules. Names match anywhere in the gallery tree; values with a slash match one exact relative path below `GALLERY_ROOT`. |
 | `DB_DIR` | `./data/db` | SQLite directory. Database file is `gallery.sqlite`. |
 | `THUMBNAILS_DIR` | `./data/thumbnails` | Generated thumbnail output root. |
 | `PREVIEWS_DIR` | `./data/previews` | Generated preview output root. |
@@ -60,6 +61,30 @@ Instead:
 - turning the toggle on enables legacy behavior, where folders literally named `stories` remain ordinary app folders
 - changing this setting requires a rescan because the indexed folder structure changes
 - if the existing library already contains candidate `stories/` folders, Settings can show a migration decision card until you choose a mode
+
+## Excluded folders
+
+Folder exclusions can come from two places:
+
+- `GALLERY_EXCLUDED_FOLDERS` in `.env` or Docker Compose
+- custom rules saved from `Settings -> General Settings`
+
+Behavior:
+
+- rules without a slash match folder names anywhere in the gallery tree, such as `@eaDir` or `thumbnails`
+- rules with a slash match one exact relative folder path under `GALLERY_ROOT`, such as `Archive/cache`
+- env-backed rules appear read-only in `General Settings`
+- custom rules are stored in SQLite `app_settings` and can be changed at runtime
+- after changing custom rules, run a full scan from `Settings -> Scan & Library` so already-indexed matches are soft-removed from the library
+
+## Settings sections
+
+The Settings sidebar is split into:
+
+- `Scan & Library` for manual scans, thumbnail rebuilds, and library-index rebuilds
+- `General Settings` for Home/Reels defaults, stories-folders mode, excluded folders, and any save-and-rescan notices tied to those app-wide rules
+- `Security & Access` for admin, viewer, and public-mode controls
+- `System Status` for storage, index, and last-scan details
 
 ## Path resolution rules
 
@@ -120,6 +145,7 @@ Behavior:
 - `Rebuild Library Index` resets and rebuilds the SQLite-backed index, then reuses any matching derivatives already on disk.
 - In `DERIVATIVE_MODE=lazy`, neither a normal scan nor `Rebuild Library Index` pre-generates missing thumbnails or previews.
 - `Regenerate Thumbnails` remains a manual thumbnail and video-poster rebuild only. It does not rebuild previews.
+- Runtime-only app-wide controls such as stories mode and excluded folders live under `Settings -> General Settings`, while the scan and rebuild actions live under `Settings -> Scan & Library`.
 
 ## Managed path ignores
 
@@ -140,6 +166,7 @@ DEV_SERVER_PORT=4140
 DEV_CLIENT_PORT=4141
 DATA_ROOT=./data
 GALLERY_ROOT=./data/gallery
+GALLERY_EXCLUDED_FOLDERS=
 DB_DIR=./data/db
 THUMBNAILS_DIR=./data/thumbnails
 PREVIEWS_DIR=./data/previews

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -45,8 +45,25 @@ folder:
 - story media is hidden from normal folder, feed, and reels surfaces while this mode is active
 
 If you already rely on folders literally named `stories` as normal app folders,
-open Settings, enable `Treat stories folders as normal app folders`, and rescan
-the library.
+open `Settings -> General Settings`, enable `Treat stories folders as normal
+app folders`, then rescan from `Settings -> Scan & Library`.
+
+## Can I exclude source folders from scanning?
+
+Yes.
+
+Foldergram supports two sources of exclusion rules:
+
+- `GALLERY_EXCLUDED_FOLDERS` in `.env` or Docker Compose
+- custom rules in `Settings -> General Settings`
+
+Rules without a slash match folder names anywhere in the gallery tree, such as
+`@eaDir` or `thumbnails`. Rules with a slash match one exact relative path
+under `GALLERY_ROOT`, such as `Archive/cache`.
+
+Changing env-backed rules requires a restart. Changing custom rules in
+`General Settings` requires saving the change and then running a scan from
+`Scan & Library`.
 
 ## Are likes shared with other users?
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -181,18 +181,18 @@ from reserved `stories/` folders.
 
 Settings is the operational control surface for the library.
 
-It exposes:
+Its left sidebar is split into:
 
-- admin-password controls
-- viewer password and public access controls
-- home and reels default feed-mode controls
-- stories-folders mode controls, migration notices, and a save-and-rescan flow
-- live scan status
-- storage and index status
-- last completed scan details
-- manual scan
-- thumbnail-only rebuild
-- library-index rebuild
+| Section | What it contains |
+| --- | --- |
+| `Scan & Library` | Live scan state, manual scan, thumbnail-only rebuild, and library-index rebuild actions. |
+| `General Settings` | Home and Reels default feed modes, stories-folders mode, excluded-folder rules, migration notices, and save-and-rescan prompts for those app-wide changes. |
+| `Security & Access` | Admin password, viewer password, public mode, sign-out, and related auth controls. |
+| `System Status` | Storage and index state plus last completed scan details. |
+
+In `General Settings`, env-backed excluded-folder rules are shown read-only and
+custom rules are saved at runtime. Changing stories mode or excluded folders
+still requires a follow-up scan from `Scan & Library`.
 
 ### Access protection
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -20,6 +20,7 @@ Foldergram recursively walks `GALLERY_ROOT` and applies these rules:
 
 - Hidden paths are skipped.
 - Managed storage paths under the gallery root are skipped.
+- Folder exclusions from `GALLERY_EXCLUDED_FOLDERS` and saved `General Settings` rules are skipped.
 - Any non-hidden folder that directly contains supported media becomes an indexed album.
 - Files directly in `GALLERY_ROOT` are ignored.
 - Nested folders are treated separately from their parent folders.
@@ -41,6 +42,23 @@ The scan model is:
 This behavior is controlled by the Settings toggle `Treat stories folders as
 normal app folders`. When that legacy mode is enabled, `stories/` folders are
 discovered like ordinary app folders again.
+
+## Excluded folders
+
+Foldergram merges exclusion rules from:
+
+- `GALLERY_EXCLUDED_FOLDERS`
+- custom rules saved from `Settings -> General Settings`
+
+Rule semantics are intentionally simple:
+
+- values without a slash match folder names anywhere in the gallery tree
+- values with a slash match one exact relative path below `GALLERY_ROOT`
+
+Excluded folders are skipped during startup scans, rescans, and watcher-driven
+discovery work. Changing the saved runtime rules updates `app_settings`
+immediately, but a follow-up scan from `Settings -> Scan & Library` is still
+required so already-indexed matches can be soft-removed from the library.
 
 ## Storage layout
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,7 +121,7 @@ features:
 <div class="cs-feature">
 <div class="cs-feature-step">6</div>
 <h3>Maintain locally</h3>
-<p>Admins can run a manual scan, rebuild thumbnails only, or do a full library-index rebuild from Settings. All controls are local — no remote calls involved.</p>
+<p>Admins manage stories mode, excluded folders, and Home/Reels defaults from <code>General Settings</code>, then run scans or rebuilds from <code>Scan &amp; Library</code>. All controls are local — no remote calls involved.</p>
 </div>
 
 </div>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -99,6 +99,13 @@ The shipped Compose file includes `IMAGE_DETAIL_SOURCE: preview` and
 If you want lazy derivatives or original-backed image detail pages, edit those
 values in `docker-compose.yml` before starting the container.
 
+To skip specific source folders from the first scan in Docker, add
+`GALLERY_EXCLUDED_FOLDERS` under the Compose `environment:` block. For example:
+
+```yaml
+GALLERY_EXCLUDED_FOLDERS: "@eaDir,thumbnails,Archive/cache"
+```
+
 For an optional read-only public demo in Docker, add `PUBLIC_DEMO_MODE: "1"`
 under the Compose `environment:` block. If the browser-visible origin differs
 from the upstream Node host, also set `CSRF_TRUSTED_ORIGINS` to that public
@@ -108,6 +115,11 @@ If the app will be reachable from other devices on your network, enable the
 admin password from the Settings page after first startup. You can then keep
 the app admin-only, add a separate viewer password, or switch to public browse
 mode with admin unlock.
+
+The Settings sidebar separates app-wide preferences from maintenance actions:
+
+- `General Settings` contains stories mode, excluded folders, and Home/Reels defaults
+- `Scan & Library` contains manual scan plus rebuild actions
 
 ## If you already cloned this repository
 
@@ -167,7 +179,7 @@ The shipped `.env.example` keeps the development ports aligned like this:
 - `.webm`
 - `.mkv`
 
-## Default local paths
+## Default local paths and scan rules
 
 The shipped `.env.example` points at:
 
@@ -175,6 +187,7 @@ The shipped `.env.example` points at:
 | --- | --- |
 | `DATA_ROOT` | `./data` |
 | `GALLERY_ROOT` | `./data/gallery` |
+| `GALLERY_EXCLUDED_FOLDERS` | empty |
 | `DB_DIR` | `./data/db` |
 | `THUMBNAILS_DIR` | `./data/thumbnails` |
 | `PREVIEWS_DIR` | `./data/previews` |
@@ -182,6 +195,10 @@ The shipped `.env.example` points at:
 `DATA_ROOT` is the base path for this layout. If you change only `DATA_ROOT`,
 Foldergram will look for `gallery`, `db`, `thumbnails`, and `previews`
 under that directory unless you override those paths individually.
+
+`GALLERY_EXCLUDED_FOLDERS` accepts comma-separated folder rules. Names match
+any folder with that name anywhere in the gallery tree; values with a slash
+match one exact relative path below `GALLERY_ROOT`.
 
 Foldergram resolves relative paths from the repository root.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -67,8 +67,8 @@ In the default mode:
 - nested folders stay inside that same highlight capsule
 
 If you need folders literally named `stories` to behave like normal app
-folders, enable `Treat stories folders as normal app folders` in Settings and
-run a rescan.
+folders, open `Settings -> General Settings`, enable `Treat stories folders as
+normal app folders`, then run a rescan from `Settings -> Scan & Library`.
 
 ## 3. Start the container
 
@@ -91,6 +91,13 @@ production defaults plus the mounted `./data/...` volumes. The source-install
 
 The shipped Compose file sets `IMAGE_DETAIL_SOURCE=preview` and
 `DERIVATIVE_MODE=eager`.
+
+If you want Docker to skip specific source folders from the start, also add
+`GALLERY_EXCLUDED_FOLDERS` in `docker-compose.yml`, for example:
+
+```yaml
+GALLERY_EXCLUDED_FOLDERS: "@eaDir,thumbnails,Archive/cache"
+```
 
 For an optional read-only public demo in Docker, add
 `PUBLIC_DEMO_MODE="1"` under the Compose `environment:` block. If the
@@ -124,6 +131,11 @@ thumbnails or previews only when they are first requested.
 If you plan to expose Foldergram on a homelab or LAN, open Settings after the
 first load and enable the admin password. From there, you can keep admin-only
 access, add a separate viewer password, or switch to public browse mode.
+
+Inside Settings:
+
+- `General Settings` contains stories mode, excluded folders, and Home/Reels defaults
+- `Scan & Library` contains manual scan plus rebuild actions
 
 Until you enable password protection, Foldergram starts without an auth gate,
 so Settings and the library-maintenance controls are available immediately to

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -83,9 +83,27 @@ of a standalone app folder.
 
 If you want folders literally named `stories` to remain ordinary app folders:
 
-1. open Settings
+1. open `Settings -> General Settings`
 2. enable `Treat stories folders as normal app folders`
-3. save the change and let the library rescan
+3. save the change
+4. run a scan from `Settings -> Scan & Library`
+
+## A folder is still showing up after I excluded it
+
+Folder exclusions can come from:
+
+- `GALLERY_EXCLUDED_FOLDERS` in `.env` or Docker Compose
+- custom rules in `Settings -> General Settings`
+
+Check:
+
+- rules without a slash match folder names anywhere in the gallery tree
+- rules with a slash match one exact relative path below `GALLERY_ROOT`
+- env-backed rules require a restart to change
+- custom rules require `Save changes`, then a full scan from `Settings -> Scan & Library`
+
+If the folder was already indexed before the rule existed, it will stay visible
+until that scan finishes and soft-removes it from the index.
 
 ## Videos fail to index or generate previews
 

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import dotenv from 'dotenv';
 import { z } from 'zod';
 
+import { parseExcludedFolderRulesFromEnv } from '../utils/excluded-folder-rules.js';
 import { getRelativePathWithinRoot, isSameOrWithinPath, normalizePath } from '../utils/path-utils.js';
 
 const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
@@ -26,6 +27,7 @@ const envSchema = z.object({
   SCAN_DERIVATIVE_CONCURRENCY: z.coerce.number().int().min(1).max(32).default(4),
   PUBLIC_DEMO_MODE: z.string().optional(),
   CSRF_TRUSTED_ORIGINS: z.string().optional(),
+  GALLERY_EXCLUDED_FOLDERS: z.string().optional(),
   IMAGE_DETAIL_SOURCE: z.enum(['preview', 'original']).default('preview'),
   DERIVATIVE_MODE: z.enum(['eager', 'lazy']).default('eager'),
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development')
@@ -97,6 +99,7 @@ const previewsDir = resolveConfiguredPath(parsed.PREVIEWS_DIR, path.join(dataRoo
 const logVerbose = parseBooleanFlag(parsed.LOG_VERBOSE);
 const publicDemoMode = parseBooleanFlag(parsed.PUBLIC_DEMO_MODE);
 const csrfTrustedOrigins = parseConfiguredOrigins(parsed.CSRF_TRUSTED_ORIGINS);
+const galleryExcludedFolders = parseExcludedFolderRulesFromEnv(parsed.GALLERY_EXCLUDED_FOLDERS);
 
 const derivativeDirectoriesOverlap =
   isSameOrWithinPath(thumbnailsDir, previewsDir) || isSameOrWithinPath(previewsDir, thumbnailsDir);
@@ -132,6 +135,7 @@ export const appConfig = {
   thumbnailsDir,
   previewsDir,
   managedGalleryRelativeIgnores,
+  galleryExcludedFolders,
   logVerbose,
   publicDemoMode,
   csrfTrustedOrigins,

--- a/server/src/constants/app-setting-keys.ts
+++ b/server/src/constants/app-setting-keys.ts
@@ -2,6 +2,7 @@ export const LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY = 'scanner.last_successful
 export const LIBRARY_REBUILD_REQUIRED_SETTING_KEY = 'scanner.library_rebuild_required';
 export const PREVIOUS_GALLERY_ROOT_SETTING_KEY = 'scanner.previous_gallery_root';
 export const TREAT_STORIES_AS_FOLDERS_SETTING_KEY = 'library.treat_stories_as_folders';
+export const EXCLUDED_FOLDERS_SETTING_KEY = 'library.excluded_folders';
 export const STORIES_MIGRATION_DECISION_SETTING_KEY = 'library.stories_migration_decision';
 export const HOME_FEED_DEFAULT_MODE_SETTING_KEY = 'feed.default_home_mode';
 export const REELS_FEED_DEFAULT_MODE_SETTING_KEY = 'feed.default_reels_mode';

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -74,6 +74,9 @@ const reelsFeedDefaultBodySchema = z.object({
 const storiesModeBodySchema = z.object({
   treatStoriesAsFolders: z.boolean()
 });
+const excludedFoldersBodySchema = z.object({
+  rules: z.array(z.string()).default([])
+});
 
 const slugSchema = z.object({
   slug: z.string().min(1).max(240)
@@ -150,7 +153,8 @@ export const authRequestBodySchemas = {
 export const settingsRequestBodySchemas = {
   homeFeedDefault: homeFeedDefaultBodySchema,
   reelsFeedDefault: reelsFeedDefaultBodySchema,
-  storiesMode: storiesModeBodySchema
+  storiesMode: storiesModeBodySchema,
+  excludedFolders: excludedFoldersBodySchema
 };
 
 export const routeParamSchemas = {
@@ -373,6 +377,15 @@ router.put(
   (request, response) => {
     const body = storiesModeBodySchema.parse(request.body);
     response.json(galleryService.setTreatStoriesAsFolders(body.treatStoriesAsFolders));
+  }
+);
+
+router.put(
+  '/admin/settings/excluded-folders',
+  requireCapability('canAccessSettings', 'Admin access is required.'),
+  (request, response) => {
+    const body = excludedFoldersBodySchema.parse(request.body);
+    response.json(galleryService.setExcludedFolders(body.rules));
   }
 );
 

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -3,6 +3,7 @@ import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 
 import {
+  EXCLUDED_FOLDERS_SETTING_KEY,
   HOME_FEED_DEFAULT_MODE_SETTING_KEY,
   LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY,
   LIBRARY_REBUILD_REQUIRED_SETTING_KEY,
@@ -14,6 +15,11 @@ import {
 import { appConfig } from '../config/env.js';
 import { appSettingsRepository, folderRepository, folderScanStateRepository, imageRepository, likeRepository, scanRunRepository } from '../db/repositories.js';
 import type { FeedImage, FolderRecord, FolderSummaryRecord, ImageDetail, MediaType, PlaybackStrategy, TrashImage } from '../types/models.js';
+import {
+  getEffectiveExcludedFolderRules,
+  parseExcludedFolderRulesFromSetting,
+  serializeExcludedFolderRulesForSetting
+} from '../utils/excluded-folder-rules.js';
 import { deserializeImageExifData } from '../utils/exif-utils.js';
 import { buildMonthDayKey, countFeedBursts, diversifyFeedCandidates, groupFeedBursts, listMonthDayKeysAroundDate } from '../utils/feed-utils.js';
 import { shouldPreferMomentRail, type FeedRailKind } from '../utils/feed-rail-utils.js';
@@ -123,6 +129,24 @@ function getDefaultReelsFeedMode(): ReelsFeedMode {
 
 function getTreatStoriesAsFolders(): boolean {
   return parseTreatStoriesAsFoldersSetting(appSettingsRepository.get(TREAT_STORIES_AS_FOLDERS_SETTING_KEY));
+}
+
+function getCustomExcludedFolders(): string[] {
+  return parseExcludedFolderRulesFromSetting(appSettingsRepository.get(EXCLUDED_FOLDERS_SETTING_KEY));
+}
+
+function getExcludedFolderSettings() {
+  const envExcludedFolders = [...appConfig.galleryExcludedFolders];
+  const customExcludedFolders = getCustomExcludedFolders();
+
+  return {
+    envExcludedFolders,
+    customExcludedFolders,
+    effectiveExcludedFolders: getEffectiveExcludedFolderRules({
+      envRules: envExcludedFolders,
+      customRules: customExcludedFolders
+    })
+  };
 }
 
 function getStoriesMigrationStatus() {
@@ -1322,6 +1346,7 @@ export const galleryService = {
     const defaultReelsFeedMode = getDefaultReelsFeedMode();
     const treatStoriesAsFolders = getTreatStoriesAsFolders();
     const storiesMigration = getStoriesMigrationStatus();
+    const excludedFolders = getExcludedFolderSettings();
 
     return {
       folders: storageState.libraryAvailable ? folderRepository.count() : 0,
@@ -1353,7 +1378,8 @@ export const galleryService = {
         defaultReelsFeedMode,
         treatStoriesAsFolders
       },
-      storiesMigration
+      storiesMigration,
+      excludedFolders
     };
   },
 
@@ -1379,6 +1405,21 @@ export const galleryService = {
 
     return {
       treatStoriesAsFolders
+    };
+  },
+
+  setExcludedFolders(rules: string[]) {
+    const serializedRules = serializeExcludedFolderRulesForSetting(rules);
+
+    if (serializedRules.length > 0) {
+      appSettingsRepository.set(EXCLUDED_FOLDERS_SETTING_KEY, serializedRules);
+    } else {
+      appSettingsRepository.remove(EXCLUDED_FOLDERS_SETTING_KEY);
+    }
+
+    return {
+      ...getExcludedFolderSettings(),
+      requiresScan: true
     };
   },
 

--- a/server/src/services/scanner-service.ts
+++ b/server/src/services/scanner-service.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import pLimit from 'p-limit';
 
 import {
+  EXCLUDED_FOLDERS_SETTING_KEY,
   LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY,
   LIBRARY_REBUILD_REQUIRED_SETTING_KEY,
   PREVIOUS_GALLERY_ROOT_SETTING_KEY,
@@ -41,6 +42,11 @@ import {
   isHiddenPath,
   normalizePath
 } from '../utils/path-utils.js';
+import {
+  getEffectiveExcludedFolderRules,
+  matchesExcludedFolder,
+  parseExcludedFolderRulesFromSetting
+} from '../utils/excluded-folder-rules.js';
 import {
   findReservedStoriesOwnerPath,
   isStoriesFolderName,
@@ -515,6 +521,17 @@ class ScannerService {
     return matchesRelativeRoot(relativePath, appConfig.managedGalleryRelativeIgnores);
   }
 
+  private getCustomExcludedFolderRules(): string[] {
+    return parseExcludedFolderRulesFromSetting(appSettingsRepository.get(EXCLUDED_FOLDERS_SETTING_KEY));
+  }
+
+  private getEffectiveExcludedFolderRules(): string[] {
+    return getEffectiveExcludedFolderRules({
+      envRules: appConfig.galleryExcludedFolders,
+      customRules: this.getCustomExcludedFolderRules()
+    });
+  }
+
   private shouldTreatStoriesAsFolders(): boolean {
     return parseTreatStoriesAsFoldersSetting(appSettingsRepository.get(TREAT_STORIES_AS_FOLDERS_SETTING_KEY));
   }
@@ -523,8 +540,13 @@ class ScannerService {
     currentAbsolutePath: string,
     onSourceFolder: (sourceFolder: SourceFolderCandidate) => Promise<void>,
     currentRelativePath: string | null = null,
-    treatStoriesAsFolders = this.shouldTreatStoriesAsFolders()
+    treatStoriesAsFolders = this.shouldTreatStoriesAsFolders(),
+    excludedFolderRules = this.getEffectiveExcludedFolderRules()
   ): Promise<void> {
+    if (currentRelativePath && matchesExcludedFolder(currentRelativePath, excludedFolderRules)) {
+      return;
+    }
+
     this.setProgress({
       currentFolder: currentRelativePath ? normalizePath(currentRelativePath) : ROOT_DISCOVERY_LABEL
     });
@@ -554,7 +576,7 @@ class ScannerService {
       }
 
       if (entry.isDirectory()) {
-        if (this.isManagedGalleryPath(relativeEntryPath)) {
+        if (this.isManagedGalleryPath(relativeEntryPath) || matchesExcludedFolder(relativeEntryPath, excludedFolderRules)) {
           continue;
         }
 
@@ -587,7 +609,13 @@ class ScannerService {
         continue;
       }
 
-      await this.walkMediaSourceFolders(childDirectory.absolutePath, onSourceFolder, childDirectory.relativePath, treatStoriesAsFolders);
+      await this.walkMediaSourceFolders(
+        childDirectory.absolutePath,
+        onSourceFolder,
+        childDirectory.relativePath,
+        treatStoriesAsFolders,
+        excludedFolderRules
+      );
     }
   }
 
@@ -739,7 +767,15 @@ class ScannerService {
     };
   }
 
-  private async collectRecursiveMediaFiles(currentAbsolutePath: string, currentRelativePath: string): Promise<IndexedFileReference[]> {
+  private async collectRecursiveMediaFiles(
+    currentAbsolutePath: string,
+    currentRelativePath: string,
+    excludedFolderRules: string[]
+  ): Promise<IndexedFileReference[]> {
+    if (matchesExcludedFolder(currentRelativePath, excludedFolderRules)) {
+      return [];
+    }
+
     const entries = await fs
       .readdir(currentAbsolutePath, { withFileTypes: true })
       .catch((error: unknown) => {
@@ -764,11 +800,11 @@ class ScannerService {
       }
 
       if (entry.isDirectory()) {
-        if (this.isManagedGalleryPath(relativeEntryPath)) {
+        if (this.isManagedGalleryPath(relativeEntryPath) || matchesExcludedFolder(relativeEntryPath, excludedFolderRules)) {
           continue;
         }
 
-        files.push(...await this.collectRecursiveMediaFiles(path.join(currentAbsolutePath, entry.name), relativeEntryPath));
+        files.push(...await this.collectRecursiveMediaFiles(path.join(currentAbsolutePath, entry.name), relativeEntryPath, excludedFolderRules));
         continue;
       }
 
@@ -792,7 +828,8 @@ class ScannerService {
     derivativeJobs: Map<string, DerivativeJob>,
     errors: string[],
     options: FullScanOptions,
-    context: ImageProcessingContext
+    context: ImageProcessingContext,
+    excludedFolderRules: string[]
   ): Promise<SourceFolderScanResult[]> {
     const ownerEntries = await fs
       .readdir(sourceFolder.absolutePath, { withFileTypes: true })
@@ -815,7 +852,12 @@ class ScannerService {
       }
 
       const relativeEntryPath = normalizePath(`${sourceFolder.relativePath}/${entry.name}`);
-      return !isHiddenPath(relativeEntryPath) && !this.isManagedGalleryPath(relativeEntryPath) && isStoriesFolderName(entry.name);
+      return (
+        !isHiddenPath(relativeEntryPath) &&
+        !this.isManagedGalleryPath(relativeEntryPath) &&
+        !matchesExcludedFolder(relativeEntryPath, excludedFolderRules) &&
+        isStoriesFolderName(entry.name)
+      );
     });
 
     if (!storiesDirectory) {
@@ -894,12 +936,20 @@ class ScannerService {
       }
 
       const capsuleRelativePath = normalizePath(`${storiesRelativePath}/${entry.name}`);
-      if (isHiddenPath(capsuleRelativePath) || this.isManagedGalleryPath(capsuleRelativePath)) {
+      if (
+        isHiddenPath(capsuleRelativePath) ||
+        this.isManagedGalleryPath(capsuleRelativePath) ||
+        matchesExcludedFolder(capsuleRelativePath, excludedFolderRules)
+      ) {
         continue;
       }
 
       const startedAt = performance.now();
-      const nestedFiles = await this.collectRecursiveMediaFiles(path.join(storiesAbsolutePath, entry.name), capsuleRelativePath);
+      const nestedFiles = await this.collectRecursiveMediaFiles(
+        path.join(storiesAbsolutePath, entry.name),
+        capsuleRelativePath,
+        excludedFolderRules
+      );
       if (nestedFiles.length === 0) {
         continue;
       }
@@ -1281,6 +1331,7 @@ class ScannerService {
       hasStoredGalleryRoot
     };
     const treatStoriesAsFolders = this.shouldTreatStoriesAsFolders();
+    const excludedFolderRules = this.getEffectiveExcludedFolderRules();
 
     if (!storageService.refreshAvailability().libraryAvailable) {
       return this.finishUnavailableRun(runId, reason);
@@ -1294,6 +1345,7 @@ class ScannerService {
         formatStep('root-changed', formatToggle(galleryRootChanged)),
         formatStep('stored-root', formatToggle(hasStoredGalleryRoot)),
         formatStep('stories-as-folders', formatToggle(treatStoriesAsFolders)),
+        excludedFolderRules.length > 0 ? formatStep('excluded-folders', excludedFolderRules.join(',')) : null,
         appConfig.managedGalleryRelativeIgnores.length > 0
           ? formatStep('ignored-managed-paths', appConfig.managedGalleryRelativeIgnores.join(','))
           : null,
@@ -1389,7 +1441,8 @@ class ScannerService {
             derivativeJobs,
             errors,
             options,
-            imageProcessingContext
+            imageProcessingContext,
+            excludedFolderRules
           );
 
           for (const storyResult of storyResults) {
@@ -1401,7 +1454,7 @@ class ScannerService {
           processedFolders: this.progress.processedFolders + 1
         });
         this.logProgress('folder');
-      }, null, treatStoriesAsFolders);
+      }, null, treatStoriesAsFolders, excludedFolderRules);
 
       for (const folder of existingFolders) {
         if (!discoveredFolderIds.has(folder.id)) {
@@ -1474,6 +1527,7 @@ class ScannerService {
     const normalizedPaths = [...new Set(relativePaths.map((value) => normalizePath(value)).filter(Boolean))];
     const impactedSourceFolders = new Set<string>();
     const treatStoriesAsFolders = this.shouldTreatStoriesAsFolders();
+    const excludedFolderRules = this.getEffectiveExcludedFolderRules();
 
     for (const relativePath of normalizedPaths) {
       if (isHiddenPath(relativePath)) {
@@ -1488,12 +1542,17 @@ class ScannerService {
         continue;
       }
 
+      const sourceFolderPath = getSourceFolderPathFromRelativePath(relativePath);
+      const exclusionTargetPath = sourceFolderPath ?? relativePath;
+      if (matchesExcludedFolder(exclusionTargetPath, excludedFolderRules)) {
+        continue;
+      }
+
       if (!treatStoriesAsFolders && findReservedStoriesOwnerPath(relativePath)) {
         fallbackReason = `${reason}:fallback`;
         break;
       }
 
-      const sourceFolderPath = getSourceFolderPathFromRelativePath(relativePath);
       if (!sourceFolderPath) {
         fallbackReason = `${reason}:fallback`;
         break;

--- a/server/src/services/watcher-service.ts
+++ b/server/src/services/watcher-service.ts
@@ -1,16 +1,26 @@
 import chokidar, { type FSWatcher } from 'chokidar';
 
 import { appConfig } from '../config/env.js';
+import { getEffectiveExcludedFolderRules, matchesExcludedFolder, parseExcludedFolderRulesFromSetting } from '../utils/excluded-folder-rules.js';
+import { EXCLUDED_FOLDERS_SETTING_KEY } from '../constants/app-setting-keys.js';
+import { appSettingsRepository } from '../db/repositories.js';
 import { scannerService } from './scanner-service.js';
 import { log } from './log-service.js';
 import { storageService } from './storage-service.js';
-import { getRelativeGalleryPath, isHiddenPath, matchesRelativeRoot } from '../utils/path-utils.js';
+import { getRelativeGalleryPath, getSourceFolderPathFromRelativePath, isHiddenPath, matchesRelativeRoot } from '../utils/path-utils.js';
 
 class WatcherService {
   private watcher: FSWatcher | null = null;
   private pendingPaths = new Set<string>();
   private debounceTimer: NodeJS.Timeout | null = null;
   private fullRescanRequested = false;
+
+  private getEffectiveExcludedFolderRules(): string[] {
+    return getEffectiveExcludedFolderRules({
+      envRules: appConfig.galleryExcludedFolders,
+      customRules: parseExcludedFolderRulesFromSetting(appSettingsRepository.get(EXCLUDED_FOLDERS_SETTING_KEY))
+    });
+  }
 
   async start(): Promise<void> {
     if (this.watcher || !appConfig.isDevelopment) {
@@ -36,6 +46,15 @@ class WatcherService {
       }
 
       if (matchesRelativeRoot(relativePath, appConfig.managedGalleryRelativeIgnores)) {
+        return;
+      }
+
+      const excludedFolderRules = this.getEffectiveExcludedFolderRules();
+      const exclusionTargetPath =
+        eventName === 'addDir' || eventName === 'unlinkDir'
+          ? relativePath
+          : (getSourceFolderPathFromRelativePath(relativePath) ?? relativePath);
+      if (matchesExcludedFolder(exclusionTargetPath, excludedFolderRules)) {
         return;
       }
 

--- a/server/src/utils/excluded-folder-rules.ts
+++ b/server/src/utils/excluded-folder-rules.ts
@@ -1,0 +1,103 @@
+import { isWithinRelativeRoot, normalizePath, splitPathSegments } from './path-utils.js';
+
+const EDGE_SLASH_PATTERN = /^\/+|\/+$/g;
+const UNSUPPORTED_PATTERN = /[*?]/;
+
+function uniq(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function normalizeRuleSegments(value: string): string[] {
+  return normalizePath(value)
+    .trim()
+    .replace(EDGE_SLASH_PATTERN, '')
+    .split('/')
+    .filter(Boolean);
+}
+
+export function normalizeExcludedFolderRule(rule: string): string {
+  const segments = normalizeRuleSegments(rule);
+
+  if (segments.length === 0) {
+    throw new Error('Excluded folder rules cannot be empty.');
+  }
+
+  if (segments.some((segment) => segment === '.' || segment === '..')) {
+    throw new Error(`Invalid excluded folder rule: ${rule}`);
+  }
+
+  if (segments.some((segment) => UNSUPPORTED_PATTERN.test(segment))) {
+    throw new Error(`Unsupported excluded folder rule: ${rule}`);
+  }
+
+  return segments.join('/');
+}
+
+export function normalizeExcludedFolderRules(rules: string[]): string[] {
+  return uniq(
+    rules
+      .map((rule) => normalizeExcludedFolderRule(rule))
+      .filter(Boolean)
+  );
+}
+
+export function parseExcludedFolderRulesFromEnv(value: string | undefined): string[] {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return [];
+  }
+
+  return normalizeExcludedFolderRules(
+    value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0)
+  );
+}
+
+export function parseExcludedFolderRulesFromSetting(value: string | null): string[] {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return [];
+  }
+
+  try {
+    return normalizeExcludedFolderRules(
+      value
+        .split(/\r?\n/u)
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0)
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function serializeExcludedFolderRulesForSetting(rules: string[]): string {
+  return normalizeExcludedFolderRules(rules).join('\n');
+}
+
+export function getEffectiveExcludedFolderRules({
+  envRules = [],
+  customRules = []
+}: {
+  envRules?: string[];
+  customRules?: string[];
+}): string[] {
+  return normalizeExcludedFolderRules([...envRules, ...customRules]);
+}
+
+export function matchesExcludedFolder(relativePath: string, rules: string[]): boolean {
+  const normalizedRelativePath = normalizeRuleSegments(relativePath).join('/');
+  if (normalizedRelativePath.length === 0 || rules.length === 0) {
+    return false;
+  }
+
+  const segments = splitPathSegments(normalizedRelativePath);
+
+  return rules.some((rule) => {
+    if (rule.includes('/')) {
+      return isWithinRelativeRoot(normalizedRelativePath, rule);
+    }
+
+    return segments.includes(rule);
+  });
+}

--- a/server/test/env-config.test.ts
+++ b/server/test/env-config.test.ts
@@ -45,12 +45,39 @@ describe.sequential('derivative mode env config', () => {
 
     expect(appConfig.imageDetailSource).toBe('preview');
     expect(appConfig.derivativeMode).toBe('eager');
+    expect(appConfig.galleryExcludedFolders).toEqual([]);
+  });
+
+  it('parses excluded folder env rules with trimming and dedupe', async () => {
+    await stubBaseEnv();
+    vi.stubEnv('GALLERY_EXCLUDED_FOLDERS', ' @eaDir , thumbnails , Archive/cache , @eaDir ');
+    vi.doMock('dotenv', () => ({
+      default: {
+        config: vi.fn()
+      }
+    }));
+
+    const { appConfig } = await import('../src/config/env.js') as EnvModule;
+
+    expect(appConfig.galleryExcludedFolders).toEqual(['@eaDir', 'thumbnails', 'Archive/cache']);
   });
 
   it('rejects invalid enum values for derivative-related env vars', async () => {
     await stubBaseEnv();
     vi.stubEnv('IMAGE_DETAIL_SOURCE', 'fullres');
     vi.stubEnv('DERIVATIVE_MODE', 'background');
+    vi.doMock('dotenv', () => ({
+      default: {
+        config: vi.fn()
+      }
+    }));
+
+    await expect(import('../src/config/env.js')).rejects.toThrow();
+  });
+
+  it('rejects invalid excluded folder env rules', async () => {
+    await stubBaseEnv();
+    vi.stubEnv('GALLERY_EXCLUDED_FOLDERS', '../outside,*/cache');
     vi.doMock('dotenv', () => ({
       default: {
         config: vi.fn()

--- a/server/test/excluded-folder-rules.test.ts
+++ b/server/test/excluded-folder-rules.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getEffectiveExcludedFolderRules,
+  matchesExcludedFolder,
+  normalizeExcludedFolderRules,
+  parseExcludedFolderRulesFromEnv,
+  parseExcludedFolderRulesFromSetting,
+  serializeExcludedFolderRulesForSetting
+} from '../src/utils/excluded-folder-rules.js';
+
+describe('excluded folder rules', () => {
+  it('parses env rules with trimming, slash normalization, and dedupe', () => {
+    expect(parseExcludedFolderRulesFromEnv(' @eaDir , Archive\\cache , thumbnails , @eaDir ')).toEqual([
+      '@eaDir',
+      'Archive/cache',
+      'thumbnails'
+    ]);
+  });
+
+  it('parses setting rules from textarea-style content', () => {
+    expect(parseExcludedFolderRulesFromSetting('@eaDir\r\n\n Archive/cache \nArchive\\cache\n')).toEqual([
+      '@eaDir',
+      'Archive/cache'
+    ]);
+  });
+
+  it('serializes normalized rules back to newline-separated storage', () => {
+    expect(serializeExcludedFolderRulesForSetting([' Archive/cache ', '@eaDir', 'Archive\\cache'])).toBe(
+      'Archive/cache\n@eaDir'
+    );
+  });
+
+  it('matches bare folder names anywhere in the folder tree', () => {
+    expect(matchesExcludedFolder('Trips/@eaDir', ['@eaDir'])).toBe(true);
+    expect(matchesExcludedFolder('Archive/2024/@eaDir', ['@eaDir'])).toBe(true);
+    expect(matchesExcludedFolder('Archive/cache', ['@eaDir'])).toBe(false);
+  });
+
+  it('matches exact relative folder roots and their descendants', () => {
+    expect(matchesExcludedFolder('Archive/cache', ['Archive/cache'])).toBe(true);
+    expect(matchesExcludedFolder('Archive/cache/nested', ['Archive/cache'])).toBe(true);
+    expect(matchesExcludedFolder('Archive/cache-2', ['Archive/cache'])).toBe(false);
+  });
+
+  it('builds the effective rule union across env and saved custom sources', () => {
+    expect(
+      getEffectiveExcludedFolderRules({
+        envRules: ['@eaDir'],
+        customRules: ['Archive/cache', '@eaDir']
+      })
+    ).toEqual(['@eaDir', 'Archive/cache']);
+  });
+
+  it('rejects invalid rules and unsupported wildcard syntax', () => {
+    expect(() => normalizeExcludedFolderRules(['.', '..', '../cache'])).toThrow();
+    expect(() => normalizeExcludedFolderRules(['cache/*'])).toThrow();
+    expect(() => normalizeExcludedFolderRules(['/'])).toThrow();
+  });
+});

--- a/server/test/excluded-folders-feature.test.ts
+++ b/server/test/excluded-folders-feature.test.ts
@@ -1,0 +1,250 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getMediaTypeFromExtension,
+  getPreviewRelativePath,
+  getThumbnailRelativePath
+} from '../src/utils/image-utils.js';
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type GalleryServiceModule = typeof import('../src/services/gallery-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type ScannerServiceModule = typeof import('../src/services/scanner-service.js');
+
+const generateThumbnailDerivativeMock = vi.fn();
+const generateDerivativesMock = vi.fn();
+const readMediaMetadataMock = vi.fn();
+
+describe.sequential('excluded folders feature', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let galleryService: GalleryServiceModule['galleryService'];
+  let scannerService: ScannerServiceModule['scannerService'];
+  let imageRepository: RepositoriesModule['imageRepository'];
+  let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-excluded-folders-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+    vi.stubEnv('GALLERY_EXCLUDED_FOLDERS', '');
+  });
+
+  beforeEach(async () => {
+    generateThumbnailDerivativeMock.mockReset();
+    generateDerivativesMock.mockReset();
+    readMediaMetadataMock.mockReset();
+
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.unstubAllEnvs();
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+    vi.stubEnv('GALLERY_EXCLUDED_FOLDERS', '');
+    vi.resetModules();
+    vi.doMock('../src/services/derivative-service.js', () => ({
+      generateDerivatives: generateDerivativesMock,
+      generateThumbnailDerivative: generateThumbnailDerivativeMock,
+      readMediaMetadata: readMediaMetadataMock
+    }));
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ galleryService } = await import('../src/services/gallery-service.js'));
+    ({ scannerService } = await import('../src/services/scanner-service.js'));
+    ({ imageRepository, maintenanceRepository } = await import('../src/db/repositories.js'));
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+
+    readMediaMetadataMock.mockImplementation(async (absolutePath: string) => {
+      const mediaType = getMediaTypeFromExtension(path.extname(absolutePath));
+      return {
+        width: mediaType === 'video' ? 1080 : 1600,
+        height: mediaType === 'video' ? 1920 : 1200,
+        takenAt: null,
+        durationMs: mediaType === 'video' ? 4_000 : null,
+        mediaType,
+        playbackStrategy: 'preview',
+        isAnimated: false
+      };
+    });
+
+    generateDerivativesMock.mockImplementation(async (_sourcePath: string, relativePath: string) => {
+      const mediaType = getMediaTypeFromExtension(path.extname(relativePath));
+
+      return {
+        width: mediaType === 'video' ? 1080 : 1600,
+        height: mediaType === 'video' ? 1920 : 1200,
+        takenAt: null,
+        durationMs: mediaType === 'video' ? 4_000 : null,
+        mediaType,
+        playbackStrategy: 'preview',
+        isAnimated: false,
+        thumbnailPath: getThumbnailRelativePath(relativePath),
+        previewPath: getPreviewRelativePath(relativePath, mediaType),
+        generatedThumbnail: true,
+        generatedPreview: true
+      };
+    });
+
+    maintenanceRepository.resetLibraryIndex();
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('applies env exclusions on the first scan and exposes them in admin stats', async () => {
+    vi.stubEnv('GALLERY_EXCLUDED_FOLDERS', '@eaDir,Archive/cache');
+    vi.resetModules();
+    vi.doMock('../src/services/derivative-service.js', () => ({
+      generateDerivatives: generateDerivativesMock,
+      generateThumbnailDerivative: generateThumbnailDerivativeMock,
+      readMediaMetadata: readMediaMetadataMock
+    }));
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ galleryService } = await import('../src/services/gallery-service.js'));
+    ({ scannerService } = await import('../src/services/scanner-service.js'));
+    ({ imageRepository, maintenanceRepository } = await import('../src/db/repositories.js'));
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+    maintenanceRepository.resetLibraryIndex();
+
+    await createSourceFile('Trips/photo-1.jpg');
+    await createSourceFile('Trips/@eaDir/ignored.jpg');
+    await createSourceFile('Archive/cache/ignored-2.jpg');
+
+    await scannerService.scanAll('manual');
+
+    expect(galleryService.listFolders().map((folder) => folder.folderPath)).toEqual(['Trips']);
+    expect(imageRepository.getByRelativePath('Trips/@eaDir/ignored.jpg')).toBeUndefined();
+    expect(imageRepository.getByRelativePath('Archive/cache/ignored-2.jpg')).toBeUndefined();
+    expect(galleryService.getStats().excludedFolders).toEqual({
+      envExcludedFolders: ['@eaDir', 'Archive/cache'],
+      customExcludedFolders: [],
+      effectiveExcludedFolders: ['@eaDir', 'Archive/cache']
+    });
+  });
+
+  it('stores custom exclusions, skips incremental updates under excluded folders, and soft-deletes them on the next full scan', async () => {
+    await createSourceFile('Trips/photo-1.jpg');
+    await createSourceFile('Trips/cache/old-1.jpg');
+    await createSourceFile('Archive/cache/old-2.jpg');
+
+    await scannerService.scanAll('manual');
+
+    expect(galleryService.listFolders().map((folder) => folder.folderPath).sort()).toEqual([
+      'Archive/cache',
+      'Trips',
+      'Trips/cache'
+    ]);
+
+    expect(galleryService.setExcludedFolders(['cache'])).toEqual({
+      envExcludedFolders: [],
+      customExcludedFolders: ['cache'],
+      effectiveExcludedFolders: ['cache'],
+      requiresScan: true
+    });
+
+    await createSourceFile('Trips/cache/new-3.jpg');
+    await scannerService.scanChangedPaths(['Trips/cache/new-3.jpg'], 'watcher');
+
+    expect(imageRepository.getByRelativePath('Trips/cache/new-3.jpg')).toBeUndefined();
+
+    await scannerService.scanAll('manual');
+
+    expect(galleryService.listFolders().map((folder) => folder.folderPath)).toEqual(['Trips']);
+    expect(imageRepository.getByRelativePath('Trips/cache/old-1.jpg')?.is_deleted).toBe(1);
+    expect(imageRepository.getByRelativePath('Archive/cache/old-2.jpg')?.is_deleted).toBe(1);
+  });
+
+  it('prevents reserved stories folders from being indexed when the exclusion rules match them', async () => {
+    galleryService.setExcludedFolders(['stories']);
+
+    await createSourceFile('Albums/beach/photo-main.jpg');
+    await createSourceFile('Albums/beach/stories/avatar-1.jpg');
+    await createSourceFile('Albums/beach/stories/highlights/day-1.jpg');
+
+    await scannerService.scanAll('manual');
+
+    const folder = galleryService.listFolders()[0]!;
+    expect(folder.folderPath).toBe('Albums/beach');
+    expect(folder.hasAvatarStory).toBe(false);
+    expect(galleryService.getFolderStories(folder.slug)?.items).toEqual([]);
+    expect(galleryService.searchMedia('avatar-1', 1, 20).total).toBe(0);
+  });
+
+  it('keeps managed gallery roots separate from bare-name excluded folder matching', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'gallery', 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+    vi.stubEnv('GALLERY_EXCLUDED_FOLDERS', '');
+    vi.resetModules();
+    vi.doMock('../src/services/derivative-service.js', () => ({
+      generateDerivatives: generateDerivativesMock,
+      generateThumbnailDerivative: generateThumbnailDerivativeMock,
+      readMediaMetadata: readMediaMetadataMock
+    }));
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ galleryService } = await import('../src/services/gallery-service.js'));
+    ({ scannerService } = await import('../src/services/scanner-service.js'));
+    ({ imageRepository, maintenanceRepository } = await import('../src/db/repositories.js'));
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+    maintenanceRepository.resetLibraryIndex();
+
+    await createSourceFile('thumbnails/managed-1.jpg');
+    await createSourceFile('Trips/photo-1.jpg');
+    await createSourceFile('Trips/thumbnails/photo-2.jpg');
+
+    await scannerService.scanAll('manual');
+
+    expect(galleryService.listFolders().map((folder) => folder.folderPath).sort()).toEqual(['Trips', 'Trips/thumbnails']);
+    expect(imageRepository.getByRelativePath('thumbnails/managed-1.jpg')).toBeUndefined();
+    expect(imageRepository.getByRelativePath('Trips/thumbnails/photo-2.jpg')?.is_deleted).toBe(0);
+
+    await createSourceFile('Trips/thumbnails/photo-3.jpg');
+    await scannerService.scanChangedPaths(['Trips/thumbnails/photo-3.jpg'], 'watcher');
+
+    expect(imageRepository.getByRelativePath('Trips/thumbnails/photo-3.jpg')?.is_deleted).toBe(0);
+  });
+
+  async function createSourceFile(relativePath: string): Promise<void> {
+    const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, `source:${relativePath}`);
+  }
+});


### PR DESCRIPTION
Closes #28 

## Summary

- adds configurable excluded folders for gallery discovery, rescans, and watcher-driven indexing
- supports excluded folder rules from both deploy-time config (.env file or inside docker file) and runtime app settings.
- adds a dedicated `General Settings` section in the Settings sidebar for app-wide controls
- shows env-backed excluded-folder rules as read-only in Settings and allows custom runtime rules to be edited there
- clarifies in the UI that stories-mode and excluded-folder changes require a follow-up scan
- updates docs and config examples to cover `GALLERY_EXCLUDED_FOLDERS`, the new Settings layout, and the save/rescan workflow

Closes the excluded folders feature request.