### PR TITLE
Support gallery root relocation without rebuilding the index

### DIFF
--- a/server/src/db/repositories.ts
+++ b/server/src/db/repositories.ts
@@ -1,5 +1,5 @@
 import { databaseManager } from './database.js';
-import { normalizePath } from '../utils/path-utils.js';
+import { normalizePath, safeJoin } from '../utils/path-utils.js';
 import type {
   AppSettingRecord,
   FeedImage,
@@ -1436,6 +1436,28 @@ export const imageRepository = {
     return database
       .prepare('SELECT * FROM images WHERE is_deleted = 0 ORDER BY folder_id ASC, sort_timestamp DESC, id DESC')
       .all() as unknown as ImageRecord[];
+  },
+
+  refreshAbsolutePathsForGalleryRoot(galleryRoot: string): number {
+    const rows = database
+      .prepare('SELECT id, relative_path, absolute_path FROM images WHERE is_deleted = 0 ORDER BY id ASC')
+      .all() as Array<Pick<ImageRecord, 'id' | 'relative_path' | 'absolute_path'>>;
+    const update = database.prepare('UPDATE images SET absolute_path = ?, updated_at = ? WHERE id = ?');
+    const updatedAt = nowIso();
+    let refreshed = 0;
+
+    for (const row of rows) {
+      const nextAbsolutePath = safeJoin(galleryRoot, row.relative_path);
+
+      if (normalizePath(row.absolute_path) === normalizePath(nextAbsolutePath)) {
+        continue;
+      }
+
+      const result = update.run(nextAbsolutePath, updatedAt, row.id);
+      refreshed += Number(result.changes ?? 0);
+    }
+
+    return refreshed;
   },
 
   listByIdRange(afterId: number, limit: number): ImageRecord[] {

--- a/server/src/routes/lazy-derivatives.ts
+++ b/server/src/routes/lazy-derivatives.ts
@@ -7,6 +7,8 @@ import { appConfig } from '../config/env.js';
 import { imageRepository } from '../db/repositories.js';
 import { log } from '../services/log-service.js';
 import { generateThumbnailDerivative, writeImagePreview, writeVideoPreview } from '../services/derivative-service.js';
+import { scannerService } from '../services/scanner-service.js';
+import { resolveOriginalPath } from '../utils/media-paths.js';
 import { applyDerivativeErrorHeaders, applyProtectedMediaHeaders } from '../utils/media-response.js';
 import { normalizePath, safeJoin } from '../utils/path-utils.js';
 
@@ -102,6 +104,12 @@ async function serveOrGenerate(
     // File does not exist — fall through to generation.
   }
 
+  if (scannerService.isLibraryRebuildRequired()) {
+    applyDerivativeErrorHeaders(response);
+    response.status(409).json({ message: 'Library rebuild required before generating derivatives.' });
+    return;
+  }
+
   // Look up the source row by derivative path.
   const imageRecord =
     kind === 'thumbnail'
@@ -126,8 +134,10 @@ async function serveOrGenerate(
 
     generationPromise = generationLimit(async () => {
       try {
+        const sourcePath = resolveOriginalPath(imageRecord.relative_path);
+
         if (kind === 'thumbnail') {
-          await generateThumbnailDerivative(imageRecord.absolute_path, imageRecord.relative_path, false, {
+          await generateThumbnailDerivative(sourcePath, imageRecord.relative_path, false, {
             thumbnailPath: imageRecord.thumbnail_path
           });
           return;
@@ -139,7 +149,7 @@ async function serveOrGenerate(
             throw new Error('Invalid derivative path.');
           }
 
-          await writeVideoPreview(imageRecord.absolute_path, previewAbsolutePath);
+          await writeVideoPreview(sourcePath, previewAbsolutePath);
           return;
         }
 
@@ -148,7 +158,7 @@ async function serveOrGenerate(
           throw new Error('Invalid derivative path.');
         }
 
-        await writeImagePreview(imageRecord.absolute_path, previewAbsolutePath);
+        await writeImagePreview(sourcePath, previewAbsolutePath);
       } finally {
         inflightGenerations.delete(absoluteOutputPath);
       }

--- a/server/src/services/derivative-migration-service.ts
+++ b/server/src/services/derivative-migration-service.ts
@@ -11,6 +11,7 @@ import { appConfig } from '../config/env.js';
 import { appSettingsRepository, imageRepository } from '../db/repositories.js';
 import type { ImageRecord } from '../types/models.js';
 import { getMediaTypeFromExtension, getPreviewRelativePath, getThumbnailRelativePath } from '../utils/image-utils.js';
+import { resolveOriginalPath } from '../utils/media-paths.js';
 import {
   DERIVATIVE_STORAGE_LAYOUT_VERSION,
   LEGACY_DERIVATIVE_STORAGE_LAYOUT_VERSIONS,
@@ -524,12 +525,19 @@ class DerivativeMigrationService {
 
     const thumbnailAbsolutePath = safeJoin(appConfig.thumbnailsDir, targetThumbnailPath);
     const previewAbsolutePath = safeJoin(appConfig.previewsDir, targetPreviewPath);
-    const sourceExists = await fileExists(row.absolute_path);
+    let sourcePath: string | null = null;
+    try {
+      sourcePath = resolveOriginalPath(row.relative_path);
+    } catch {
+      sourcePath = null;
+    }
+
+    const sourceExists = sourcePath ? await fileExists(sourcePath) : false;
     const thumbnailExistsBeforeGenerate = await fileExists(thumbnailAbsolutePath);
     const previewExistsBeforeGenerate = await fileExists(previewAbsolutePath);
 
-    if ((!thumbnailExistsBeforeGenerate || !previewExistsBeforeGenerate) && sourceExists) {
-      const derivatives = await generateDerivatives(row.absolute_path, row.relative_path, false, {
+    if ((!thumbnailExistsBeforeGenerate || !previewExistsBeforeGenerate) && sourcePath && sourceExists) {
+      const derivatives = await generateDerivatives(sourcePath, row.relative_path, false, {
         thumbnailPath: targetThumbnailPath,
         previewPath: targetPreviewPath
       });

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -24,6 +24,7 @@ import { deserializeImageExifData } from '../utils/exif-utils.js';
 import { buildMonthDayKey, countFeedBursts, diversifyFeedCandidates, groupFeedBursts, listMonthDayKeysAroundDate } from '../utils/feed-utils.js';
 import { shouldPreferMomentRail, type FeedRailKind } from '../utils/feed-rail-utils.js';
 import { countSupportedRootMediaFiles } from '../utils/gallery-root-utils.js';
+import { resolveOriginalPath } from '../utils/media-paths.js';
 import { getPathBreadcrumb } from '../utils/path-utils.js';
 import { buildReelQueue, shuffleReelCandidates, type ReelAffinitySignals } from '../utils/reels-utils.js';
 import { parseTreatStoriesAsFoldersSetting, serializeTreatStoriesAsFoldersSetting } from '../utils/stories-utils.js';
@@ -214,7 +215,7 @@ function mapPlaceSummaryFromRow(image: PlaceRowFields) {
 }
 
 function resolveOriginalMediaFile(id: number): { path: string; filename: string } | null {
-  if (!storageService.getState().libraryAvailable) {
+  if (!storageService.getState().libraryAvailable || scannerService.isLibraryRebuildRequired()) {
     return null;
   }
 
@@ -223,7 +224,13 @@ function resolveOriginalMediaFile(id: number): { path: string; filename: string 
     return null;
   }
 
-  const resolvedPath = resolveWithinRoot(appConfig.galleryRoot, detail.absolute_path);
+  let resolvedPath: string;
+  try {
+    resolvedPath = resolveOriginalPath(detail.relative_path);
+  } catch {
+    return null;
+  }
+
   if (!resolvedPath || !fs.existsSync(resolvedPath)) {
     return null;
   }
@@ -232,6 +239,14 @@ function resolveOriginalMediaFile(id: number): { path: string; filename: string 
     path: resolvedPath,
     filename: detail.filename
   };
+}
+
+function resolveIndexedOriginalPath(relativePath: string): string | null {
+  try {
+    return resolveOriginalPath(relativePath);
+  } catch {
+    return null;
+  }
 }
 
 function resolveWithinRoot(rootPath: string, targetPath: string): string | null {
@@ -1588,7 +1603,7 @@ export const galleryService = {
   },
 
   async deleteImage(id: number) {
-    if (!storageService.getState().libraryAvailable) {
+    if (!storageService.getState().libraryAvailable || scannerService.isLibraryRebuildRequired()) {
       return null;
     }
 
@@ -1602,7 +1617,7 @@ export const galleryService = {
       return null;
     }
 
-    const originalPath = resolveWithinRoot(appConfig.galleryRoot, imageRecord.absolute_path);
+    const originalPath = resolveIndexedOriginalPath(imageRecord.relative_path);
     const thumbnailPath = resolveStoredPathWithinRoot(appConfig.thumbnailsDir, imageRecord.thumbnail_path, 'thumbnail');
     const previewPath = resolveStoredPathWithinRoot(appConfig.previewsDir, imageRecord.preview_path, 'preview');
 
@@ -1630,7 +1645,7 @@ export const galleryService = {
   },
 
   async deleteFolder(slug: string, options: DeleteFolderOptions = {}) {
-    if (!storageService.getState().libraryAvailable) {
+    if (!storageService.getState().libraryAvailable || scannerService.isLibraryRebuildRequired()) {
       return null;
     }
 
@@ -1680,7 +1695,7 @@ export const galleryService = {
 
     await Promise.all(
       images.map(async (imageRecord) => {
-        const originalPath = resolveWithinRoot(appConfig.galleryRoot, imageRecord.absolute_path);
+        const originalPath = resolveIndexedOriginalPath(imageRecord.relative_path);
         const thumbnailPath = resolveStoredPathWithinRoot(appConfig.thumbnailsDir, imageRecord.thumbnail_path, 'thumbnail');
         const previewPath = resolveStoredPathWithinRoot(appConfig.previewsDir, imageRecord.preview_path, 'preview');
 

--- a/server/src/services/library-relocation-service.ts
+++ b/server/src/services/library-relocation-service.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { appConfig } from '../config/env.js';
+import { LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY } from '../constants/app-setting-keys.js';
+import { appSettingsRepository, folderRepository, imageRepository } from '../db/repositories.js';
+import type { ImageRecord } from '../types/models.js';
+import { resolveOriginalPath } from '../utils/media-paths.js';
+import { normalizePath } from '../utils/path-utils.js';
+
+export type LibraryRelocationValidationResult =
+  | { status: 'not_needed' }
+  | { status: 'validated'; checked: number; missing: number; refreshed: number }
+  | { status: 'failed'; checked: number; missing: number; reason: string };
+
+function getStoredGalleryRoot(): string | null {
+  const storedGalleryRoot = appSettingsRepository.get(LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY);
+  return storedGalleryRoot ? normalizePath(storedGalleryRoot) : null;
+}
+
+function validateSourceFile(row: ImageRecord): { ok: true } | { ok: false; missing: boolean; reason: string } {
+  let sourcePath: string;
+
+  try {
+    sourcePath = resolveOriginalPath(row.relative_path);
+  } catch {
+    return {
+      ok: false,
+      missing: true,
+      reason: `Indexed relative path escapes the gallery root: ${row.relative_path}`
+    };
+  }
+
+  let stats: fs.Stats;
+  try {
+    stats = fs.statSync(sourcePath);
+  } catch {
+    return {
+      ok: false,
+      missing: true,
+      reason: `Indexed source file is missing: ${row.relative_path}`
+    };
+  }
+
+  if (!stats.isFile()) {
+    return {
+      ok: false,
+      missing: true,
+      reason: `Indexed source path is not a file: ${row.relative_path}`
+    };
+  }
+
+  if (stats.size !== row.file_size) {
+    return {
+      ok: false,
+      missing: false,
+      reason: `Indexed source file size changed: ${row.relative_path}`
+    };
+  }
+
+  if (Math.round(stats.mtimeMs) !== Math.round(row.mtime_ms)) {
+    return {
+      ok: false,
+      missing: false,
+      reason: `Indexed source file mtime changed: ${row.relative_path}`
+    };
+  }
+
+  if (path.extname(row.relative_path).toLowerCase() !== row.extension.toLowerCase()) {
+    return {
+      ok: false,
+      missing: false,
+      reason: `Indexed source file extension changed: ${row.relative_path}`
+    };
+  }
+
+  return { ok: true };
+}
+
+class LibraryRelocationService {
+  validateCurrentGalleryRoot(): LibraryRelocationValidationResult {
+    const currentGalleryRoot = normalizePath(appConfig.galleryRoot);
+    const storedGalleryRoot = getStoredGalleryRoot();
+
+    if (!storedGalleryRoot || storedGalleryRoot === currentGalleryRoot || folderRepository.getAll().length === 0) {
+      return { status: 'not_needed' };
+    }
+
+    let checked = 0;
+    let missing = 0;
+
+    for (const row of imageRepository.listActive()) {
+      checked += 1;
+      const validation = validateSourceFile(row);
+
+      if (!validation.ok) {
+        if (validation.missing) {
+          missing += 1;
+        }
+
+        return {
+          status: 'failed',
+          checked,
+          missing,
+          reason: validation.reason
+        };
+      }
+    }
+
+    return {
+      status: 'validated',
+      checked,
+      missing,
+      refreshed: imageRepository.refreshAbsolutePathsForGalleryRoot(appConfig.galleryRoot)
+    };
+  }
+}
+
+export const libraryRelocationService = new LibraryRelocationService();

--- a/server/src/services/scanner-service.ts
+++ b/server/src/services/scanner-service.ts
@@ -28,6 +28,7 @@ import {
   type DerivativeMigrationProgress,
   type DerivativeMigrationSummary
 } from './derivative-migration-service.js';
+import { libraryRelocationService } from './library-relocation-service.js';
 import { log } from './log-service.js';
 import { placeResolutionService } from './place-service.js';
 import { storageService } from './storage-service.js';
@@ -40,6 +41,7 @@ import {
 } from '../utils/image-utils.js';
 import { generateAssetKey, getPreviewPathForAssetKey, getThumbnailPathForAssetKey } from '../utils/derivative-paths.js';
 import { resolveTakenAt, serializeImageExifData } from '../utils/exif-utils.js';
+import { resolveOriginalPath } from '../utils/media-paths.js';
 import {
   getFolderDisplayInfo,
   getRelativeGalleryPath,
@@ -394,16 +396,33 @@ class ScannerService {
     const requiresDerivativeMigration = pendingDerivativeMigrationRows > 0;
 
     if (galleryRootChanged && normalizedStoredGalleryRoot && hasIndexedFolders) {
-      this.markLibraryRebuildRequired(normalizedStoredGalleryRoot);
-      log.info(
-        joinLogParts([
-          'Startup scan deferred',
-          'rebuild required',
-          formatStep('previous', normalizedStoredGalleryRoot),
-          formatStep('current', currentGalleryRoot)
-        ])
-      );
-      return 'blocked';
+      const relocationValidation = libraryRelocationService.validateCurrentGalleryRoot();
+
+      if (relocationValidation.status === 'validated') {
+        this.clearLibraryRebuildRequirement();
+        appSettingsRepository.set(LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY, currentGalleryRoot);
+        log.info(
+          joinLogParts([
+            'Gallery root relocation validated',
+            formatStep('previous', normalizedStoredGalleryRoot),
+            formatStep('current', currentGalleryRoot),
+            formatStep('checked', relocationValidation.checked),
+            formatStep('refreshed', relocationValidation.refreshed)
+          ])
+        );
+      } else {
+        this.markLibraryRebuildRequired(normalizedStoredGalleryRoot);
+        log.info(
+          joinLogParts([
+            'Startup scan deferred',
+            'rebuild required',
+            formatStep('previous', normalizedStoredGalleryRoot),
+            formatStep('current', currentGalleryRoot),
+            relocationValidation.status === 'failed' ? relocationValidation.reason : null
+          ])
+        );
+        return 'blocked';
+      }
     }
 
     if (!galleryRootChanged || !hasStoredGalleryRoot || !hasIndexedFolders) {
@@ -1390,7 +1409,7 @@ class ScannerService {
           .filter((folderPath): folderPath is string => Boolean(folderPath))
       );
       const derivativeJobs: DerivativeJob[] = indexedImages.map((image) => ({
-        absolutePath: image.absolute_path,
+        absolutePath: resolveOriginalPath(image.relative_path),
         relativePath: image.relative_path,
         thumbnailPath: image.thumbnail_path,
         previewPath: image.preview_path,
@@ -2154,7 +2173,14 @@ class ScannerService {
 
     const missingCandidates: ImageRecord[] = [];
     for (const candidate of candidates) {
-      if (!(await this.pathExists(candidate.absolute_path))) {
+      let candidatePath: string | null = null;
+      try {
+        candidatePath = resolveOriginalPath(candidate.relative_path);
+      } catch {
+        candidatePath = null;
+      }
+
+      if (!candidatePath || !(await this.pathExists(candidatePath))) {
         missingCandidates.push(candidate);
       }
     }

--- a/server/src/utils/media-paths.ts
+++ b/server/src/utils/media-paths.ts
@@ -1,0 +1,6 @@
+import { appConfig } from '../config/env.js';
+import { safeJoin } from './path-utils.js';
+
+export function resolveOriginalPath(relativePath: string): string {
+  return safeJoin(appConfig.galleryRoot, relativePath);
+}

--- a/server/test/lazy-derivatives.test.ts
+++ b/server/test/lazy-derivatives.test.ts
@@ -12,6 +12,7 @@ import {
   getPreviewRelativePath,
   getThumbnailRelativePath
 } from '../src/utils/image-utils.js';
+import { LIBRARY_REBUILD_REQUIRED_SETTING_KEY } from '../src/constants/app-setting-keys.js';
 
 type AppConfigModule = typeof import('../src/config/env.js');
 type AuthServiceModule = typeof import('../src/services/auth-service.js');
@@ -39,6 +40,7 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
   let folderRepository: RepositoriesModule['folderRepository'];
   let imageRepository: RepositoriesModule['imageRepository'];
   let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+  let appSettingsRepository: RepositoriesModule['appSettingsRepository'];
 
   async function reset(derivativeMode = 'lazy', scanDerivativeConcurrency = 4) {
     generateThumbnailDerivativeMock.mockReset();
@@ -72,7 +74,7 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
     ({ authService } = await import('../src/services/auth-service.js'));
     ({ lazyThumbnailsRouter, lazyPreviewsRouter } = await import('../src/routes/lazy-derivatives.js'));
     ({ scannerService } = await import('../src/services/scanner-service.js'));
-    ({ folderRepository, imageRepository, maintenanceRepository } = await import('../src/db/repositories.js'));
+    ({ folderRepository, imageRepository, maintenanceRepository, appSettingsRepository } = await import('../src/db/repositories.js'));
 
     await Promise.all([
       fs.mkdir(appConfig.galleryRoot, { recursive: true }),
@@ -251,10 +253,13 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
     filename: string,
     mtimeMs: number,
     playbackStrategy: PlaybackStrategy,
-    durationMs: number | null = null
+    durationMs: number | null = null,
+    options: { storedGalleryRoot?: string } = {}
   ) {
     const relativePath = `${folder.folder_path}/${filename}`;
-    const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+    const absolutePath = options.storedGalleryRoot
+      ? path.join(options.storedGalleryRoot, relativePath)
+      : path.join(appConfig.galleryRoot, relativePath);
     const extension = path.extname(filename).toLowerCase();
     const mediaType = getMediaTypeFromExtension(extension);
     const previewRelativePath = getPreviewRelativePath(relativePath, mediaType);
@@ -369,6 +374,27 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
     expect(generateThumbnailDerivativeMock).toHaveBeenCalledOnce();
   });
 
+  it('generates a missing thumbnail from the current gallery root when the cached absolute path is stale', async () => {
+    await reset('lazy');
+
+    maintenanceRepository.resetLibraryIndex();
+    const folder = folderRepository.upsert({ slug: 'relocated-thumbs', name: 'Relocated Thumbs', folderPath: 'relocated-thumbs' });
+    await createSourceFile('relocated-thumbs/photo.jpg');
+    const image = createIndexedMedia(folder, 'photo.jpg', 2_200, 'preview', null, {
+      storedGalleryRoot: path.join(tempRoot, 'old-gallery-root')
+    });
+
+    const response = await dispatchRoute(lazyThumbnailsRouter, `/${encodeRelativePath(image.thumbnail_path)}`);
+
+    expect(response.statusCode).toBe(200);
+    expect(generateThumbnailDerivativeMock).toHaveBeenCalledWith(
+      path.join(appConfig.galleryRoot, image.relative_path),
+      image.relative_path,
+      false,
+      { thumbnailPath: image.thumbnail_path }
+    );
+  });
+
   it('uses private browser caching headers for protected derivative responses', async () => {
     await reset('lazy');
 
@@ -395,6 +421,25 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
     expect(response.body).toBe('image-preview:photo.webp');
     expect(writeImagePreviewMock).toHaveBeenCalledOnce();
     expect(writeVideoPreviewMock).not.toHaveBeenCalled();
+  });
+
+  it('generates a missing image preview from the current gallery root when the cached absolute path is stale', async () => {
+    await reset('lazy');
+
+    maintenanceRepository.resetLibraryIndex();
+    const folder = folderRepository.upsert({ slug: 'relocated-previews', name: 'Relocated Previews', folderPath: 'relocated-previews' });
+    await createSourceFile('relocated-previews/photo.jpg');
+    const image = createIndexedMedia(folder, 'photo.jpg', 3_200, 'preview', null, {
+      storedGalleryRoot: path.join(tempRoot, 'old-gallery-root')
+    });
+
+    const response = await dispatchRoute(lazyPreviewsRouter, `/${encodeRelativePath(image.preview_path)}`);
+
+    expect(response.statusCode).toBe(200);
+    expect(writeImagePreviewMock).toHaveBeenCalledWith(
+      path.join(appConfig.galleryRoot, image.relative_path),
+      path.join(appConfig.previewsDir, image.preview_path)
+    );
   });
 
   it('deduplicates concurrent requests for the same missing video preview', async () => {
@@ -495,6 +540,21 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
     expect(response.statusCode).toBe(404);
     expect(response.body).toEqual({ message: 'Derivative not found.' });
     expect(response.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('does not generate missing derivatives while a library rebuild is required', async () => {
+    await reset('lazy');
+
+    maintenanceRepository.resetLibraryIndex();
+    const folder = folderRepository.upsert({ slug: 'blocked', name: 'Blocked', folderPath: 'blocked' });
+    const image = createIndexedMedia(folder, 'photo.jpg', 4_700, 'preview');
+    appSettingsRepository.set(LIBRARY_REBUILD_REQUIRED_SETTING_KEY, '1');
+
+    const response = await dispatchRoute(lazyThumbnailsRouter, `/${encodeRelativePath(image.thumbnail_path)}`);
+
+    expect(response.statusCode).toBe(409);
+    expect(response.body).toEqual({ message: 'Library rebuild required before generating derivatives.' });
+    expect(generateThumbnailDerivativeMock).not.toHaveBeenCalled();
   });
 
   it('does not emit a JSON error after sendFile fails once headers are already sent', async () => {

--- a/server/test/original-media-download.test.ts
+++ b/server/test/original-media-download.test.ts
@@ -12,6 +12,7 @@ import {
   getPreviewRelativePath,
   getThumbnailRelativePath
 } from '../src/utils/image-utils.js';
+import { LIBRARY_REBUILD_REQUIRED_SETTING_KEY } from '../src/constants/app-setting-keys.js';
 
 type ApiModule = typeof import('../src/routes/api.js');
 type EnvModule = typeof import('../src/config/env.js');
@@ -43,6 +44,7 @@ describe.sequential('original media route download behavior', () => {
   let folderRepository: RepositoriesModule['folderRepository'];
   let imageRepository: RepositoriesModule['imageRepository'];
   let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+  let appSettingsRepository: RepositoriesModule['appSettingsRepository'];
 
   beforeAll(async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-original-media-download-'));
@@ -62,7 +64,7 @@ describe.sequential('original media route download behavior', () => {
     vi.resetModules();
     ({ appConfig } = await import('../src/config/env.js'));
     ({ apiRouter } = await import('../src/routes/api.js'));
-    ({ folderRepository, imageRepository, maintenanceRepository } = await import('../src/db/repositories.js'));
+    ({ folderRepository, imageRepository, maintenanceRepository, appSettingsRepository } = await import('../src/db/repositories.js'));
 
     await Promise.all([
       fs.mkdir(appConfig.galleryRoot, { recursive: true }),
@@ -120,6 +122,95 @@ describe.sequential('original media route download behavior', () => {
     expect(response.status).not.toHaveBeenCalled();
   });
 
+  it('resolves originals from the current gallery root when cached absolute paths are stale', async () => {
+    const folder = folderRepository.upsert({ slug: 'album-relocated', name: 'Album Relocated', folderPath: 'album-relocated' });
+    const oldGalleryRoot = path.join(tempRoot, 'old-gallery-root');
+    const image = await createIndexedMedia(folder, 'photo.jpg', 2_500, 'preview', null, {
+      storedGalleryRoot: oldGalleryRoot
+    });
+    const handler = getRouteHandler('/originals/:id', 'get');
+    const response = createResponse();
+
+    handler(
+      {
+        params: { id: String(image.id) },
+        query: {}
+      } as unknown as express.Request,
+      response as unknown as express.Response,
+      vi.fn()
+    );
+
+    expect(response.sendFile).toHaveBeenCalledWith(path.join(appConfig.galleryRoot, image.relative_path));
+    expect(response.sendFile).not.toHaveBeenCalledWith(image.absolute_path);
+    expect(response.status).not.toHaveBeenCalled();
+  });
+
+  it('does not serve an indexed original path that would escape the current gallery root', async () => {
+    const folder = folderRepository.upsert({ slug: 'album-traversal', name: 'Album Traversal', folderPath: 'album-traversal' });
+    const outsidePath = path.join(tempRoot, 'outside.jpg');
+    await fs.writeFile(outsidePath, 'outside');
+    const image = imageRepository.upsert({
+      folderId: folder.id,
+      filename: 'outside.jpg',
+      extension: '.jpg',
+      relativePath: '../outside.jpg',
+      absolutePath: outsidePath,
+      fileSize: 7,
+      width: 1280,
+      height: 960,
+      mediaType: 'image',
+      mimeType: 'image/jpeg',
+      durationMs: null,
+      fingerprint: createFingerprint('../outside.jpg', 7, 3_000),
+      mtimeMs: 3_000,
+      firstSeenAt: '2026-01-01T00:00:00.000Z',
+      sortTimestamp: 3_000,
+      takenAt: 3_000,
+      takenAtSource: 'mtime',
+      exifJson: '{}',
+      thumbnailPath: getThumbnailRelativePath('../outside.jpg'),
+      previewPath: getPreviewRelativePath('../outside.jpg', 'image'),
+      playbackStrategy: 'preview'
+    });
+    const handler = getRouteHandler('/originals/:id', 'get');
+    const response = createResponse();
+
+    handler(
+      {
+        params: { id: String(image.id) },
+        query: {}
+      } as unknown as express.Request,
+      response as unknown as express.Response,
+      vi.fn()
+    );
+
+    expect(response.status).toHaveBeenCalledWith(404);
+    expect(response.sendFile).not.toHaveBeenCalled();
+    expect(response.download).not.toHaveBeenCalled();
+  });
+
+  it('does not serve originals while a library rebuild is required after failed relocation', async () => {
+    const folder = folderRepository.upsert({ slug: 'album-blocked', name: 'Album Blocked', folderPath: 'album-blocked' });
+    const image = await createIndexedMedia(folder, 'photo.jpg', 2_750, 'preview');
+    const handler = getRouteHandler('/originals/:id', 'get');
+    const response = createResponse();
+
+    appSettingsRepository.set(LIBRARY_REBUILD_REQUIRED_SETTING_KEY, '1');
+
+    handler(
+      {
+        params: { id: String(image.id) },
+        query: {}
+      } as unknown as express.Request,
+      response as unknown as express.Response,
+      vi.fn()
+    );
+
+    expect(response.status).toHaveBeenCalledWith(404);
+    expect(response.sendFile).not.toHaveBeenCalled();
+    expect(response.download).not.toHaveBeenCalled();
+  });
+
   it('returns 404 when the original file is no longer available on disk', async () => {
     const folder = folderRepository.upsert({ slug: 'album-missing', name: 'Album Missing', folderPath: 'album-missing' });
     const image = await createIndexedMedia(folder, 'missing.jpg', 3_000, 'preview');
@@ -168,18 +259,22 @@ describe.sequential('original media route download behavior', () => {
     filename: string,
     mtimeMs: number,
     playbackStrategy: PlaybackStrategy,
-    durationMs: number | null = null
+    durationMs: number | null = null,
+    options: { storedGalleryRoot?: string } = {}
   ) {
     const relativePath = `${folder.folder_path}/${filename}`;
-    const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+    const sourceAbsolutePath = path.join(appConfig.galleryRoot, relativePath);
+    const absolutePath = options.storedGalleryRoot
+      ? path.join(options.storedGalleryRoot, relativePath)
+      : sourceAbsolutePath;
     const extension = path.extname(filename).toLowerCase();
     const mediaType = getMediaTypeFromExtension(extension);
     const previewRelativePath = getPreviewRelativePath(relativePath, mediaType);
     const thumbnailRelativePath = getThumbnailRelativePath(relativePath);
     const fileSize = 2_048 + mtimeMs;
 
-    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-    await fs.writeFile(absolutePath, `original:${filename}`);
+    await fs.mkdir(path.dirname(sourceAbsolutePath), { recursive: true });
+    await fs.writeFile(sourceAbsolutePath, `original:${filename}`);
 
     return imageRepository.upsert({
       folderId: folder.id,

--- a/server/test/startup-behavior.test.ts
+++ b/server/test/startup-behavior.test.ts
@@ -9,6 +9,13 @@ import {
   getPreviewRelativePath,
   getThumbnailRelativePath
 } from '../src/utils/image-utils.js';
+import {
+  LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY,
+  LIBRARY_REBUILD_REQUIRED_SETTING_KEY,
+  PREVIOUS_GALLERY_ROOT_SETTING_KEY
+} from '../src/constants/app-setting-keys.js';
+import { getPreviewPathForAssetKey, getThumbnailPathForAssetKey } from '../src/utils/derivative-paths.js';
+import { normalizePath } from '../src/utils/path-utils.js';
 
 type AppConfigModule = typeof import('../src/config/env.js');
 type ScannerServiceModule = typeof import('../src/services/scanner-service.js');
@@ -26,6 +33,7 @@ describe.sequential('startup behavior', () => {
   let imageRepository: RepositoriesModule['imageRepository'];
   let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
   let scanRunRepository: RepositoriesModule['scanRunRepository'];
+  let appSettingsRepository: RepositoriesModule['appSettingsRepository'];
 
   beforeAll(async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-startup-behavior-'));
@@ -55,7 +63,13 @@ describe.sequential('startup behavior', () => {
 
     ({ appConfig } = await import('../src/config/env.js'));
     ({ scannerService } = await import('../src/services/scanner-service.js'));
-    ({ folderRepository, imageRepository, maintenanceRepository, scanRunRepository } = await import('../src/db/repositories.js'));
+    ({
+      folderRepository,
+      imageRepository,
+      maintenanceRepository,
+      scanRunRepository,
+      appSettingsRepository
+    } = await import('../src/db/repositories.js'));
 
     await Promise.all([
       fs.mkdir(appConfig.galleryRoot, { recursive: true }),
@@ -181,11 +195,129 @@ describe.sequential('startup behavior', () => {
     expect(migrated?.preview_path).not.toBe(previewPath);
   });
 
+  it('validates a moved gallery root and refreshes cached absolute paths without requiring a rebuild', async () => {
+    const oldGalleryRoot = path.join(tempRoot, 'old-gallery-root');
+    const indexed = await createIndexedRelocationMedia({
+      relativePath: 'relocated/photo-1.jpg',
+      storedGalleryRoot: oldGalleryRoot
+    });
+    appSettingsRepository.set(LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY, oldGalleryRoot);
+
+    const action = scannerService.handleStartup('startup');
+
+    expect(action).toBe('idle');
+    expect(appSettingsRepository.get(LIBRARY_REBUILD_REQUIRED_SETTING_KEY)).toBeNull();
+    expect(appSettingsRepository.get(PREVIOUS_GALLERY_ROOT_SETTING_KEY)).toBeNull();
+    expect(appSettingsRepository.get(LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY)).toBe(normalizePath(appConfig.galleryRoot));
+
+    const refreshed = imageRepository.getByRelativePath(indexed.relative_path);
+    expect(refreshed?.absolute_path).toBe(path.join(appConfig.galleryRoot, indexed.relative_path));
+  });
+
+  it('requires a rebuild when a moved gallery root is missing an indexed active file', async () => {
+    const oldGalleryRoot = path.join(tempRoot, 'old-gallery-root');
+    await createIndexedRelocationMedia({
+      relativePath: 'missing/photo-1.jpg',
+      storedGalleryRoot: oldGalleryRoot,
+      skipSourceFile: true
+    });
+    appSettingsRepository.set(LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY, oldGalleryRoot);
+
+    const action = scannerService.handleStartup('startup');
+
+    expect(action).toBe('blocked');
+    expect(appSettingsRepository.get(LIBRARY_REBUILD_REQUIRED_SETTING_KEY)).toBe('1');
+    expect(appSettingsRepository.get(PREVIOUS_GALLERY_ROOT_SETTING_KEY)).toBe(normalizePath(oldGalleryRoot));
+  });
+
+  it('requires a rebuild when a moved gallery root has a size mismatch', async () => {
+    const oldGalleryRoot = path.join(tempRoot, 'old-gallery-root');
+    await createIndexedRelocationMedia({
+      relativePath: 'mismatch/photo-1.jpg',
+      storedGalleryRoot: oldGalleryRoot,
+      indexedFileSizeOffset: 1
+    });
+    appSettingsRepository.set(LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY, oldGalleryRoot);
+
+    const action = scannerService.handleStartup('startup');
+
+    expect(action).toBe('blocked');
+    expect(appSettingsRepository.get(LIBRARY_REBUILD_REQUIRED_SETTING_KEY)).toBe('1');
+  });
+
+  it('requires a rebuild when a moved gallery root has an mtime mismatch', async () => {
+    const oldGalleryRoot = path.join(tempRoot, 'old-gallery-root');
+    await createIndexedRelocationMedia({
+      relativePath: 'mtime/photo-1.jpg',
+      storedGalleryRoot: oldGalleryRoot,
+      indexedMtimeMs: Date.parse('2026-03-08T12:00:00.000Z')
+    });
+    appSettingsRepository.set(LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY, oldGalleryRoot);
+
+    const action = scannerService.handleStartup('startup');
+
+    expect(action).toBe('blocked');
+    expect(appSettingsRepository.get(LIBRARY_REBUILD_REQUIRED_SETTING_KEY)).toBe('1');
+  });
+
   async function createSourceFile(relativePath: string): Promise<string> {
     const absolutePath = path.join(appConfig.galleryRoot, relativePath);
     await fs.mkdir(path.dirname(absolutePath), { recursive: true });
     await fs.writeFile(absolutePath, `source:${relativePath}`);
     return absolutePath;
+  }
+
+  async function createIndexedRelocationMedia(options: {
+    relativePath: string;
+    storedGalleryRoot: string;
+    indexedFileSizeOffset?: number;
+    indexedMtimeMs?: number;
+    skipSourceFile?: boolean;
+  }) {
+    const folderPath = path.posix.dirname(options.relativePath);
+    const filename = path.posix.basename(options.relativePath);
+    const extension = path.extname(filename).toLowerCase();
+    const mediaType = getMediaTypeFromExtension(extension);
+    const assetKey = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const contents = `source:${options.relativePath}`;
+    const actualMtimeMs = Date.parse('2026-03-07T12:00:00.000Z');
+    const sourcePath = path.join(appConfig.galleryRoot, options.relativePath);
+    const folder = folderRepository.upsert({
+      slug: folderPath.replaceAll('/', '-'),
+      name: path.posix.basename(folderPath),
+      folderPath
+    });
+
+    if (!options.skipSourceFile) {
+      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+      await fs.writeFile(sourcePath, contents);
+      await fs.utimes(sourcePath, new Date(actualMtimeMs), new Date(actualMtimeMs));
+    }
+
+    return imageRepository.upsert({
+      folderId: folder.id,
+      assetKey,
+      filename,
+      extension,
+      relativePath: options.relativePath,
+      absolutePath: path.join(options.storedGalleryRoot, options.relativePath),
+      fileSize: Buffer.byteLength(contents) + (options.indexedFileSizeOffset ?? 0),
+      width: 1600,
+      height: 1200,
+      mediaType,
+      mimeType: mediaType === 'video' ? 'video/mp4' : 'image/jpeg',
+      durationMs: mediaType === 'video' ? 12_000 : null,
+      fingerprint: `${options.relativePath}:relocation`,
+      mtimeMs: options.indexedMtimeMs ?? actualMtimeMs,
+      firstSeenAt: '2026-03-07T12:00:00.000Z',
+      sortTimestamp: actualMtimeMs,
+      takenAt: actualMtimeMs,
+      takenAtSource: 'mtime',
+      exifJson: mediaType === 'image' ? '{}' : null,
+      thumbnailPath: getThumbnailPathForAssetKey(assetKey),
+      previewPath: getPreviewPathForAssetKey(assetKey, mediaType),
+      playbackStrategy: 'preview'
+    });
   }
 });
 

--- a/server/test/thumbnail-rebuild.test.ts
+++ b/server/test/thumbnail-rebuild.test.ts
@@ -207,6 +207,29 @@ describe.sequential('thumbnail-only rebuild', () => {
     expect(imageRepository.getByRelativePath('broken/clip-missing.mp4')?.is_deleted).toBe(0);
   });
 
+  it('rebuilds thumbnails from the current gallery root when cached absolute paths are stale', async () => {
+    await createCompletedScanRun({
+      scanned_files: 1,
+      new_files: 0,
+      updated_files: 0,
+      removed_files: 0
+    });
+    const oldGalleryRoot = path.join(tempRoot, 'old-gallery-root');
+    const indexed = await createIndexedFolder('relocated', [
+      { filename: 'photo-1.jpg', storedGalleryRoot: oldGalleryRoot }
+    ]);
+
+    const lastScan = await scannerService.rebuildThumbnails('relocated');
+
+    expect(lastScan?.status).toBe('completed');
+    expect(generateThumbnailDerivativeMock).toHaveBeenCalledWith(
+      path.join(appConfig.galleryRoot, indexed.images[0]!.relative_path),
+      indexed.images[0]!.relative_path,
+      true,
+      { thumbnailPath: indexed.images[0]!.thumbnail_path }
+    );
+  });
+
   it('refuses thumbnail rebuilds when a full library rebuild is required', async () => {
     appSettingsRepository.set(libraryRebuildRequiredSettingKey, '1');
 
@@ -218,7 +241,7 @@ describe.sequential('thumbnail-only rebuild', () => {
 
   async function createIndexedFolder(
     relativeFolderPath: string,
-    entries: Array<{ filename: string; missingSource?: boolean; like?: boolean }>
+    entries: Array<{ filename: string; missingSource?: boolean; like?: boolean; storedGalleryRoot?: string }>
   ): Promise<{
     folder: FolderRecord;
     images: ImageRecord[];
@@ -238,7 +261,10 @@ describe.sequential('thumbnail-only rebuild', () => {
 
     for (const [index, entry] of entries.entries()) {
       const relativePath = `${relativeFolderPath}/${entry.filename}`;
-      const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+      const sourceAbsolutePath = path.join(appConfig.galleryRoot, relativePath);
+      const absolutePath = entry.storedGalleryRoot
+        ? path.join(entry.storedGalleryRoot, relativePath)
+        : sourceAbsolutePath;
       const extension = path.extname(entry.filename).toLowerCase();
       const mediaType = getMediaTypeFromExtension(extension);
       const thumbnailRelativePath = getThumbnailRelativePath(relativePath);
@@ -250,8 +276,8 @@ describe.sequential('thumbnail-only rebuild', () => {
       const mtimeMs = 1_700_000_000_000 + index;
 
       if (!entry.missingSource) {
-        await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-        await fs.writeFile(absolutePath, sourceContents);
+        await fs.mkdir(path.dirname(sourceAbsolutePath), { recursive: true });
+        await fs.writeFile(sourceAbsolutePath, sourceContents);
       }
 
       await fs.mkdir(path.dirname(thumbnailPath), { recursive: true });


### PR DESCRIPTION
This PR allows an existing library index to remain usable when `GALLERY_ROOT` changes but still points to the same media library.

It adds support for:
- validating relocated libraries before startup marks a rebuild as required
- continuing to use existing folders, posts, sort order, likes, thumbnails, and previews after a valid relocation
- refreshing stored source paths after relocation
- serving originals from the current gallery root
- generating lazy derivatives and rebuilt thumbnails after relocation
- preserving rebuild-required behavior when the new root is missing files or does not match the indexed library

Closes #56 