### PR TITLE
Fix trash state freshness and empty-trash loading behavior

### DIFF
--- a/client/src/api/http.test.ts
+++ b/client/src/api/http.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { requestJson } from './http';
+
+describe('requestJson', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses no-store caching for safe reads by default', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ ok: true })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await requestJson('/api/feed');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/feed',
+      expect.objectContaining({
+        cache: 'no-store',
+        credentials: 'same-origin'
+      })
+    );
+  });
+
+  it('preserves an explicit cache mode when one is provided', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ ok: true })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await requestJson('/api/feed', {
+      cache: 'reload'
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/feed',
+      expect.objectContaining({
+        cache: 'reload'
+      })
+    );
+  });
+});

--- a/client/src/api/http.ts
+++ b/client/src/api/http.ts
@@ -14,6 +14,7 @@ export class RequestError extends Error {
 export async function requestJson<T>(input: RequestInfo | URL, init?: RequestInit): Promise<T> {
   const method = (init?.method ?? 'GET').toUpperCase();
   const headers = new Headers(init?.headers);
+  const isSafeRead = method === 'GET' || method === 'HEAD';
 
   if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
     headers.set('x-foldergram-intent', '1');
@@ -21,6 +22,7 @@ export async function requestJson<T>(input: RequestInfo | URL, init?: RequestIni
 
   const response = await fetch(input, {
     ...init,
+    cache: init?.cache ?? (isSafeRead ? 'no-store' : undefined),
     credentials: 'same-origin',
     headers
   });

--- a/client/src/stores/trash.test.ts
+++ b/client/src/stores/trash.test.ts
@@ -1,0 +1,77 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useTrashStore } from './trash';
+
+const { fetchTrashImagesMock } = vi.hoisted(() => ({
+  fetchTrashImagesMock: vi.fn()
+}));
+
+vi.mock('../api/gallery', () => ({
+  fetchTrashImages: fetchTrashImagesMock
+}));
+
+function createDeferred<T>() {
+  let resolve: ((value: T) => void) | null = null;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+
+  return {
+    promise,
+    resolve(value: T) {
+      resolve?.(value);
+    }
+  };
+}
+
+describe('trash store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    fetchTrashImagesMock.mockReset();
+  });
+
+  it('keeps initialized empty state visible during a forced refresh', async () => {
+    const trashStore = useTrashStore();
+    const deferred = createDeferred<{
+      items: [];
+      page: number;
+      limit: number;
+      total: number;
+      hasMore: boolean;
+    }>();
+
+    trashStore.$patch({
+      items: [],
+      page: 2,
+      hasMore: false,
+      loading: false,
+      error: null,
+      initialized: true
+    });
+
+    fetchTrashImagesMock.mockReturnValue(deferred.promise);
+
+    const refreshPromise = trashStore.loadInitial(true);
+
+    expect(trashStore.loading).toBe(true);
+    expect(trashStore.initialized).toBe(true);
+    expect(trashStore.items).toEqual([]);
+
+    deferred.resolve({
+      items: [],
+      page: 1,
+      limit: trashStore.limit,
+      total: 0,
+      hasMore: false
+    });
+
+    await refreshPromise;
+
+    expect(trashStore.loading).toBe(false);
+    expect(trashStore.initialized).toBe(true);
+    expect(trashStore.items).toEqual([]);
+    expect(trashStore.hasMore).toBe(false);
+    expect(trashStore.page).toBe(2);
+  });
+});

--- a/client/src/stores/trash.ts
+++ b/client/src/stores/trash.ts
@@ -51,12 +51,31 @@ export const useTrashStore = defineStore('trash', {
         return;
       }
 
-      this.items = [];
+      const preserveExistingState = force && this.initialized;
+
       this.page = 1;
       this.hasMore = true;
+
+      if (!preserveExistingState) {
+        this.items = [];
+        this.error = null;
+        this.initialized = false;
+      }
+
+      this.loading = true;
       this.error = null;
-      this.initialized = false;
-      await this.loadMore();
+
+      try {
+        const payload = await fetchTrashImages(this.page, this.limit);
+        this.items = payload.items;
+        this.page += 1;
+        this.hasMore = payload.hasMore;
+        this.initialized = true;
+      } catch (error) {
+        this.error = error instanceof Error ? error.message : 'Unable to load trash';
+      } finally {
+        this.loading = false;
+      }
     },
 
     async loadMore() {

--- a/client/src/views/TrashView.test.ts
+++ b/client/src/views/TrashView.test.ts
@@ -1,0 +1,273 @@
+import { defineComponent } from 'vue';
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TrashItem } from '../types/api';
+import { useAppStore } from '../stores/app';
+import { useFeedStore } from '../stores/feed';
+import { useFoldersStore } from '../stores/folders';
+import { useLikesStore } from '../stores/likes';
+import { useMomentsStore } from '../stores/moments';
+import { useTrashStore } from '../stores/trash';
+import TrashView from './TrashView.vue';
+
+const { restoreImageMock, deleteImageMock } = vi.hoisted(() => ({
+  restoreImageMock: vi.fn(),
+  deleteImageMock: vi.fn()
+}));
+
+vi.mock('../api/gallery', async () => {
+  const actual = await vi.importActual<typeof import('../api/gallery')>('../api/gallery');
+
+  return {
+    ...actual,
+    restoreImage: restoreImageMock,
+    deleteImage: deleteImageMock
+  };
+});
+
+vi.mock('../components/ConfirmDialog.vue', async () => {
+  const { defineComponent } = await import('vue');
+
+  return {
+    default: defineComponent({
+      name: 'ConfirmDialog',
+      props: {
+        loading: Boolean
+      },
+      emits: ['cancel', 'confirm'],
+      template: `
+        <div data-test="confirm-dialog">
+          <button data-test="confirm-button" type="button" :disabled="loading" @click="$emit('confirm')">Confirm</button>
+          <button data-test="cancel-button" type="button" @click="$emit('cancel')">Cancel</button>
+          <slot />
+          <slot name="details" />
+        </div>
+      `
+    })
+  };
+});
+
+vi.mock('../components/EmptyState.vue', async () => ({
+  default: defineComponent({
+    name: 'EmptyState',
+    template: '<div data-test="empty-state" />'
+  })
+}));
+
+vi.mock('../components/ErrorState.vue', async () => ({
+  default: defineComponent({
+    name: 'ErrorState',
+    template: '<div data-test="error-state" />'
+  })
+}));
+
+vi.mock('../components/InfiniteLoader.vue', async () => ({
+  default: defineComponent({
+    name: 'InfiniteLoader',
+    template: '<div data-test="infinite-loader" />'
+  })
+}));
+
+vi.mock('../components/ResilientImage.vue', async () => ({
+  default: defineComponent({
+    name: 'ResilientImage',
+    template: '<img data-test="resilient-image" />'
+  })
+}));
+
+function createTrashItem(id: number): TrashItem {
+  return {
+    id,
+    folderId: 12,
+    folderSlug: 'trip',
+    folderName: 'Trip',
+    folderPath: 'trip',
+    folderBreadcrumb: null,
+    filename: `photo-${id}.jpg`,
+    width: 1200,
+    height: 800,
+    mediaType: 'image',
+    durationMs: null,
+    isAnimated: false,
+    thumbnailUrl: `/thumbnails/${id}.webp`,
+    previewUrl: `/previews/${id}.webp`,
+    sortTimestamp: 1_777_000_000_000 + id,
+    takenAt: 1_777_000_000_000 + id,
+    trashedAt: '2026-04-04T12:00:00.000Z'
+  };
+}
+
+function createDeferred() {
+  let resolve: (() => void) | null = null;
+  const promise = new Promise<void>((nextResolve) => {
+    resolve = nextResolve;
+  });
+
+  return {
+    promise,
+    resolve: () => resolve?.()
+  };
+}
+
+describe('TrashView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    restoreImageMock.mockReset();
+    deleteImageMock.mockReset();
+  });
+
+  it('closes the restore dialog without waiting for background refreshes', async () => {
+    const appStore = useAppStore();
+    const trashStore = useTrashStore();
+    const foldersStore = useFoldersStore();
+    const feedStore = useFeedStore();
+    const likesStore = useLikesStore();
+    const momentsStore = useMomentsStore();
+    const backgroundRefresh = createDeferred();
+    const item = createTrashItem(41);
+
+    appStore.$patch({
+      stats: {
+        folders: 1,
+        indexedImages: 1,
+        indexedVideos: 0,
+        scan: {
+          isScanning: false,
+          lastCompletedScan: null
+        },
+        storage: {
+          available: true,
+          reason: null
+        },
+        libraryIndex: {
+          rebuildRequired: false,
+          reason: null,
+          ignoredRootMediaCount: 0
+        },
+        preferences: {
+          defaultHomeFeedMode: 'random',
+          defaultReelsFeedMode: 'recommended',
+          treatStoriesAsFolders: false
+        },
+        storiesMigration: {
+          hasLegacyStoriesCandidates: false,
+          decisionPending: false
+        }
+      } as never
+    });
+
+    trashStore.$patch({
+      items: [item],
+      initialized: true,
+      loading: false,
+      hasMore: false,
+      error: null
+    });
+
+    vi.spyOn(trashStore, 'loadInitial').mockResolvedValue(undefined);
+    vi.spyOn(foldersStore, 'fetchFolders').mockReturnValue(backgroundRefresh.promise);
+    vi.spyOn(feedStore, 'loadInitial').mockReturnValue(backgroundRefresh.promise);
+    vi.spyOn(likesStore, 'initialize').mockReturnValue(backgroundRefresh.promise);
+    vi.spyOn(momentsStore, 'fetchMoments').mockReturnValue(backgroundRefresh.promise);
+    vi.spyOn(appStore, 'fetchStats').mockReturnValue(backgroundRefresh.promise);
+    restoreImageMock.mockResolvedValue({
+      id: item.id,
+      folderSlug: item.folderSlug
+    });
+
+    const wrapper = mount(TrashView, {
+      global: {
+        stubs: {
+          RouterLink: {
+            template: '<a><slot /></a>'
+          }
+        }
+      }
+    });
+
+    await wrapper.get('input[type="checkbox"]').setValue(true);
+    const restoreButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'Restore');
+
+    expect(restoreButton).toBeDefined();
+
+    await restoreButton!.trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="confirm-dialog"]').exists()).toBe(true);
+
+    await wrapper.get('[data-test="confirm-button"]').trigger('click');
+    await flushPromises();
+
+    expect(restoreImageMock).toHaveBeenCalledWith(item.id);
+    expect(foldersStore.fetchFolders).toHaveBeenCalledWith(true);
+    expect(wrapper.find('[data-test="confirm-dialog"]').exists()).toBe(false);
+    expect(trashStore.items).toEqual([]);
+
+    backgroundRefresh.resolve();
+    await flushPromises();
+  });
+
+  it('shows the empty state instead of the blocking loader while an initialized empty trash refresh is running', async () => {
+    const appStore = useAppStore();
+    const trashStore = useTrashStore();
+
+    appStore.$patch({
+      stats: {
+        folders: 1,
+        indexedImages: 1,
+        indexedVideos: 0,
+        scan: {
+          isScanning: false,
+          lastCompletedScan: null
+        },
+        storage: {
+          available: true,
+          reason: null
+        },
+        libraryIndex: {
+          rebuildRequired: false,
+          reason: null,
+          ignoredRootMediaCount: 0
+        },
+        preferences: {
+          defaultHomeFeedMode: 'random',
+          defaultReelsFeedMode: 'recommended',
+          treatStoriesAsFolders: false
+        },
+        storiesMigration: {
+          hasLegacyStoriesCandidates: false,
+          decisionPending: false
+        }
+      } as never
+    });
+
+    trashStore.$patch({
+      items: [],
+      initialized: true,
+      loading: true,
+      hasMore: false,
+      error: null
+    });
+
+    vi.spyOn(trashStore, 'loadInitial').mockResolvedValue(undefined);
+
+    const wrapper = mount(TrashView, {
+      global: {
+        stubs: {
+          RouterLink: {
+            template: '<a><slot /></a>'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="empty-state"]').exists()).toBe(true);
+    expect(wrapper.text()).not.toContain('Loading trash...');
+  });
+});

--- a/client/src/views/TrashView.vue
+++ b/client/src/views/TrashView.vue
@@ -47,7 +47,7 @@
         {{ actionError }}
       </p>
 
-      <section v-if="trashStore.loading && trashStore.items.length === 0" class="card p-8 text-center">
+      <section v-if="trashStore.loading && !trashStore.initialized && trashStore.items.length === 0" class="card p-8 text-center">
         <p class="m-0 text-muted">Loading trash...</p>
       </section>
       <EmptyState
@@ -243,10 +243,19 @@ async function refreshVisibleData() {
   ]);
 }
 
+function refreshVisibleDataInBackground() {
+  void refreshVisibleData().catch((error) => {
+    actionError.value = error instanceof Error ? error.message : 'Unable to refresh the updated library state.';
+  });
+}
+
 async function processSelection(action: 'restore' | 'delete') {
   const ids = [...selectedIds.value];
   if (ids.length === 0) {
-    return;
+    return {
+      succeededCount: 0,
+      failedCount: 0
+    };
   }
 
   processing.value = true;
@@ -270,7 +279,6 @@ async function processSelection(action: 'restore' | 'delete') {
   if (succeeded.length > 0) {
     trashStore.removeItems(succeeded);
     selectedIds.value = selectedIds.value.filter((id) => !succeeded.includes(id));
-    await refreshVisibleData();
   }
 
   if (failedCount > 0) {
@@ -278,20 +286,38 @@ async function processSelection(action: 'restore' | 'delete') {
   }
 
   processing.value = false;
+
+  if (succeeded.length > 0) {
+    refreshVisibleDataInBackground();
+  }
+
+  return {
+    succeededCount: succeeded.length,
+    failedCount
+  };
 }
 
 async function handleRestore() {
-  await processSelection('restore');
-  restoreConfirmOpen.value = false;
+  const result = await processSelection('restore');
+  if (result.succeededCount > 0 || result.failedCount === 0) {
+    restoreConfirmOpen.value = false;
+  }
 }
 
 async function handlePermanentDelete() {
-  await processSelection('delete');
-  permanentConfirmOpen.value = false;
+  const result = await processSelection('delete');
+  if (result.succeededCount > 0 || result.failedCount === 0) {
+    permanentConfirmOpen.value = false;
+  }
 }
 
 onMounted(async () => {
   if (appStore.isLibraryUnavailable) {
+    return;
+  }
+
+  if (trashStore.initialized) {
+    void trashStore.loadInitial(true);
     return;
   }
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -8,8 +8,16 @@ import { requireApiAuthentication, requireMediaAuthentication } from './middlewa
 import { requireTrustedMutationRequest } from './middleware/csrf-protection.js';
 import { blockPublicDemoMutations } from './middleware/public-demo-mode.js';
 import { apiRouter } from './routes/api.js';
+import { authService } from './services/auth-service.js';
 import { lazyThumbnailsRouter, lazyPreviewsRouter } from './routes/lazy-derivatives.js';
 import { createProtectedStaticOptions } from './utils/media-response.js';
+
+export function applyApiNoStoreHeaders(response: Pick<express.Response, 'setHeader'>) {
+  authService.setNoStoreHeaders(response as express.Response);
+  if (authService.isEnabled()) {
+    response.setHeader('Vary', 'Cookie');
+  }
+}
 
 export function createApp() {
   const app = express();
@@ -24,6 +32,10 @@ export function createApp() {
     app.use('/previews', requireMediaAuthentication, express.static(appConfig.previewsDir, createProtectedStaticOptions()));
   }
 
+  app.use('/api', (_request, response, next) => {
+    applyApiNoStoreHeaders(response);
+    next();
+  });
   app.use('/api', blockPublicDemoMutations, requireTrustedMutationRequest, requireApiAuthentication, apiRouter);
 
   if (appConfig.nodeEnv === 'production') {

--- a/server/test/api-cache-control.test.ts
+++ b/server/test/api-cache-control.test.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type AppModule = typeof import('../src/app.js');
+type AuthServiceModule = typeof import('../src/services/auth-service.js');
+
+describe.sequential('api cache control', () => {
+  let tempRoot = '';
+  let applyApiNoStoreHeaders: AppModule['applyApiNoStoreHeaders'];
+  let authService: AuthServiceModule['authService'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-api-cache-control-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.resetModules();
+    ({ applyApiNoStoreHeaders } = await import('../src/app.js'));
+    ({ authService } = await import('../src/services/auth-service.js'));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('marks API responses as no-store when auth is disabled', () => {
+    const response = {
+      setHeader: vi.fn()
+    };
+
+    expect(authService.isEnabled()).toBe(false);
+
+    applyApiNoStoreHeaders(response as never);
+
+    expect(response.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+    expect(response.setHeader).not.toHaveBeenCalledWith('Vary', 'Cookie');
+  });
+});


### PR DESCRIPTION
Fixes #48 

This updates the trash flow so delete and restore actions reflect immediately and consistently, prevents stale cached API reads from bringing removed posts back after refresh, and avoids showing a blocking loading state when Trash is already empty.