### PR TITLE
Add app folder photo order setting

### DIFF
--- a/client/src/api/gallery.ts
+++ b/client/src/api/gallery.ts
@@ -13,6 +13,8 @@ import type {
   DeleteImageResult,
   DeleteFolderResult,
   FeedMode,
+  FolderImageOrder,
+  FolderImageOrderDefaultSetting,
   ImageDetail,
   LikeMutationResult,
   LikesPayload,
@@ -366,6 +368,14 @@ export function updateReelsFeedDefault(defaultMode: ReelsFeedMode) {
     method: 'PUT',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ defaultMode })
+  });
+}
+
+export function updateFolderImageOrderDefault(defaultOrder: FolderImageOrder) {
+  return requestJson<FolderImageOrderDefaultSetting>('/api/admin/settings/folder-image-order-default', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ defaultOrder })
   });
 }
 

--- a/client/src/stores/app.ts
+++ b/client/src/stores/app.ts
@@ -6,7 +6,7 @@ import {
   fetchScanProgress,
   fetchStats as fetchStatus
 } from '../api/gallery';
-import type { AppStatus, FeedMode, ReelsFeedMode, ScanProgress } from '../types/api';
+import type { AppStatus, FeedMode, FolderImageOrder, ReelsFeedMode, ScanProgress } from '../types/api';
 import { useAuthStore } from './auth';
 
 interface AppState {
@@ -75,6 +75,7 @@ export const useAppStore = defineStore('app', {
     isInitialScan: (state) => state.stats?.scan.isScanning === true && state.stats?.scan.lastCompletedScan === null,
     defaultHomeFeedMode: (state): FeedMode => state.stats?.preferences.defaultHomeFeedMode ?? 'random',
     defaultReelsFeedMode: (state): ReelsFeedMode => state.stats?.preferences.defaultReelsFeedMode ?? 'random',
+    defaultFolderImageOrder: (state): FolderImageOrder => state.stats?.preferences.defaultFolderImageOrder ?? 'newest',
     treatStoriesAsFolders: (state) => state.stats?.preferences.treatStoriesAsFolders === true
   },
   actions: {

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -1,5 +1,6 @@
 export type FeedMode = 'recent' | 'rediscover' | 'random';
 export type ReelsFeedMode = 'recommended' | 'recent' | 'random';
+export type FolderImageOrder = 'newest' | 'oldest';
 export type FeedRailKind = 'moments' | 'highlights';
 export type StoryCapsulePresentation = 'avatar' | 'highlight';
 export type ScanOperation =
@@ -21,6 +22,10 @@ export interface HomeFeedDefaultSetting {
 
 export interface ReelsFeedDefaultSetting {
   defaultMode: ReelsFeedMode;
+}
+
+export interface FolderImageOrderDefaultSetting {
+  defaultOrder: FolderImageOrder;
 }
 
 export interface StoriesModeSetting {
@@ -323,6 +328,7 @@ export interface AppStatus {
   preferences: {
     defaultHomeFeedMode: FeedMode;
     defaultReelsFeedMode: ReelsFeedMode;
+    defaultFolderImageOrder?: FolderImageOrder;
     treatStoriesAsFolders: boolean;
   };
   storiesMigration: {

--- a/client/src/views/SettingsView.test.ts
+++ b/client/src/views/SettingsView.test.ts
@@ -17,7 +17,8 @@ const scrollIntoViewSpy = vi.fn();
 
 function createAppStatus(
   defaultHomeFeedMode: AppStatus['preferences']['defaultHomeFeedMode'] = 'rediscover',
-  defaultReelsFeedMode: AppStatus['preferences']['defaultReelsFeedMode'] = 'random'
+  defaultReelsFeedMode: AppStatus['preferences']['defaultReelsFeedMode'] = 'random',
+  defaultFolderImageOrder: NonNullable<AppStatus['preferences']['defaultFolderImageOrder']> = 'newest'
 ): AppStatus {
   return {
     folders: 3,
@@ -56,6 +57,7 @@ function createAppStatus(
     preferences: {
       defaultHomeFeedMode,
       defaultReelsFeedMode,
+      defaultFolderImageOrder,
       treatStoriesAsFolders: false
     },
     storiesMigration: {
@@ -161,15 +163,18 @@ describe('SettingsView', () => {
 
     expect(wrapper.text()).toContain('Home feed sort order');
     expect(wrapper.text()).toContain('Reels feed sort order');
+    expect(wrapper.text()).toContain('App folder photo order');
     expect(wrapper.text()).toContain('Excluded source folders');
     expect(wrapper.text().indexOf('Home feed sort order')).toBeLessThan(wrapper.text().indexOf('Reels feed sort order'));
-    expect(wrapper.text().indexOf('Reels feed sort order')).toBeLessThan(
+    expect(wrapper.text().indexOf('Reels feed sort order')).toBeLessThan(wrapper.text().indexOf('App folder photo order'));
+    expect(wrapper.text().indexOf('App folder photo order')).toBeLessThan(
       wrapper.text().indexOf('Treat stories folders as normal app folders')
     );
 
-    const [homeButton, reelsButton] = wrapper.findAll('button[aria-expanded]');
+    const [homeButton, reelsButton, folderButton] = wrapper.findAll('button[aria-expanded]');
     expect(homeButton?.text()).toContain('Rediscover');
     expect(reelsButton?.text()).toContain('Random');
+    expect(folderButton?.text()).toContain('Newest First');
 
     const saveButton = wrapper
       .findAll('button')
@@ -194,14 +199,15 @@ describe('SettingsView', () => {
 
     appStore.$patch({
       loadingStats: false,
-      stats: createAppStatus('recent', 'random')
+      stats: createAppStatus('recent', 'random', 'oldest')
     });
 
     await flushPromises();
 
-    const [homeButton, reelsButton] = wrapper.findAll('button[aria-expanded]');
+    const [homeButton, reelsButton, folderButton] = wrapper.findAll('button[aria-expanded]');
     expect(homeButton?.text()).toContain('Recent');
     expect(reelsButton?.text()).toContain('Random');
+    expect(folderButton?.text()).toContain('Oldest First');
 
     const saveButton = wrapper
       .findAll('button')
@@ -330,6 +336,52 @@ describe('SettingsView', () => {
     expect(updateExcludedFoldersSpy).not.toHaveBeenCalled();
     expect(appStore.stats?.preferences.defaultReelsFeedMode).toBe('recommended');
     expect(wrapper.text()).toContain('Reels now opens with Recommended.');
+  });
+
+  it('saves the app folder photo order from the general settings card', async () => {
+    const appStore = useAppStore();
+    appStore.$patch({
+      stats: createAppStatus()
+    });
+
+    vi.spyOn(appStore, 'fetchStats').mockResolvedValue();
+    const updateFolderImageOrderDefaultSpy = vi.spyOn(galleryApi, 'updateFolderImageOrderDefault').mockResolvedValue({
+      defaultOrder: 'oldest'
+    });
+
+    const wrapper = mountSettingsView();
+
+    await flushPromises();
+    await openGeneralSettingsSidebarTab(wrapper);
+
+    const [, , folderButton] = wrapper.findAll('button[aria-expanded]');
+    expect(folderButton).toBeDefined();
+
+    await folderButton!.trigger('click');
+    await flushPromises();
+    const oldestOption = wrapper.findAll('button').find((button) => button.text().includes('Oldest First'));
+    expect(oldestOption).toBeDefined();
+    await oldestOption!.trigger('click');
+    await flushPromises();
+
+    const updateHomeFeedDefaultSpy = vi.spyOn(galleryApi, 'updateHomeFeedDefault');
+    const updateReelsFeedDefaultSpy = vi.spyOn(galleryApi, 'updateReelsFeedDefault');
+    const updateExcludedFoldersSpy = vi.spyOn(galleryApi, 'updateExcludedFolders');
+    const saveButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'Save changes');
+
+    expect(saveButton).toBeDefined();
+
+    await saveButton!.trigger('click');
+    await flushPromises();
+
+    expect(updateFolderImageOrderDefaultSpy).toHaveBeenCalledWith('oldest');
+    expect(updateHomeFeedDefaultSpy).not.toHaveBeenCalled();
+    expect(updateReelsFeedDefaultSpy).not.toHaveBeenCalled();
+    expect(updateExcludedFoldersSpy).not.toHaveBeenCalled();
+    expect(appStore.stats?.preferences.defaultFolderImageOrder).toBe('oldest');
+    expect(wrapper.text()).toContain('App folders now open with Oldest First.');
   });
 
   it('saves custom excluded folder rules from the settings textarea', async () => {

--- a/client/src/views/SettingsView.vue
+++ b/client/src/views/SettingsView.vue
@@ -517,7 +517,7 @@
             <div class="border-b border-border px-6 py-5">
               <div>
                 <h2 class="m-0 text-[1.18rem]">General Settings</h2>
-                <p class="m-0 mt-[0.25rem] text-muted">App-wide defaults for stories folders, excluded folders, Home, and Reels.</p>
+                <p class="m-0 mt-[0.25rem] text-muted">App-wide defaults for stories folders, excluded folders, Home, Reels, and app folders.</p>
               </div>
             </div>
 
@@ -641,6 +641,67 @@
                       >
                         <span class="mt-[0.05rem] inline-flex h-5 w-5 items-center justify-center shrink-0 text-accent-strong">
                           <span v-if="reelsFeedDefaultMode === mode.id" class="i-fluent-checkmark-20-filled h-4 w-4" aria-hidden="true" />
+                        </span>
+                        <span class="grid min-w-0 gap-[0.08rem]">
+                          <span class="text-[0.9rem] font-semibold text-text">{{ mode.label }}</span>
+                          <span class="text-[0.78rem] text-muted">{{ mode.description }}</span>
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="grid gap-3 px-6 py-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+                <div class="min-w-0">
+                  <p class="m-0 text-[0.96rem] font-semibold text-text">App folder photo order</p>
+                  <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">Choose the default order for photos inside app folders.</p>
+                </div>
+
+                <div class="relative w-full md:w-[18rem] md:justify-self-end" @keydown.escape.stop.prevent="closeGeneralSettingsMenu">
+                  <button
+                    class="inline-flex w-full items-center justify-between gap-3 rounded-[0.9rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_80%,transparent_20%)] px-3 py-[0.85rem] text-left transition-[border-color,box-shadow] duration-180 hover:border-[color-mix(in_srgb,var(--accent)_22%,var(--border)_78%)] hover:bg-surface-hover focus-visible:border-[color-mix(in_srgb,var(--accent)_35%,var(--border)_65%)] focus-visible:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
+                    type="button"
+                    :aria-expanded="activeGeneralSettingsMenu === 'folder'"
+                    :disabled="savingGeneralSettings || waitingForInitialStatus"
+                    @click="toggleGeneralSettingsMenu('folder')"
+                  >
+                    <span class="min-w-0 truncate text-[0.9rem] font-semibold text-text">
+                      {{ selectedFolderImageOrderOption.label }}
+                    </span>
+                    <span
+                      class="i-fluent-chevron-down-20-regular h-5 w-5 shrink-0 text-muted transition-transform duration-180"
+                      :class="activeGeneralSettingsMenu === 'folder' ? 'rotate-180 text-text' : ''"
+                      aria-hidden="true"
+                    />
+                  </button>
+
+                  <button
+                    v-if="activeGeneralSettingsMenu === 'folder'"
+                    class="fixed inset-0 z-40 border-0 bg-transparent"
+                    type="button"
+                    aria-label="Close app folder photo order menu"
+                    @click="closeGeneralSettingsMenu"
+                  />
+
+                  <div
+                    v-if="activeGeneralSettingsMenu === 'folder'"
+                    class="absolute right-0 top-[calc(100%+0.45rem)] z-50 w-full overflow-hidden rounded-[1rem] border border-border bg-[color-mix(in_srgb,var(--surface)_97%,var(--bg)_3%)] shadow-[0_28px_70px_rgba(0,0,0,0.16)]"
+                  >
+                    <div class="border-b border-border px-4 py-3">
+                      <p class="m-0 text-[0.83rem] font-semibold text-text">App folder photo order</p>
+                    </div>
+                    <div class="grid gap-1 p-2">
+                      <button
+                        v-for="mode in folderImageOrderOptions"
+                        :key="mode.id"
+                        class="flex items-start gap-3 rounded-[0.85rem] border-0 px-3 py-3 text-left cursor-pointer transition-colors duration-150 hover:bg-surface-hover"
+                        :class="folderImageOrderDefault === mode.id ? 'bg-[color-mix(in_srgb,var(--accent-soft)_72%,transparent_28%)]' : 'bg-transparent'"
+                        type="button"
+                        @click="selectFolderImageOrderDefault(mode.id)"
+                      >
+                        <span class="mt-[0.05rem] inline-flex h-5 w-5 items-center justify-center shrink-0 text-accent-strong">
+                          <span v-if="folderImageOrderDefault === mode.id" class="i-fluent-checkmark-20-filled h-4 w-4" aria-hidden="true" />
                         </span>
                         <span class="grid min-w-0 gap-[0.08rem]">
                           <span class="text-[0.9rem] font-semibold text-text">{{ mode.label }}</span>
@@ -1041,6 +1102,7 @@ import {
   triggerManualScan,
   triggerThumbnailRebuild,
   updateExcludedFolders,
+  updateFolderImageOrderDefault,
   updateHomeFeedDefault,
   updateReelsFeedDefault,
   updateStoriesMode
@@ -1053,7 +1115,7 @@ import { useLikesStore } from '../stores/likes';
 import { useMomentsStore } from '../stores/moments';
 import { usePlacesStore } from '../stores/places';
 import { useViewerStore } from '../stores/viewer';
-import type { AppStats, FeedMode, ReelsFeedMode, ViewerAccessMode } from '../types/api';
+import type { AppStats, FeedMode, FolderImageOrder, ReelsFeedMode, ViewerAccessMode } from '../types/api';
 
 const appStore = useAppStore();
 const authStore = useAuthStore();
@@ -1088,10 +1150,11 @@ const nextPasswordConfirmation = ref('');
 const disablePassword = ref('');
 const homeFeedDefaultMode = ref<FeedMode>('random');
 const reelsFeedDefaultMode = ref<ReelsFeedMode>('random');
+const folderImageOrderDefault = ref<FolderImageOrder>('newest');
 const storiesMode = ref(false);
 const feedDefaultsHydrated = ref(false);
 const storiesModeHydrated = ref(false);
-const activeGeneralSettingsMenu = ref<'home' | 'reels' | null>(null);
+const activeGeneralSettingsMenu = ref<'home' | 'reels' | 'folder' | null>(null);
 const showStoriesAnnouncementStructure = ref(false);
 const generalSettingsSaveArea = ref<HTMLElement | null>(null);
 const acknowledgedStoriesMigrationChoice = ref(false);
@@ -1310,6 +1373,7 @@ function validatePasswordConfirmation(password: string, confirmation: string): s
 function syncFeedDefaultsFromSaved() {
   homeFeedDefaultMode.value = appStore.defaultHomeFeedMode;
   reelsFeedDefaultMode.value = appStore.defaultReelsFeedMode;
+  folderImageOrderDefault.value = appStore.defaultFolderImageOrder;
   feedDefaultsHydrated.value = true;
 }
 
@@ -1360,6 +1424,18 @@ const reelsFeedDefaultOptions: Array<{ id: ReelsFeedMode; label: string; descrip
     description: 'Affinity-ranked mix.'
   }
 ];
+const folderImageOrderOptions: Array<{ id: FolderImageOrder; label: string; description: string }> = [
+  {
+    id: 'newest',
+    label: 'Newest First',
+    description: 'Recent photos appear first.'
+  },
+  {
+    id: 'oldest',
+    label: 'Oldest First',
+    description: 'Earlier photos appear first.'
+  }
+];
 const isLibraryRebuildActive = computed(
   () => rebuilding.value || (appStore.isScanning && activeScanReason.value === 'rebuild')
 );
@@ -1372,6 +1448,7 @@ const highlightRebuildAction = computed(() => route.query.action === 'rebuild');
 const waitingForInitialStatus = computed(() => !appStore.stats || appStore.loadingStats);
 const savedHomeFeedDefaultMode = computed(() => appStore.defaultHomeFeedMode);
 const savedReelsFeedDefaultMode = computed(() => appStore.defaultReelsFeedMode);
+const savedFolderImageOrderDefault = computed(() => appStore.defaultFolderImageOrder);
 const savedStoriesMode = computed(() => appStore.treatStoriesAsFolders);
 const savedCustomExcludedFolders = computed(() => adminStats.value?.excludedFolders.customExcludedFolders ?? []);
 const envExcludedFolders = computed(() => adminStats.value?.excludedFolders.envExcludedFolders ?? []);
@@ -1387,11 +1464,17 @@ const savedHomeFeedDefaultModeLabel = computed(
 const savedReelsFeedDefaultModeLabel = computed(
   () => reelsFeedDefaultOptions.find((mode) => mode.id === savedReelsFeedDefaultMode.value)?.label ?? 'Random'
 );
+const savedFolderImageOrderDefaultLabel = computed(
+  () => folderImageOrderOptions.find((mode) => mode.id === savedFolderImageOrderDefault.value)?.label ?? 'Newest First'
+);
 const selectedHomeFeedDefaultOption = computed(
   () => homeFeedDefaultOptions.find((mode) => mode.id === homeFeedDefaultMode.value) ?? homeFeedDefaultOptions[0]
 );
 const selectedReelsFeedDefaultOption = computed(
   () => reelsFeedDefaultOptions.find((mode) => mode.id === reelsFeedDefaultMode.value) ?? reelsFeedDefaultOptions[0]
+);
+const selectedFolderImageOrderOption = computed(
+  () => folderImageOrderOptions.find((mode) => mode.id === folderImageOrderDefault.value) ?? folderImageOrderOptions[0]
 );
 const homeFeedDefaultDirty = computed(
   () => feedDefaultsHydrated.value && homeFeedDefaultMode.value !== savedHomeFeedDefaultMode.value
@@ -1399,7 +1482,10 @@ const homeFeedDefaultDirty = computed(
 const reelsFeedDefaultDirty = computed(
   () => feedDefaultsHydrated.value && reelsFeedDefaultMode.value !== savedReelsFeedDefaultMode.value
 );
-const feedDefaultsDirty = computed(() => homeFeedDefaultDirty.value || reelsFeedDefaultDirty.value);
+const folderImageOrderDirty = computed(
+  () => feedDefaultsHydrated.value && folderImageOrderDefault.value !== savedFolderImageOrderDefault.value
+);
+const feedDefaultsDirty = computed(() => homeFeedDefaultDirty.value || reelsFeedDefaultDirty.value || folderImageOrderDirty.value);
 const storiesModeDirty = computed(() => storiesModeHydrated.value && storiesMode.value !== savedStoriesMode.value);
 const excludedFoldersDirty = computed(() => {
   if (!excludedFoldersHydrated.value) {
@@ -1446,15 +1532,15 @@ const generalSettingsActionNote = computed(() => {
   }
 
   if (storiesModeDirty.value && feedDefaultsDirty.value) {
-    return 'Save the new stories rule and the updated feed defaults together.';
+    return 'Save the new stories rule and the updated browsing defaults together.';
   }
 
   if (storiesModeDirty.value || storiesModeRequiresDecision.value) {
     return 'This saves the stories folders rule only. Run a library scan afterward to reindex with the new behavior.';
   }
 
-  if (homeFeedDefaultDirty.value && reelsFeedDefaultDirty.value) {
-    return 'Save both feed defaults together. Home visitors can still switch modes on the homepage; Reels stays app-default only.';
+  if ([homeFeedDefaultDirty.value, reelsFeedDefaultDirty.value, folderImageOrderDirty.value].filter(Boolean).length > 1) {
+    return 'Save these browsing defaults together. Home visitors can still switch modes on the homepage; Reels and app folders use app defaults.';
   }
 
   if (homeFeedDefaultDirty.value) {
@@ -1465,7 +1551,11 @@ const generalSettingsActionNote = computed(() => {
     return 'This updates the queue style used when Reels opens for this app. Visitors cannot switch modes from the reels page.';
   }
 
-  return 'These are the current app-wide defaults for Home, Reels, stories folders, and excluded folders.';
+  if (folderImageOrderDirty.value) {
+    return 'This updates the default photo order used by app folder grids.';
+  }
+
+  return 'These are the current app-wide defaults for Home, Reels, app folders, stories folders, and excluded folders.';
 });
 const generalSettingsRescanNotice = computed(() => {
   if (excludedFoldersDirty.value && (storiesModeDirty.value || storiesModeRequiresDecision.value)) {
@@ -2112,7 +2202,7 @@ function closeGeneralSettingsMenu() {
   activeGeneralSettingsMenu.value = null;
 }
 
-function toggleGeneralSettingsMenu(menu: 'home' | 'reels') {
+function toggleGeneralSettingsMenu(menu: 'home' | 'reels' | 'folder') {
   clearGeneralSettingsFeedback();
   activeGeneralSettingsMenu.value = activeGeneralSettingsMenu.value === menu ? null : menu;
 }
@@ -2162,6 +2252,12 @@ function selectReelsFeedDefault(mode: ReelsFeedMode) {
   closeGeneralSettingsMenu();
 }
 
+function selectFolderImageOrderDefault(order: FolderImageOrder) {
+  clearGeneralSettingsFeedback();
+  folderImageOrderDefault.value = order;
+  closeGeneralSettingsMenu();
+}
+
 async function saveGeneralSettings() {
   if (generalSettingsSaveDisabled.value) {
     return;
@@ -2171,6 +2267,7 @@ async function saveGeneralSettings() {
   const shouldSaveStories = storiesModeDirty.value || storiesModeRequiresDecision.value;
   const shouldSaveHome = homeFeedDefaultDirty.value;
   const shouldSaveReels = reelsFeedDefaultDirty.value;
+  const shouldSaveFolderOrder = folderImageOrderDirty.value;
   const savedParts: string[] = [];
   let nextExcludedFolders: string[] = [];
 
@@ -2234,24 +2331,33 @@ async function saveGeneralSettings() {
       reelsFeedDefaultMode.value = payload.defaultMode;
     }
 
+    if (shouldSaveFolderOrder) {
+      const payload = await updateFolderImageOrderDefault(folderImageOrderDefault.value);
+      savedParts.push('app folder order');
+      if (appStore.stats) {
+        appStore.stats.preferences.defaultFolderImageOrder = payload.defaultOrder;
+      }
+      folderImageOrderDefault.value = payload.defaultOrder;
+    }
+
     await appStore.fetchStats({ background: true });
 
     if (shouldSaveStories || shouldSaveExcludedFolders) {
       await loadAdminStats().catch(() => {});
     }
 
-    if ((shouldSaveStories || shouldSaveExcludedFolders) && (shouldSaveHome || shouldSaveReels)) {
+    if ((shouldSaveStories || shouldSaveExcludedFolders) && (shouldSaveHome || shouldSaveReels || shouldSaveFolderOrder)) {
       setGeneralSettingsFeedback('success', 'Settings were saved. Run a library scan to apply the folder rule changes.');
     } else if (shouldSaveExcludedFolders && shouldSaveStories) {
       setGeneralSettingsFeedback('success', 'Folder exclusion rules and stories folder behavior were saved. Run a library scan to apply them.');
     } else if (shouldSaveExcludedFolders) {
       setGeneralSettingsFeedback('success', 'Excluded folders were saved. Run a library scan to apply them.');
-    } else if (shouldSaveStories && (shouldSaveHome || shouldSaveReels)) {
+    } else if (shouldSaveStories && (shouldSaveHome || shouldSaveReels || shouldSaveFolderOrder)) {
       setGeneralSettingsFeedback('success', 'Settings were saved. Run a library scan to apply the stories folder change.');
     } else if (shouldSaveStories) {
       setGeneralSettingsFeedback('success', 'Stories folder behavior was saved. Run a library scan to apply it.');
-    } else if (shouldSaveHome && shouldSaveReels) {
-      setGeneralSettingsFeedback('success', 'Home and Reels defaults were updated.');
+    } else if ([shouldSaveHome, shouldSaveReels, shouldSaveFolderOrder].filter(Boolean).length > 1) {
+      setGeneralSettingsFeedback('success', 'App-wide browsing defaults were updated.');
     } else if (shouldSaveHome) {
       setGeneralSettingsFeedback(
         'success',
@@ -2261,6 +2367,11 @@ async function saveGeneralSettings() {
       setGeneralSettingsFeedback(
         'success',
         `Reels now opens with ${selectedReelsFeedDefaultOption.value.label}.`
+      );
+    } else if (shouldSaveFolderOrder) {
+      setGeneralSettingsFeedback(
+        'success',
+        `App folders now open with ${selectedFolderImageOrderOption.value.label}.`
       );
     }
   } catch (error) {
@@ -2409,7 +2520,15 @@ onMounted(async () => {
 });
 
 watch(
-  () => [appStore.stats, appStore.loadingStats, savedHomeFeedDefaultMode.value, savedReelsFeedDefaultMode.value, savedStoriesMode.value] as const,
+  () =>
+    [
+      appStore.stats,
+      appStore.loadingStats,
+      savedHomeFeedDefaultMode.value,
+      savedReelsFeedDefaultMode.value,
+      savedFolderImageOrderDefault.value,
+      savedStoriesMode.value
+    ] as const,
   ([stats, loadingStats]) => {
     if (!stats || loadingStats) {
       return;

--- a/server/src/constants/app-setting-keys.ts
+++ b/server/src/constants/app-setting-keys.ts
@@ -10,6 +10,7 @@ export const EXCLUDED_FOLDERS_SETTING_KEY = 'library.excluded_folders';
 export const STORIES_MIGRATION_DECISION_SETTING_KEY = 'library.stories_migration_decision';
 export const HOME_FEED_DEFAULT_MODE_SETTING_KEY = 'feed.default_home_mode';
 export const REELS_FEED_DEFAULT_MODE_SETTING_KEY = 'feed.default_reels_mode';
+export const FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY = 'folder.default_image_order';
 export const AUTH_PASSWORD_HASH_SETTING_KEY = 'auth.password_hash';
 export const AUTH_PASSWORD_SALT_SETTING_KEY = 'auth.password_salt';
 export const AUTH_SESSION_SECRET_SETTING_KEY = 'auth.session_secret';

--- a/server/src/db/repositories.ts
+++ b/server/src/db/repositories.ts
@@ -4,6 +4,7 @@ import type {
   AppSettingRecord,
   FeedImage,
   FolderAvatarSource,
+  FolderImageOrder,
   FolderRole,
   FolderScanStateRecord,
   ImageDetail,
@@ -93,6 +94,18 @@ const FOLDER_SUMMARY_AVATAR_THUMBNAIL_PATH_SQL = `
     )
   )
 `;
+
+function getQualifiedFolderImageOrderSql(order: FolderImageOrder): string {
+  return order === 'oldest'
+    ? 'images.sort_timestamp ASC, images.id ASC'
+    : 'images.sort_timestamp DESC, images.id DESC';
+}
+
+function getUnscopedFolderImageOrderSql(order: FolderImageOrder): string {
+  return order === 'oldest'
+    ? 'sort_timestamp ASC, id ASC'
+    : 'sort_timestamp DESC, id DESC';
+}
 const IMAGE_FILENAME_SEARCH_SQL = 'LOWER(images.filename)';
 const FOLDER_NAME_SEARCH_SQL = 'LOWER(folders.name)';
 const FOLDER_SLUG_SEARCH_SQL = 'LOWER(folders.slug)';
@@ -1276,14 +1289,21 @@ export const imageRepository = {
     ).all(startTimestamp, endTimestamp, limit, offset) as unknown as FeedImage[];
   },
 
-  listFolderImages(folderId: number, page: number, limit: number, mediaType?: MediaType): FeedImage[] {
+  listFolderImages(
+    folderId: number,
+    page: number,
+    limit: number,
+    mediaType?: MediaType,
+    order: FolderImageOrder = 'newest'
+  ): FeedImage[] {
     const offset = (page - 1) * limit;
     const mediaTypeClause = mediaType ? ' AND images.media_type = ?' : '';
+    const orderBySql = getQualifiedFolderImageOrderSql(order);
     return database.prepare(
       `
       ${FEED_IMAGE_SELECT_SQL}
       WHERE images.folder_id = ? AND ${VISIBLE_IMAGE_WHERE_SQL}${mediaTypeClause}
-      ORDER BY images.sort_timestamp DESC, images.id DESC
+      ORDER BY ${orderBySql}
       LIMIT ? OFFSET ?
       `
     ).all(...(mediaType ? [folderId, mediaType, limit, offset] : [folderId, limit, offset])) as unknown as FeedImage[];
@@ -1599,8 +1619,21 @@ export const imageRepository = {
     return row?.id ?? null;
   },
 
-  getImageDetail(id: number, mediaType?: MediaType, allowHiddenCover = false): ImageDetail | undefined {
+  getImageDetail(
+    id: number,
+    mediaType?: MediaType,
+    allowHiddenCover = false,
+    folderImageOrder: FolderImageOrder = 'newest'
+  ): ImageDetail | undefined {
     const whereClause = allowHiddenCover ? 'images.is_deleted = 0 AND images.is_trashed = 0' : VISIBLE_IMAGE_WHERE_SQL;
+    const nextComparisonSql = folderImageOrder === 'oldest'
+      ? '(sort_timestamp > ? OR (sort_timestamp = ? AND id > ?))'
+      : '(sort_timestamp < ? OR (sort_timestamp = ? AND id < ?))';
+    const previousComparisonSql = folderImageOrder === 'oldest'
+      ? '(sort_timestamp < ? OR (sort_timestamp = ? AND id < ?))'
+      : '(sort_timestamp > ? OR (sort_timestamp = ? AND id > ?))';
+    const nextOrderSql = getUnscopedFolderImageOrderSql(folderImageOrder);
+    const previousOrderSql = getUnscopedFolderImageOrderSql(folderImageOrder === 'oldest' ? 'newest' : 'oldest');
     const detail = database.prepare(
       `
       SELECT
@@ -1649,8 +1682,8 @@ export const imageRepository = {
       FROM images
       WHERE folder_id = ? AND ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL}
         ${mediaTypeClause}
-        AND (sort_timestamp < ? OR (sort_timestamp = ? AND id < ?))
-      ORDER BY sort_timestamp DESC, id DESC
+        AND ${nextComparisonSql}
+      ORDER BY ${nextOrderSql}
       LIMIT 1
       `
     ).get(...(mediaType
@@ -1663,8 +1696,8 @@ export const imageRepository = {
       FROM images
       WHERE folder_id = ? AND ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL}
         ${mediaTypeClause}
-        AND (sort_timestamp > ? OR (sort_timestamp = ? AND id > ?))
-      ORDER BY sort_timestamp ASC, id ASC
+        AND ${previousComparisonSql}
+      ORDER BY ${previousOrderSql}
       LIMIT 1
       `
     ).get(...(mediaType

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -71,6 +71,9 @@ const homeFeedDefaultBodySchema = z.object({
 const reelsFeedDefaultBodySchema = z.object({
   defaultMode: z.enum(['recommended', 'recent', 'random'])
 });
+const folderImageOrderDefaultBodySchema = z.object({
+  defaultOrder: z.enum(['newest', 'oldest'])
+});
 const storiesModeBodySchema = z.object({
   treatStoriesAsFolders: z.boolean()
 });
@@ -153,6 +156,7 @@ export const authRequestBodySchemas = {
 export const settingsRequestBodySchemas = {
   homeFeedDefault: homeFeedDefaultBodySchema,
   reelsFeedDefault: reelsFeedDefaultBodySchema,
+  folderImageOrderDefault: folderImageOrderDefaultBodySchema,
   storiesMode: storiesModeBodySchema,
   excludedFolders: excludedFoldersBodySchema
 };
@@ -376,6 +380,15 @@ router.put(
   (request, response) => {
     const body = reelsFeedDefaultBodySchema.parse(request.body);
     response.json(galleryService.setDefaultReelsFeedMode(body.defaultMode));
+  }
+);
+
+router.put(
+  '/admin/settings/folder-image-order-default',
+  requireCapability('canAccessSettings', 'Admin access is required.'),
+  (request, response) => {
+    const body = folderImageOrderDefaultBodySchema.parse(request.body);
+    response.json(galleryService.setDefaultFolderImageOrder(body.defaultOrder));
   }
 );
 

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import {
   EXCLUDED_FOLDERS_SETTING_KEY,
+  FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY,
   HOME_FEED_DEFAULT_MODE_SETTING_KEY,
   LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY,
   LIBRARY_REBUILD_REQUIRED_SETTING_KEY,
@@ -14,7 +15,7 @@ import {
 } from '../constants/app-setting-keys.js';
 import { appConfig } from '../config/env.js';
 import { appSettingsRepository, folderRepository, folderScanStateRepository, imageRepository, likeRepository, placeRepository, scanRunRepository } from '../db/repositories.js';
-import type { FeedImage, FolderRecord, FolderSummaryRecord, ImageDetail, MediaType, PlaceKind, PlaybackStrategy, TrashImage } from '../types/models.js';
+import type { FeedImage, FolderImageOrder, FolderRecord, FolderSummaryRecord, ImageDetail, MediaType, PlaceKind, PlaybackStrategy, TrashImage } from '../types/models.js';
 import {
   getEffectiveExcludedFolderRules,
   parseExcludedFolderRulesFromSetting,
@@ -135,6 +136,14 @@ function parseReelsFeedMode(value: string | null): ReelsFeedMode {
 
 function getDefaultReelsFeedMode(): ReelsFeedMode {
   return parseReelsFeedMode(appSettingsRepository.get(REELS_FEED_DEFAULT_MODE_SETTING_KEY));
+}
+
+function parseFolderImageOrder(value: string | null): FolderImageOrder {
+  return value === 'oldest' ? 'oldest' : 'newest';
+}
+
+function getDefaultFolderImageOrder(): FolderImageOrder {
+  return parseFolderImageOrder(appSettingsRepository.get(FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY));
 }
 
 function getTreatStoriesAsFolders(): boolean {
@@ -1294,10 +1303,13 @@ export const galleryService = {
 
     const total = mediaType ? imageRepository.countVisibleByFolder(folder.id, mediaType) : folder.image_count;
     const derivativeVersion = getDerivativeAssetVersion();
+    const defaultFolderImageOrder = getDefaultFolderImageOrder();
 
     return {
       folder: buildFolderSummary(folder),
-      items: imageRepository.listFolderImages(folder.id, page, limit, mediaType).map((image) => mapFeedImage(image, derivativeVersion)),
+      items: imageRepository
+        .listFolderImages(folder.id, page, limit, mediaType, defaultFolderImageOrder)
+        .map((image) => mapFeedImage(image, derivativeVersion)),
       page,
       limit,
       total,
@@ -1310,9 +1322,10 @@ export const galleryService = {
       return null;
     }
 
-    let detail = imageRepository.getImageDetail(id, mediaType);
+    const defaultFolderImageOrder = getDefaultFolderImageOrder();
+    let detail = imageRepository.getImageDetail(id, mediaType, false, defaultFolderImageOrder);
     if (!detail) {
-      const avatarDetail = imageRepository.getImageDetail(id, mediaType, true);
+      const avatarDetail = imageRepository.getImageDetail(id, mediaType, true, defaultFolderImageOrder);
       if (avatarDetail && avatarDetail.folderAvatarImageId === avatarDetail.id) {
         detail = avatarDetail;
       }
@@ -1458,6 +1471,7 @@ export const galleryService = {
     const rebuildRequired = appSettingsRepository.get(LIBRARY_REBUILD_REQUIRED_SETTING_KEY) === '1';
     const defaultHomeFeedMode = getDefaultHomeFeedMode();
     const defaultReelsFeedMode = getDefaultReelsFeedMode();
+    const defaultFolderImageOrder = getDefaultFolderImageOrder();
     const treatStoriesAsFolders = getTreatStoriesAsFolders();
     const storiesMigration = getStoriesMigrationStatus();
 
@@ -1478,6 +1492,7 @@ export const galleryService = {
       preferences: {
         defaultHomeFeedMode,
         defaultReelsFeedMode,
+        defaultFolderImageOrder,
         treatStoriesAsFolders
       },
       storiesMigration
@@ -1516,6 +1531,7 @@ export const galleryService = {
     const pendingDerivativeMigrationRows = storageState.libraryAvailable ? imageRepository.countPendingDerivativeMigrationRows() : 0;
     const defaultHomeFeedMode = getDefaultHomeFeedMode();
     const defaultReelsFeedMode = getDefaultReelsFeedMode();
+    const defaultFolderImageOrder = getDefaultFolderImageOrder();
     const treatStoriesAsFolders = getTreatStoriesAsFolders();
     const storiesMigration = getStoriesMigrationStatus();
     const excludedFolders = getExcludedFolderSettings();
@@ -1547,6 +1563,7 @@ export const galleryService = {
       preferences: {
         defaultHomeFeedMode,
         defaultReelsFeedMode,
+        defaultFolderImageOrder,
         treatStoriesAsFolders
       },
       storiesMigration,
@@ -1567,6 +1584,14 @@ export const galleryService = {
 
     return {
       defaultMode: mode
+    };
+  },
+
+  setDefaultFolderImageOrder(order: FolderImageOrder) {
+    appSettingsRepository.set(FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY, order);
+
+    return {
+      defaultOrder: order
     };
   },
 

--- a/server/src/types/models.ts
+++ b/server/src/types/models.ts
@@ -1,4 +1,5 @@
 export type MediaType = 'image' | 'video';
+export type FolderImageOrder = 'newest' | 'oldest';
 export type TakenAtSource = 'exif' | 'mtime' | 'first_seen' | 'sort_timestamp';
 export type PlaybackStrategy = 'preview' | 'original';
 export type FolderAvatarSource = 'auto' | 'manual' | 'cover';

--- a/server/test/auth-route-validation.test.ts
+++ b/server/test/auth-route-validation.test.ts
@@ -117,6 +117,24 @@ describe.sequential('auth route validation', () => {
     });
   });
 
+  it('rejects invalid folder image order defaults', () => {
+    expect(() =>
+      settingsRequestBodySchemas.folderImageOrderDefault.parse({
+        defaultOrder: 'recent'
+      })
+    ).toThrowError();
+  });
+
+  it('accepts oldest as a valid folder image order default', () => {
+    expect(
+      settingsRequestBodySchemas.folderImageOrderDefault.parse({
+        defaultOrder: 'oldest'
+      })
+    ).toEqual({
+      defaultOrder: 'oldest'
+    });
+  });
+
   it('accepts long story ids up to the folder-slug route limit', () => {
     expect(
       routeParamSchemas.storyId.parse({

--- a/server/test/folder-customization-scan-behavior.test.ts
+++ b/server/test/folder-customization-scan-behavior.test.ts
@@ -10,6 +10,7 @@ type AppConfigModule = typeof import('../src/config/env.js');
 type GalleryServiceModule = typeof import('../src/services/gallery-service.js');
 type ScannerServiceModule = typeof import('../src/services/scanner-service.js');
 type RepositoriesModule = typeof import('../src/db/repositories.js');
+type AppSettingKeysModule = typeof import('../src/constants/app-setting-keys.js');
 
 const generateThumbnailDerivativeMock = vi.fn();
 const generateDerivativesMock = vi.fn();
@@ -23,6 +24,8 @@ describe.sequential('folder customization scan behavior', () => {
   let imageRepository: RepositoriesModule['imageRepository'];
   let folderRepository: RepositoriesModule['folderRepository'];
   let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+  let appSettingsRepository: RepositoriesModule['appSettingsRepository'];
+  let FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY: AppSettingKeysModule['FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY'];
 
   beforeAll(async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-folder-customization-scan-'));
@@ -53,7 +56,8 @@ describe.sequential('folder customization scan behavior', () => {
     ({ appConfig } = await import('../src/config/env.js'));
     ({ galleryService } = await import('../src/services/gallery-service.js'));
     ({ scannerService } = await import('../src/services/scanner-service.js'));
-    ({ imageRepository, folderRepository, maintenanceRepository } = await import('../src/db/repositories.js'));
+    ({ imageRepository, folderRepository, maintenanceRepository, appSettingsRepository } = await import('../src/db/repositories.js'));
+    ({ FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY } = await import('../src/constants/app-setting-keys.js'));
 
     await Promise.all([
       fs.mkdir(appConfig.galleryRoot, { recursive: true }),
@@ -156,6 +160,34 @@ describe.sequential('folder customization scan behavior', () => {
     expect(feedPayload.items.map((item) => item.id)).not.toContain(coverImage!.id);
 
     expect(galleryService.getImageDetail(coverImage!.id)?.id).toBe(coverImage!.id);
+  });
+
+  it('uses the saved app folder photo order for folder grids and detail navigation', async () => {
+    maintenanceRepository.resetLibraryIndex();
+
+    await createSourceFile('albums/older.jpg', 20_000);
+    await createSourceFile('albums/newer.jpg');
+    await scannerService.scanAll('manual');
+
+    const olderImage = imageRepository.getByRelativePath('albums/older.jpg');
+    const newerImage = imageRepository.getByRelativePath('albums/newer.jpg');
+
+    expect(olderImage).toBeDefined();
+    expect(newerImage).toBeDefined();
+
+    expect(galleryService.getFolderImages('albums', 1, 24)?.items.map((item) => item.id)).toEqual([
+      newerImage!.id,
+      olderImage!.id
+    ]);
+
+    appSettingsRepository.set(FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY, 'oldest');
+
+    expect(galleryService.getFolderImages('albums', 1, 24)?.items.map((item) => item.id)).toEqual([
+      olderImage!.id,
+      newerImage!.id
+    ]);
+    expect(galleryService.getImageDetail(olderImage!.id)?.nextImageId).toBe(newerImage!.id);
+    expect(galleryService.getImageDetail(newerImage!.id)?.previousImageId).toBe(olderImage!.id);
   });
 
   async function createSourceFile(relativePath: string, mtimeOffsetMs = 0): Promise<void> {

--- a/server/test/viewer-status.test.ts
+++ b/server/test/viewer-status.test.ts
@@ -23,6 +23,7 @@ describe.sequential('viewer-safe status payload', () => {
   let storageService: StorageServiceModule['storageService'];
   let HOME_FEED_DEFAULT_MODE_SETTING_KEY: AppSettingKeysModule['HOME_FEED_DEFAULT_MODE_SETTING_KEY'];
   let REELS_FEED_DEFAULT_MODE_SETTING_KEY: AppSettingKeysModule['REELS_FEED_DEFAULT_MODE_SETTING_KEY'];
+  let FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY: AppSettingKeysModule['FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY'];
 
   beforeAll(async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-viewer-status-'));
@@ -41,13 +42,14 @@ describe.sequential('viewer-safe status payload', () => {
     ({ scannerService } = await import('../src/services/scanner-service.js'));
     ({ imageRepository, maintenanceRepository, appSettingsRepository, scanRunRepository } = await import('../src/db/repositories.js'));
     ({ storageService } = await import('../src/services/storage-service.js'));
-    ({ HOME_FEED_DEFAULT_MODE_SETTING_KEY, REELS_FEED_DEFAULT_MODE_SETTING_KEY } = await import('../src/constants/app-setting-keys.js'));
+    ({ HOME_FEED_DEFAULT_MODE_SETTING_KEY, REELS_FEED_DEFAULT_MODE_SETTING_KEY, FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY } = await import('../src/constants/app-setting-keys.js'));
   });
 
   beforeEach(async () => {
     maintenanceRepository.resetLibraryIndex();
     appSettingsRepository.remove(HOME_FEED_DEFAULT_MODE_SETTING_KEY);
     appSettingsRepository.remove(REELS_FEED_DEFAULT_MODE_SETTING_KEY);
+    appSettingsRepository.remove(FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY);
     await Promise.all([
       fs.rm(appConfig.galleryRoot, { recursive: true, force: true }),
       fs.rm(appConfig.thumbnailsDir, { recursive: true, force: true }),
@@ -181,19 +183,22 @@ describe.sequential('viewer-safe status payload', () => {
     expect(status.preferences).toEqual({
       defaultHomeFeedMode: 'random',
       defaultReelsFeedMode: 'random',
+      defaultFolderImageOrder: 'newest',
       treatStoriesAsFolders: false
     });
   });
 
-  it('includes configured home and reels defaults in the viewer-safe status payload', () => {
+  it('includes configured home, reels, and folder defaults in the viewer-safe status payload', () => {
     appSettingsRepository.set(HOME_FEED_DEFAULT_MODE_SETTING_KEY, 'rediscover');
     appSettingsRepository.set(REELS_FEED_DEFAULT_MODE_SETTING_KEY, 'recommended');
+    appSettingsRepository.set(FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY, 'oldest');
 
     const status = galleryService.getStatus();
 
     expect(status.preferences).toEqual({
       defaultHomeFeedMode: 'rediscover',
       defaultReelsFeedMode: 'recommended',
+      defaultFolderImageOrder: 'oldest',
       treatStoriesAsFolders: false
     });
   });


### PR DESCRIPTION
Closes #44

Adds a General Settings option for choosing the default app folder photo order, with Newest First as the default and Oldest First as the alternative.

App Folder grids and folder post navigation now follow the selected default order.