### PR TITLE
Add bookmark collections for saved posts

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -31,6 +31,7 @@ import { canAccessRoute } from './router';
 import PostView from './views/PostView.vue';
 import { useAppStore } from './stores/app';
 import { useAuthStore } from './stores/auth';
+import { useCollectionsStore } from './stores/collections';
 import { useExploreStore } from './stores/explore';
 import { useLikesStore } from './stores/likes';
 import { useFoldersStore } from './stores/folders';
@@ -42,6 +43,7 @@ import { useViewerStore } from './stores/viewer';
 
 const appStore = useAppStore();
 const authStore = useAuthStore();
+const collectionsStore = useCollectionsStore();
 const exploreStore = useExploreStore();
 const feedStore = useFeedStore();
 const likesStore = useLikesStore();
@@ -100,6 +102,7 @@ function resetProtectedState() {
   feedStore.resetForRebuild();
   foldersStore.resetForRebuild();
   likesStore.resetForRebuild();
+  collectionsStore.resetForRebuild();
   momentsStore.resetForRebuild();
   reelsStore.reset();
   exploreStore.reset();
@@ -112,8 +115,10 @@ async function loadProtectedState(force = false) {
 
   if (authStore.canUseSavedItems) {
     tasks.push(likesStore.initialize(force));
+    tasks.push(collectionsStore.initialize(force));
   } else {
     likesStore.resetForRebuild();
+    collectionsStore.resetForRebuild();
   }
 
   await Promise.all(tasks);
@@ -212,7 +217,9 @@ watch(
       authStore.capabilities.canAccessSettings,
       authStore.capabilities.canDeleteMedia,
       authStore.capabilities.canUseSharedLikes,
-      authStore.capabilities.canUseLocalFavorites
+      authStore.capabilities.canUseLocalFavorites,
+      authStore.capabilities.canUseSharedCollections,
+      authStore.capabilities.canUseLocalCollections
     ] as const,
   async () => {
     if (!authStore.ready) {

--- a/client/src/api/gallery.ts
+++ b/client/src/api/gallery.ts
@@ -3,9 +3,15 @@ import type {
   AppStats,
   AuthMutationResult,
   AuthStatus,
+  CollectionImagesPayload,
+  CollectionMutationResult,
+  CollectionsPayload,
+  CreateCollectionResult,
+  DeleteCollectionResult,
   FolderStoriesPayload,
   FolderStoryFeedPayload,
   HomeFeedDefaultSetting,
+  UpdateCollectionResult,
   UpdateExcludedFoldersSettingResult,
   ReelsFeedDefaultSetting,
   StoriesModeSetting,
@@ -16,6 +22,7 @@ import type {
   FolderImageOrder,
   FolderImageOrderDefaultSetting,
   ImageDetail,
+  ImageCollectionsPayload,
   LikeMutationResult,
   LikesPayload,
   ManualScanResult,
@@ -186,6 +193,40 @@ export function fetchLikes() {
   return requestJson<LikesPayload>('/api/likes');
 }
 
+export function fetchCollections() {
+  return requestJson<CollectionsPayload>('/api/collections');
+}
+
+export function createCollection(name: string) {
+  return requestJson<CreateCollectionResult>('/api/collections', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name })
+  });
+}
+
+export function updateCollection(slug: string, name: string) {
+  return requestJson<UpdateCollectionResult>(`/api/collections/${encodeURIComponent(slug)}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name })
+  });
+}
+
+export function deleteCollection(slug: string) {
+  return requestJson<DeleteCollectionResult>(`/api/collections/${encodeURIComponent(slug)}`, {
+    method: 'DELETE'
+  });
+}
+
+export function fetchCollectionImages(slug: string, page = 1, limit = 24) {
+  return requestJson<CollectionImagesPayload>(`/api/collections/${encodeURIComponent(slug)}/images?page=${page}&limit=${limit}`);
+}
+
+export function fetchImageCollections(id: number) {
+  return requestJson<ImageCollectionsPayload>(`/api/images/${id}/collections`);
+}
+
 export function fetchTrashImages(page = 1, limit = 24) {
   return requestJson<TrashImagesPayload>(`/api/trash/images?page=${page}&limit=${limit}`);
 }
@@ -198,6 +239,30 @@ export function likeImage(id: number) {
 
 export function unlikeImage(id: number) {
   return requestJson<LikeMutationResult>(`/api/images/${id}/like`, {
+    method: 'DELETE'
+  });
+}
+
+export function saveImage(id: number) {
+  return requestJson<CollectionMutationResult>(`/api/images/${id}/save`, {
+    method: 'POST'
+  });
+}
+
+export function unsaveImage(id: number) {
+  return requestJson<CollectionMutationResult>(`/api/images/${id}/save`, {
+    method: 'DELETE'
+  });
+}
+
+export function addImageToCollection(slug: string, id: number) {
+  return requestJson<CollectionMutationResult>(`/api/collections/${encodeURIComponent(slug)}/images/${id}`, {
+    method: 'POST'
+  });
+}
+
+export function removeImageFromCollection(slug: string, id: number) {
+  return requestJson<CollectionMutationResult>(`/api/collections/${encodeURIComponent(slug)}/images/${id}`, {
     method: 'DELETE'
   });
 }

--- a/client/src/components/CollectionBookmark.test.ts
+++ b/client/src/components/CollectionBookmark.test.ts
@@ -1,0 +1,261 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CollectionMembership, CollectionSummary, FeedItem } from '../types/api';
+import { useAuthStore } from '../stores/auth';
+import { useCollectionsStore } from '../stores/collections';
+import CollectionBookmark from './CollectionBookmark.vue';
+
+function createFeedItem(id: number): FeedItem {
+  return {
+    id,
+    folderId: 11,
+    folderSlug: 'album',
+    folderName: 'Album',
+    folderPath: 'album',
+    folderBreadcrumb: null,
+    filename: `photo-${id}.jpg`,
+    width: 1200,
+    height: 1500,
+    mediaType: 'image',
+    durationMs: null,
+    isAnimated: false,
+    thumbnailUrl: `/thumbnails/${id}.webp`,
+    previewUrl: `/previews/${id}.webp`,
+    sortTimestamp: 1_800_000_000_000 + id,
+    takenAt: 1_800_000_000_000 + id,
+    isSaved: false
+  };
+}
+
+function createCollection(slug: string, name: string, isDefault = false): CollectionSummary {
+  return {
+    id: isDefault ? 1 : Math.abs(slug.length * 17),
+    slug,
+    name,
+    isDefault,
+    itemCount: 0,
+    coverImage: null,
+    previewImages: [],
+    createdAt: '2026-04-28T00:00:00.000Z',
+    updatedAt: '2026-04-28T00:00:00.000Z'
+  };
+}
+
+function createMembership(collection: CollectionSummary, containsImage: boolean): CollectionMembership {
+  return {
+    ...collection,
+    containsImage
+  };
+}
+
+describe('CollectionBookmark', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setActivePinia(createPinia());
+    const authStore = useAuthStore();
+    authStore.$patch({
+      capabilities: {
+        canManageLibrary: false,
+        canDeleteMedia: false,
+        canAccessSettings: false,
+        canUseSharedLikes: false,
+        canUseLocalFavorites: true,
+        canUseSharedCollections: false,
+        canUseLocalCollections: true
+      }
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('opens on hover and focus, hides the default collection row, and closes on leave or Escape', async () => {
+    const item = createFeedItem(42);
+    const collectionsStore = useCollectionsStore();
+    const savedCollection = createCollection('saved', 'Saved', true);
+    const membershipPayload = {
+      imageId: item.id,
+      isSaved: false,
+      items: [createMembership(savedCollection, false)]
+    };
+
+    collectionsStore.$patch({
+      items: [savedCollection],
+      membershipByImageId: {
+        [item.id]: membershipPayload
+      }
+    });
+    vi.spyOn(collectionsStore, 'fetchMembership').mockResolvedValue(membershipPayload);
+
+    const wrapper = mount(CollectionBookmark, {
+      attachTo: document.body,
+      props: {
+        item,
+        placement: 'feed'
+      },
+      global: {
+        stubs: {
+          ResilientImage: {
+            template: '<img data-test="cover" />'
+          }
+        }
+      }
+    });
+
+    await wrapper.get('.collection-bookmark').trigger('pointerenter');
+    await flushPromises();
+
+    expect(document.body.textContent).toContain('Collections');
+    expect(document.body.textContent).toContain('No collections yet');
+    expect(document.body.textContent).not.toContain('Saved');
+
+    await wrapper.get('.collection-bookmark').trigger('pointerleave');
+    vi.advanceTimersByTime(200);
+    await flushPromises();
+    expect(document.querySelector('.collection-bookmark__popover')).toBeNull();
+
+    await wrapper.get('.collection-bookmark').trigger('focusin');
+    await flushPromises();
+    expect(document.querySelector('.collection-bookmark__popover')).not.toBeNull();
+
+    await wrapper.get('.collection-bookmark').trigger('keydown', { key: 'Escape' });
+    await flushPromises();
+    expect(document.querySelector('.collection-bookmark__popover')).toBeNull();
+
+    wrapper.unmount();
+  });
+
+  it('creates a collection from the popover and keeps the default collection hidden', async () => {
+    const item = createFeedItem(84);
+    const collectionsStore = useCollectionsStore();
+    const savedCollection = createCollection('saved', 'Saved', true);
+    const travelCollection = createCollection('travel', 'Travel');
+    const initialPayload = {
+      imageId: item.id,
+      isSaved: false,
+      items: [createMembership(savedCollection, false)]
+    };
+    const createdPayload = {
+      imageId: item.id,
+      isSaved: true,
+      items: [createMembership(savedCollection, true), createMembership(travelCollection, true)]
+    };
+
+    collectionsStore.$patch({
+      items: [savedCollection],
+      membershipByImageId: {
+        [item.id]: initialPayload
+      }
+    });
+
+    vi.spyOn(collectionsStore, 'fetchMembership').mockImplementation(async (_imageId, force) => {
+      if (force) {
+        collectionsStore.membershipByImageId[item.id] = createdPayload;
+        collectionsStore.items = [savedCollection, travelCollection];
+        collectionsStore.setSavedState(item.id, true);
+        return createdPayload;
+      }
+
+      return collectionsStore.membershipByImageId[item.id] ?? initialPayload;
+    });
+    const createAndAddSpy = vi.spyOn(collectionsStore, 'createAndAdd').mockImplementation(async (name) => {
+      expect(name).toBe('Travel');
+      collectionsStore.items = [savedCollection, travelCollection];
+      collectionsStore.membershipByImageId[item.id] = createdPayload;
+      collectionsStore.setSavedState(item.id, true);
+    });
+
+    const wrapper = mount(CollectionBookmark, {
+      attachTo: document.body,
+      props: {
+        item,
+        placement: 'feed'
+      },
+      global: {
+        stubs: {
+          ResilientImage: {
+            template: '<img data-test="cover" />'
+          }
+        }
+      }
+    });
+
+    await wrapper.get('.collection-bookmark').trigger('focusin');
+    await flushPromises();
+
+    const createButton = document.body.querySelector<HTMLButtonElement>('.collection-bookmark__create-button');
+    expect(createButton).not.toBeNull();
+    createButton!.click();
+    await flushPromises();
+
+    const input = document.body.querySelector<HTMLInputElement>('.collection-bookmark__input');
+    expect(input).not.toBeNull();
+    input!.value = 'Travel';
+    input!.dispatchEvent(new Event('input'));
+    await flushPromises();
+
+    const form = document.body.querySelector<HTMLFormElement>('.collection-bookmark__create');
+    form!.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    await flushPromises();
+
+    expect(createAndAddSpy).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('.collection-bookmark__popover')).toBeNull();
+    expect(wrapper.get('.collection-bookmark__button').attributes('aria-label')).toBe('Remove saved post');
+
+    wrapper.unmount();
+  });
+
+  it('keeps the popover open and shows an inline error when a custom row toggle fails', async () => {
+    const item = createFeedItem(85);
+    const collectionsStore = useCollectionsStore();
+    const savedCollection = createCollection('saved', 'Saved', true);
+    const travelCollection = createCollection('travel', 'Travel');
+    const membershipPayload = {
+      imageId: item.id,
+      isSaved: true,
+      items: [createMembership(savedCollection, true), createMembership(travelCollection, false)]
+    };
+
+    collectionsStore.$patch({
+      items: [savedCollection, travelCollection],
+      membershipByImageId: {
+        [item.id]: membershipPayload
+      }
+    });
+
+    vi.spyOn(collectionsStore, 'fetchMembership').mockResolvedValue(membershipPayload);
+    vi.spyOn(collectionsStore, 'toggleCollectionMembership').mockRejectedValue(new Error('Unable to update collection'));
+
+    const wrapper = mount(CollectionBookmark, {
+      attachTo: document.body,
+      props: {
+        item,
+        placement: 'feed'
+      },
+      global: {
+        stubs: {
+          ResilientImage: {
+            template: '<img data-test="cover" />'
+          }
+        }
+      }
+    });
+
+    await wrapper.get('.collection-bookmark').trigger('focusin');
+    await flushPromises();
+
+    const row = document.body.querySelector<HTMLButtonElement>('.collection-bookmark__row');
+    expect(row).not.toBeNull();
+    row!.click();
+    await flushPromises();
+
+    expect(document.querySelector('.collection-bookmark__popover')).not.toBeNull();
+    expect(document.body.textContent).toContain('Unable to update collection');
+
+    wrapper.unmount();
+  });
+});

--- a/client/src/components/CollectionBookmark.test.ts
+++ b/client/src/components/CollectionBookmark.test.ts
@@ -69,11 +69,12 @@ describe('CollectionBookmark', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
     document.body.innerHTML = '';
   });
 
-  it('opens on hover and focus, hides the default collection row, and closes on leave or Escape', async () => {
+  it('opens on hover and focus after a delay, hides the default collection row, and closes on leave or Escape', async () => {
     const item = createFeedItem(42);
     const collectionsStore = useCollectionsStore();
     const savedCollection = createCollection('saved', 'Saved', true);
@@ -107,6 +108,11 @@ describe('CollectionBookmark', () => {
     });
 
     await wrapper.get('.collection-bookmark').trigger('pointerenter');
+    vi.advanceTimersByTime(999);
+    await flushPromises();
+    expect(document.querySelector('.collection-bookmark__popover')).toBeNull();
+
+    vi.advanceTimersByTime(1);
     await flushPromises();
 
     expect(document.body.textContent).toContain('Collections');
@@ -119,11 +125,57 @@ describe('CollectionBookmark', () => {
     expect(document.querySelector('.collection-bookmark__popover')).toBeNull();
 
     await wrapper.get('.collection-bookmark').trigger('focusin');
+    vi.advanceTimersByTime(1_000);
     await flushPromises();
     expect(document.querySelector('.collection-bookmark__popover')).not.toBeNull();
 
     await wrapper.get('.collection-bookmark').trigger('keydown', { key: 'Escape' });
     await flushPromises();
+    expect(document.querySelector('.collection-bookmark__popover')).toBeNull();
+
+    wrapper.unmount();
+  });
+
+  it('lets a normal click save immediately without opening the delayed popover', async () => {
+    const item = createFeedItem(43);
+    const collectionsStore = useCollectionsStore();
+    const savedCollection = createCollection('saved', 'Saved', true);
+    const membershipPayload = {
+      imageId: item.id,
+      isSaved: true,
+      items: [createMembership(savedCollection, true)]
+    };
+
+    collectionsStore.$patch({
+      items: [savedCollection]
+    });
+
+    const toggleDefaultSaveSpy = vi.spyOn(collectionsStore, 'toggleDefaultSave').mockResolvedValue(undefined);
+    vi.spyOn(collectionsStore, 'fetchMembership').mockResolvedValue(membershipPayload);
+
+    const wrapper = mount(CollectionBookmark, {
+      attachTo: document.body,
+      props: {
+        item,
+        placement: 'feed'
+      },
+      global: {
+        stubs: {
+          ResilientImage: {
+            template: '<img data-test="cover" />'
+          }
+        }
+      }
+    });
+
+    await wrapper.get('.collection-bookmark').trigger('focusin');
+    await wrapper.get('.collection-bookmark__button').trigger('click');
+    await flushPromises();
+
+    vi.advanceTimersByTime(1_100);
+    await flushPromises();
+
+    expect(toggleDefaultSaveSpy).toHaveBeenCalledTimes(1);
     expect(document.querySelector('.collection-bookmark__popover')).toBeNull();
 
     wrapper.unmount();
@@ -185,6 +237,7 @@ describe('CollectionBookmark', () => {
     });
 
     await wrapper.get('.collection-bookmark').trigger('focusin');
+    vi.advanceTimersByTime(1_000);
     await flushPromises();
 
     const createButton = document.body.querySelector<HTMLButtonElement>('.collection-bookmark__create-button');
@@ -246,6 +299,7 @@ describe('CollectionBookmark', () => {
     });
 
     await wrapper.get('.collection-bookmark').trigger('focusin');
+    vi.advanceTimersByTime(1_000);
     await flushPromises();
 
     const row = document.body.querySelector<HTMLButtonElement>('.collection-bookmark__row');
@@ -255,6 +309,106 @@ describe('CollectionBookmark', () => {
 
     expect(document.querySelector('.collection-bookmark__popover')).not.toBeNull();
     expect(document.body.textContent).toContain('Unable to update collection');
+
+    wrapper.unmount();
+  });
+
+  it('positions the popover below the icon when there is not enough space above', async () => {
+    const item = createFeedItem(86);
+    const collectionsStore = useCollectionsStore();
+    const savedCollection = createCollection('saved', 'Saved', true);
+    const travelCollection = createCollection('travel', 'Travel');
+    const membershipPayload = {
+      imageId: item.id,
+      isSaved: true,
+      items: [createMembership(savedCollection, true), createMembership(travelCollection, false)]
+    };
+
+    collectionsStore.$patch({
+      items: [savedCollection, travelCollection],
+      membershipByImageId: {
+        [item.id]: membershipPayload
+      }
+    });
+
+    vi.spyOn(collectionsStore, 'fetchMembership').mockResolvedValue(membershipPayload);
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function mockRect() {
+      const element = this as HTMLElement;
+
+      if (element.classList.contains('collection-bookmark__button')) {
+        return {
+          x: 200,
+          y: 40,
+          top: 40,
+          left: 200,
+          width: 40,
+          height: 40,
+          right: 240,
+          bottom: 80,
+          toJSON: () => ({})
+        } as DOMRect;
+      }
+
+      if (element.classList.contains('collection-bookmark__popover')) {
+        return {
+          x: 0,
+          y: 0,
+          top: 0,
+          left: 0,
+          width: 280,
+          height: 220,
+          right: 280,
+          bottom: 220,
+          toJSON: () => ({})
+        } as DOMRect;
+      }
+
+      return {
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        width: 0,
+        height: 0,
+        right: 0,
+        bottom: 0,
+        toJSON: () => ({})
+      } as DOMRect;
+    });
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 400
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 320
+    });
+
+    const wrapper = mount(CollectionBookmark, {
+      attachTo: document.body,
+      props: {
+        item,
+        placement: 'feed'
+      },
+      global: {
+        stubs: {
+          ResilientImage: {
+            template: '<img data-test="cover" />'
+          }
+        }
+      }
+    });
+
+    await wrapper.get('.collection-bookmark').trigger('focusin');
+    vi.advanceTimersByTime(1_000);
+    await flushPromises();
+
+    const popover = document.body.querySelector<HTMLElement>('.collection-bookmark__popover');
+    expect(popover).not.toBeNull();
+    expect(popover?.dataset.placement).toBe('bottom');
+    expect(popover?.style.top).toBe('90px');
+    expect(popover?.style.maxHeight).toBe('218px');
 
     wrapper.unmount();
   });

--- a/client/src/components/CollectionBookmark.vue
+++ b/client/src/components/CollectionBookmark.vue
@@ -4,7 +4,7 @@
     ref="rootElement"
     class="collection-bookmark"
     :class="[`collection-bookmark--${placement}`, { 'collection-bookmark--open': popoverOpen }]"
-    @focusin="openPopover"
+    @focusin="handleFocusIn"
     @focusout="handleFocusOut"
     @pointerenter="handlePointerEnter"
     @pointerleave="handlePointerLeave"
@@ -37,6 +37,7 @@
         v-if="popoverOpen"
         ref="popoverElement"
         class="collection-bookmark__popover"
+        :data-placement="popoverPlacement"
         :style="popoverStyle"
         role="dialog"
         aria-label="Collections"
@@ -128,6 +129,7 @@ const buttonElement = ref<HTMLButtonElement | null>(null);
 const popoverElement = ref<HTMLElement | null>(null);
 const createInputElement = ref<HTMLInputElement | null>(null);
 const popoverOpen = ref(false);
+const popoverPlacement = ref<'top' | 'bottom'>('top');
 const popoverStyle = ref<Record<string, string>>({});
 const creating = ref(false);
 const creatingCollection = ref(false);
@@ -135,9 +137,14 @@ const collectionName = ref('');
 const localError = ref<string | null>(null);
 const longPressTimer = ref<ReturnType<typeof setTimeout> | null>(null);
 const suppressNextClick = ref(false);
+let openTimer: ReturnType<typeof setTimeout> | null = null;
 let closeTimer: ReturnType<typeof setTimeout> | null = null;
 const popoverViewportMargin = 12;
 const popoverGap = 10;
+const popoverOpenDelayMs = 1000;
+const popoverMinHeightPx = 116;
+const popoverPreferredMaxHeightPx = 324;
+const popoverArrowEdgePaddingPx = 20;
 
 const canUseCollections = computed(() => authStore.canUseSharedCollections || authStore.canUseLocalCollections);
 const isSaved = computed(() => collectionsStore.isSaved(props.item.id));
@@ -165,6 +172,25 @@ function clearCloseTimer() {
   }
 }
 
+function clearOpenTimer() {
+  if (openTimer) {
+    clearTimeout(openTimer);
+    openTimer = null;
+  }
+}
+
+function scheduleOpen() {
+  clearCloseTimer();
+  if (popoverOpen.value || openTimer) {
+    return;
+  }
+
+  openTimer = setTimeout(() => {
+    openTimer = null;
+    void openPopover();
+  }, popoverOpenDelayMs);
+}
+
 function scheduleClose() {
   clearCloseTimer();
   closeTimer = setTimeout(() => {
@@ -175,6 +201,7 @@ function scheduleClose() {
 }
 
 async function openPopover() {
+  clearOpenTimer();
   clearCloseTimer();
   popoverOpen.value = true;
   localError.value = null;
@@ -188,11 +215,21 @@ async function openPopover() {
 }
 
 function closePopover() {
+  clearOpenTimer();
   clearCloseTimer();
   popoverOpen.value = false;
+  popoverPlacement.value = 'top';
   popoverStyle.value = {};
   creating.value = false;
   localError.value = null;
+}
+
+function clamp(value: number, min: number, max: number) {
+  if (max < min) {
+    return min;
+  }
+
+  return Math.min(Math.max(value, min), max);
 }
 
 function updatePopoverPosition() {
@@ -204,16 +241,39 @@ function updatePopoverPosition() {
 
   const buttonRect = button.getBoundingClientRect();
   const popoverRect = popover.getBoundingClientRect();
+  const measuredWidth = popoverRect.width || popover.offsetWidth;
+  const measuredHeight = popoverRect.height || popover.offsetHeight || popoverPreferredMaxHeightPx;
+  const availableAbove = Math.max(buttonRect.top - popoverViewportMargin - popoverGap, 0);
+  const availableBelow = Math.max(window.innerHeight - buttonRect.bottom - popoverViewportMargin - popoverGap, 0);
+  const nextPlacement = availableAbove >= measuredHeight || availableAbove >= availableBelow ? 'top' : 'bottom';
+  const availableHeight = nextPlacement === 'top' ? availableAbove : availableBelow;
+  const maxHeight = availableHeight >= popoverMinHeightPx
+    ? Math.min(availableHeight, popoverPreferredMaxHeightPx)
+    : Math.max(availableHeight, popoverMinHeightPx);
+  const constrainedHeight = Math.min(measuredHeight, maxHeight);
   const centeredLeft = buttonRect.left + buttonRect.width / 2 - popoverRect.width / 2;
-  const left = Math.min(
-    Math.max(centeredLeft, popoverViewportMargin),
-    window.innerWidth - popoverRect.width - popoverViewportMargin
+  const left = clamp(
+    centeredLeft,
+    popoverViewportMargin,
+    window.innerWidth - measuredWidth - popoverViewportMargin
   );
-  const top = Math.max(buttonRect.top - popoverRect.height - popoverGap, popoverViewportMargin);
+  const top = nextPlacement === 'top'
+    ? Math.max(buttonRect.top - constrainedHeight - popoverGap, popoverViewportMargin)
+    : Math.min(buttonRect.bottom + popoverGap, window.innerHeight - constrainedHeight - popoverViewportMargin);
+  const buttonCenter = buttonRect.left + buttonRect.width / 2;
+  const arrowLeft = clamp(
+    buttonCenter - left,
+    popoverArrowEdgePaddingPx,
+    measuredWidth - popoverArrowEdgePaddingPx
+  );
 
+  popoverPlacement.value = nextPlacement;
   popoverStyle.value = {
+    '--collection-bookmark-arrow-left': `${Math.round(arrowLeft)}px`,
     left: `${Math.round(left)}px`,
-    top: `${Math.round(top)}px`
+    top: `${Math.round(top)}px`,
+    minHeight: `${Math.min(popoverMinHeightPx, Math.round(maxHeight))}px`,
+    maxHeight: `${Math.round(maxHeight)}px`
   };
 }
 
@@ -227,12 +287,19 @@ function removePopoverPositionListeners() {
   window.removeEventListener('scroll', updatePopoverPosition, true);
 }
 
+function handleFocusIn() {
+  scheduleOpen();
+}
+
 function handlePointerEnter() {
-  void openPopover();
+  scheduleOpen();
 }
 
 function handlePointerLeave() {
-  scheduleClose();
+  clearOpenTimer();
+  if (popoverOpen.value) {
+    scheduleClose();
+  }
 }
 
 function handleFocusOut(event: FocusEvent) {
@@ -244,10 +311,14 @@ function handleFocusOut(event: FocusEvent) {
     return;
   }
 
-  scheduleClose();
+  clearOpenTimer();
+  if (popoverOpen.value) {
+    scheduleClose();
+  }
 }
 
 async function handleBookmarkClick() {
+  clearOpenTimer();
   if (suppressNextClick.value) {
     suppressNextClick.value = false;
     return;
@@ -350,6 +421,7 @@ watch(popoverOpen, (isOpen) => {
 });
 
 onBeforeUnmount(() => {
+  clearOpenTimer();
   clearCloseTimer();
   clearLongPressTimer();
   removePopoverPositionListeners();

--- a/client/src/components/CollectionBookmark.vue
+++ b/client/src/components/CollectionBookmark.vue
@@ -1,0 +1,357 @@
+<template>
+  <div
+    v-if="canUseCollections"
+    ref="rootElement"
+    class="collection-bookmark"
+    :class="[`collection-bookmark--${placement}`, { 'collection-bookmark--open': popoverOpen }]"
+    @focusin="openPopover"
+    @focusout="handleFocusOut"
+    @pointerenter="handlePointerEnter"
+    @pointerleave="handlePointerLeave"
+    @keydown.esc.stop.prevent="closePopover"
+  >
+    <button
+      ref="buttonElement"
+      class="collection-bookmark__button"
+      :class="{ 'collection-bookmark__button--saved': isSaved }"
+      type="button"
+      aria-haspopup="dialog"
+      :aria-expanded="popoverOpen"
+      :aria-label="buttonLabel"
+      :title="buttonLabel"
+      :disabled="collectionsStore.isPending(item.id)"
+      @click.stop="handleBookmarkClick"
+      @pointerdown="handlePointerDown"
+      @pointerup="handlePointerUp"
+      @pointercancel="handlePointerCancel"
+    >
+      <span
+        class="collection-bookmark__icon"
+        :class="isSaved ? 'i-fluent-bookmark-20-filled' : 'i-fluent-bookmark-20-regular'"
+        aria-hidden="true"
+      />
+    </button>
+
+    <Teleport to="body">
+      <div
+        v-if="popoverOpen"
+        ref="popoverElement"
+        class="collection-bookmark__popover"
+        :style="popoverStyle"
+        role="dialog"
+        aria-label="Collections"
+        @click.stop
+        @focusout="handleFocusOut"
+        @keydown.esc.stop.prevent="closePopover"
+        @pointerenter="handlePointerEnter"
+        @pointerleave="handlePointerLeave"
+      >
+        <div class="collection-bookmark__header">
+          <strong>Collections</strong>
+          <button
+            class="collection-bookmark__create-button"
+            type="button"
+            aria-label="Create collection"
+            title="Create collection"
+            @click="startCreating"
+          >
+            <span class="i-fluent-add-16-filled" aria-hidden="true" />
+          </button>
+        </div>
+
+        <form v-if="creating" class="collection-bookmark__create" @submit.prevent="submitCreate">
+          <input
+            ref="createInputElement"
+            v-model="collectionName"
+            class="collection-bookmark__input"
+            type="text"
+            maxlength="80"
+            placeholder="Collection name"
+            @keydown.esc.stop.prevent="cancelCreating"
+          />
+          <button class="collection-bookmark__submit" type="submit" :disabled="creatingCollection">
+            <span class="i-fluent-checkmark-16-filled" aria-hidden="true" />
+          </button>
+        </form>
+
+        <p v-if="localError" class="collection-bookmark__error">{{ localError }}</p>
+        <p v-else-if="collectionsStore.error" class="collection-bookmark__error">{{ collectionsStore.error }}</p>
+
+        <div class="collection-bookmark__rows">
+          <p v-if="customMemberships.length === 0" class="collection-bookmark__empty">No collections yet</p>
+          <button
+            v-for="collection in customMemberships"
+            :key="collection.slug"
+            class="collection-bookmark__row"
+            type="button"
+            :disabled="collectionsStore.isCollectionPending(collection.slug, item.id)"
+            @click="toggleCollection(collection.slug)"
+          >
+            <span class="collection-bookmark__cover">
+              <ResilientImage
+                v-if="collection.coverImage"
+                :src="collection.coverImage.thumbnailUrl"
+                :alt="displayCollectionName(collection)"
+                loading="lazy"
+              />
+            </span>
+            <span class="collection-bookmark__name">{{ displayCollectionName(collection) }}</span>
+            <span
+              v-if="collection.containsImage"
+              class="collection-bookmark__check i-fluent-checkmark-16-filled"
+              aria-hidden="true"
+            />
+          </button>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
+
+import { useAuthStore } from '../stores/auth';
+import { useCollectionsStore } from '../stores/collections';
+import type { CollectionSummary, FeedItem, ImageDetail } from '../types/api';
+import ResilientImage from './ResilientImage.vue';
+
+const props = defineProps<{
+  item: FeedItem | ImageDetail;
+  placement: 'feed' | 'viewer';
+}>();
+
+const authStore = useAuthStore();
+const collectionsStore = useCollectionsStore();
+const rootElement = ref<HTMLElement | null>(null);
+const buttonElement = ref<HTMLButtonElement | null>(null);
+const popoverElement = ref<HTMLElement | null>(null);
+const createInputElement = ref<HTMLInputElement | null>(null);
+const popoverOpen = ref(false);
+const popoverStyle = ref<Record<string, string>>({});
+const creating = ref(false);
+const creatingCollection = ref(false);
+const collectionName = ref('');
+const localError = ref<string | null>(null);
+const longPressTimer = ref<ReturnType<typeof setTimeout> | null>(null);
+const suppressNextClick = ref(false);
+let closeTimer: ReturnType<typeof setTimeout> | null = null;
+const popoverViewportMargin = 12;
+const popoverGap = 10;
+
+const canUseCollections = computed(() => authStore.canUseSharedCollections || authStore.canUseLocalCollections);
+const isSaved = computed(() => collectionsStore.isSaved(props.item.id));
+const buttonLabel = computed(() => (isSaved.value ? 'Remove saved post' : 'Save post'));
+const memberships = computed(() => collectionsStore.membershipByImageId[props.item.id]?.items ?? collectionsStore.items.map((collection) => ({
+  ...collection,
+  containsImage: collection.isDefault && isSaved.value
+})));
+const customMemberships = computed(() => memberships.value.filter((collection) => !collection.isDefault));
+
+watch(
+  () => props.item,
+  (item) => {
+    collectionsStore.syncSavedState(item);
+  },
+  {
+    immediate: true
+  }
+);
+
+function clearCloseTimer() {
+  if (closeTimer) {
+    clearTimeout(closeTimer);
+    closeTimer = null;
+  }
+}
+
+function scheduleClose() {
+  clearCloseTimer();
+  closeTimer = setTimeout(() => {
+    if (!creating.value) {
+      popoverOpen.value = false;
+    }
+  }, 180);
+}
+
+async function openPopover() {
+  clearCloseTimer();
+  popoverOpen.value = true;
+  localError.value = null;
+  await nextTick();
+  updatePopoverPosition();
+  await collectionsStore.fetchMembership(props.item.id).catch((error) => {
+    localError.value = error instanceof Error ? error.message : 'Unable to load collections';
+  });
+  await nextTick();
+  updatePopoverPosition();
+}
+
+function closePopover() {
+  clearCloseTimer();
+  popoverOpen.value = false;
+  popoverStyle.value = {};
+  creating.value = false;
+  localError.value = null;
+}
+
+function updatePopoverPosition() {
+  const button = buttonElement.value;
+  const popover = popoverElement.value;
+  if (!button || !popover) {
+    return;
+  }
+
+  const buttonRect = button.getBoundingClientRect();
+  const popoverRect = popover.getBoundingClientRect();
+  const centeredLeft = buttonRect.left + buttonRect.width / 2 - popoverRect.width / 2;
+  const left = Math.min(
+    Math.max(centeredLeft, popoverViewportMargin),
+    window.innerWidth - popoverRect.width - popoverViewportMargin
+  );
+  const top = Math.max(buttonRect.top - popoverRect.height - popoverGap, popoverViewportMargin);
+
+  popoverStyle.value = {
+    left: `${Math.round(left)}px`,
+    top: `${Math.round(top)}px`
+  };
+}
+
+function addPopoverPositionListeners() {
+  window.addEventListener('resize', updatePopoverPosition);
+  window.addEventListener('scroll', updatePopoverPosition, true);
+}
+
+function removePopoverPositionListeners() {
+  window.removeEventListener('resize', updatePopoverPosition);
+  window.removeEventListener('scroll', updatePopoverPosition, true);
+}
+
+function handlePointerEnter() {
+  void openPopover();
+}
+
+function handlePointerLeave() {
+  scheduleClose();
+}
+
+function handleFocusOut(event: FocusEvent) {
+  const nextTarget = event.relatedTarget;
+  if (
+    nextTarget instanceof Node &&
+    (rootElement.value?.contains(nextTarget) || popoverElement.value?.contains(nextTarget))
+  ) {
+    return;
+  }
+
+  scheduleClose();
+}
+
+async function handleBookmarkClick() {
+  if (suppressNextClick.value) {
+    suppressNextClick.value = false;
+    return;
+  }
+
+  await collectionsStore.toggleDefaultSave(props.item);
+  await collectionsStore.fetchMembership(props.item.id, true);
+}
+
+function handlePointerDown(event: PointerEvent) {
+  if (event.pointerType === 'mouse') {
+    return;
+  }
+
+  clearLongPressTimer();
+  longPressTimer.value = setTimeout(() => {
+    suppressNextClick.value = true;
+    void openPopover();
+  }, 480);
+}
+
+function handlePointerUp() {
+  clearLongPressTimer();
+}
+
+function handlePointerCancel() {
+  clearLongPressTimer();
+}
+
+function clearLongPressTimer() {
+  if (!longPressTimer.value) {
+    return;
+  }
+
+  clearTimeout(longPressTimer.value);
+  longPressTimer.value = null;
+}
+
+async function startCreating() {
+  creating.value = true;
+  localError.value = null;
+  await nextTick();
+  createInputElement.value?.focus();
+  updatePopoverPosition();
+}
+
+function cancelCreating() {
+  creating.value = false;
+  collectionName.value = '';
+  localError.value = null;
+}
+
+async function submitCreate() {
+  const name = collectionName.value.trim();
+  if (!name) {
+    localError.value = 'Collection name is required.';
+    return;
+  }
+
+  creatingCollection.value = true;
+  localError.value = null;
+
+  try {
+    await collectionsStore.createAndAdd(name, props.item);
+    collectionName.value = '';
+    closePopover();
+  } catch (error) {
+    localError.value = error instanceof Error ? error.message : 'Unable to create collection';
+    await nextTick();
+    updatePopoverPosition();
+  } finally {
+    creatingCollection.value = false;
+  }
+}
+
+async function toggleCollection(slug: string) {
+  localError.value = null;
+
+  try {
+    await collectionsStore.toggleCollectionMembership(slug, props.item);
+    if (!creating.value) {
+      closePopover();
+    }
+  } catch (error) {
+    localError.value = error instanceof Error ? error.message : 'Unable to update collection';
+  }
+}
+
+function displayCollectionName(collection: CollectionSummary) {
+  return collection.isDefault ? 'All Posts' : collection.name;
+}
+
+watch(popoverOpen, (isOpen) => {
+  if (isOpen) {
+    addPopoverPositionListeners();
+    void nextTick(updatePopoverPosition);
+  } else {
+    removePopoverPositionListeners();
+  }
+});
+
+onBeforeUnmount(() => {
+  clearCloseTimer();
+  clearLongPressTimer();
+  removePopoverPositionListeners();
+});
+</script>

--- a/client/src/components/FeedCard.vue
+++ b/client/src/components/FeedCard.vue
@@ -288,6 +288,10 @@
               />
             </svg>
           </a>
+          <CollectionBookmark
+            :item="item"
+            placement="feed"
+          />
         </div>
       </div>
 
@@ -416,6 +420,7 @@ import { formatMediaDuration } from '../utils/media';
 import { resolveFeedAspectRatio } from '../utils/media-layout';
 import { getOriginalMediaDownloadUrl, getOriginalMediaUrl } from '../utils/original-media';
 import Avatar from './Avatar.vue';
+import CollectionBookmark from './CollectionBookmark.vue';
 import ConfirmDialog from './ConfirmDialog.vue';
 import ResilientImage from './ResilientImage.vue';
 

--- a/client/src/components/FolderGrid.vue
+++ b/client/src/components/FolderGrid.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="grid gap-[1px] grid-cols-3 md:grid-cols-4">
+  <section class="grid gap-[1px]" :class="columns === 'three' ? 'grid-cols-3' : 'grid-cols-3 md:grid-cols-4'">
     <RouterLink v-for="item in items" :key="item.id" custom :to="buildImageRoute(item.id)" v-slot="{ href, navigate }">
       <a
         :href="href"
@@ -38,9 +38,11 @@ withDefaults(
   defineProps<{
     items: FeedItem[];
     variant?: 'square' | 'posts' | 'reels';
+    columns?: 'adaptive' | 'three';
   }>(),
   {
-    variant: 'square'
+    variant: 'square',
+    columns: 'adaptive'
   }
 );
 

--- a/client/src/components/PostViewer.vue
+++ b/client/src/components/PostViewer.vue
@@ -415,31 +415,38 @@
 
         <!-- Actions -->
         <div
-          class="viewer__sidebar-actions flex items-center justify-between gap-4 px-5 pt-[0.7rem] pb-5 mt-auto"
+          class="viewer__sidebar-actions flex items-center justify-between gap-3 px-5 pt-[0.7rem] pb-5 mt-auto"
         >
-          <!-- Like -->
-          <button
-            v-if="authStore.canUseSavedItems"
-            class="viewer__sidebar-action inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer transition-[opacity,transform,color] duration-180 hover:opacity-72 hover:-translate-y-px disabled:opacity-45 disabled:cursor-wait disabled:transform-none"
-            :class="{ 'text-[#e5484d]': likesStore.isLiked(image.id) }"
-            type="button"
-            :aria-label="likesStore.toggleAriaLabel(likesStore.isLiked(image.id))"
-            :aria-pressed="likesStore.isLiked(image.id)"
-            :disabled="likesStore.isPending(image.id)"
-            @click="likesStore.toggleLike(image)"
-          >
-            <span
-              class="w-[1.55rem] h-[1.55rem]"
-              :class="
-                likesStore.isLiked(image.id)
-                  ? 'i-fluent-heart-20-filled'
-                  : 'i-fluent-heart-20-regular'
-              "
-              aria-hidden="true"
+          <div class="viewer__sidebar-actions-group flex items-center gap-[0.55rem]">
+            <!-- Like -->
+            <button
+              v-if="authStore.canUseSavedItems"
+              class="viewer__sidebar-action inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer transition-[opacity,transform,color] duration-180 hover:opacity-72 hover:-translate-y-px disabled:opacity-45 disabled:cursor-wait disabled:transform-none"
+              :class="{ 'text-[#e5484d]': likesStore.isLiked(image.id) }"
+              type="button"
+              :aria-label="likesStore.toggleAriaLabel(likesStore.isLiked(image.id))"
+              :aria-pressed="likesStore.isLiked(image.id)"
+              :disabled="likesStore.isPending(image.id)"
+              @click="likesStore.toggleLike(image)"
+            >
+              <span
+                class="w-[1.55rem] h-[1.55rem]"
+                :class="
+                  likesStore.isLiked(image.id)
+                    ? 'i-fluent-heart-20-filled'
+                    : 'i-fluent-heart-20-regular'
+                "
+                aria-hidden="true"
+              />
+            </button>
+            <CollectionBookmark
+              v-if="image"
+              :item="image"
+              placement="viewer"
             />
-          </button>
+          </div>
 
-          <div class="viewer__sidebar-actions-group flex items-center gap-4">
+          <div class="viewer__sidebar-actions-group flex items-center gap-[0.55rem]">
             <!-- Set as cover -->
             <button
               v-if="authStore.canManageLibrary"
@@ -561,6 +568,7 @@
   import { useFoldersStore } from "../stores/folders"
   import { getOriginalMediaDownloadUrl, getOriginalMediaUrl } from "../utils/original-media"
   import Avatar from "./Avatar.vue"
+  import CollectionBookmark from "./CollectionBookmark.vue"
   import ResilientImage from "./ResilientImage.vue"
   import { formatMediaDuration, videoPreviewWouldDownscale } from "../utils/media"
 

--- a/client/src/components/SidebarNav.vue
+++ b/client/src/components/SidebarNav.vue
@@ -216,6 +216,39 @@
         </a>
       </RouterLink>
 
+      <RouterLink
+        v-if="authStore.canUseSharedCollections || authStore.canUseLocalCollections"
+        custom
+        :to="{ name: 'collections' }"
+        v-slot="{ href, navigate, isActive }"
+      >
+        <a
+          :href="href"
+          class="sidebar__link sidebar-item"
+          :class="isActive || isCollectionsRoute ? sidebarActiveClass : ''"
+          @click="navigate"
+        >
+          <span
+            class="sidebar__icon flex-shrink-0 w-[1.52rem] h-[1.52rem]"
+            :class="
+              isActive || isCollectionsRoute
+                ? 'i-fluent-bookmark-20-filled'
+                : 'i-fluent-bookmark-20-regular'
+            "
+            aria-hidden="true"
+          />
+          <span
+            class="sidebar__label max-w-0 overflow-hidden whitespace-nowrap text-[0.9rem] opacity-0 group-hover:max-w-[12rem] group-hover:opacity-100"
+            style="
+              transition:
+                opacity 0.18s ease,
+                max-width 0.22s ease;
+            "
+            >Collections</span
+          >
+        </a>
+      </RouterLink>
+
       <span
         class="sidebar__section-label sidebar__meta inline-flex min-h-[1rem] items-center self-start mt-7 max-w-0 overflow-hidden whitespace-nowrap px-[0.75rem] text-[0.68rem] leading-[1.2] font-semibold uppercase tracking-[0.12em] text-muted opacity-0 group-hover:max-w-[12rem] group-hover:opacity-100"
         style="
@@ -423,6 +456,9 @@
   )
   const isPlacesRoute = computed(() =>
     route.name === "places" || route.name === "place",
+  )
+  const isCollectionsRoute = computed(() =>
+    route.name === "collections" || route.name === "collection",
   )
   const signOutLabel = computed(() =>
     authStore.accessMode === "public" ? "Return to public view" : "Sign out",

--- a/client/src/components/TopNav.vue
+++ b/client/src/components/TopNav.vue
@@ -77,6 +77,23 @@
           </a>
         </RouterLink>
 
+        <RouterLink
+          v-if="authStore.canUseSharedCollections || authStore.canUseLocalCollections"
+          custom
+          :to="{ name: 'collections' }"
+          v-slot="{ href, navigate, isActive }"
+        >
+          <a
+            :href="href"
+            class="mobile-nav__item mobile-nav__item--collections"
+            :class="isActive || isCollectionsRoute ? mobileNavActiveClass : ''"
+            aria-label="Collections"
+            @click="handleNavNavigate($event, navigate)"
+          >
+            <span class="mobile-nav__icon" :class="isActive || isCollectionsRoute ? 'i-fluent-bookmark-20-filled' : 'i-fluent-bookmark-20-regular'" aria-hidden="true" />
+          </a>
+        </RouterLink>
+
         <div class="mobile-nav__more">
           <button
             class="mobile-nav__item mobile-nav__more-button"
@@ -102,6 +119,24 @@
                 <span class="mobile-nav__menu-icon" :class="isActive ? 'i-fluent-heart-20-filled' : 'i-fluent-heart-20-regular'" aria-hidden="true" />
                 <span>{{ likesStore.collectionLabel }}</span>
                 <small class="mobile-nav__menu-badge">{{ likesStore.items.length }}</small>
+              </a>
+            </RouterLink>
+
+            <RouterLink
+              v-if="authStore.canUseSharedCollections || authStore.canUseLocalCollections"
+              custom
+              :to="{ name: 'collections' }"
+              v-slot="{ href, navigate, isActive }"
+            >
+              <a
+                :href="href"
+                class="mobile-nav__menu-item mobile-nav__menu-item--collections"
+                :class="isActive || isCollectionsRoute ? menuItemActiveClass : ''"
+                @click="handleNavNavigate($event, navigate)"
+              >
+                <span class="mobile-nav__menu-icon" :class="isActive || isCollectionsRoute ? 'i-fluent-bookmark-20-filled' : 'i-fluent-bookmark-20-regular'" aria-hidden="true" />
+                <span>Collections</span>
+                <small class="mobile-nav__menu-badge">{{ collectionsStore.defaultCollection?.itemCount ?? 0 }}</small>
               </a>
             </RouterLink>
 
@@ -184,12 +219,14 @@ import { RouterLink, useRoute } from 'vue-router';
 
 import { useAppStore } from '../stores/app';
 import { useAuthStore } from '../stores/auth';
+import { useCollectionsStore } from '../stores/collections';
 import { useLikesStore } from '../stores/likes';
 import { usePlacesStore } from '../stores/places';
 import BrandMark from './BrandMark.vue';
 
 const appStore = useAppStore();
 const authStore = useAuthStore();
+const collectionsStore = useCollectionsStore();
 const likesStore = useLikesStore();
 const placesStore = usePlacesStore();
 const route = useRoute();
@@ -199,12 +236,14 @@ const signOutLabel = computed(() => (authStore.accessMode === 'public' ? 'Return
 const showPlacesNav = computed(() => placesStore.items.length > 0 && placesStore.listError === null);
 const isPlacesRoute = computed(() => route.name === 'places' || route.name === 'place');
 const isLikesRoute = computed(() => route.name === 'likes');
-const isStaticMoreRoute = computed(() => route.name === 'trash' || route.name === 'settings');
+const isCollectionsRoute = computed(() => route.name === 'collections' || route.name === 'collection');
+const isStaticMoreRoute = computed(() => route.name === 'trash' || route.name === 'settings' || isCollectionsRoute.value);
 const mobileNavActiveClass = 'mobile-nav__item--active';
 const menuItemActiveClass = 'mobile-nav__menu-item--active';
 const moreButtonClasses = computed(() => ({
   [mobileNavActiveClass]: moreMenuOpen.value || isStaticMoreRoute.value || isLikesRoute.value,
-  'mobile-nav__more-button--likes-active': isLikesRoute.value
+  'mobile-nav__more-button--likes-active': isLikesRoute.value,
+  'mobile-nav__more-button--collections-active': isCollectionsRoute.value
 }));
 
 function closeMoreMenu() {
@@ -359,6 +398,10 @@ onUnmounted(() => {
     display: none;
   }
 
+  .mobile-nav__item--collections {
+    display: none;
+  }
+
   .mobile-nav__more {
     position: relative;
     flex: 0 0 auto;
@@ -439,7 +482,28 @@ onUnmounted(() => {
   }
 
   @media (min-width: 360px) {
+    .mobile-nav__bar {
+      grid-template-columns: 2.8rem minmax(0, 1fr);
+      gap: 0.28rem;
+    }
+
+    .mobile-nav__links {
+      gap: 0.12rem;
+    }
+
+    .mobile-nav__item {
+      width: 2.35rem;
+    }
+
+    .mobile-nav__brand {
+      width: 2.8rem;
+    }
+
     .mobile-nav__item--likes {
+      display: inline-flex;
+    }
+
+    .mobile-nav__item--collections {
       display: inline-flex;
     }
 
@@ -447,7 +511,12 @@ onUnmounted(() => {
       display: none;
     }
 
-    .mobile-nav__more-button--likes-active:not([data-open='true']) {
+    .mobile-nav__menu-item--collections {
+      display: none;
+    }
+
+    .mobile-nav__more-button--likes-active:not([data-open='true']),
+    .mobile-nav__more-button--collections-active:not([data-open='true']) {
       background: transparent;
       color: var(--muted);
       font-weight: 400;

--- a/client/src/router/index.test.ts
+++ b/client/src/router/index.test.ts
@@ -49,6 +49,28 @@ vi.mock('../views/LikesView.vue', async () => {
   };
 });
 
+vi.mock('../views/CollectionsView.vue', async () => {
+  const { defineComponent } = await import('vue');
+
+  return {
+    default: defineComponent({
+      name: 'CollectionsView',
+      template: '<div data-test="collections-view">collections-view</div>'
+    })
+  };
+});
+
+vi.mock('../views/CollectionView.vue', async () => {
+  const { defineComponent } = await import('vue');
+
+  return {
+    default: defineComponent({
+      name: 'CollectionView',
+      template: '<div data-test="collection-view">collection-view</div>'
+    })
+  };
+});
+
 vi.mock('../views/ExploreView.vue', async () => {
   const { defineComponent } = await import('vue');
 
@@ -138,6 +160,8 @@ vi.mock('../views/SettingsView.vue', async () => {
 });
 
 import { router } from './index';
+import { canAccessRoute } from './index';
+import { useAuthStore } from '../stores/auth';
 
 describe('router', () => {
   it('uses /post/:id as the canonical post route while keeping /image/:id as a legacy alias', async () => {
@@ -224,5 +248,48 @@ describe('router', () => {
     expect(router.currentRoute.value.name).toBe('reels');
     expect(router.currentRoute.value.meta.shell).toBe('reels');
     expect(wrapper.get('[data-test="reels-view-route"]').text()).toBe('reels-view-route');
+  });
+
+  it('requires saved-item access for collections routes', async () => {
+    const authStore = useAuthStore(pinia);
+    authStore.$patch({
+      ready: true,
+      capabilities: {
+        canManageLibrary: false,
+        canDeleteMedia: false,
+        canAccessSettings: false,
+        canUseSharedLikes: false,
+        canUseLocalFavorites: false,
+        canUseSharedCollections: false,
+        canUseLocalCollections: false
+      }
+    });
+
+    expect(canAccessRoute(router.resolve('/collections'))).toBe(false);
+    expect(canAccessRoute(router.resolve('/collections/saved'))).toBe(false);
+
+    await router.replace('/collections');
+    await flushPromises();
+    expect(router.currentRoute.value.name).toBe('home');
+
+    authStore.$patch({
+      capabilities: {
+        canManageLibrary: false,
+        canDeleteMedia: false,
+        canAccessSettings: false,
+        canUseSharedLikes: false,
+        canUseLocalFavorites: false,
+        canUseSharedCollections: false,
+        canUseLocalCollections: true
+      }
+    });
+
+    expect(canAccessRoute(router.resolve('/collections'))).toBe(true);
+    expect(canAccessRoute(router.resolve('/collections/saved'))).toBe(true);
+
+    await router.replace('/collections/saved');
+    await flushPromises();
+    expect(router.currentRoute.value.name).toBe('collection');
+    expect(router.currentRoute.value.params.slug).toBe('saved');
   });
 });

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -4,6 +4,8 @@ import HomeView from '../views/HomeView.vue';
 import PostView from '../views/PostView.vue';
 import LibraryView from '../views/LibraryView.vue';
 import LikesView from '../views/LikesView.vue';
+import CollectionsView from '../views/CollectionsView.vue';
+import CollectionView from '../views/CollectionView.vue';
 import ExploreView from '../views/ExploreView.vue';
 import FolderView from '../views/FolderView.vue';
 import MomentView from '../views/MomentView.vue';
@@ -79,6 +81,23 @@ export const router = createRouter({
       }
     },
     {
+      path: '/collections',
+      name: 'collections',
+      component: CollectionsView,
+      meta: {
+        requiresSavedItems: true
+      }
+    },
+    {
+      path: '/collections/:slug',
+      name: 'collection',
+      component: CollectionView,
+      props: true,
+      meta: {
+        requiresSavedItems: true
+      }
+    },
+    {
       path: '/trash',
       name: 'trash',
       component: TrashView,
@@ -146,7 +165,7 @@ export function canAccessRoute(route: Pick<RouteLocationNormalized, 'meta'>): bo
   const requiredCapability = getRouteRequiredCapability(route);
 
   if (requiredCapability) {
-    return authStore.capabilities[requiredCapability];
+    return authStore.capabilities[requiredCapability] === true;
   }
 
   if (routeRequiresSavedItems(route)) {

--- a/client/src/stores/auth.ts
+++ b/client/src/stores/auth.ts
@@ -32,7 +32,9 @@ function createCapabilities(role: AuthRole): AuthCapabilities {
       canDeleteMedia: true,
       canAccessSettings: true,
       canUseSharedLikes: true,
-      canUseLocalFavorites: false
+      canUseLocalFavorites: false,
+      canUseSharedCollections: true,
+      canUseLocalCollections: false
     };
   }
 
@@ -42,7 +44,9 @@ function createCapabilities(role: AuthRole): AuthCapabilities {
       canDeleteMedia: false,
       canAccessSettings: false,
       canUseSharedLikes: true,
-      canUseLocalFavorites: false
+      canUseLocalFavorites: false,
+      canUseSharedCollections: true,
+      canUseLocalCollections: false
     };
   }
 
@@ -51,7 +55,9 @@ function createCapabilities(role: AuthRole): AuthCapabilities {
     canDeleteMedia: false,
     canAccessSettings: false,
     canUseSharedLikes: false,
-    canUseLocalFavorites: true
+    canUseLocalFavorites: true,
+    canUseSharedCollections: false,
+    canUseLocalCollections: true
   };
 }
 
@@ -97,7 +103,13 @@ export const useAuthStore = defineStore('auth', {
     canAccessSettings: (state) => state.capabilities.canAccessSettings,
     canUseSharedLikes: (state) => state.capabilities.canUseSharedLikes,
     canUseLocalFavorites: (state) => state.capabilities.canUseLocalFavorites,
-    canUseSavedItems: (state) => state.capabilities.canUseSharedLikes || state.capabilities.canUseLocalFavorites,
+    canUseSharedCollections: (state) => state.capabilities.canUseSharedCollections === true,
+    canUseLocalCollections: (state) => state.capabilities.canUseLocalCollections === true,
+    canUseSavedItems: (state) =>
+      state.capabilities.canUseSharedLikes ||
+      state.capabilities.canUseLocalFavorites ||
+      state.capabilities.canUseSharedCollections === true ||
+      state.capabilities.canUseLocalCollections === true,
     canUnlockAdmin: (state) => state.enabled && !state.capabilities.canAccessSettings
   },
   actions: {

--- a/client/src/stores/collections.test.ts
+++ b/client/src/stores/collections.test.ts
@@ -1,0 +1,297 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CollectionSummary, FeedItem } from '../types/api';
+import { useAuthStore } from './auth';
+import { useCollectionsStore } from './collections';
+
+const {
+  addImageToCollectionMock,
+  createCollectionMock,
+  deleteCollectionMock,
+  fetchCollectionImagesMock,
+  fetchCollectionsMock,
+  fetchImageCollectionsMock,
+  removeImageFromCollectionMock,
+  saveImageMock,
+  unsaveImageMock,
+  updateCollectionMock
+} = vi.hoisted(() => ({
+  addImageToCollectionMock: vi.fn(),
+  createCollectionMock: vi.fn(),
+  deleteCollectionMock: vi.fn(),
+  fetchCollectionImagesMock: vi.fn(),
+  fetchCollectionsMock: vi.fn(),
+  fetchImageCollectionsMock: vi.fn(),
+  removeImageFromCollectionMock: vi.fn(),
+  saveImageMock: vi.fn(),
+  unsaveImageMock: vi.fn(),
+  updateCollectionMock: vi.fn()
+}));
+
+vi.mock('../api/gallery', () => ({
+  addImageToCollection: addImageToCollectionMock,
+  createCollection: createCollectionMock,
+  deleteCollection: deleteCollectionMock,
+  fetchCollectionImages: fetchCollectionImagesMock,
+  fetchCollections: fetchCollectionsMock,
+  fetchImageCollections: fetchImageCollectionsMock,
+  removeImageFromCollection: removeImageFromCollectionMock,
+  saveImage: saveImageMock,
+  unsaveImage: unsaveImageMock,
+  updateCollection: updateCollectionMock
+}));
+
+function createFeedItem(id: number): FeedItem {
+  return {
+    id,
+    folderId: 11,
+    folderSlug: 'album',
+    folderName: 'Album',
+    folderPath: 'album',
+    folderBreadcrumb: null,
+    filename: `photo-${id}.jpg`,
+    width: 1200,
+    height: 1500,
+    mediaType: 'image',
+    durationMs: null,
+    isAnimated: false,
+    thumbnailUrl: `/thumbnails/${id}.webp`,
+    previewUrl: `/previews/${id}.webp`,
+    sortTimestamp: 1_800_000_000_000 + id,
+    takenAt: 1_800_000_000_000 + id,
+    isSaved: false
+  };
+}
+
+function createCollection(slug: string, name: string, isDefault = false): CollectionSummary {
+  return {
+    id: isDefault ? 1 : Math.abs(slug.length * 17),
+    slug,
+    name,
+    isDefault,
+    itemCount: 0,
+    coverImage: null,
+    previewImages: [],
+    createdAt: '2026-04-28T00:00:00.000Z',
+    updatedAt: '2026-04-28T00:00:00.000Z'
+  };
+}
+
+function useLocalCollectionsMode() {
+  const authStore = useAuthStore();
+  authStore.$patch({
+    role: 'anonymous',
+    likesMode: 'local',
+    capabilities: {
+      canManageLibrary: false,
+      canDeleteMedia: false,
+      canAccessSettings: false,
+      canUseSharedLikes: false,
+      canUseLocalFavorites: true,
+      canUseSharedCollections: false,
+      canUseLocalCollections: true
+    }
+  });
+}
+
+describe('collections store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    window.localStorage.clear();
+    addImageToCollectionMock.mockReset();
+    createCollectionMock.mockReset();
+    deleteCollectionMock.mockReset();
+    fetchCollectionImagesMock.mockReset();
+    fetchCollectionsMock.mockReset();
+    fetchImageCollectionsMock.mockReset();
+    removeImageFromCollectionMock.mockReset();
+    saveImageMock.mockReset();
+    unsaveImageMock.mockReset();
+    updateCollectionMock.mockReset();
+  });
+
+  it('adds local custom collections on top of the Saved source of truth', async () => {
+    useLocalCollectionsMode();
+    const collectionsStore = useCollectionsStore();
+    const item = createFeedItem(42);
+
+    await collectionsStore.initialize();
+    expect(collectionsStore.items).toMatchObject([{ slug: 'saved', name: 'Saved', isDefault: true, itemCount: 0 }]);
+
+    await collectionsStore.createAndAdd('Travel', item);
+
+    expect(collectionsStore.items.find((collection) => collection.slug === 'travel')?.itemCount).toBe(1);
+    expect(collectionsStore.defaultCollection?.itemCount).toBe(1);
+    expect(collectionsStore.isSaved(item.id)).toBe(true);
+    expect(collectionsStore.isBookmarked(item.id)).toBe(true);
+
+    await collectionsStore.loadCollection('saved');
+    expect(collectionsStore.currentImages.map((entry) => entry.id)).toEqual([item.id]);
+  });
+
+  it('removes local custom memberships when a post is unsaved', async () => {
+    useLocalCollectionsMode();
+    const collectionsStore = useCollectionsStore();
+    const item = createFeedItem(43);
+
+    await collectionsStore.initialize();
+    await collectionsStore.createAndAdd('Travel', item);
+    await collectionsStore.toggleDefaultSave(item);
+
+    expect(collectionsStore.isSaved(item.id)).toBe(false);
+    expect(collectionsStore.isBookmarked(item.id)).toBe(false);
+    expect(collectionsStore.items.find((collection) => collection.slug === 'saved')?.itemCount).toBe(0);
+    expect(collectionsStore.items.find((collection) => collection.slug === 'travel')?.itemCount).toBe(0);
+
+    const storedValue = window.localStorage.getItem('foldergram-local-collections-v1');
+    expect(storedValue).toContain('"slug":"travel"');
+    expect(storedValue).not.toContain('"id":43');
+  });
+
+  it('removing a local custom membership keeps the post saved', async () => {
+    useLocalCollectionsMode();
+    const collectionsStore = useCollectionsStore();
+    const item = createFeedItem(44);
+
+    await collectionsStore.initialize();
+    await collectionsStore.createAndAdd('Travel', item);
+    await collectionsStore.toggleCollectionMembership('travel', item);
+
+    expect(collectionsStore.isSaved(item.id)).toBe(true);
+    expect(collectionsStore.isBookmarked(item.id)).toBe(true);
+    expect(collectionsStore.defaultCollection?.itemCount).toBe(1);
+    expect(collectionsStore.items.find((collection) => collection.slug === 'travel')?.itemCount).toBe(0);
+  });
+
+  it('repairs custom-only local storage data into the Saved collection on initialize', async () => {
+    const item = createFeedItem(55);
+    window.localStorage.setItem(
+      'foldergram-local-collections-v1',
+      JSON.stringify({
+        collections: [
+          {
+            slug: 'saved',
+            name: 'Saved',
+            isDefault: true,
+            createdAt: '2026-04-28T00:00:00.000Z',
+            updatedAt: '2026-04-28T00:00:00.000Z',
+            items: []
+          },
+          {
+            slug: 'travel',
+            name: 'Travel',
+            isDefault: false,
+            createdAt: '2026-04-28T00:00:00.000Z',
+            updatedAt: '2026-04-28T00:00:00.000Z',
+            items: [item]
+          }
+        ]
+      })
+    );
+
+    useLocalCollectionsMode();
+    const collectionsStore = useCollectionsStore();
+    await collectionsStore.initialize();
+
+    expect(collectionsStore.defaultCollection?.itemCount).toBe(1);
+    expect(collectionsStore.isSaved(item.id)).toBe(true);
+    expect(collectionsStore.isBookmarked(item.id)).toBe(true);
+
+    await collectionsStore.loadCollection('saved');
+    expect(collectionsStore.currentImages.map((entry) => entry.id)).toEqual([item.id]);
+  });
+
+  it('renames and deletes local custom collections while keeping their posts saved', async () => {
+    useLocalCollectionsMode();
+    const collectionsStore = useCollectionsStore();
+    const item = createFeedItem(56);
+
+    await collectionsStore.initialize();
+    await collectionsStore.createAndAdd('Travel', item);
+
+    await collectionsStore.updateCollectionName('travel', 'Trips');
+    expect(collectionsStore.items.find((collection) => collection.slug === 'travel')?.name).toBe('Trips');
+
+    await collectionsStore.deleteCollection('travel');
+    expect(collectionsStore.items.some((collection) => collection.slug === 'travel')).toBe(false);
+    expect(collectionsStore.defaultCollection?.itemCount).toBe(1);
+    expect(collectionsStore.isSaved(item.id)).toBe(true);
+    expect(collectionsStore.isBookmarked(item.id)).toBe(true);
+  });
+
+  it('does not call shared collection APIs in anonymous local mode', async () => {
+    useLocalCollectionsMode();
+    const collectionsStore = useCollectionsStore();
+    const item = createFeedItem(57);
+
+    await collectionsStore.initialize();
+    await collectionsStore.createAndAdd('Travel', item);
+    await collectionsStore.toggleCollectionMembership('travel', item);
+    await collectionsStore.toggleDefaultSave(item);
+
+    expect(createCollectionMock).not.toHaveBeenCalled();
+    expect(addImageToCollectionMock).not.toHaveBeenCalled();
+    expect(removeImageFromCollectionMock).not.toHaveBeenCalled();
+    expect(saveImageMock).not.toHaveBeenCalled();
+    expect(unsaveImageMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate collection names before calling the shared create endpoint', async () => {
+    fetchCollectionsMock.mockResolvedValue({
+      items: [
+        createCollection('saved', 'Saved', true),
+        createCollection('travel', 'Travel')
+      ]
+    });
+
+    const collectionsStore = useCollectionsStore();
+    await collectionsStore.initialize();
+
+    await expect(collectionsStore.createAndAdd(' travel ', createFeedItem(7))).rejects.toThrow('Collection name already exists.');
+    expect(createCollectionMock).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the optimistic saved state when a shared save fails', async () => {
+    fetchCollectionsMock.mockResolvedValue({
+      items: [createCollection('saved', 'Saved', true)]
+    });
+    saveImageMock.mockRejectedValue(new Error('Save failed'));
+
+    const collectionsStore = useCollectionsStore();
+    const item = createFeedItem(9);
+    await collectionsStore.initialize();
+
+    await collectionsStore.toggleDefaultSave(item);
+
+    expect(collectionsStore.isSaved(item.id)).toBe(false);
+    expect(collectionsStore.isBookmarked(item.id)).toBe(false);
+    expect(collectionsStore.error).toBe('Save failed');
+  });
+
+  it('rejects shared custom membership failures so the popover can keep the inline error visible', async () => {
+    const savedCollection = createCollection('saved', 'Saved', true);
+    const travelCollection = createCollection('travel', 'Travel');
+    const item = createFeedItem(12);
+
+    fetchCollectionsMock.mockResolvedValue({
+      items: [savedCollection, travelCollection]
+    });
+    fetchImageCollectionsMock.mockResolvedValue({
+      imageId: item.id,
+      isSaved: true,
+      items: [
+        { ...savedCollection, containsImage: true },
+        { ...travelCollection, containsImage: false }
+      ]
+    });
+    addImageToCollectionMock.mockRejectedValue(new Error('Add failed'));
+
+    const collectionsStore = useCollectionsStore();
+    await collectionsStore.initialize();
+
+    await expect(collectionsStore.toggleCollectionMembership('travel', item)).rejects.toThrow('Add failed');
+    expect(collectionsStore.error).toBe('Add failed');
+    expect(collectionsStore.pendingCollectionKeys).toEqual([]);
+  });
+});

--- a/client/src/stores/collections.ts
+++ b/client/src/stores/collections.ts
@@ -1,0 +1,792 @@
+import { acceptHMRUpdate, defineStore } from 'pinia';
+
+import {
+  addImageToCollection,
+  createCollection,
+  deleteCollection as deleteCollectionRequest,
+  fetchCollectionImages,
+  fetchCollections,
+  fetchImageCollections,
+  removeImageFromCollection,
+  saveImage,
+  unsaveImage,
+  updateCollection as updateCollectionRequest
+} from '../api/gallery';
+import type {
+  CollectionImagesPayload,
+  CollectionMembership,
+  CollectionSummary,
+  FeedItem,
+  ImageCollectionsPayload
+} from '../types/api';
+import { useAuthStore } from './auth';
+
+type CollectionsMode = 'shared' | 'local';
+
+interface LocalCollection {
+  slug: string;
+  name: string;
+  isDefault: boolean;
+  createdAt: string;
+  updatedAt: string;
+  items: FeedItem[];
+}
+
+interface LocalCollectionsPayload {
+  collections: LocalCollection[];
+}
+
+interface CollectionsState {
+  mode: CollectionsMode;
+  items: CollectionSummary[];
+  membershipByImageId: Record<number, ImageCollectionsPayload>;
+  savedStateByImageId: Record<number, boolean>;
+  bookmarkedStateByImageId: Record<number, boolean>;
+  pendingImageIds: number[];
+  pendingCollectionKeys: string[];
+  loading: boolean;
+  error: string | null;
+  initialized: boolean;
+  currentCollection: CollectionSummary | null;
+  currentImages: FeedItem[];
+  currentPage: number;
+  currentLimit: number;
+  currentHasMore: boolean;
+  loadingCollection: boolean;
+  collectionError: string | null;
+}
+
+const LOCAL_COLLECTIONS_STORAGE_KEY = 'foldergram-local-collections-v1';
+const DEFAULT_COLLECTION_SLUG = 'saved';
+const DEFAULT_COLLECTION_NAME = 'Saved';
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function slugifyCollectionName(name: string): string {
+  const slug = name
+    .normalize('NFKD')
+    .replace(/[^\w\s-]/g, ' ')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return slug || 'collection';
+}
+
+function createUniqueSlug(name: string, existingSlugs: Set<string>): string {
+  const base = slugifyCollectionName(name);
+  if (!existingSlugs.has(base)) {
+    return base;
+  }
+
+  let index = 2;
+  while (existingSlugs.has(`${base}-${index}`)) {
+    index += 1;
+  }
+
+  return `${base}-${index}`;
+}
+
+function isFeedItem(value: unknown): value is FeedItem {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const item = value as Partial<FeedItem>;
+  return (
+    typeof item.id === 'number' &&
+    typeof item.folderId === 'number' &&
+    typeof item.folderSlug === 'string' &&
+    typeof item.folderName === 'string' &&
+    typeof item.folderPath === 'string' &&
+    (item.folderBreadcrumb === null || item.folderBreadcrumb === undefined || typeof item.folderBreadcrumb === 'string') &&
+    typeof item.filename === 'string' &&
+    typeof item.width === 'number' &&
+    typeof item.height === 'number' &&
+    (item.mediaType === 'image' || item.mediaType === 'video') &&
+    (item.durationMs === null || item.durationMs === undefined || typeof item.durationMs === 'number') &&
+    (item.isAnimated === null || item.isAnimated === undefined || typeof item.isAnimated === 'boolean') &&
+    typeof item.thumbnailUrl === 'string' &&
+    typeof item.previewUrl === 'string' &&
+    typeof item.sortTimestamp === 'number' &&
+    (item.takenAt === null || item.takenAt === undefined || typeof item.takenAt === 'number')
+  );
+}
+
+function normalizeFeedItem(item: FeedItem): FeedItem {
+  return {
+    ...item,
+    folderBreadcrumb: item.folderBreadcrumb ?? null,
+    durationMs: item.durationMs ?? null,
+    isAnimated: item.isAnimated ?? false,
+    takenAt: item.takenAt ?? null,
+    isSaved: true
+  };
+}
+
+function createDefaultLocalCollection(): LocalCollection {
+  const timestamp = nowIso();
+  return {
+    slug: DEFAULT_COLLECTION_SLUG,
+    name: DEFAULT_COLLECTION_NAME,
+    isDefault: true,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    items: []
+  };
+}
+
+function readLocalCollections(): LocalCollection[] {
+  if (typeof window === 'undefined') {
+    return [createDefaultLocalCollection()];
+  }
+
+  const rawValue = window.localStorage.getItem(LOCAL_COLLECTIONS_STORAGE_KEY);
+  if (!rawValue) {
+    return [createDefaultLocalCollection()];
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue) as Partial<LocalCollectionsPayload>;
+    if (!Array.isArray(parsed.collections)) {
+      return [createDefaultLocalCollection()];
+    }
+
+    const seenSlugs = new Set<string>();
+    const collections = parsed.collections.flatMap((collection): LocalCollection[] => {
+      if (!collection || typeof collection !== 'object') {
+        return [];
+      }
+
+      const slug = typeof collection.slug === 'string' && collection.slug.trim() ? collection.slug : null;
+      const name = typeof collection.name === 'string' && collection.name.trim() ? collection.name : null;
+      if (!slug || !name || seenSlugs.has(slug)) {
+        return [];
+      }
+
+      seenSlugs.add(slug);
+      const seenIds = new Set<number>();
+      const items = Array.isArray(collection.items)
+        ? collection.items.filter((entry): entry is FeedItem => {
+            if (!isFeedItem(entry) || seenIds.has(entry.id)) {
+              return false;
+            }
+
+            seenIds.add(entry.id);
+            return true;
+          }).map(normalizeFeedItem)
+        : [];
+
+      return [{
+        slug,
+        name,
+        isDefault: collection.isDefault === true || slug === DEFAULT_COLLECTION_SLUG,
+        createdAt: typeof collection.createdAt === 'string' ? collection.createdAt : nowIso(),
+        updatedAt: typeof collection.updatedAt === 'string' ? collection.updatedAt : nowIso(),
+        items
+      }];
+    });
+
+    const defaultCollection = collections.find((collection) => collection.slug === DEFAULT_COLLECTION_SLUG);
+    const normalizedDefault = defaultCollection
+      ? { ...defaultCollection, name: DEFAULT_COLLECTION_NAME, isDefault: true }
+      : createDefaultLocalCollection();
+    const customCollections = collections
+      .filter((collection) => collection.slug !== DEFAULT_COLLECTION_SLUG)
+      .map((collection) => ({ ...collection, isDefault: false }));
+    const seenDefaultItemIds = new Set(normalizedDefault.items.map((item) => item.id));
+    const missingDefaultItems: FeedItem[] = [];
+    for (const collection of customCollections) {
+      for (const item of collection.items) {
+        if (seenDefaultItemIds.has(item.id)) {
+          continue;
+        }
+
+        seenDefaultItemIds.add(item.id);
+        missingDefaultItems.push(item);
+      }
+    }
+
+    return [
+      missingDefaultItems.length > 0
+        ? {
+            ...normalizedDefault,
+            updatedAt: nowIso(),
+            items: [...missingDefaultItems, ...normalizedDefault.items]
+          }
+        : normalizedDefault,
+      ...customCollections
+    ];
+  } catch {
+    return [createDefaultLocalCollection()];
+  }
+}
+
+function writeLocalCollections(collections: LocalCollection[]) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(LOCAL_COLLECTIONS_STORAGE_KEY, JSON.stringify({ collections }));
+}
+
+function toCollectionSummary(collection: LocalCollection): CollectionSummary {
+  return {
+    id: collection.slug === DEFAULT_COLLECTION_SLUG ? 1 : Math.abs(hashSlug(collection.slug)),
+    slug: collection.slug,
+    name: collection.name,
+    isDefault: collection.isDefault,
+    itemCount: collection.items.length,
+    coverImage: collection.items[0] ?? null,
+    previewImages: collection.items.slice(0, 4),
+    createdAt: collection.createdAt,
+    updatedAt: collection.updatedAt
+  };
+}
+
+function hashSlug(slug: string): number {
+  let hash = 0;
+  for (let index = 0; index < slug.length; index += 1) {
+    hash = ((hash << 5) - hash + slug.charCodeAt(index)) | 0;
+  }
+
+  return hash;
+}
+
+function getCollectionMode(): CollectionsMode {
+  const authStore = useAuthStore();
+  return authStore.canUseSharedCollections ? 'shared' : 'local';
+}
+
+export const useCollectionsStore = defineStore('collections', {
+  state: (): CollectionsState => ({
+    mode: 'shared',
+    items: [],
+    membershipByImageId: {},
+    savedStateByImageId: {},
+    bookmarkedStateByImageId: {},
+    pendingImageIds: [],
+    pendingCollectionKeys: [],
+    loading: false,
+    error: null,
+    initialized: false,
+    currentCollection: null,
+    currentImages: [],
+    currentPage: 1,
+    currentLimit: 24,
+    currentHasMore: true,
+    loadingCollection: false,
+    collectionError: null
+  }),
+  getters: {
+    hasCustomCollections: (state) => state.items.some((collection) => !collection.isDefault),
+    defaultCollection: (state) => state.items.find((collection) => collection.isDefault) ?? null,
+    isSaved: (state) => (id: number) => state.savedStateByImageId[id] === true,
+    isBookmarked: (state) => (id: number) => {
+      if (state.bookmarkedStateByImageId[id] !== undefined) {
+        return state.bookmarkedStateByImageId[id] === true;
+      }
+
+      const membership = state.membershipByImageId[id];
+      if (membership) {
+        return membership.isSaved === true;
+      }
+
+      return state.savedStateByImageId[id] === true;
+    },
+    isPending: (state) => (id: number) => state.pendingImageIds.includes(id),
+    isCollectionPending: (state) => (slug: string, id: number) => state.pendingCollectionKeys.includes(`${slug}:${id}`)
+  },
+  actions: {
+    syncSavedState(item: FeedItem) {
+      if (this.savedStateByImageId[item.id] === undefined) {
+        this.savedStateByImageId[item.id] = item.isSaved === true;
+      }
+
+      if (item.isSaved === true) {
+        this.setBookmarkedState(item.id, true);
+      }
+    },
+
+    setSavedState(id: number, isSaved: boolean) {
+      this.savedStateByImageId[id] = isSaved;
+      this.bookmarkedStateByImageId[id] = isSaved;
+      this.currentImages = this.currentImages.map((item) => (item.id === id ? { ...item, isSaved } : item));
+    },
+
+    setBookmarkedState(id: number, isBookmarked: boolean) {
+      this.bookmarkedStateByImageId[id] = isBookmarked;
+    },
+
+    resetForRebuild() {
+      this.mode = getCollectionMode();
+      this.items = [];
+      this.membershipByImageId = {};
+      this.savedStateByImageId = {};
+      this.bookmarkedStateByImageId = {};
+      this.pendingImageIds = [];
+      this.pendingCollectionKeys = [];
+      this.loading = false;
+      this.error = null;
+      this.initialized = false;
+      this.currentCollection = null;
+      this.currentImages = [];
+      this.currentPage = 1;
+      this.currentHasMore = true;
+      this.loadingCollection = false;
+      this.collectionError = null;
+    },
+
+    async initialize(force = false) {
+      const authStore = useAuthStore();
+      if (!authStore.canUseSharedCollections && !authStore.canUseLocalCollections) {
+        this.resetForRebuild();
+        return;
+      }
+
+      const mode = getCollectionMode();
+      if ((this.initialized && this.mode === mode && !force) || this.loading) {
+        return;
+      }
+
+      this.mode = mode;
+      this.loading = true;
+      this.error = null;
+
+      try {
+        if (mode === 'shared') {
+          const payload = await fetchCollections();
+          this.items = payload.items;
+        } else {
+          const collections = readLocalCollections();
+          this.items = collections.map(toCollectionSummary);
+          const defaultCollection = collections.find((collection) => collection.isDefault);
+          this.savedStateByImageId = Object.fromEntries((defaultCollection?.items ?? []).map((item) => [item.id, true]));
+          this.bookmarkedStateByImageId = { ...this.savedStateByImageId };
+          writeLocalCollections(collections);
+        }
+
+        this.initialized = true;
+      } catch (error) {
+        this.error = error instanceof Error ? error.message : 'Unable to load collections';
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async fetchMembership(imageId: number, force = false) {
+      await this.initialize();
+      if (!force && this.membershipByImageId[imageId]) {
+        return this.membershipByImageId[imageId];
+      }
+
+      if (this.mode === 'local') {
+        const collections = readLocalCollections();
+        const items: CollectionMembership[] = collections.map((collection) => ({
+          ...toCollectionSummary(collection),
+          containsImage: collection.items.some((item) => item.id === imageId)
+        }));
+        const payload = {
+          imageId,
+          isSaved: items.some((item) => item.isDefault && item.containsImage),
+          items
+        };
+        this.membershipByImageId[imageId] = payload;
+        this.setSavedState(imageId, payload.isSaved);
+        return payload;
+      }
+
+      const payload = await fetchImageCollections(imageId);
+      this.membershipByImageId[imageId] = payload;
+      this.setSavedState(imageId, payload.isSaved);
+      return payload;
+    },
+
+    async toggleDefaultSave(item: FeedItem) {
+      const authStore = useAuthStore();
+      if ((!authStore.canUseSharedCollections && !authStore.canUseLocalCollections) || this.pendingImageIds.includes(item.id)) {
+        return;
+      }
+
+      await this.initialize();
+      this.syncSavedState(item);
+      const wasSaved = this.savedStateByImageId[item.id] === true;
+      this.pendingImageIds.push(item.id);
+      this.setSavedState(item.id, !wasSaved);
+
+      try {
+        if (this.mode === 'local') {
+          this.toggleLocalDefaultSave(item, wasSaved);
+        } else if (wasSaved) {
+          await unsaveImage(item.id);
+        } else {
+          await saveImage(item.id);
+        }
+
+        await this.refreshAfterMembershipChange(item.id);
+      } catch (error) {
+        this.setSavedState(item.id, wasSaved);
+        this.error = error instanceof Error ? error.message : 'Unable to update saved post';
+      } finally {
+        this.pendingImageIds = this.pendingImageIds.filter((id) => id !== item.id);
+      }
+    },
+
+    async createAndAdd(name: string, item: FeedItem) {
+      const trimmedName = name.trim();
+      if (!trimmedName) {
+        throw new Error('Collection name is required.');
+      }
+
+      await this.initialize();
+      if (this.items.some((collection) => collection.name.toLocaleLowerCase() === trimmedName.toLocaleLowerCase())) {
+        throw new Error('Collection name already exists.');
+      }
+
+      if (this.mode === 'local') {
+        const collections = readLocalCollections();
+        const slug = createUniqueSlug(trimmedName, new Set(collections.map((collection) => collection.slug)));
+        const timestamp = nowIso();
+        collections.push({
+          slug,
+          name: trimmedName,
+          isDefault: false,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+          items: []
+        });
+        writeLocalCollections(collections);
+        this.items = collections.map(toCollectionSummary);
+        await this.toggleCollectionMembership(slug, item, true);
+        return;
+      }
+
+      const payload = await createCollection(trimmedName);
+      this.items = (await fetchCollections()).items;
+      await this.toggleCollectionMembership(payload.collection.slug, item, true);
+    },
+
+    async updateCollectionName(collectionSlug: string, name: string) {
+      const trimmedName = name.trim();
+      if (!trimmedName) {
+        throw new Error('Collection name is required.');
+      }
+
+      await this.initialize();
+      const existingCollection = this.items.find((collection) => collection.slug === collectionSlug);
+      if (!existingCollection || existingCollection.isDefault) {
+        throw new Error('Collection not found.');
+      }
+
+      if (
+        this.items.some(
+          (collection) =>
+            collection.slug !== collectionSlug &&
+            collection.name.toLocaleLowerCase() === trimmedName.toLocaleLowerCase()
+        )
+      ) {
+        throw new Error('Collection name already exists.');
+      }
+
+      const updatedCollection = this.mode === 'local'
+        ? this.updateLocalCollectionName(collectionSlug, trimmedName)
+        : (await updateCollectionRequest(collectionSlug, trimmedName)).collection;
+
+      this.items = this.items.map((collection) =>
+        collection.slug === collectionSlug ? updatedCollection : collection
+      );
+      if (this.currentCollection?.slug === collectionSlug) {
+        this.currentCollection = updatedCollection;
+      }
+
+      this.membershipByImageId = Object.fromEntries(
+        Object.entries(this.membershipByImageId).map(([imageId, payload]) => [
+          imageId,
+          {
+            ...payload,
+            items: payload.items.map((collection) =>
+              collection.slug === collectionSlug
+                ? { ...updatedCollection, containsImage: collection.containsImage }
+                : collection
+            )
+          }
+        ])
+      );
+
+      return updatedCollection;
+    },
+
+    async deleteCollection(collectionSlug: string) {
+      await this.initialize();
+      const existingCollection = this.items.find((collection) => collection.slug === collectionSlug);
+      if (!existingCollection || existingCollection.isDefault) {
+        throw new Error('Collection not found.');
+      }
+
+      const visibleCurrentItems = this.currentCollection?.slug === collectionSlug
+        ? [...this.currentImages]
+        : [];
+      const deletedCollection = this.mode === 'local'
+        ? this.deleteLocalCollection(collectionSlug)
+        : (await deleteCollectionRequest(collectionSlug)).collection;
+
+      if (this.mode === 'shared') {
+        const collectionsPayload = await fetchCollections();
+        this.items = collectionsPayload.items;
+      }
+
+      this.membershipByImageId = {};
+      for (const item of visibleCurrentItems) {
+        this.setSavedState(item.id, true);
+        this.setBookmarkedState(item.id, true);
+      }
+
+      if (this.currentCollection?.slug === collectionSlug) {
+        this.currentCollection = null;
+        this.currentImages = [];
+        this.currentPage = 1;
+        this.currentHasMore = true;
+      }
+
+      return deletedCollection;
+    },
+
+    async toggleCollectionMembership(collectionSlug: string, item: FeedItem, forceAdd = false) {
+      await this.initialize();
+      if (collectionSlug === DEFAULT_COLLECTION_SLUG) {
+        throw new Error('Default collection membership is managed by the bookmark button.');
+      }
+
+      const key = `${collectionSlug}:${item.id}`;
+      if (this.pendingCollectionKeys.includes(key)) {
+        return;
+      }
+
+      const membership = await this.fetchMembership(item.id);
+      const collection = membership.items.find((entry) => entry.slug === collectionSlug);
+      const containsImage = collection?.containsImage === true;
+      const shouldAdd = forceAdd || !containsImage;
+
+      this.error = null;
+      this.pendingCollectionKeys.push(key);
+
+      try {
+        if (this.mode === 'local') {
+          this.updateLocalCollectionMembership(collectionSlug, item, shouldAdd);
+        } else if (shouldAdd) {
+          await addImageToCollection(collectionSlug, item.id);
+        } else {
+          await removeImageFromCollection(collectionSlug, item.id);
+        }
+
+        await this.refreshAfterMembershipChange(item.id);
+      } catch (error) {
+        const mutationError = error instanceof Error ? error : new Error('Unable to update collection');
+        this.error = mutationError.message;
+        throw mutationError;
+      } finally {
+        this.pendingCollectionKeys = this.pendingCollectionKeys.filter((entry) => entry !== key);
+      }
+    },
+
+    async loadCollection(slug = DEFAULT_COLLECTION_SLUG, reset = true) {
+      await this.initialize();
+
+      if (reset) {
+        this.currentCollection = null;
+        this.currentImages = [];
+        this.currentPage = 1;
+        this.currentHasMore = true;
+      }
+
+      if (this.loadingCollection || !this.currentHasMore) {
+        return;
+      }
+
+      this.loadingCollection = true;
+      this.collectionError = null;
+
+      try {
+        const payload = this.mode === 'local'
+          ? this.loadLocalCollection(slug, this.currentPage, this.currentLimit)
+          : await fetchCollectionImages(slug, this.currentPage, this.currentLimit);
+
+        this.currentCollection = payload.collection;
+        this.currentImages.push(...payload.items);
+        for (const item of payload.items) {
+          this.setSavedState(item.id, item.isSaved === true);
+        }
+        this.currentPage += 1;
+        this.currentHasMore = payload.hasMore;
+      } catch (error) {
+        this.currentCollection = null;
+        this.collectionError = error instanceof Error ? error.message : 'Unable to load collection';
+      } finally {
+        this.loadingCollection = false;
+      }
+    },
+
+    removeImage(id: number) {
+      this.setSavedState(id, false);
+      this.setBookmarkedState(id, false);
+      this.currentImages = this.currentImages.filter((item) => item.id !== id);
+      delete this.membershipByImageId[id];
+    },
+
+    removeFolderItems(folderSlug: string) {
+      this.currentImages = this.currentImages.filter((item) => item.folderSlug !== folderSlug);
+      for (const [id, payload] of Object.entries(this.membershipByImageId)) {
+        const numericId = Number(id);
+        if (payload.items.some((collection) => collection.coverImage?.folderSlug === folderSlug)) {
+          delete this.membershipByImageId[numericId];
+        }
+      }
+    },
+
+    toggleLocalDefaultSave(item: FeedItem, wasSaved: boolean) {
+      const collections = readLocalCollections();
+      const normalizedItem = normalizeFeedItem(item);
+      const timestamp = nowIso();
+      const defaultCollection = collections.find((collection) => collection.isDefault) ?? createDefaultLocalCollection();
+
+      if (!collections.includes(defaultCollection)) {
+        collections.unshift(defaultCollection);
+      }
+
+      if (wasSaved) {
+        for (const collection of collections) {
+          const nextItems = collection.items.filter((entry) => entry.id !== item.id);
+          if (nextItems.length === collection.items.length) {
+            continue;
+          }
+
+          collection.items = nextItems;
+          collection.updatedAt = timestamp;
+        }
+      } else {
+        defaultCollection.items = [normalizedItem, ...defaultCollection.items.filter((entry) => entry.id !== item.id)];
+        defaultCollection.updatedAt = timestamp;
+      }
+
+      writeLocalCollections(collections);
+    },
+
+    updateLocalCollectionMembership(collectionSlug: string, item: FeedItem, shouldAdd: boolean) {
+      const collections = readLocalCollections();
+      const timestamp = nowIso();
+      const normalizedItem = normalizeFeedItem(item);
+      const defaultCollection = collections.find((collection) => collection.isDefault) ?? createDefaultLocalCollection();
+      const targetCollection = collections.find((collection) => collection.slug === collectionSlug);
+
+      if (!collections.includes(defaultCollection)) {
+        collections.unshift(defaultCollection);
+      }
+
+      if (!targetCollection || targetCollection.isDefault) {
+        throw new Error('Collection not found.');
+      }
+
+      if (shouldAdd) {
+        if (!defaultCollection.items.some((entry) => entry.id === item.id)) {
+          defaultCollection.items = [normalizedItem, ...defaultCollection.items];
+          defaultCollection.updatedAt = timestamp;
+        }
+        targetCollection.items = [normalizedItem, ...targetCollection.items.filter((entry) => entry.id !== item.id)];
+        targetCollection.updatedAt = timestamp;
+      } else {
+        targetCollection.items = targetCollection.items.filter((entry) => entry.id !== item.id);
+        targetCollection.updatedAt = timestamp;
+      }
+
+      writeLocalCollections(collections);
+    },
+
+    updateLocalCollectionName(collectionSlug: string, name: string): CollectionSummary {
+      const collections = readLocalCollections();
+      const targetCollection = collections.find((collection) => collection.slug === collectionSlug);
+      if (!targetCollection || targetCollection.isDefault) {
+        throw new Error('Collection not found.');
+      }
+
+      if (
+        collections.some(
+          (collection) =>
+            collection.slug !== collectionSlug &&
+            collection.name.toLocaleLowerCase() === name.toLocaleLowerCase()
+        )
+      ) {
+        throw new Error('Collection name already exists.');
+      }
+
+      targetCollection.name = name;
+      targetCollection.updatedAt = nowIso();
+      writeLocalCollections(collections);
+
+      return toCollectionSummary(targetCollection);
+    },
+
+    deleteLocalCollection(collectionSlug: string): CollectionSummary {
+      const collections = readLocalCollections();
+      const targetCollection = collections.find((collection) => collection.slug === collectionSlug);
+      if (!targetCollection || targetCollection.isDefault) {
+        throw new Error('Collection not found.');
+      }
+
+      const deletedSummary = toCollectionSummary(targetCollection);
+      const nextCollections = collections.filter((collection) => collection.slug !== collectionSlug);
+      writeLocalCollections(nextCollections);
+      this.items = nextCollections.map(toCollectionSummary);
+
+      for (const item of targetCollection.items) {
+        this.setSavedState(item.id, true);
+        this.setBookmarkedState(item.id, true);
+      }
+
+      return deletedSummary;
+    },
+
+    loadLocalCollection(slug: string, page: number, limit: number): CollectionImagesPayload {
+      const collections = readLocalCollections();
+      const collection = collections.find((entry) => entry.slug === slug);
+      if (!collection) {
+        throw new Error('Collection not found.');
+      }
+
+      const defaultCollection = collections.find((entry) => entry.isDefault);
+      const offset = (page - 1) * limit;
+      const items = collection.items.slice(offset, offset + limit).map((item) => ({
+        ...item,
+        isSaved: defaultCollection?.items.some((entry) => entry.id === item.id) === true
+      }));
+      return {
+        collection: toCollectionSummary(collection),
+        items,
+        page,
+        limit,
+        total: collection.items.length,
+        hasMore: page * limit < collection.items.length
+      };
+    },
+
+    async refreshAfterMembershipChange(imageId: number) {
+      if (this.mode === 'local') {
+        const collections = readLocalCollections();
+        this.items = collections.map(toCollectionSummary);
+        writeLocalCollections(collections);
+        delete this.membershipByImageId[imageId];
+        await this.fetchMembership(imageId, true);
+      } else {
+        const collectionsPayload = await fetchCollections();
+        this.items = collectionsPayload.items;
+        await this.fetchMembership(imageId, true);
+      }
+    }
+  }
+});
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useCollectionsStore, import.meta.hot));
+}

--- a/client/src/stores/likes.ts
+++ b/client/src/stores/likes.ts
@@ -38,7 +38,8 @@ function isFeedItem(value: unknown): value is FeedItem {
     typeof item.thumbnailUrl === 'string' &&
     typeof item.previewUrl === 'string' &&
     typeof item.sortTimestamp === 'number' &&
-    (item.takenAt === null || item.takenAt === undefined || typeof item.takenAt === 'number')
+    (item.takenAt === null || item.takenAt === undefined || typeof item.takenAt === 'number') &&
+    (item.isSaved === undefined || typeof item.isSaved === 'boolean')
   );
 }
 
@@ -66,7 +67,10 @@ function readLocalFavorites(): FeedItem[] {
 
       seenIds.add(entry.id);
       return true;
-    });
+    }).map((item) => ({
+      ...item,
+      isSaved: item.isSaved ?? false
+    }));
   } catch {
     return [];
   }

--- a/client/src/styles/base.css
+++ b/client/src/styles/base.css
@@ -28,15 +28,13 @@
   --accent-strong: #1877f2;
   --accent-soft: rgba(0, 149, 246, 0.1);
   --shadow: 0 12px 30px rgba(15, 20, 25, 0.08);
-  --story-ring: conic-gradient(
-    from 210deg,
-    #feda75 0deg,
-    #fa7e1e 56deg,
-    #d62976 150deg,
-    #962fbf 255deg,
-    #4f5bd5 320deg,
-    #feda75 360deg
-  );
+  --story-ring: conic-gradient(from 210deg,
+      #feda75 0deg,
+      #fa7e1e 56deg,
+      #d62976 150deg,
+      #962fbf 255deg,
+      #4f5bd5 320deg,
+      #feda75 360deg);
   --avatar-fallback: linear-gradient(135deg, #ff9e57, #ff5b7f);
   --desktop-sidebar-width: 4.85rem;
   --desktop-content-compensation: 47px;
@@ -57,15 +55,13 @@
   --accent-strong: #4cb5f9;
   --accent-soft: rgba(76, 181, 249, 0.18);
   --shadow: 0 14px 36px rgba(0, 0, 0, 0.32);
-  --story-ring: conic-gradient(
-    from 210deg,
-    #feda75 0deg,
-    #fa7e1e 56deg,
-    #d62976 150deg,
-    #962fbf 255deg,
-    #4f5bd5 320deg,
-    #feda75 360deg
-  );
+  --story-ring: conic-gradient(from 210deg,
+      #feda75 0deg,
+      #fa7e1e 56deg,
+      #d62976 150deg,
+      #962fbf 255deg,
+      #4f5bd5 320deg,
+      #feda75 360deg);
   --avatar-fallback: linear-gradient(135deg, #ff9d5c, #ff5b7f);
 }
 
@@ -275,23 +271,19 @@ img[data-loaded="true"] {
   .story-rail-shell::before {
     left: 0;
     width: 0.95rem;
-    background: linear-gradient(
-      270deg,
-      rgba(var(--primary-background), 0) 0%,
-      rgba(var(--primary-background), 0.72) 100%
-    );
+    background: linear-gradient(270deg,
+        rgba(var(--primary-background), 0) 0%,
+        rgba(var(--primary-background), 0.72) 100%);
     backdrop-filter: blur(4px);
   }
 
   .story-rail-shell::after {
     right: 0;
     width: 1.55rem;
-    background: linear-gradient(
-      90deg,
-      rgba(var(--primary-background), 0) 0%,
-      rgba(var(--primary-background), 0.52) 48%,
-      rgba(var(--primary-background), 0.96) 100%
-    );
+    background: linear-gradient(90deg,
+        rgba(var(--primary-background), 0) 0%,
+        rgba(var(--primary-background), 0.52) 48%,
+        rgba(var(--primary-background), 0.96) 100%);
     backdrop-filter: blur(7px);
   }
 }
@@ -376,11 +368,9 @@ img[data-loaded="true"] {
   flex-shrink: 0;
   border-left: 1px solid color-mix(in srgb, var(--border) 86%, transparent 14%);
   background:
-    linear-gradient(
-      180deg,
+    linear-gradient(180deg,
       color-mix(in srgb, var(--surface) 96%, white 4%) 0%,
-      color-mix(in srgb, var(--surface) 93%, var(--surface-alt) 7%) 100%
-    );
+      color-mix(in srgb, var(--surface) 93%, var(--surface-alt) 7%) 100%);
 }
 
 .viewer__sidebar-handle {
@@ -528,7 +518,7 @@ img[data-loaded="true"] {
 .viewer__sidebar-actions-group {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.55rem;
 }
 
 .viewer__sidebar-actions {
@@ -768,12 +758,10 @@ img[data-loaded="true"] {
   gap: 0.75rem;
   padding: 0.55rem 0.7rem 0.7rem;
   background:
-    linear-gradient(
-      180deg,
+    linear-gradient(180deg,
       rgba(0, 0, 0, 0) 0%,
       rgba(0, 0, 0, 0.55) 58%,
-      rgba(0, 0, 0, 0.82) 100%
-    );
+      rgba(0, 0, 0, 0.82) 100%);
 }
 
 .viewer__player-controls-group {
@@ -926,12 +914,10 @@ img[data-loaded="true"] {
   gap: 0.5rem;
   padding: 0.5rem 0.7rem 0.55rem;
   background:
-    linear-gradient(
-      180deg,
+    linear-gradient(180deg,
       rgba(0, 0, 0, 0) 0%,
       rgba(0, 0, 0, 0.52) 54%,
-      rgba(0, 0, 0, 0.82) 100%
-    );
+      rgba(0, 0, 0, 0.82) 100%);
 }
 
 .feed-card__player-controls-group {
@@ -1052,9 +1038,7 @@ img[data-loaded="true"] {
     border-radius: 1.4rem;
     background: color-mix(in srgb, var(--surface) 95%, var(--surface-alt) 5%);
     box-shadow: 0 28px 72px rgba(15, 20, 25, 0.28);
-    transform: translateY(
-      calc(var(--viewer-sidebar-base-translate-y) + var(--viewer-sidebar-drag-offset, 0px))
-    );
+    transform: translateY(calc(var(--viewer-sidebar-base-translate-y) + var(--viewer-sidebar-drag-offset, 0px)));
     overflow: hidden;
     overscroll-behavior: contain;
     touch-action: pan-y;
@@ -1187,7 +1171,7 @@ img[data-loaded="true"] {
   }
 
   .viewer__sidebar-actions-group {
-    gap: 0.75rem;
+    gap: 0.55rem;
   }
 
   .viewer__sidebar-action {
@@ -1229,21 +1213,540 @@ img[data-loaded="true"] {
   }
 }
 
+/* ── Collection management ─────────────────────────────────── */
+.collection-page__header {
+  display: grid;
+  gap: 1.05rem;
+  padding: 1.1rem 0.1rem 1rem;
+}
+
+.collection-page__back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  width: fit-content;
+  color: var(--muted);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.collection-page__back-link:hover {
+  color: var(--text);
+}
+
+.collection-page__back-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.collection-page__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 2.5rem;
+}
+
+.collection-page__title {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--text);
+  font-size: 1.65rem;
+  line-height: 1.1;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.collection-page__menu-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 2.35rem;
+  height: 2.35rem;
+  padding: 0;
+  border: 0;
+  color: var(--text);
+  background: transparent;
+  cursor: pointer;
+  transition:
+    opacity 0.18s ease,
+    transform 0.18s ease;
+}
+
+.collection-page__menu-button:hover {
+  opacity: 0.72;
+  transform: translateY(-1px);
+}
+
+.collection-page__menu-button span {
+  width: 1.45rem;
+  height: 1.45rem;
+}
+
+.collection-action-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 130;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.48);
+}
+
+.collection-action-sheet,
+.collection-edit-dialog,
+.collection-delete-dialog {
+  width: min(100%, 36rem);
+  overflow: hidden;
+  color: #f7f7f7;
+  background: #202124;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.35rem;
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.42);
+}
+
+.collection-action-sheet__item,
+.collection-delete-dialog__action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 3.7rem;
+  padding: 0.9rem 1.25rem;
+  border: 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  color: #f7f7f7;
+  background: transparent;
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: center;
+  cursor: pointer;
+}
+
+.collection-action-sheet__item:last-child,
+.collection-delete-dialog__action:last-child {
+  border-bottom: 0;
+}
+
+.collection-action-sheet__item:hover,
+.collection-delete-dialog__action:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.collection-action-sheet__item:disabled,
+.collection-delete-dialog__action:disabled {
+  cursor: wait;
+  opacity: 0.68;
+}
+
+.collection-action-sheet__item--danger,
+.collection-delete-dialog__action--danger {
+  color: #ff4d5e;
+  font-weight: 800;
+}
+
+.collection-edit-dialog {
+  display: grid;
+}
+
+.collection-edit-dialog__header {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 4.25rem;
+  padding: 0 3.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.collection-edit-dialog__header h2,
+.collection-delete-dialog__copy h2 {
+  margin: 0;
+  color: #f7f7f7;
+  font-size: 1.18rem;
+  line-height: 1.2;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.collection-edit-dialog__close {
+  position: absolute;
+  right: 1.05rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  padding: 0;
+  border: 0;
+  color: #f7f7f7;
+  background: transparent;
+  cursor: pointer;
+}
+
+.collection-edit-dialog__close:disabled {
+  cursor: wait;
+  opacity: 0.62;
+}
+
+.collection-edit-dialog__close span {
+  width: 1.55rem;
+  height: 1.55rem;
+}
+
+.collection-edit-dialog__form {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.55rem 1.5rem 0;
+}
+
+.collection-edit-dialog__input {
+  width: 100%;
+  min-width: 0;
+  height: 3.1rem;
+  padding: 0 0.95rem;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 0.45rem;
+  color: #f7f7f7;
+  background: transparent;
+  font-size: 1rem;
+  outline: none;
+}
+
+.collection-edit-dialog__input:focus {
+  border-color: rgba(255, 255, 255, 0.48);
+}
+
+.collection-edit-dialog__done {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(100% + 3rem);
+  min-height: 3.9rem;
+  margin: 0 -1.5rem;
+  padding: 0.9rem 1.25rem;
+  border: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: #536dfe;
+  background: transparent;
+  font-size: 1rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.collection-edit-dialog__done:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.collection-edit-dialog__done:disabled {
+  cursor: wait;
+  opacity: 0.68;
+}
+
+.collection-delete-dialog__copy {
+  display: grid;
+  gap: 0.65rem;
+  padding: 1.9rem 1.7rem 1.7rem;
+  text-align: center;
+}
+
+.collection-delete-dialog__copy h2 {
+  font-size: 1.5rem;
+  font-weight: 500;
+}
+
+.collection-delete-dialog__copy p {
+  margin: 0;
+  color: #a8b0bb;
+  font-size: 1rem;
+  line-height: 1.45;
+}
+
+.collection-management-error {
+  margin: 0;
+  color: #ffb4ad;
+  font-size: 0.88rem;
+  text-align: center;
+}
+
+.collection-management-error--dialog {
+  padding: 0 1.5rem 1rem;
+}
+
+@media (max-width: 768px) {
+  .collection-page__header {
+    padding: 0.9rem 0.85rem 0.8rem;
+  }
+
+  .collection-page__title {
+    font-size: 1.45rem;
+  }
+
+  .collection-action-backdrop {
+    padding: 0.85rem;
+  }
+
+  .collection-action-sheet,
+  .collection-edit-dialog,
+  .collection-delete-dialog {
+    width: 100%;
+    border-radius: 1.15rem;
+  }
+}
+
+/* ── Collection bookmark popover ─────────────────────────────── */
+.collection-bookmark {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.collection-bookmark__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 0;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+  transition:
+    opacity 0.18s ease,
+    transform 0.18s ease,
+    color 0.18s ease;
+}
+
+.collection-bookmark__button:hover {
+  opacity: 0.72;
+  transform: translateY(-1px);
+}
+
+.collection-bookmark__button:disabled {
+  cursor: wait;
+  opacity: 0.5;
+  transform: none;
+}
+
+.collection-bookmark__button--saved {
+  color: var(--text);
+}
+
+.collection-bookmark__icon {
+  width: 1.45rem !important;
+  height: 1.45rem !important;
+}
+
+.collection-bookmark--viewer .collection-bookmark__button {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.95rem;
+  background: color-mix(in srgb, var(--surface-alt) 82%, var(--surface) 18%);
+  border: 1px solid color-mix(in srgb, var(--border) 84%, transparent 16%);
+  box-shadow: 0 10px 24px rgba(15, 20, 25, 0.08);
+}
+
+.collection-bookmark__popover {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 120;
+  width: min(23rem, calc(100vw - 1.5rem));
+  max-height: min(25rem, calc(100vh - 6rem));
+  display: grid;
+  grid-template-rows: auto auto auto minmax(0, 1fr);
+  gap: 0.35rem;
+  padding: 1rem;
+  color: #f7f7f7;
+  background: #252525;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.75rem;
+  box-shadow: 0 24px 72px rgba(0, 0, 0, 0.32);
+}
+
+.collection-bookmark__popover::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: -0.42rem;
+  width: 0.85rem;
+  height: 0.85rem;
+  background: #252525;
+  transform: translateX(-50%) rotate(45deg);
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.collection-bookmark__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 2rem;
+  font-size: 1.08rem;
+}
+
+.collection-bookmark__create-button,
+.collection-bookmark__submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 0;
+  color: #f7f7f7;
+  background: transparent;
+  cursor: pointer;
+}
+
+.collection-bookmark__create-button span,
+.collection-bookmark__submit span {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.collection-bookmark__create {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.45rem;
+  align-items: center;
+}
+
+.collection-bookmark__input {
+  width: 100%;
+  min-width: 0;
+  height: 2.35rem;
+  padding: 0 0.72rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 0.55rem;
+  color: #f7f7f7;
+  background: rgba(255, 255, 255, 0.08);
+  outline: none;
+}
+
+.collection-bookmark__input:focus {
+  border-color: rgba(255, 255, 255, 0.42);
+}
+
+.collection-bookmark__error {
+  margin: 0;
+  color: #ffb4ad;
+  font-size: 0.82rem;
+}
+
+.collection-bookmark__empty {
+  margin: 0;
+  padding: 0.4rem 0.2rem 0.2rem;
+  color: rgba(247, 247, 247, 0.7);
+  font-size: 0.86rem;
+}
+
+.collection-bookmark__rows {
+  min-height: 0;
+  overflow-y: auto;
+  display: grid;
+  gap: 0.25rem;
+  padding-right: 0.1rem;
+}
+
+.collection-bookmark__row {
+  display: grid;
+  grid-template-columns: 3rem minmax(0, 1fr) 1.25rem;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 3.55rem;
+  width: 100%;
+  padding: 0.28rem;
+  border: 0;
+  border-radius: 0.58rem;
+  color: inherit;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.collection-bookmark__row:hover,
+.collection-bookmark__row:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  outline: none;
+}
+
+.collection-bookmark__row:disabled {
+  cursor: wait;
+  opacity: 0.62;
+}
+
+.collection-bookmark__cover {
+  width: 3rem;
+  height: 3rem;
+  overflow: hidden;
+  border-radius: 0.45rem;
+  background: #1f252c;
+}
+
+.collection-bookmark__cover img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.collection-bookmark__name {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 0.95rem;
+  font-weight: 650;
+}
+
+.collection-bookmark__check {
+  width: 1.05rem;
+  height: 1.05rem;
+  color: #f7f7f7;
+}
+
+@media (max-width: 768px) {
+  .collection-bookmark__popover {
+    position: fixed;
+    left: 0.75rem !important;
+    right: 0.75rem;
+    bottom: calc(4.75rem + env(safe-area-inset-bottom)) !important;
+    top: auto !important;
+    width: auto;
+  }
+
+  .collection-bookmark__popover::after {
+    display: none;
+  }
+}
+
 /* ── Keyframe animations ────────────────────────────────────── */
 @keyframes shimmer {
   0% {
     background-position: 200% 0;
   }
+
   100% {
     background-position: -200% 0;
   }
 }
 
 @keyframes pulse {
+
   0%,
   100% {
     opacity: 1;
   }
+
   50% {
     opacity: 0.92;
   }

--- a/client/src/styles/base.css
+++ b/client/src/styles/base.css
@@ -1558,8 +1558,9 @@ img[data-loaded="true"] {
   top: 0;
   left: 0;
   z-index: 120;
-  width: min(23rem, calc(100vw - 1.5rem));
-  max-height: min(25rem, calc(100vh - 6rem));
+  width: min(21rem, calc(100vw - 1.5rem));
+  min-height: 7.25rem;
+  max-height: min(20.25rem, calc(100vh - 1.5rem));
   display: grid;
   grid-template-rows: auto auto auto minmax(0, 1fr);
   gap: 0.35rem;
@@ -1574,14 +1575,23 @@ img[data-loaded="true"] {
 .collection-bookmark__popover::after {
   content: "";
   position: absolute;
-  left: 50%;
-  bottom: -0.42rem;
+  left: var(--collection-bookmark-arrow-left, 50%);
   width: 0.85rem;
   height: 0.85rem;
   background: #252525;
   transform: translateX(-50%) rotate(45deg);
+}
+
+.collection-bookmark__popover[data-placement='top']::after {
+  bottom: -0.42rem;
   border-right: 1px solid rgba(255, 255, 255, 0.08);
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.collection-bookmark__popover[data-placement='bottom']::after {
+  top: -0.42rem;
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .collection-bookmark__header {
@@ -1651,10 +1661,26 @@ img[data-loaded="true"] {
 
 .collection-bookmark__rows {
   min-height: 0;
-  overflow-y: auto;
+  max-height: 230px;
+  overflow: hidden auto;
   display: grid;
   gap: 0.25rem;
   padding-right: 0.1rem;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+}
+
+.collection-bookmark__rows::-webkit-scrollbar {
+  width: 0.42rem;
+}
+
+.collection-bookmark__rows::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.collection-bookmark__rows::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .collection-bookmark__row {

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -59,6 +59,7 @@ export interface FeedItem {
   previewUrl: string;
   sortTimestamp: number;
   takenAt: number | null;
+  isSaved?: boolean;
   place?: PlaceSummary | null;
 }
 
@@ -210,6 +211,59 @@ export interface PlacesRebuildResult {
 
 export interface LikesPayload {
   items: FeedItem[];
+}
+
+export interface CollectionSummary {
+  id: number;
+  slug: string;
+  name: string;
+  isDefault: boolean;
+  itemCount: number;
+  coverImage: FeedItem | null;
+  previewImages: FeedItem[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CollectionMembership extends CollectionSummary {
+  containsImage: boolean;
+}
+
+export interface CollectionsPayload {
+  items: CollectionSummary[];
+}
+
+export interface ImageCollectionsPayload {
+  imageId: number;
+  isSaved: boolean;
+  items: CollectionMembership[];
+}
+
+export interface CollectionImagesPayload extends PaginatedFeed {
+  collection: CollectionSummary;
+}
+
+export interface CreateCollectionResult {
+  ok: boolean;
+  collection: CollectionSummary;
+}
+
+export interface UpdateCollectionResult {
+  ok: boolean;
+  collection: CollectionSummary;
+}
+
+export interface DeleteCollectionResult {
+  ok: boolean;
+  collection: CollectionSummary;
+}
+
+export interface CollectionMutationResult {
+  ok: boolean;
+  id?: number;
+  imageId: number;
+  isSaved: boolean;
+  collection?: CollectionSummary;
 }
 
 export interface ImageDetail extends FeedItem {
@@ -365,6 +419,8 @@ export interface AuthCapabilities {
   canAccessSettings: boolean;
   canUseSharedLikes: boolean;
   canUseLocalFavorites: boolean;
+  canUseSharedCollections?: boolean;
+  canUseLocalCollections?: boolean;
 }
 
 export interface AuthStatus {

--- a/client/src/views/CollectionView.test.ts
+++ b/client/src/views/CollectionView.test.ts
@@ -1,0 +1,139 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CollectionSummary } from '../types/api';
+import { useCollectionsStore } from '../stores/collections';
+import CollectionView from './CollectionView.vue';
+
+vi.mock('vue-router', () => ({
+  RouterLink: {
+    template: '<a><slot /></a>'
+  },
+  useRouter: () => ({
+    push: vi.fn()
+  })
+}));
+
+function createCollection(slug: string, name: string, isDefault = false): CollectionSummary {
+  return {
+    id: isDefault ? 1 : Math.abs(slug.length * 17),
+    slug,
+    name,
+    isDefault,
+    itemCount: 0,
+    coverImage: null,
+    previewImages: [],
+    createdAt: '2026-04-28T00:00:00.000Z',
+    updatedAt: '2026-04-28T00:00:00.000Z'
+  };
+}
+
+function createFeedItem(id: number) {
+  return {
+    id,
+    folderId: 11,
+    folderSlug: 'album',
+    folderName: 'Album',
+    folderPath: 'album',
+    folderBreadcrumb: null,
+    filename: `photo-${id}.jpg`,
+    width: 1200,
+    height: 1500,
+    mediaType: 'image' as const,
+    durationMs: null,
+    isAnimated: false,
+    thumbnailUrl: `/thumbnails/${id}.webp`,
+    previewUrl: `/previews/${id}.webp`,
+    sortTimestamp: 1_800_000_000_000 + id,
+    takenAt: 1_800_000_000_000 + id,
+    isSaved: true
+  };
+}
+
+describe('CollectionView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('uses All Posts as the default collection title and Collections as the back label', async () => {
+    const collectionsStore = useCollectionsStore();
+    collectionsStore.$patch({
+      currentCollection: createCollection('saved', 'Saved', true),
+      currentImages: [],
+      loadingCollection: false,
+      collectionError: null
+    });
+    vi.spyOn(collectionsStore, 'loadCollection').mockResolvedValue(undefined);
+
+    const wrapper = mount(CollectionView, {
+      props: {
+        slug: 'saved'
+      },
+      global: {
+        stubs: {
+          EmptyState: {
+            props: ['title', 'description'],
+            template: '<div data-test="empty-state"><h2>{{ title }}</h2><p>{{ description }}</p></div>'
+          },
+          ErrorState: {
+            template: '<div data-test="error-state" />'
+          },
+          FolderGrid: {
+            props: ['columns', 'variant'],
+            template: '<div data-test="folder-grid" :data-columns="columns" :data-variant="variant" />'
+          },
+          InfiniteLoader: {
+            template: '<div data-test="infinite-loader" />'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Collections');
+    expect(wrapper.text()).toContain('All Posts');
+    expect(wrapper.text()).toContain('Use the bookmark action under any post to save it here.');
+    expect(wrapper.find('.collection-page__menu-button').exists()).toBe(false);
+  });
+
+  it('renders collection items in a three-column portrait grid', async () => {
+    const collectionsStore = useCollectionsStore();
+    collectionsStore.$patch({
+      currentCollection: createCollection('saved', 'Saved', true),
+      currentImages: [createFeedItem(1)],
+      loadingCollection: false,
+      collectionError: null
+    });
+    vi.spyOn(collectionsStore, 'loadCollection').mockResolvedValue(undefined);
+
+    const wrapper = mount(CollectionView, {
+      props: {
+        slug: 'saved'
+      },
+      global: {
+        stubs: {
+          EmptyState: {
+            template: '<div data-test="empty-state" />'
+          },
+          ErrorState: {
+            template: '<div data-test="error-state" />'
+          },
+          FolderGrid: {
+            props: ['columns', 'variant'],
+            template: '<div data-test="folder-grid" :data-columns="columns" :data-variant="variant" />'
+          },
+          InfiniteLoader: {
+            template: '<div data-test="infinite-loader" />'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="folder-grid"]').attributes('data-columns')).toBe('three');
+    expect(wrapper.find('[data-test="folder-grid"]').attributes('data-variant')).toBe('posts');
+  });
+});

--- a/client/src/views/CollectionView.vue
+++ b/client/src/views/CollectionView.vue
@@ -1,0 +1,250 @@
+<template>
+  <section class="w-[min(100%,58rem)] mx-auto">
+    <EmptyState
+      v-if="appStore.isLibraryUnavailable"
+      title="Library storage unavailable"
+      :description="appStore.libraryUnavailableReason"
+    />
+    <ErrorState v-else-if="collectionsStore.collectionError" title="Could not load collection" :message="collectionsStore.collectionError" />
+    <template v-else>
+      <header class="collection-page__header" :aria-label="collectionTitle">
+        <RouterLink class="collection-page__back-link" :to="{ name: 'collections' }">
+          <span class="i-fluent-chevron-left-20-regular collection-page__back-icon" aria-hidden="true" />
+          <span>Collections</span>
+        </RouterLink>
+        <div class="collection-page__title-row">
+          <h1 class="collection-page__title">{{ collectionTitle }}</h1>
+          <button
+            v-if="canManageCurrentCollection"
+            class="collection-page__menu-button"
+            type="button"
+            aria-label="Collection options"
+            title="Collection options"
+            @click="menuOpen = true"
+          >
+            <span class="i-fluent-more-horizontal-24-filled" aria-hidden="true" />
+          </button>
+        </div>
+      </header>
+
+      <EmptyState
+        v-if="!collectionsStore.loadingCollection && collectionsStore.currentImages.length === 0"
+        :title="`${collectionTitle} is empty`"
+        :description="emptyDescription"
+      />
+      <div v-else-if="collectionsStore.loadingCollection && collectionsStore.currentImages.length === 0" class="card p-8 text-center">
+        <p class="text-muted">Loading collection...</p>
+      </div>
+      <FolderGrid v-else :items="collectionsStore.currentImages" variant="posts" columns="three" />
+      <InfiniteLoader
+        v-if="collectionsStore.currentImages.length > 0"
+        :loading="collectionsStore.loadingCollection"
+        :has-more="collectionsStore.currentHasMore"
+        @load-more="collectionsStore.loadCollection(slug, false)"
+      />
+    </template>
+
+    <div v-if="menuOpen" class="collection-action-backdrop" @click.self="menuOpen = false">
+      <div class="collection-action-sheet" role="dialog" aria-modal="true" aria-label="Collection actions">
+        <button class="collection-action-sheet__item collection-action-sheet__item--danger" type="button" @click="openDeleteDialog">
+          Delete collection
+        </button>
+        <button class="collection-action-sheet__item" type="button" @click="openEditDialog">
+          Edit Collection
+        </button>
+        <button class="collection-action-sheet__item" type="button" @click="menuOpen = false">
+          Cancel
+        </button>
+      </div>
+    </div>
+
+    <div v-if="editDialogOpen" class="collection-action-backdrop" @click.self="closeEditDialog">
+      <section class="collection-edit-dialog" role="dialog" aria-modal="true" aria-labelledby="edit-collection-title">
+        <header class="collection-edit-dialog__header">
+          <h2 id="edit-collection-title">Edit collection</h2>
+          <button
+            class="collection-edit-dialog__close"
+            type="button"
+            aria-label="Close"
+            title="Close"
+            :disabled="editingCollection"
+            @click="closeEditDialog"
+          >
+            <span class="i-fluent-dismiss-24-regular" aria-hidden="true" />
+          </button>
+        </header>
+        <form class="collection-edit-dialog__form" @submit.prevent="submitRename">
+          <input
+            ref="editInputElement"
+            v-model="editName"
+            class="collection-edit-dialog__input"
+            type="text"
+            maxlength="80"
+            :disabled="editingCollection"
+          />
+          <p v-if="actionError" class="collection-management-error">{{ actionError }}</p>
+          <button class="collection-edit-dialog__done" type="submit" :disabled="editingCollection">
+            {{ editingCollection ? 'Saving...' : 'Done' }}
+          </button>
+        </form>
+      </section>
+    </div>
+
+    <div v-if="deleteDialogOpen" class="collection-action-backdrop" @click.self="closeDeleteDialog">
+      <section class="collection-delete-dialog" role="dialog" aria-modal="true" aria-labelledby="delete-collection-title">
+        <div class="collection-delete-dialog__copy">
+          <h2 id="delete-collection-title">Delete collection?</h2>
+          <p>When you delete this collection, the photos and videos will still be saved.</p>
+        </div>
+        <p v-if="actionError" class="collection-management-error collection-management-error--dialog">{{ actionError }}</p>
+        <button
+          class="collection-delete-dialog__action collection-delete-dialog__action--danger"
+          type="button"
+          :disabled="deletingCollection"
+          @click="confirmDelete"
+        >
+          {{ deletingCollection ? 'Deleting...' : 'Delete' }}
+        </button>
+        <button
+          class="collection-delete-dialog__action"
+          type="button"
+          :disabled="deletingCollection"
+          @click="closeDeleteDialog"
+        >
+          Cancel
+        </button>
+      </section>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref, watch } from 'vue';
+import { RouterLink, useRouter } from 'vue-router';
+
+import EmptyState from '../components/EmptyState.vue';
+import ErrorState from '../components/ErrorState.vue';
+import FolderGrid from '../components/FolderGrid.vue';
+import InfiniteLoader from '../components/InfiniteLoader.vue';
+import { useAppStore } from '../stores/app';
+import { useCollectionsStore } from '../stores/collections';
+
+const props = defineProps<{
+  slug: string;
+}>();
+
+const appStore = useAppStore();
+const collectionsStore = useCollectionsStore();
+const router = useRouter();
+const menuOpen = ref(false);
+const editDialogOpen = ref(false);
+const deleteDialogOpen = ref(false);
+const editInputElement = ref<HTMLInputElement | null>(null);
+const editName = ref('');
+const actionError = ref<string | null>(null);
+const editingCollection = ref(false);
+const deletingCollection = ref(false);
+const collectionTitle = computed(() => {
+  if (!collectionsStore.currentCollection) {
+    return 'Collection';
+  }
+
+  return collectionsStore.currentCollection.isDefault ? 'All Posts' : collectionsStore.currentCollection.name;
+});
+const emptyDescription = computed(() =>
+  collectionsStore.currentCollection?.isDefault
+    ? 'Use the bookmark action under any post to save it here.'
+    : 'Bookmarked posts assigned to this collection will appear here.'
+);
+const canManageCurrentCollection = computed(() => collectionsStore.currentCollection?.isDefault === false);
+
+async function loadCollection() {
+  if (appStore.isLibraryUnavailable) {
+    return;
+  }
+
+  await collectionsStore.loadCollection(props.slug, true);
+}
+
+async function openEditDialog() {
+  menuOpen.value = false;
+  actionError.value = null;
+  editName.value = collectionsStore.currentCollection?.name ?? '';
+  editDialogOpen.value = true;
+  await nextTick();
+  editInputElement.value?.focus();
+  editInputElement.value?.select();
+}
+
+function closeEditDialog() {
+  if (editingCollection.value) {
+    return;
+  }
+
+  editDialogOpen.value = false;
+  actionError.value = null;
+}
+
+function openDeleteDialog() {
+  menuOpen.value = false;
+  actionError.value = null;
+  deleteDialogOpen.value = true;
+}
+
+function closeDeleteDialog() {
+  if (deletingCollection.value) {
+    return;
+  }
+
+  deleteDialogOpen.value = false;
+  actionError.value = null;
+}
+
+async function submitRename() {
+  const name = editName.value.trim();
+  if (!name) {
+    actionError.value = 'Collection name is required.';
+    return;
+  }
+
+  editingCollection.value = true;
+  actionError.value = null;
+
+  try {
+    await collectionsStore.updateCollectionName(props.slug, name);
+    editDialogOpen.value = false;
+  } catch (error) {
+    actionError.value = error instanceof Error ? error.message : 'Unable to update collection';
+  } finally {
+    editingCollection.value = false;
+  }
+}
+
+async function confirmDelete() {
+  deletingCollection.value = true;
+  actionError.value = null;
+
+  try {
+    await collectionsStore.deleteCollection(props.slug);
+    deleteDialogOpen.value = false;
+    await router.push({ name: 'collections' });
+  } catch (error) {
+    actionError.value = error instanceof Error ? error.message : 'Unable to delete collection';
+  } finally {
+    deletingCollection.value = false;
+  }
+}
+
+onMounted(loadCollection);
+
+watch(
+  () => props.slug,
+  () => {
+    menuOpen.value = false;
+    editDialogOpen.value = false;
+    deleteDialogOpen.value = false;
+    actionError.value = null;
+    void loadCollection();
+  }
+);
+</script>

--- a/client/src/views/CollectionsView.test.ts
+++ b/client/src/views/CollectionsView.test.ts
@@ -1,0 +1,90 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CollectionSummary, FeedItem } from '../types/api';
+import { useCollectionsStore } from '../stores/collections';
+import CollectionsView from './CollectionsView.vue';
+
+function createFeedItem(id: number): FeedItem {
+  return {
+    id,
+    folderId: 11,
+    folderSlug: 'album',
+    folderName: 'Album',
+    folderPath: 'album',
+    folderBreadcrumb: null,
+    filename: `photo-${id}.jpg`,
+    width: 1200,
+    height: 1500,
+    mediaType: 'image',
+    durationMs: null,
+    isAnimated: false,
+    thumbnailUrl: `/thumbnails/${id}.webp`,
+    previewUrl: `/previews/${id}.webp`,
+    sortTimestamp: 1_800_000_000_000 + id,
+    takenAt: 1_800_000_000_000 + id,
+    isSaved: true
+  };
+}
+
+function createCollection(slug: string, name: string, isDefault = false, previewImages: FeedItem[] = []): CollectionSummary {
+  return {
+    id: isDefault ? 1 : Math.abs(slug.length * 17),
+    slug,
+    name,
+    isDefault,
+    itemCount: isDefault ? 4 : 2,
+    coverImage: previewImages[0] ?? null,
+    previewImages,
+    createdAt: '2026-04-28T00:00:00.000Z',
+    updatedAt: '2026-04-28T00:00:00.000Z'
+  };
+}
+
+describe('CollectionsView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('shows All Posts as the first collection card without the synthetic tabs UI', async () => {
+    const collectionsStore = useCollectionsStore();
+    collectionsStore.$patch({
+      loading: false,
+      error: null,
+      initialized: true,
+      items: [
+        createCollection('saved', 'Saved', true, [1, 2, 3, 4].map(createFeedItem)),
+        createCollection('travel', 'Travel', false, [createFeedItem(9)])
+      ]
+    });
+    vi.spyOn(collectionsStore, 'initialize').mockResolvedValue(undefined);
+
+    const wrapper = mount(CollectionsView, {
+      global: {
+        stubs: {
+          RouterLink: {
+            props: ['to'],
+            template: '<a :data-to="JSON.stringify(to)"><slot /></a>'
+          },
+          ResilientImage: {
+            props: ['src', 'alt'],
+            template: '<img data-test="cover" :src="src" :alt="alt" />'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    expect(wrapper.find('[aria-label="Collections sections"]').exists()).toBe(false);
+    const cards = wrapper.findAll('a[data-to]');
+    expect(cards).toHaveLength(2);
+    expect(cards[0]?.text()).toContain('All Posts');
+    expect(cards[0]?.attributes('data-to')).toContain('"slug":"saved"');
+    expect(cards[0]?.findAll('img[data-test="cover"]')).toHaveLength(4);
+    expect(cards[1]?.text()).toContain('Travel');
+    expect(cards[1]?.findAll('img[data-test="cover"]')).toHaveLength(1);
+    expect(wrapper.text()).not.toContain('Default Collection');
+  });
+});

--- a/client/src/views/CollectionsView.vue
+++ b/client/src/views/CollectionsView.vue
@@ -1,0 +1,104 @@
+<template>
+  <section class="w-[min(100%,58rem)] mx-auto">
+    <EmptyState
+      v-if="appStore.isLibraryUnavailable"
+      title="Library storage unavailable"
+      :description="appStore.libraryUnavailableReason"
+    />
+    <ErrorState v-else-if="collectionsStore.error" title="Could not load collections" :message="collectionsStore.error" />
+    <template v-else>
+      <div v-if="collectionsStore.loading" class="card p-8 text-center">
+        <p class="text-muted">Loading collections...</p>
+      </div>
+
+      <section v-else-if="collectionsStore.items.length > 0" class="grid gap-[1px] grid-cols-2 md:grid-cols-3">
+        <RouterLink
+          v-for="collection in collectionsStore.items"
+          :key="collection.slug"
+          class="group relative aspect-square overflow-hidden bg-surface-alt text-white"
+          :to="{ name: 'collection', params: { slug: collection.slug } }"
+        >
+          <div
+            v-if="showAllPostsMosaic(collection)"
+            class="grid h-full w-full grid-cols-2 grid-rows-2 gap-[1px] bg-black/12"
+          >
+            <div
+              v-for="slotIndex in 4"
+              :key="`${collection.slug}-${slotIndex}`"
+              class="overflow-hidden bg-[linear-gradient(135deg,#262b31_0%,#111827_100%)]"
+            >
+              <ResilientImage
+                v-if="getPreviewImage(collection, slotIndex - 1)"
+                :src="getPreviewImage(collection, slotIndex - 1)?.thumbnailUrl || ''"
+                :alt="displayCollectionName(collection)"
+                loading="lazy"
+                class="h-full w-full object-cover transition-[transform,opacity] duration-220 group-hover:scale-[1.03] group-hover:opacity-90"
+              />
+            </div>
+          </div>
+          <ResilientImage
+            v-else-if="collection.coverImage"
+            :src="collection.coverImage.thumbnailUrl"
+            :alt="displayCollectionName(collection)"
+            loading="lazy"
+            class="h-full w-full object-cover transition-[transform,opacity] duration-220 group-hover:scale-[1.03] group-hover:opacity-90"
+          />
+          <div v-else class="h-full w-full bg-[linear-gradient(135deg,#262b31_0%,#111827_100%)]"></div>
+          <div class="absolute inset-x-0 bottom-0 grid gap-[0.15rem] px-3 py-3 bg-[linear-gradient(180deg,rgba(10,14,24,0)_0%,rgba(10,14,24,0.82)_100%)]">
+            <strong class="truncate text-[0.95rem]">{{ displayCollectionName(collection) }}</strong>
+            <span class="text-[0.74rem] font-semibold text-white/78">{{ formatCount(collection.itemCount) }} posts</span>
+          </div>
+        </RouterLink>
+      </section>
+
+      <EmptyState
+        v-else
+        title="No collections yet"
+        description="Saved posts will appear in All Posts."
+      />
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { RouterLink } from 'vue-router';
+
+import EmptyState from '../components/EmptyState.vue';
+import ErrorState from '../components/ErrorState.vue';
+import ResilientImage from '../components/ResilientImage.vue';
+import { useAppStore } from '../stores/app';
+import { useCollectionsStore } from '../stores/collections';
+import type { CollectionSummary } from '../types/api';
+
+const appStore = useAppStore();
+const collectionsStore = useCollectionsStore();
+
+function formatCount(value: number) {
+  return new Intl.NumberFormat().format(value);
+}
+
+function displayCollectionName(collection: CollectionSummary) {
+  return collection.isDefault ? 'All Posts' : collection.name;
+}
+
+function showAllPostsMosaic(collection: CollectionSummary) {
+  return collection.isDefault && collection.previewImages.length > 0;
+}
+
+function getPreviewImage(collection: CollectionSummary, index: number) {
+  return collection.previewImages[index] ?? null;
+}
+
+async function loadCollections() {
+  if (appStore.isLibraryUnavailable) {
+    return;
+  }
+
+  await collectionsStore.initialize();
+}
+
+onMounted(() => {
+  void loadCollections();
+});
+</script>

--- a/server/src/db/database.ts
+++ b/server/src/db/database.ts
@@ -158,6 +158,10 @@ class DatabaseManager {
     this.database.exec('CREATE INDEX IF NOT EXISTS idx_places_slug ON places(slug)');
     this.database.exec('CREATE INDEX IF NOT EXISTS idx_places_display_name ON places(display_name)');
     this.database.exec('CREATE INDEX IF NOT EXISTS idx_places_geonames_id ON places(geonames_id)');
+    this.database.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_collections_single_default ON collections(is_default) WHERE is_default = 1');
+    this.database.exec('CREATE INDEX IF NOT EXISTS idx_collections_updated_at ON collections(updated_at DESC)');
+    this.database.exec('CREATE INDEX IF NOT EXISTS idx_collection_items_image ON collection_items(image_id)');
+    this.database.exec('CREATE INDEX IF NOT EXISTS idx_collection_items_created ON collection_items(collection_id, created_at DESC, image_id DESC)');
   }
 }
 

--- a/server/src/db/repositories.ts
+++ b/server/src/db/repositories.ts
@@ -1,7 +1,11 @@
 import { databaseManager } from './database.js';
 import { normalizePath, safeJoin } from '../utils/path-utils.js';
+import { resolveUniqueSlug, slugifyFolderName } from '../utils/slug.js';
 import type {
   AppSettingRecord,
+  CollectionMembershipRecord,
+  CollectionRecord,
+  CollectionSummaryRecord,
   FeedImage,
   FolderAvatarSource,
   FolderImageOrder,
@@ -24,6 +28,8 @@ import type {
 
 const database = databaseManager.connection;
 const EFFECTIVE_FEED_TIME_SQL = 'COALESCE(images.taken_at, images.sort_timestamp)';
+const DEFAULT_COLLECTION_SLUG = 'saved';
+const DEFAULT_COLLECTION_NAME = 'Saved';
 const COVER_FILENAMES = ['cover.jpg', 'cover.jpeg', 'cover.png', 'cover.webp', 'cover.gif'] as const;
 const COVER_FILENAME_SQL = COVER_FILENAMES.map((name) => `'${name}'`).join(', ');
 const NORMAL_FOLDER_ROLE_SQL = "folders.role = 'normal'";
@@ -125,6 +131,15 @@ const MEDIA_SEARCH_FIELD_SQL = [
   EXIF_CAMERA_MODEL_SEARCH_SQL,
   EXIF_LENS_MODEL_SEARCH_SQL
 ] as const;
+const IMAGE_SAVED_SELECT_SQL = `
+    CASE WHEN EXISTS (
+      SELECT 1
+      FROM collections
+      INNER JOIN collection_items ON collection_items.collection_id = collections.id
+      WHERE collections.is_default = 1
+        AND collection_items.image_id = images.id
+    ) THEN 1 ELSE 0 END AS isSaved
+`;
 const FEED_IMAGE_SELECT_SQL = `
   SELECT
     images.id,
@@ -143,6 +158,7 @@ const FEED_IMAGE_SELECT_SQL = `
     images.playback_strategy AS playbackStrategy,
     images.sort_timestamp AS sortTimestamp,
     images.taken_at AS takenAt,
+    ${IMAGE_SAVED_SELECT_SQL},
     places.id AS placeId,
     places.slug AS placeSlug,
     places.display_name AS placeName,
@@ -1133,6 +1149,7 @@ export const imageRepository = {
         images.playback_strategy AS playbackStrategy,
         images.sort_timestamp AS sortTimestamp,
         images.taken_at AS takenAt,
+        ${IMAGE_SAVED_SELECT_SQL},
         places.id AS placeId,
         places.slug AS placeSlug,
         places.display_name AS placeName,
@@ -1175,6 +1192,7 @@ export const imageRepository = {
         search_results.playbackStrategy,
         search_results.sortTimestamp,
         search_results.takenAt,
+        search_results.isSaved,
         search_results.placeId,
         search_results.placeSlug,
         search_results.placeName,
@@ -1198,6 +1216,7 @@ export const imageRepository = {
           images.playback_strategy AS playbackStrategy,
           images.sort_timestamp AS sortTimestamp,
           images.taken_at AS takenAt,
+          ${IMAGE_SAVED_SELECT_SQL},
           places.id AS placeId,
           places.slug AS placeSlug,
           places.display_name AS placeName,
@@ -1371,6 +1390,7 @@ export const imageRepository = {
         images.playback_strategy AS playbackStrategy,
         images.sort_timestamp AS sortTimestamp,
         images.taken_at AS takenAt,
+        ${IMAGE_SAVED_SELECT_SQL},
         images.trashed_at AS trashedAt,
         places.id AS placeId,
         places.slug AS placeSlug,
@@ -1659,6 +1679,7 @@ export const imageRepository = {
         images.absolute_path AS originalUrl,
         images.sort_timestamp AS sortTimestamp,
         images.taken_at AS takenAt,
+        ${IMAGE_SAVED_SELECT_SQL},
         places.id AS placeId,
         places.slug AS placeSlug,
         places.display_name AS placeName,
@@ -1817,7 +1838,8 @@ export const likeRepository = {
         images.preview_path AS previewUrl,
         images.playback_strategy AS playbackStrategy,
         images.sort_timestamp AS sortTimestamp,
-        images.taken_at AS takenAt
+        images.taken_at AS takenAt,
+        ${IMAGE_SAVED_SELECT_SQL}
       FROM likes
       INNER JOIN images ON images.id = likes.image_id
       INNER JOIN folders ON folders.id = images.folder_id
@@ -1866,7 +1888,8 @@ export const likeRepository = {
         images.preview_path AS previewUrl,
         images.playback_strategy AS playbackStrategy,
         images.sort_timestamp AS sortTimestamp,
-        images.taken_at AS takenAt
+        images.taken_at AS takenAt,
+        ${IMAGE_SAVED_SELECT_SQL}
       FROM likes
       INNER JOIN images ON images.id = likes.image_id
       INNER JOIN folders ON folders.id = images.folder_id
@@ -1902,6 +1925,386 @@ export const likeRepository = {
     return Number(result.changes ?? 0);
   }
 };
+
+export const collectionRepository = {
+  ensureDefaultCollection(): CollectionRecord {
+    const existingDefault = database.prepare('SELECT * FROM collections WHERE is_default = 1 LIMIT 1').get() as CollectionRecord | undefined;
+    if (existingDefault) {
+      if (existingDefault.name !== DEFAULT_COLLECTION_NAME) {
+        database.prepare('UPDATE collections SET name = ?, updated_at = ? WHERE id = ?').run(DEFAULT_COLLECTION_NAME, nowIso(), existingDefault.id);
+      }
+
+      return this.getById(existingDefault.id) as CollectionRecord;
+    }
+
+    const savedCollection = this.getBySlug(DEFAULT_COLLECTION_SLUG);
+    if (savedCollection) {
+      database
+        .prepare('UPDATE collections SET name = ?, is_default = 1, updated_at = ? WHERE id = ?')
+        .run(DEFAULT_COLLECTION_NAME, nowIso(), savedCollection.id);
+      return this.getById(savedCollection.id) as CollectionRecord;
+    }
+
+    database
+      .prepare('INSERT INTO collections (slug, name, is_default, created_at, updated_at) VALUES (?, ?, 1, ?, ?)')
+      .run(DEFAULT_COLLECTION_SLUG, DEFAULT_COLLECTION_NAME, nowIso(), nowIso());
+
+    return this.getBySlug(DEFAULT_COLLECTION_SLUG) as CollectionRecord;
+  },
+
+  getById(id: number): CollectionRecord | undefined {
+    return database.prepare('SELECT * FROM collections WHERE id = ?').get(id) as CollectionRecord | undefined;
+  },
+
+  getDefaultCollection(): CollectionRecord {
+    return this.ensureDefaultCollection();
+  },
+
+  repairDefaultMemberships(): number {
+    const defaultCollection = this.ensureDefaultCollection();
+    const timestamp = nowIso();
+    const result = database
+      .prepare(
+        `
+        INSERT OR IGNORE INTO collection_items (collection_id, image_id, created_at)
+        SELECT ?, custom_items.image_id, ?
+        FROM collection_items AS custom_items
+        INNER JOIN collections AS custom_collections ON custom_collections.id = custom_items.collection_id
+        LEFT JOIN collection_items AS default_items
+          ON default_items.collection_id = ? AND default_items.image_id = custom_items.image_id
+        WHERE custom_collections.is_default = 0
+          AND default_items.image_id IS NULL
+        `
+      )
+      .run(defaultCollection.id, timestamp, defaultCollection.id);
+
+    const repairedCount = Number(result.changes ?? 0);
+    if (repairedCount > 0) {
+      database.prepare('UPDATE collections SET updated_at = ? WHERE id = ?').run(timestamp, defaultCollection.id);
+    }
+
+    return repairedCount;
+  },
+
+  getBySlug(slug: string): CollectionRecord | undefined {
+    return database.prepare('SELECT * FROM collections WHERE slug = ?').get(slug) as CollectionRecord | undefined;
+  },
+
+  create(name: string): CollectionRecord {
+    this.ensureDefaultCollection();
+    const normalizedName = name.trim().toLocaleLowerCase();
+    const existingName = database
+      .prepare('SELECT id FROM collections WHERE LOWER(name) = ? LIMIT 1')
+      .get(normalizedName) as { id: number } | undefined;
+    if (existingName) {
+      throw new Error('Collection name already exists.');
+    }
+
+    const existingSlugs = new Set((database.prepare('SELECT slug FROM collections').all() as Array<{ slug: string }>).map((row) => row.slug));
+    const slug = resolveUniqueSlug(name, existingSlugs, slugifyFolderName);
+    const timestamp = nowIso();
+
+    database
+      .prepare('INSERT INTO collections (slug, name, is_default, created_at, updated_at) VALUES (?, ?, 0, ?, ?)')
+      .run(slug, name, timestamp, timestamp);
+
+    return this.getBySlug(slug) as CollectionRecord;
+  },
+
+  updateName(slug: string, name: string): CollectionRecord | undefined {
+    this.ensureDefaultCollection();
+    const collection = this.getBySlug(slug);
+    if (!collection || collection.is_default === 1) {
+      return undefined;
+    }
+
+    const normalizedName = name.trim().toLocaleLowerCase();
+    const existingName = database
+      .prepare('SELECT id FROM collections WHERE LOWER(name) = ? AND id != ? LIMIT 1')
+      .get(normalizedName, collection.id) as { id: number } | undefined;
+    if (existingName) {
+      throw new Error('Collection name already exists.');
+    }
+
+    database
+      .prepare('UPDATE collections SET name = ?, updated_at = ? WHERE id = ?')
+      .run(name.trim(), nowIso(), collection.id);
+
+    return this.getById(collection.id);
+  },
+
+  delete(slug: string): CollectionRecord | undefined {
+    const collection = this.getBySlug(slug);
+    if (!collection || collection.is_default === 1) {
+      return undefined;
+    }
+
+    database.prepare('DELETE FROM collections WHERE id = ?').run(collection.id);
+
+    return collection;
+  },
+
+  listSummaries(): CollectionSummaryRecord[] {
+    this.ensureDefaultCollection();
+    return database
+      .prepare(
+        `
+        SELECT
+          collections.*,
+          (
+            SELECT COUNT(*)
+            FROM collection_items
+            INNER JOIN images ON images.id = collection_items.image_id
+            INNER JOIN folders ON folders.id = images.folder_id
+            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
+          ) AS item_count,
+          (
+            SELECT images.id
+            FROM collection_items
+            INNER JOIN images ON images.id = collection_items.image_id
+            INNER JOIN folders ON folders.id = images.folder_id
+            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
+            ORDER BY collection_items.created_at DESC, collection_items.image_id DESC
+            LIMIT 1
+          ) AS cover_image_id,
+          (
+            SELECT images.thumbnail_path
+            FROM collection_items
+            INNER JOIN images ON images.id = collection_items.image_id
+            INNER JOIN folders ON folders.id = images.folder_id
+            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
+            ORDER BY collection_items.created_at DESC, collection_items.image_id DESC
+            LIMIT 1
+          ) AS cover_thumbnail_path,
+          (
+            SELECT GROUP_CONCAT(preview_images.image_id)
+            FROM (
+              SELECT collection_items.image_id
+              FROM collection_items
+              INNER JOIN images ON images.id = collection_items.image_id
+              INNER JOIN folders ON folders.id = images.folder_id
+              WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
+              ORDER BY collection_items.created_at DESC, collection_items.image_id DESC
+              LIMIT 4
+            ) AS preview_images
+          ) AS preview_image_ids
+        FROM collections
+        ORDER BY collections.is_default DESC, collections.updated_at DESC, collections.id DESC
+        `
+      )
+      .all() as unknown as CollectionSummaryRecord[];
+  },
+
+  listMembershipsForImage(imageId: number): CollectionMembershipRecord[] {
+    this.ensureDefaultCollection();
+    return database
+      .prepare(
+        `
+        SELECT
+          collections.*,
+          (
+            SELECT COUNT(*)
+            FROM collection_items
+            INNER JOIN images ON images.id = collection_items.image_id
+            INNER JOIN folders ON folders.id = images.folder_id
+            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
+          ) AS item_count,
+          (
+            SELECT images.id
+            FROM collection_items
+            INNER JOIN images ON images.id = collection_items.image_id
+            INNER JOIN folders ON folders.id = images.folder_id
+            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
+            ORDER BY collection_items.created_at DESC, collection_items.image_id DESC
+            LIMIT 1
+          ) AS cover_image_id,
+          (
+            SELECT images.thumbnail_path
+            FROM collection_items
+            INNER JOIN images ON images.id = collection_items.image_id
+            INNER JOIN folders ON folders.id = images.folder_id
+            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
+            ORDER BY collection_items.created_at DESC, collection_items.image_id DESC
+            LIMIT 1
+          ) AS cover_thumbnail_path,
+          (
+            SELECT GROUP_CONCAT(preview_images.image_id)
+            FROM (
+              SELECT collection_items.image_id
+              FROM collection_items
+              INNER JOIN images ON images.id = collection_items.image_id
+              INNER JOIN folders ON folders.id = images.folder_id
+              WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
+              ORDER BY collection_items.created_at DESC, collection_items.image_id DESC
+              LIMIT 4
+            ) AS preview_images
+          ) AS preview_image_ids,
+          CASE WHEN EXISTS (
+            SELECT 1
+            FROM collection_items
+            WHERE collection_items.collection_id = collections.id
+              AND collection_items.image_id = ?
+          ) THEN 1 ELSE 0 END AS contains_image
+        FROM collections
+        ORDER BY collections.is_default DESC, collections.updated_at DESC, collections.id DESC
+        `
+      )
+      .all(imageId) as unknown as CollectionMembershipRecord[];
+  },
+
+  listImages(slug: string, page: number, limit: number): FeedImage[] {
+    this.ensureDefaultCollection();
+    const offset = (page - 1) * limit;
+    return database
+      .prepare(
+        `
+        ${FEED_IMAGE_SELECT_SQL}
+        INNER JOIN collection_items ON collection_items.image_id = images.id
+        INNER JOIN collections ON collections.id = collection_items.collection_id
+        WHERE collections.slug = ? AND ${VISIBLE_IMAGE_WHERE_SQL}
+        ORDER BY collection_items.created_at DESC, collection_items.image_id DESC
+        LIMIT ? OFFSET ?
+        `
+      )
+      .all(slug, limit, offset) as unknown as FeedImage[];
+  },
+
+  countImages(slug: string): number {
+    this.ensureDefaultCollection();
+    return Number(
+      (
+        database
+          .prepare(
+            `
+            SELECT COUNT(*) AS count
+            FROM collection_items
+            INNER JOIN collections ON collections.id = collection_items.collection_id
+            INNER JOIN images ON images.id = collection_items.image_id
+            INNER JOIN folders ON folders.id = images.folder_id
+            WHERE collections.slug = ? AND ${VISIBLE_IMAGE_WHERE_SQL}
+            `
+          )
+          .get(slug) as { count: number }
+      ).count
+    );
+  },
+
+  isImageSaved(imageId: number): boolean {
+    this.ensureDefaultCollection();
+    const row = database
+      .prepare(
+        `
+        SELECT 1 AS found
+        FROM collection_items
+        INNER JOIN collections ON collections.id = collection_items.collection_id
+        WHERE collections.is_default = 1 AND collection_items.image_id = ?
+        LIMIT 1
+        `
+      )
+      .get(imageId) as { found: number } | undefined;
+    return row?.found === 1;
+  },
+
+  saveToDefault(imageId: number): CollectionRecord {
+    const defaultCollection = this.ensureDefaultCollection();
+    const timestamp = nowIso();
+
+    database
+      .prepare(
+        `
+        INSERT INTO collection_items (collection_id, image_id, created_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(collection_id, image_id) DO UPDATE SET
+          created_at = excluded.created_at
+        `
+      )
+      .run(defaultCollection.id, imageId, timestamp);
+    database.prepare('UPDATE collections SET updated_at = ? WHERE id = ?').run(timestamp, defaultCollection.id);
+
+    return this.getById(defaultCollection.id) as CollectionRecord;
+  },
+
+  unsaveEverywhere(imageId: number): void {
+    const timestamp = nowIso();
+    database
+      .prepare(
+        `
+        UPDATE collections
+        SET updated_at = ?
+        WHERE id IN (
+          SELECT collection_id
+          FROM collection_items
+          WHERE image_id = ?
+        )
+        `
+      )
+      .run(timestamp, imageId);
+    database.prepare('DELETE FROM collection_items WHERE image_id = ?').run(imageId);
+  },
+
+  addImage(collectionSlug: string, imageId: number): CollectionRecord | undefined {
+    const defaultCollection = this.ensureDefaultCollection();
+    const collection = this.getBySlug(collectionSlug);
+    if (!collection) {
+      return undefined;
+    }
+
+    const timestamp = nowIso();
+    if (collection.id !== defaultCollection.id) {
+      const defaultInsertResult = database
+        .prepare(
+          `
+          INSERT OR IGNORE INTO collection_items (collection_id, image_id, created_at)
+          VALUES (?, ?, ?)
+          `
+        )
+        .run(defaultCollection.id, imageId, timestamp);
+
+      if (Number(defaultInsertResult.changes ?? 0) > 0) {
+        database.prepare('UPDATE collections SET updated_at = ? WHERE id = ?').run(timestamp, defaultCollection.id);
+      }
+    }
+
+    database
+      .prepare(
+        `
+        INSERT INTO collection_items (collection_id, image_id, created_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(collection_id, image_id) DO UPDATE SET
+          created_at = excluded.created_at
+        `
+      )
+      .run(collection.id, imageId, timestamp);
+    database.prepare('UPDATE collections SET updated_at = ? WHERE id = ?').run(timestamp, collection.id);
+
+    return this.getById(collection.id);
+  },
+
+  removeImage(collectionSlug: string, imageId: number): CollectionRecord | undefined {
+    this.ensureDefaultCollection();
+    const collection = this.getBySlug(collectionSlug);
+    if (!collection) {
+      return undefined;
+    }
+
+    database.prepare('DELETE FROM collection_items WHERE collection_id = ? AND image_id = ?').run(collection.id, imageId);
+    database.prepare('UPDATE collections SET updated_at = ? WHERE id = ?').run(nowIso(), collection.id);
+
+    return this.getById(collection.id);
+  },
+
+  removeByFolder(folderId: number): number {
+    const result = database.prepare(
+      'DELETE FROM collection_items WHERE image_id IN (SELECT id FROM images WHERE folder_id = ?)'
+    ).run(folderId);
+    return Number(result.changes ?? 0);
+  }
+};
+
+export const collectionConstants = {
+  defaultCollectionSlug: DEFAULT_COLLECTION_SLUG,
+  defaultCollectionName: DEFAULT_COLLECTION_NAME
+} as const;
 
 export const appSettingsRepository = {
   get(key: string): string | null {

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -109,6 +109,24 @@ CREATE TABLE IF NOT EXISTS likes (
   FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS collections (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  is_default INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS collection_items (
+  collection_id INTEGER NOT NULL,
+  image_id INTEGER NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (collection_id, image_id),
+  FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE CASCADE,
+  FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
+);
+
 CREATE INDEX IF NOT EXISTS idx_folders_slug ON folders(slug);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_folders_folder_path ON folders(folder_path);
 CREATE INDEX IF NOT EXISTS idx_folders_role ON folders(role);
@@ -136,4 +154,8 @@ CREATE INDEX IF NOT EXISTS idx_places_display_name ON places(display_name);
 CREATE INDEX IF NOT EXISTS idx_places_geonames_id ON places(geonames_id);
 CREATE INDEX IF NOT EXISTS idx_folder_scan_state_updated_at ON folder_scan_state(updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_likes_created_at ON likes(created_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_collections_single_default ON collections(is_default) WHERE is_default = 1;
+CREATE INDEX IF NOT EXISTS idx_collections_updated_at ON collections(updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_collection_items_image ON collection_items(image_id);
+CREATE INDEX IF NOT EXISTS idx_collection_items_created ON collection_items(collection_id, created_at DESC, image_id DESC);
 `;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -20,6 +20,7 @@ import { createServer } from "node:http";
 
 import { appConfig } from "./config/env.js";
 import { createApp } from "./app.js";
+import { collectionRepository } from "./db/repositories.js";
 import { log } from "./services/log-service.js";
 import { scannerService } from "./services/scanner-service.js";
 import { watcherService } from "./services/watcher-service.js";
@@ -50,6 +51,11 @@ async function bootstrap(): Promise<void> {
   const app = createApp();
   const server = createServer(app);
   const portVariableName = appConfig.nodeEnv === "production" ? "SERVER_PORT" : "DEV_SERVER_PORT";
+  collectionRepository.ensureDefaultCollection();
+  const repairedCollectionMemberships = collectionRepository.repairDefaultMemberships();
+  if (repairedCollectionMemberships > 0) {
+    log.info(`Repaired ${repairedCollectionMemberships} saved collection memberships`);
+  }
 
   server.on("error", (error: NodeJS.ErrnoException) => {
     if (error.code === "EADDRINUSE") {

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -80,6 +80,9 @@ const storiesModeBodySchema = z.object({
 const excludedFoldersBodySchema = z.object({
   rules: z.array(z.string()).default([])
 });
+const collectionBodySchema = z.object({
+  name: z.string().trim().min(1).max(80)
+});
 
 const slugSchema = z.object({
   slug: z.string().min(1).max(240)
@@ -562,6 +565,99 @@ router.get('/likes', requireCapability('canUseSharedLikes', 'Authentication requ
   response.json(galleryService.getLikes());
 });
 
+router.get('/collections', requireCapability('canUseSharedCollections', 'Authentication required.'), (_request, response) => {
+  response.json(galleryService.getCollections());
+});
+
+router.post('/collections', requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
+  const body = collectionBodySchema.parse(request.body);
+  const collection = galleryService.createCollection(body.name);
+
+  if (!collection) {
+    response.status(404).json({ message: 'Collection could not be created' });
+    return;
+  }
+
+  response.json({
+    ok: true,
+    collection
+  });
+});
+
+router.patch('/collections/:slug', requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
+  const params = slugSchema.parse(request.params);
+  const body = collectionBodySchema.parse(request.body);
+  const collection = galleryService.updateCollection(params.slug, body.name);
+
+  if (!collection) {
+    response.status(404).json({ message: 'Collection not found' });
+    return;
+  }
+
+  response.json({
+    ok: true,
+    collection
+  });
+});
+
+router.delete('/collections/:slug', requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
+  const params = slugSchema.parse(request.params);
+  const collection = galleryService.deleteCollection(params.slug);
+
+  if (!collection) {
+    response.status(404).json({ message: 'Collection not found' });
+    return;
+  }
+
+  response.json({
+    ok: true,
+    collection
+  });
+});
+
+router.get('/collections/:slug/images', requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
+  const params = slugSchema.parse(request.params);
+  const query = paginationQuerySchema.parse(request.query);
+  const payload = galleryService.getCollectionImages(params.slug, query.page, query.limit);
+
+  if (!payload) {
+    response.status(404).json({ message: 'Collection not found' });
+    return;
+  }
+
+  response.json(payload);
+});
+
+router.post('/collections/:slug/images/:id', requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
+  const params = slugSchema.merge(imageIdSchema).parse(request.params);
+  const payload = galleryService.addImageToCollection(params.slug, params.id);
+
+  if (!payload) {
+    response.status(404).json({ message: 'Collection or image not found' });
+    return;
+  }
+
+  response.json({
+    ok: true,
+    ...payload
+  });
+});
+
+router.delete('/collections/:slug/images/:id', requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
+  const params = slugSchema.merge(imageIdSchema).parse(request.params);
+  const payload = galleryService.removeImageFromCollection(params.slug, params.id);
+
+  if (!payload) {
+    response.status(404).json({ message: 'Collection or image not found' });
+    return;
+  }
+
+  response.json({
+    ok: true,
+    ...payload
+  });
+});
+
 router.get('/trash/images', requireCapability('canDeleteMedia', 'Admin access is required.'), (request, response) => {
   const query = paginationQuerySchema.parse(request.query);
   response.json(galleryService.getTrashImages(query.page, query.limit));
@@ -578,6 +674,48 @@ router.get('/images/:id', (request, response) => {
   }
 
   response.json(image);
+});
+
+router.get('/images/:id/collections', requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
+  const params = imageIdSchema.parse(request.params);
+  const payload = galleryService.getImageCollections(params.id);
+
+  if (!payload) {
+    response.status(404).json({ message: 'Post not found' });
+    return;
+  }
+
+  response.json(payload);
+});
+
+router.post('/images/:id/save', requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
+  const params = imageIdSchema.parse(request.params);
+  const payload = galleryService.saveImage(params.id);
+
+  if (!payload) {
+    response.status(404).json({ message: 'Image not found' });
+    return;
+  }
+
+  response.json({
+    ok: true,
+    ...payload
+  });
+});
+
+router.delete('/images/:id/save', requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
+  const params = imageIdSchema.parse(request.params);
+  const payload = galleryService.unsaveImage(params.id);
+
+  if (!payload) {
+    response.status(404).json({ message: 'Image not found' });
+    return;
+  }
+
+  response.json({
+    ok: true,
+    ...payload
+  });
 });
 
 router.post('/images/:id/like', requireCapability('canUseSharedLikes', 'Authentication required.'), (request, response) => {

--- a/server/src/services/auth-service.ts
+++ b/server/src/services/auth-service.ts
@@ -24,6 +24,8 @@ export interface AuthCapabilities {
   canAccessSettings: boolean;
   canUseSharedLikes: boolean;
   canUseLocalFavorites: boolean;
+  canUseSharedCollections: boolean;
+  canUseLocalCollections: boolean;
 }
 
 interface AuthConfigSnapshot {
@@ -95,7 +97,9 @@ function createCapabilities(role: AuthRole): AuthCapabilities {
       canDeleteMedia: true,
       canAccessSettings: true,
       canUseSharedLikes: true,
-      canUseLocalFavorites: false
+      canUseLocalFavorites: false,
+      canUseSharedCollections: true,
+      canUseLocalCollections: false
     };
   }
 
@@ -105,7 +109,9 @@ function createCapabilities(role: AuthRole): AuthCapabilities {
       canDeleteMedia: false,
       canAccessSettings: false,
       canUseSharedLikes: true,
-      canUseLocalFavorites: false
+      canUseLocalFavorites: false,
+      canUseSharedCollections: true,
+      canUseLocalCollections: false
     };
   }
 
@@ -114,7 +120,9 @@ function createCapabilities(role: AuthRole): AuthCapabilities {
     canDeleteMedia: false,
     canAccessSettings: false,
     canUseSharedLikes: false,
-    canUseLocalFavorites: true
+    canUseLocalFavorites: true,
+    canUseSharedCollections: false,
+    canUseLocalCollections: true
   };
 }
 

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -14,8 +14,30 @@ import {
   TREAT_STORIES_AS_FOLDERS_SETTING_KEY
 } from '../constants/app-setting-keys.js';
 import { appConfig } from '../config/env.js';
-import { appSettingsRepository, folderRepository, folderScanStateRepository, imageRepository, likeRepository, placeRepository, scanRunRepository } from '../db/repositories.js';
-import type { FeedImage, FolderImageOrder, FolderRecord, FolderSummaryRecord, ImageDetail, MediaType, PlaceKind, PlaybackStrategy, TrashImage } from '../types/models.js';
+import {
+  appSettingsRepository,
+  collectionConstants,
+  collectionRepository,
+  folderRepository,
+  folderScanStateRepository,
+  imageRepository,
+  likeRepository,
+  placeRepository,
+  scanRunRepository
+} from '../db/repositories.js';
+import type {
+  CollectionMembershipRecord,
+  CollectionSummaryRecord,
+  FeedImage,
+  FolderImageOrder,
+  FolderRecord,
+  FolderSummaryRecord,
+  ImageDetail,
+  MediaType,
+  PlaceKind,
+  PlaybackStrategy,
+  TrashImage
+} from '../types/models.js';
 import {
   getEffectiveExcludedFolderRules,
   parseExcludedFolderRulesFromSetting,
@@ -383,10 +405,11 @@ function isSameOrDescendantFolderPath(rootFolderPath: string, candidateFolderPat
 }
 
 function mapFeedImage(image: IndexedFeedImage, derivativeVersion = getDerivativeAssetVersion()): FeedImage {
-  const { playbackStrategy, placeId, placeSlug, placeName, placeKind, placeIsApproximate, ...rest } = image;
+  const { playbackStrategy, placeId, placeSlug, placeName, placeKind, placeIsApproximate, isSaved, ...rest } = image;
   return {
     ...rest,
     isAnimated: Boolean(rest.isAnimated),
+    isSaved: Boolean(isSaved),
     folderBreadcrumb: getPathBreadcrumb(rest.folderPath),
     thumbnailUrl: toPublicMediaUrl('/thumbnails', rest.thumbnailUrl, derivativeVersion),
     previewUrl: buildPreviewUrl({
@@ -399,11 +422,12 @@ function mapFeedImage(image: IndexedFeedImage, derivativeVersion = getDerivative
 }
 
 function mapImageDetail(image: IndexedImageDetail, derivativeVersion = getDerivativeAssetVersion()): ImageDetail {
-  const { playbackStrategy, exifJson, placeId, placeSlug, placeName, placeKind, placeIsApproximate, ...rest } = image;
+  const { playbackStrategy, exifJson, placeId, placeSlug, placeName, placeKind, placeIsApproximate, isSaved, ...rest } = image;
   const useOriginalForImages = appConfig.imageDetailSource === 'original';
   return {
     ...rest,
     isAnimated: Boolean(rest.isAnimated),
+    isSaved: Boolean(isSaved),
     exif: deserializeImageExifData(exifJson),
     folderBreadcrumb: getPathBreadcrumb(rest.folderPath),
     thumbnailUrl: toPublicMediaUrl('/thumbnails', rest.thumbnailUrl, derivativeVersion),
@@ -419,10 +443,11 @@ function mapImageDetail(image: IndexedImageDetail, derivativeVersion = getDeriva
 }
 
 function mapTrashImage(image: IndexedTrashImage, derivativeVersion = getDerivativeAssetVersion()): TrashImage {
-  const { playbackStrategy, placeId, placeSlug, placeName, placeKind, placeIsApproximate, ...rest } = image;
+  const { playbackStrategy, placeId, placeSlug, placeName, placeKind, placeIsApproximate, isSaved, ...rest } = image;
   return {
     ...rest,
     isAnimated: Boolean(rest.isAnimated),
+    isSaved: Boolean(isSaved),
     folderBreadcrumb: getPathBreadcrumb(rest.folderPath),
     thumbnailUrl: toPublicMediaUrl('/thumbnails', rest.thumbnailUrl, derivativeVersion),
     previewUrl: buildPreviewUrl({
@@ -538,6 +563,46 @@ function formatMonthYear(date: Date): string {
 
 function mapFeedItems(items: IndexedFeedImage[], derivativeVersion = getDerivativeAssetVersion()): FeedImage[] {
   return items.map((item) => mapFeedImage(item, derivativeVersion));
+}
+
+function mapCollectionSummary(collection: CollectionSummaryRecord, derivativeVersion = getDerivativeAssetVersion()) {
+  const previewImages = collection.preview_image_ids
+    ? collection.preview_image_ids
+      .split(',')
+      .map((value) => Number.parseInt(value, 10))
+      .filter((value, index, values) => Number.isInteger(value) && value > 0 && values.indexOf(value) === index)
+      .map((id) => {
+        const previewDetail = imageRepository.getImageDetail(id, undefined, false);
+        return previewDetail ? mapImageDetail(previewDetail, derivativeVersion) : null;
+      })
+      .filter((image): image is ImageDetail => image !== null)
+    : [];
+  const coverImage = previewImages[0]
+    ?? (collection.cover_image_id
+      ? (() => {
+          const coverDetail = imageRepository.getImageDetail(collection.cover_image_id, undefined, false);
+          return coverDetail ? mapImageDetail(coverDetail, derivativeVersion) : null;
+        })()
+      : null);
+
+  return {
+    id: collection.id,
+    slug: collection.slug,
+    name: collection.name,
+    isDefault: collection.is_default === 1,
+    itemCount: collection.item_count,
+    coverImage,
+    previewImages,
+    createdAt: collection.created_at,
+    updatedAt: collection.updated_at
+  };
+}
+
+function mapCollectionMembership(collection: CollectionMembershipRecord, derivativeVersion = getDerivativeAssetVersion()) {
+  return {
+    ...mapCollectionSummary(collection, derivativeVersion),
+    containsImage: collection.contains_image === 1
+  };
 }
 
 function buildPaginatedPayload(items: FeedImage[], page: number, limit: number, total: number) {
@@ -1366,6 +1431,214 @@ export const galleryService = {
     const items = imageRepository.listTrashed(page, limit).map((image) => mapTrashImage(image as IndexedTrashImage, derivativeVersion));
 
     return buildTrashPaginatedPayload(items, page, limit, total);
+  },
+
+  getCollections() {
+    if (!storageService.getState().libraryAvailable) {
+      return {
+        items: []
+      };
+    }
+
+    const derivativeVersion = getDerivativeAssetVersion();
+    return {
+      items: collectionRepository.listSummaries().map((collection) => mapCollectionSummary(collection, derivativeVersion))
+    };
+  },
+
+  getCollectionImages(slug: string, page: number, limit: number) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const collection = collectionRepository.getBySlug(slug);
+    if (!collection) {
+      return null;
+    }
+
+    const total = collectionRepository.countImages(slug);
+    const derivativeVersion = getDerivativeAssetVersion();
+
+    return {
+      collection: mapCollectionSummary(
+        collectionRepository.listSummaries().find((entry) => entry.slug === slug) ?? {
+          ...collection,
+          item_count: total,
+          cover_image_id: null,
+          cover_thumbnail_path: null,
+          preview_image_ids: null
+        },
+        derivativeVersion
+      ),
+      ...buildPaginatedPayload(
+        collectionRepository.listImages(slug, page, limit).map((image) => mapFeedImage(image, derivativeVersion)),
+        page,
+        limit,
+        total
+      )
+    };
+  },
+
+  getImageCollections(id: number) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const image = imageRepository.getById(id);
+    if (!image || image.is_deleted || image.is_trashed) {
+      return null;
+    }
+
+    const derivativeVersion = getDerivativeAssetVersion();
+    return {
+      imageId: id,
+      isSaved: collectionRepository.isImageSaved(id),
+      items: collectionRepository.listMembershipsForImage(id).map((collection) => mapCollectionMembership(collection, derivativeVersion))
+    };
+  },
+
+  createCollection(name: string) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const collection = collectionRepository.create(name);
+    const summary = collectionRepository.listSummaries().find((entry) => entry.id === collection.id);
+    return summary ? mapCollectionSummary(summary) : null;
+  },
+
+  updateCollection(slug: string, name: string) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const collection = collectionRepository.updateName(slug, name);
+    if (!collection) {
+      return null;
+    }
+
+    const summary = collectionRepository.listSummaries().find((entry) => entry.id === collection.id);
+    return summary ? mapCollectionSummary(summary) : null;
+  },
+
+  deleteCollection(slug: string) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const summary = collectionRepository.listSummaries().find((entry) => entry.slug === slug);
+    if (!summary) {
+      return null;
+    }
+
+    const deleted = collectionRepository.delete(slug);
+    if (!deleted) {
+      return null;
+    }
+
+    return mapCollectionSummary(summary);
+  },
+
+  saveImage(id: number) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const image = imageRepository.getById(id);
+    if (!image || image.is_deleted || image.is_trashed) {
+      return null;
+    }
+
+    const collection = collectionRepository.saveToDefault(id);
+    const summary = collectionRepository.listSummaries().find((entry) => entry.id === collection.id);
+
+    return {
+      id,
+      imageId: id,
+      isSaved: collectionRepository.isImageSaved(id),
+      collection: summary ? mapCollectionSummary(summary) : undefined
+    };
+  },
+
+  unsaveImage(id: number) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const image = imageRepository.getById(id);
+    if (!image || image.is_deleted || image.is_trashed) {
+      return null;
+    }
+
+    collectionRepository.unsaveEverywhere(id);
+
+    return {
+      id,
+      imageId: id,
+      isSaved: false
+    };
+  },
+
+  addImageToCollection(slug: string, id: number) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const image = imageRepository.getById(id);
+    if (!image || image.is_deleted || image.is_trashed) {
+      return null;
+    }
+
+    const collection = slug === collectionConstants.defaultCollectionSlug
+      ? collectionRepository.saveToDefault(id)
+      : collectionRepository.addImage(slug, id);
+    if (!collection) {
+      return null;
+    }
+
+    const summary = collectionRepository.listSummaries().find((entry) => entry.id === collection.id);
+
+    return {
+      id,
+      imageId: id,
+      isSaved: true,
+      collection: summary ? mapCollectionSummary(summary) : undefined
+    };
+  },
+
+  removeImageFromCollection(slug: string, id: number) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const image = imageRepository.getById(id);
+    if (!image || image.is_deleted || image.is_trashed) {
+      return null;
+    }
+
+    const collection = collectionRepository.getBySlug(slug);
+    if (!collection) {
+      return null;
+    }
+
+    if (collection.is_default === 1) {
+      collectionRepository.unsaveEverywhere(id);
+      return {
+        id,
+        imageId: id,
+        isSaved: false
+      };
+    }
+
+    collectionRepository.removeImage(slug, id);
+    const summary = collectionRepository.listSummaries().find((entry) => entry.id === collection.id);
+
+    return {
+      id,
+      imageId: id,
+      isSaved: collectionRepository.isImageSaved(id),
+      collection: summary ? mapCollectionSummary(summary) : undefined
+    };
   },
 
   getLikes() {

--- a/server/src/types/models.ts
+++ b/server/src/types/models.ts
@@ -140,6 +140,26 @@ export interface LikeRecord {
   created_at: string;
 }
 
+export interface CollectionRecord {
+  id: number;
+  slug: string;
+  name: string;
+  is_default: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CollectionSummaryRecord extends CollectionRecord {
+  item_count: number;
+  cover_image_id: number | null;
+  cover_thumbnail_path: string | null;
+  preview_image_ids: string | null;
+}
+
+export interface CollectionMembershipRecord extends CollectionSummaryRecord {
+  contains_image: number;
+}
+
 export interface FeedImage {
   id: number;
   folderId: number;
@@ -157,6 +177,7 @@ export interface FeedImage {
   previewUrl: string;
   sortTimestamp: number;
   takenAt: number | null;
+  isSaved: boolean;
   place?: PlaceSummary | null;
 }
 

--- a/server/test/collection-routes.test.ts
+++ b/server/test/collection-routes.test.ts
@@ -1,0 +1,162 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import type express from 'express';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type ApiModule = typeof import('../src/routes/api.js');
+type EnvModule = typeof import('../src/config/env.js');
+
+interface MockResponse {
+  json: ReturnType<typeof vi.fn>;
+  setHeader: ReturnType<typeof vi.fn>;
+  status: ReturnType<typeof vi.fn>;
+}
+
+interface RouteLayer {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: express.RequestHandler }>;
+  };
+}
+
+type RouteMethod = 'get' | 'post' | 'patch' | 'delete';
+
+describe.sequential('collection routes', () => {
+  let tempRoot = '';
+  let apiRouter: ApiModule['apiRouter'];
+  let appConfig: EnvModule['appConfig'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-collection-routes-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.resetModules();
+    ({ apiRouter } = await import('../src/routes/api.js'));
+    ({ appConfig } = await import('../src/config/env.js'));
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.dbDir, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('surfaces a useful duplicate-name error that the app error middleware returns as 400 JSON', () => {
+    const createHandlerError = invokeRoute('/collections', 'post', {
+      body: { name: 'Travel' },
+      headers: {}
+    });
+    expect(createHandlerError).toBeUndefined();
+
+    const duplicateResponse = createResponse();
+    const duplicateError = invokeRoute(
+      '/collections',
+      'post',
+      {
+        body: { name: ' travel ' },
+        headers: {}
+      },
+      duplicateResponse
+    );
+
+    applyAppErrorResponse(duplicateError, duplicateResponse);
+
+    expect(duplicateResponse.status).toHaveBeenCalledWith(400);
+    expect(duplicateResponse.json).toHaveBeenCalledWith({ message: 'Collection name already exists.' });
+  });
+
+  it('returns 404 for the removed synthetic __all collection route', () => {
+    const response = createResponse();
+    const error = invokeRoute(
+      '/collections/:slug/images',
+      'get',
+      {
+        params: { slug: '__all' },
+        query: {},
+        headers: {}
+      },
+      response
+    );
+
+    expect(error).toBeUndefined();
+    expect(response.status).toHaveBeenCalledWith(404);
+    expect(response.json).toHaveBeenCalledWith({ message: 'Collection not found' });
+  });
+
+  function createResponse(): MockResponse {
+    const response: MockResponse = {
+      setHeader: vi.fn(),
+      status: vi.fn(),
+      json: vi.fn()
+    };
+
+    response.status.mockReturnValue(response);
+    return response;
+  }
+
+  function applyAppErrorResponse(error: unknown, response: MockResponse) {
+    const message = error instanceof Error ? error.message : 'Unexpected server error';
+    response.status(400).json({ message });
+  }
+
+  function getRouteHandlers(pathname: string, method: RouteMethod) {
+    const routerLayers = (apiRouter as unknown as { stack: RouteLayer[] }).stack;
+    const route = routerLayers.find((layer) => layer.route?.path === pathname && layer.route.methods[method])?.route;
+    if (!route) {
+      throw new Error(`Route ${method.toUpperCase()} ${pathname} not found`);
+    }
+
+    return route.stack.map((layer) => layer.handle);
+  }
+
+  function invokeRoute(
+    pathname: string,
+    method: RouteMethod,
+    request: Partial<express.Request>,
+    response = createResponse()
+  ) {
+    const handlers = getRouteHandlers(pathname, method);
+    let currentIndex = 0;
+    let thrownError: unknown;
+
+    const next: express.NextFunction = (error?: unknown) => {
+      if (error) {
+        throw error;
+      }
+
+      currentIndex += 1;
+      if (currentIndex < handlers.length) {
+        handlers[currentIndex]?.(request as express.Request, response as unknown as express.Response, next);
+      }
+    };
+
+    try {
+      handlers[0]?.(request as express.Request, response as unknown as express.Response, next);
+    } catch (error) {
+      thrownError = error;
+    }
+
+    return thrownError;
+  }
+});

--- a/server/test/collections.test.ts
+++ b/server/test/collections.test.ts
@@ -1,0 +1,308 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createFingerprint,
+  getMediaTypeFromExtension,
+  getMimeTypeFromExtension,
+  getPreviewRelativePath,
+  getThumbnailRelativePath
+} from '../src/utils/image-utils.js';
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type GalleryServiceModule = typeof import('../src/services/gallery-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type ModelsModule = typeof import('../src/types/models.js');
+
+type FolderRole = ModelsModule['FolderRole'];
+type ImageRecord = ModelsModule['ImageRecord'];
+type MediaType = ModelsModule['MediaType'];
+
+describe.sequential('bookmark collections', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let galleryService: GalleryServiceModule['galleryService'];
+  let collectionRepository: RepositoriesModule['collectionRepository'];
+  let folderRepository: RepositoriesModule['folderRepository'];
+  let imageRepository: RepositoriesModule['imageRepository'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-bookmark-collections-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.resetModules();
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ galleryService } = await import('../src/services/gallery-service.js'));
+    ({ collectionRepository, folderRepository, imageRepository } = await import('../src/db/repositories.js'));
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('creates exactly one Saved default collection', () => {
+    const first = collectionRepository.ensureDefaultCollection();
+    const second = collectionRepository.ensureDefaultCollection();
+    const summaries = collectionRepository.listSummaries();
+
+    expect(first.id).toBe(second.id);
+    expect(first.slug).toBe('saved');
+    expect(first.name).toBe('Saved');
+    expect(summaries.filter((collection) => collection.is_default === 1)).toHaveLength(1);
+  });
+
+  it('adds custom collection membership through Saved', async () => {
+    const image = await createIndexedMedia('trips', 'photo-a.jpg', 1_800_000_000_000);
+
+    const custom = galleryService.createCollection('Trip Picks');
+    expect(custom).toMatchObject({ slug: 'trip-picks', name: 'Trip Picks', isDefault: false });
+
+    expect(galleryService.addImageToCollection('trip-picks', image.id)).toMatchObject({
+      imageId: image.id,
+      isSaved: true
+    });
+
+    const memberships = galleryService.getImageCollections(image.id);
+    expect(memberships?.isSaved).toBe(true);
+    expect(memberships?.items.find((collection) => collection.slug === 'saved')?.containsImage).toBe(true);
+    expect(memberships?.items.find((collection) => collection.slug === 'trip-picks')?.containsImage).toBe(true);
+    expect(galleryService.getCollectionImages('saved', 1, 20)?.items.map((item) => item.id)).toEqual([image.id]);
+    expect(galleryService.getCollectionImages('trip-picks', 1, 20)?.items.map((item) => item.id)).toEqual([image.id]);
+  });
+
+  it('removes custom memberships when a post is unsaved', async () => {
+    const image = await createIndexedMedia('trips-unsave', 'photo-a.jpg', 1_800_000_005_000);
+    galleryService.createCollection('Trip Picks');
+
+    expect(galleryService.addImageToCollection('trip-picks', image.id)).toMatchObject({
+      imageId: image.id,
+      isSaved: true
+    });
+    expect(galleryService.unsaveImage(image.id)).toMatchObject({
+      imageId: image.id,
+      isSaved: false
+    });
+
+    const memberships = galleryService.getImageCollections(image.id);
+    expect(memberships?.isSaved).toBe(false);
+    expect(memberships?.items.find((collection) => collection.slug === 'saved')?.containsImage).toBe(false);
+    expect(memberships?.items.find((collection) => collection.slug === 'trip-picks')?.containsImage).toBe(false);
+    expect(galleryService.getCollectionImages('saved', 1, 20)?.items).toHaveLength(0);
+    expect(galleryService.getCollectionImages('trip-picks', 1, 20)?.items).toHaveLength(0);
+  });
+
+  it('removing a post from a custom collection keeps it saved', async () => {
+    const image = await createIndexedMedia('trips-remove-custom', 'photo-a.jpg', 1_800_000_007_500);
+    galleryService.createCollection('Trip Picks');
+    galleryService.addImageToCollection('trip-picks', image.id);
+
+    expect(galleryService.removeImageFromCollection('trip-picks', image.id)).toMatchObject({
+      imageId: image.id,
+      isSaved: true
+    });
+
+    const memberships = galleryService.getImageCollections(image.id);
+    expect(memberships?.isSaved).toBe(true);
+    expect(memberships?.items.find((collection) => collection.slug === 'saved')?.containsImage).toBe(true);
+    expect(memberships?.items.find((collection) => collection.slug === 'trip-picks')?.containsImage).toBe(false);
+  });
+
+  it('removing the default collection membership clears every collection membership', async () => {
+    const image = await createIndexedMedia('trips-remove-default', 'photo-a.jpg', 1_800_000_009_000);
+    galleryService.createCollection('Trip Picks');
+    galleryService.addImageToCollection('trip-picks', image.id);
+
+    expect(galleryService.removeImageFromCollection('saved', image.id)).toMatchObject({
+      imageId: image.id,
+      isSaved: false
+    });
+
+    const memberships = galleryService.getImageCollections(image.id);
+    expect(memberships?.isSaved).toBe(false);
+    expect(memberships?.items.find((collection) => collection.slug === 'saved')?.containsImage).toBe(false);
+    expect(memberships?.items.find((collection) => collection.slug === 'trip-picks')?.containsImage).toBe(false);
+  });
+
+  it('does not save to the default collection when the target custom collection is missing', async () => {
+    const image = await createIndexedMedia('missing-target', 'photo-a.jpg', 1_800_000_010_000);
+
+    expect(galleryService.addImageToCollection('does-not-exist', image.id)).toBeNull();
+    expect(collectionRepository.isImageSaved(image.id)).toBe(false);
+  });
+
+  it('repairs legacy custom-only collection memberships into Saved', async () => {
+    const image = await createIndexedMedia('repair-membership', 'photo-a.jpg', 1_800_000_012_500);
+    galleryService.createCollection('Repair Picks');
+    galleryService.addImageToCollection('repair-picks', image.id);
+
+    collectionRepository.removeImage('saved', image.id);
+    expect(collectionRepository.isImageSaved(image.id)).toBe(false);
+    expect(galleryService.getImageCollections(image.id)?.items.find((collection) => collection.slug === 'repair-picks')?.containsImage).toBe(true);
+
+    expect(collectionRepository.repairDefaultMemberships()).toBe(1);
+
+    const memberships = galleryService.getImageCollections(image.id);
+    expect(memberships?.isSaved).toBe(true);
+    expect(memberships?.items.find((collection) => collection.slug === 'saved')?.containsImage).toBe(true);
+    expect(memberships?.items.find((collection) => collection.slug === 'repair-picks')?.containsImage).toBe(true);
+  });
+
+  it('renames and deletes custom collections while preserving saved membership', async () => {
+    const image = await createIndexedMedia('collection-management', 'photo-a.jpg', 1_800_000_015_000);
+    expect(galleryService.createCollection('Rename Me')).toMatchObject({
+      slug: 'rename-me',
+      name: 'Rename Me',
+      isDefault: false
+    });
+
+    expect(galleryService.updateCollection('rename-me', 'Trip Archive')).toMatchObject({
+      slug: 'rename-me',
+      name: 'Trip Archive',
+      isDefault: false
+    });
+    expect(galleryService.addImageToCollection('rename-me', image.id)).toMatchObject({
+      imageId: image.id,
+      isSaved: true
+    });
+
+    expect(galleryService.deleteCollection('rename-me')).toMatchObject({
+      slug: 'rename-me',
+      name: 'Trip Archive'
+    });
+    expect(galleryService.getCollectionImages('rename-me', 1, 20)).toBeNull();
+
+    const memberships = galleryService.getImageCollections(image.id);
+    expect(memberships?.isSaved).toBe(true);
+    expect(memberships?.items.some((collection) => collection.slug === 'rename-me')).toBe(false);
+    expect(memberships?.items.find((collection) => collection.slug === 'saved')?.containsImage).toBe(true);
+    expect(galleryService.getCollectionImages('saved', 1, 20)?.items.map((item) => item.id)).toEqual([image.id]);
+  });
+
+  it('filters hidden collection members while keeping membership metadata', async () => {
+    const visible = await createIndexedMedia('visible', 'photo-a.jpg', 1_800_000_020_000);
+    const cover = await createIndexedMedia('visible', 'cover.jpg', 1_800_000_021_000);
+    const deleted = await createIndexedMedia('visible', 'deleted.jpg', 1_800_000_022_000);
+    const trashed = await createIndexedMedia('visible', 'trashed.jpg', 1_800_000_023_000);
+    const story = await createIndexedMedia('story-capsule', 'story.jpg', 1_800_000_024_000, 'story_capsule');
+
+    for (const image of [visible, cover, deleted, trashed, story]) {
+      expect(galleryService.saveImage(image.id)).toMatchObject({ imageId: image.id, isSaved: true });
+    }
+    imageRepository.markDeleted(deleted.relative_path);
+    imageRepository.moveToTrash(trashed.id);
+
+    const saved = galleryService.getCollectionImages('saved', 1, 20);
+    expect(saved?.total).toBe(1);
+    expect(saved?.items.map((item) => item.id)).toEqual([visible.id]);
+    expect(collectionRepository.isImageSaved(deleted.id)).toBe(true);
+    expect(collectionRepository.isImageSaved(story.id)).toBe(true);
+  });
+
+  it('restores collection listing when a soft-deleted image reappears', async () => {
+    const image = await createIndexedMedia('reactivated', 'photo-a.jpg', 1_800_000_030_000);
+    expect(galleryService.saveImage(image.id)).toMatchObject({ imageId: image.id, isSaved: true });
+
+    imageRepository.markDeleted(image.relative_path);
+    expect(galleryService.getCollectionImages('saved', 1, 20)?.items).toHaveLength(0);
+
+    const reappeared = await createIndexedMedia('reactivated', 'photo-a.jpg', 1_800_000_031_000);
+    expect(reappeared.id).toBe(image.id);
+    expect(galleryService.getCollectionImages('saved', 1, 20)?.items.map((item) => item.id)).toEqual([image.id]);
+  });
+
+  it('cascades membership when an image row is hard-deleted', async () => {
+    const image = await createIndexedMedia('hard-delete', 'photo-a.jpg', 1_800_000_040_000);
+    galleryService.createCollection('Keepers');
+    expect(galleryService.addImageToCollection('keepers', image.id)).toMatchObject({ imageId: image.id, isSaved: true });
+
+    imageRepository.deleteById(image.id);
+
+    expect(collectionRepository.isImageSaved(image.id)).toBe(false);
+    expect(galleryService.getCollectionImages('keepers', 1, 20)?.items).toHaveLength(0);
+  });
+
+  it('rejects synthetic __all collection queries', async () => {
+    await createIndexedMedia('all/default', 'photo-a.jpg', 1_800_000_045_000);
+    expect(galleryService.getCollectionImages('__all', 1, 20)).toBeNull();
+  });
+
+  it('includes isSaved on feed and detail payloads', async () => {
+    const image = await createIndexedMedia('payloads', 'photo-a.jpg', 1_800_000_050_000);
+    expect(galleryService.saveImage(image.id)).toMatchObject({ imageId: image.id, isSaved: true });
+
+    expect(galleryService.getFeed(1, 10, 'recent').items.find((item) => item.id === image.id)?.isSaved).toBe(true);
+    expect(galleryService.getImageDetail(image.id)?.isSaved).toBe(true);
+  });
+
+  async function createIndexedMedia(
+    folderPath: string,
+    filename: string,
+    timestamp: number,
+    role: FolderRole = 'normal'
+  ): Promise<ImageRecord> {
+    const folder = folderRepository.upsert({
+      slug: folderPath.replaceAll('/', '-'),
+      name: path.posix.basename(folderPath),
+      folderPath,
+      role
+    });
+    const relativePath = `${folderPath}/${filename}`;
+    const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+    const extension = path.extname(filename).toLowerCase();
+    const mediaType = getMediaTypeFromExtension(extension);
+
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, `source:${relativePath}`);
+
+    return imageRepository.upsert({
+      folderId: folder.id,
+      filename,
+      extension,
+      relativePath,
+      absolutePath,
+      fileSize: 2_048,
+      width: mediaType === 'video' ? 1080 : 1600,
+      height: mediaType === 'video' ? 1920 : 1200,
+      mediaType,
+      mimeType: getMimeTypeFromExtension(extension),
+      durationMs: getDurationForMediaType(mediaType),
+      isAnimated: false,
+      fingerprint: createFingerprint(relativePath, 2_048, timestamp),
+      mtimeMs: timestamp,
+      firstSeenAt: new Date(timestamp).toISOString(),
+      sortTimestamp: timestamp,
+      takenAt: timestamp,
+      takenAtSource: 'mtime',
+      exifJson: '{}',
+      thumbnailPath: getThumbnailRelativePath(relativePath),
+      previewPath: getPreviewRelativePath(relativePath, mediaType),
+      playbackStrategy: 'preview'
+    });
+  }
+
+  function getDurationForMediaType(mediaType: MediaType): number | null {
+    return mediaType === 'video' ? 18_000 : null;
+  }
+});


### PR DESCRIPTION
This pull request adds bookmark collections, allowing saved posts to be organized into custom collections in both shared and local modes.

It includes the collection views and routing, bookmark popover collection management, saved-post membership syncing, and test coverage for collection behavior and access rules.

Closes #51.