### PR TITLE
perf: parallelize thumbnail and preview generation per file

### DIFF
--- a/server/src/services/derivative-service.ts
+++ b/server/src/services/derivative-service.ts
@@ -354,16 +354,15 @@ async function generateImageDerivatives(
   previewAbsolutePath: string,
   force: boolean
 ): Promise<Pick<DerivativeResult, 'generatedThumbnail' | 'generatedPreview'>> {
-  const shouldWriteThumbnail = force || !(await fileExists(thumbnailAbsolutePath));
-  const shouldWritePreview = force || !(await fileExists(previewAbsolutePath));
+  const [shouldWriteThumbnail, shouldWritePreview] = await Promise.all([
+    force ? Promise.resolve(true) : fileExists(thumbnailAbsolutePath).then((exists) => !exists),
+    force ? Promise.resolve(true) : fileExists(previewAbsolutePath).then((exists) => !exists)
+  ]);
 
-  if (shouldWriteThumbnail) {
-    await writeImageThumbnail(sourcePath, thumbnailAbsolutePath);
-  }
-
-  if (shouldWritePreview) {
-    await writeImagePreview(sourcePath, previewAbsolutePath);
-  }
+  await Promise.all([
+    shouldWriteThumbnail ? writeImageThumbnail(sourcePath, thumbnailAbsolutePath) : Promise.resolve(),
+    shouldWritePreview ? writeImagePreview(sourcePath, previewAbsolutePath) : Promise.resolve()
+  ]);
 
   return {
     generatedThumbnail: shouldWriteThumbnail,
@@ -377,16 +376,15 @@ async function generateVideoDerivatives(
   previewAbsolutePath: string,
   force: boolean
 ): Promise<Pick<DerivativeResult, 'generatedThumbnail' | 'generatedPreview'>> {
-  const shouldWriteThumbnail = force || !(await fileExists(thumbnailAbsolutePath));
-  const shouldWritePreview = force || !(await fileExists(previewAbsolutePath));
+  const [shouldWriteThumbnail, shouldWritePreview] = await Promise.all([
+    force ? Promise.resolve(true) : fileExists(thumbnailAbsolutePath).then((exists) => !exists),
+    force ? Promise.resolve(true) : fileExists(previewAbsolutePath).then((exists) => !exists)
+  ]);
 
-  if (shouldWriteThumbnail) {
-    await writeVideoThumbnail(sourcePath, thumbnailAbsolutePath);
-  }
-
-  if (shouldWritePreview) {
-    await writeVideoPreview(sourcePath, previewAbsolutePath);
-  }
+  await Promise.all([
+    shouldWriteThumbnail ? writeVideoThumbnail(sourcePath, thumbnailAbsolutePath) : Promise.resolve(),
+    shouldWritePreview ? writeVideoPreview(sourcePath, previewAbsolutePath) : Promise.resolve()
+  ]);
 
   return {
     generatedThumbnail: shouldWriteThumbnail,


### PR DESCRIPTION
Run thumbnail and preview writes concurrently using Promise.all in both generateImageDerivatives and generateVideoDerivatives, eliminating the sequential bottleneck where each output waited for the previous to finish. File existence checks are also parallelized.