### PR TITLE
Align stories video timing, add seekable bottom progress UI across players & other UI/UX fixes

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#4f46e5" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/client/src/components/AppShell.vue
+++ b/client/src/components/AppShell.vue
@@ -4,6 +4,7 @@
   <div
     class="app-shell flex min-h-screen overflow-x-clip"
     :class="{
+      'app-shell--standalone': isStandaloneDisplay,
       'app-shell--explore': isExploreShell,
       'app-shell--reels': isReelsShell
     }"
@@ -80,7 +81,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useRoute } from 'vue-router';
 
 import SidebarNav from './SidebarNav.vue';
@@ -97,6 +98,7 @@ import {
 
 const appStore = useAppStore();
 const route = useRoute();
+const isStandaloneDisplay = ref(false);
 const isExploreShell = computed(() => route.meta.shell === 'explore');
 const isReelsShell = computed(() => route.meta.shell === 'reels');
 const isImmersiveShell = computed(() => isExploreShell.value || isReelsShell.value);
@@ -120,11 +122,23 @@ const stickyScanSummary = computed(() => getScanSummary(activeScan.value));
 const stickyScanActionLine = computed(() => getScanActionLine(activeScan.value));
 const stickyScanMetricLine = computed(() => getScanMetricLine(activeScan.value));
 const stickyScanBarState = computed(() => getScanBarState(activeScan.value));
+
+onMounted(() => {
+  const navigatorWithStandalone = navigator as Navigator & { standalone?: boolean };
+  isStandaloneDisplay.value =
+    window.matchMedia('(display-mode: standalone)').matches ||
+    navigatorWithStandalone.standalone === true;
+});
 </script>
 
 <style scoped>
 .app-shell {
-  --mobile-bottom-nav-height: calc(4.1rem + env(safe-area-inset-bottom));
+  --mobile-safe-area-bottom: 0px;
+  --mobile-bottom-nav-height: calc(3.55rem + var(--mobile-safe-area-bottom));
+}
+
+.app-shell--standalone {
+  --mobile-safe-area-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 .app-shell--reels {

--- a/client/src/components/FeedCard.test.ts
+++ b/client/src/components/FeedCard.test.ts
@@ -23,6 +23,8 @@ class FakeMediaPlayerElement extends HTMLElement {
   paused = true;
   playCallCount = 0;
   pauseCallCount = 0;
+  currentTime = 0;
+  duration = 0;
 
   async play() {
     this.playCallCount += 1;
@@ -42,6 +44,7 @@ class FakeMediaControlsGroupElement extends HTMLElement {}
 class FakeMediaPlayButtonElement extends HTMLElement {}
 class FakeMediaMuteButtonElement extends HTMLElement {}
 class FakeMediaFullscreenButtonElement extends HTMLElement {}
+class FakeMediaTimeSliderElement extends HTMLElement {}
 
 if (!customElements.get('media-player')) {
   customElements.define('media-player', FakeMediaPlayerElement);
@@ -73,6 +76,10 @@ if (!customElements.get('media-mute-button')) {
 
 if (!customElements.get('media-fullscreen-button')) {
   customElements.define('media-fullscreen-button', FakeMediaFullscreenButtonElement);
+}
+
+if (!customElements.get('media-time-slider')) {
+  customElements.define('media-time-slider', FakeMediaTimeSliderElement);
 }
 
 function createVideoItem(id: number): FeedItem {
@@ -221,6 +228,46 @@ describe('FeedCard', () => {
     expect(player.playCallCount).toBeGreaterThanOrEqual(2);
     expect(player.paused).toBe(false);
     expect(wrapper.find('.feed-card__pause-indicator').exists()).toBe(false);
+  });
+
+  it('renders the bottom progress UI and keeps slider clicks from pausing the home video', async () => {
+    const wrapper = mount(FeedCard, {
+      props: {
+        item: createVideoItem(8051),
+        avatarUrl: null,
+        context: 'home',
+        isActiveVideo: true
+      },
+      global: {
+        stubs: globalStubs
+      }
+    });
+
+    await flushPromises();
+
+    const player = wrapper.get('media-player').element as unknown as FakeMediaPlayerElement;
+    expect(wrapper.find('media-time-slider').exists()).toBe(true);
+    expect(wrapper.get('.video-progress-footer__time').text()).toBe('0:00 / 0:31');
+
+    await wrapper.get('media-time-slider').trigger('click');
+    await flushPromises();
+
+    expect(player.pauseCallCount).toBe(0);
+
+    player.dispatchEvent(new CustomEvent('time-update', {
+      detail: {
+        currentTime: 30,
+        played: { length: 0, start: () => 0, end: () => 0 }
+      }
+    }));
+    await flushPromises();
+
+    expect(wrapper.get('.video-progress-footer__time').text()).toBe('0:30 / 0:31');
+
+    player.dispatchEvent(new Event('ended'));
+    await flushPromises();
+
+    expect(wrapper.get('.video-progress-footer__time').text()).toBe('0:31 / 0:31');
   });
 
   it('renders a story ring on the home avatar and emits an in-place story open event', async () => {

--- a/client/src/components/FeedCard.vue
+++ b/client/src/components/FeedCard.vue
@@ -130,57 +130,59 @@
           :src.prop="item.thumbnailUrl"
           :alt.prop="item.filename"
         />
-        <media-controls
-          v-if="showHomeVideoControls"
-          class="feed-card__player-controls"
-          @click.stop
-          @keydown.stop
+        <VideoProgressFooter
+          variant="feed"
+          :time-label="homeVideoTimeLabel"
         >
-          <media-controls-group class="feed-card__player-controls-group">
-            <media-play-button
-              class="feed-card__player-control"
-              aria-label="Toggle playback"
-            >
-              <span
-                class="feed-card__player-control-icon feed-card__player-play-icon feed-card__player-play-icon--play i-fluent-play-16-filled"
-                aria-hidden="true"
-              />
-              <span
-                class="feed-card__player-control-icon feed-card__player-play-icon feed-card__player-play-icon--pause i-fluent-pause-16-filled"
-                aria-hidden="true"
-              />
-            </media-play-button>
-            <media-mute-button
-              class="feed-card__player-control"
-              aria-label="Toggle sound"
-            >
-              <span
-                class="feed-card__player-control-icon feed-card__player-mute-icon feed-card__player-mute-icon--on i-fluent-speaker-2-16-regular"
-                aria-hidden="true"
-              />
-              <span
-                class="feed-card__player-control-icon feed-card__player-mute-icon feed-card__player-mute-icon--off i-fluent-speaker-mute-16-regular"
-                aria-hidden="true"
-              />
-            </media-mute-button>
-          </media-controls-group>
-          <media-controls-group class="feed-card__player-controls-group">
-            <media-fullscreen-button
-              class="feed-card__player-control"
-              aria-label="Toggle fullscreen"
-              target="media"
-            >
-              <span
-                class="feed-card__player-control-icon feed-card__player-fullscreen-icon feed-card__player-fullscreen-icon--enter i-fluent-full-screen-maximize-16-regular"
-                aria-hidden="true"
-              />
-              <span
-                class="feed-card__player-control-icon feed-card__player-fullscreen-icon feed-card__player-fullscreen-icon--exit i-fluent-full-screen-minimize-16-regular"
-                aria-hidden="true"
-              />
-            </media-fullscreen-button>
-          </media-controls-group>
-        </media-controls>
+          <template #leading>
+            <div v-if="showHomeVideoControls" class="feed-card__player-controls-group">
+              <media-play-button
+                class="feed-card__player-control"
+                aria-label="Toggle playback"
+              >
+                <span
+                  class="feed-card__player-control-icon feed-card__player-play-icon feed-card__player-play-icon--play i-fluent-play-16-filled"
+                  aria-hidden="true"
+                />
+                <span
+                  class="feed-card__player-control-icon feed-card__player-play-icon feed-card__player-play-icon--pause i-fluent-pause-16-filled"
+                  aria-hidden="true"
+                />
+              </media-play-button>
+            </div>
+          </template>
+          <template #trailing>
+            <div v-if="showHomeVideoControls" class="feed-card__player-controls-group">
+              <media-mute-button
+                class="feed-card__player-control"
+                aria-label="Toggle sound"
+              >
+                <span
+                  class="feed-card__player-control-icon feed-card__player-mute-icon feed-card__player-mute-icon--on i-fluent-speaker-2-16-regular"
+                  aria-hidden="true"
+                />
+                <span
+                  class="feed-card__player-control-icon feed-card__player-mute-icon feed-card__player-mute-icon--off i-fluent-speaker-mute-16-regular"
+                  aria-hidden="true"
+                />
+              </media-mute-button>
+              <media-fullscreen-button
+                class="feed-card__player-control"
+                aria-label="Toggle fullscreen"
+                target="media"
+              >
+                <span
+                  class="feed-card__player-control-icon feed-card__player-fullscreen-icon feed-card__player-fullscreen-icon--enter i-fluent-full-screen-maximize-16-regular"
+                  aria-hidden="true"
+                />
+                <span
+                  class="feed-card__player-control-icon feed-card__player-fullscreen-icon feed-card__player-fullscreen-icon--exit i-fluent-full-screen-minimize-16-regular"
+                  aria-hidden="true"
+                />
+              </media-fullscreen-button>
+            </div>
+          </template>
+        </VideoProgressFooter>
       </media-player>
       <div
         v-if="showHomeVideoPausedIndicator"
@@ -188,14 +190,6 @@
         aria-hidden="true"
       >
         <span class="feed-card__pause-icon i-fluent-play-20-filled" />
-      </div>
-      <div
-        class="absolute inset-x-0 top-0 flex items-center justify-between gap-3 px-4 py-3 text-white pointer-events-none bg-[linear-gradient(180deg,rgba(10,14,24,0.82)_0%,rgba(10,14,24,0)_100%)]"
-      >
-        <span class="i-fluent-play-circle-24-filled w-[1.15rem] h-[1.15rem] text-white" aria-hidden="true" />
-        <span v-if="item.durationMs" class="rounded-full bg-black/55 px-[0.55rem] py-[0.18rem] text-[0.76rem] font-semibold">
-          {{ formattedDuration }}
-        </span>
       </div>
     </div>
 
@@ -416,13 +410,14 @@ import { useFoldersStore } from '../stores/folders';
 import { useLikesStore } from '../stores/likes';
 import { useMomentsStore } from '../stores/moments';
 import type { FeedItem } from '../types/api';
-import { formatMediaDuration } from '../utils/media';
+import { formatMediaDuration, formatVideoTimestamp } from '../utils/media';
 import { resolveFeedAspectRatio } from '../utils/media-layout';
 import { getOriginalMediaDownloadUrl, getOriginalMediaUrl } from '../utils/original-media';
 import Avatar from './Avatar.vue';
 import CollectionBookmark from './CollectionBookmark.vue';
 import ConfirmDialog from './ConfirmDialog.vue';
 import ResilientImage from './ResilientImage.vue';
+import VideoProgressFooter from './VideoProgressFooter.vue';
 
 interface HomeVideoVisibilityChange {
   id: number;
@@ -470,12 +465,15 @@ const homePlayerElement = ref<MediaPlayerElement | null>(null);
 const loadedHomeVideoAspectRatio = ref<string | null>(null);
 const isHomeVideoPaused = ref(false);
 const isHomeVideoFullscreen = ref(false);
+const homeVideoDurationMs = ref(props.item.durationMs ?? 0);
+const homeVideoCurrentTimeMs = ref(0);
 const lastHomeImageTapAt = ref(0);
 const heartBurstEl = ref<HTMLElement | null>(null);
 
 let homeImageTapResetTimer: ReturnType<typeof setTimeout> | null = null;
 let homeVideoObserver: IntersectionObserver | null = null;
 let homeVideoMuteSyncToken = 0;
+let homePlayerReady = false;
 let removeHomePlayerEventListeners: (() => void) | null = null;
 
 const imageRoute = computed(() => ({
@@ -514,6 +512,12 @@ const homeVideoSource = computed<PlayerSrc>(() => ({
   src: props.item.previewUrl,
   type: 'video/mp4'
 }));
+const homeVideoTimeLabel = computed(() =>
+  formatVideoTimestamp(
+    homeVideoDurationMs.value > 0 ? homeVideoDurationMs.value : props.item.durationMs,
+    homeVideoCurrentTimeMs.value
+  )
+);
 const showHomeVideoControls = computed(() => props.isActiveVideo || isHomeVideoFullscreen.value);
 const showHomeVideoSurfaceControls = computed(() => props.isActiveVideo || isHomeVideoFullscreen.value);
 const showHomeVideoPausedIndicator = computed(() => showHomeVideoSurfaceControls.value && isHomeVideoPaused.value);
@@ -530,7 +534,9 @@ function isPrimaryPlainClick(event: MouseEvent) {
 
 function isInteractiveTarget(target: EventTarget | null): boolean {
   return target instanceof HTMLElement && Boolean(
-    target.closest('a, button, input, textarea, select, media-play-button, media-mute-button, media-fullscreen-button, media-controls')
+    target.closest(
+      'a, button, input, textarea, select, media-play-button, media-mute-button, media-fullscreen-button, media-time-slider'
+    )
   );
 }
 
@@ -634,6 +640,20 @@ function syncHomeVideoAspectRatio(player: MediaPlayerElement | null = homePlayer
   loadedHomeVideoAspectRatio.value = resolveFeedAspectRatio(video.videoWidth, video.videoHeight);
 }
 
+function syncHomeVideoTimelineState(player: MediaPlayerElement | null = homePlayerElement.value) {
+  if (!player) {
+    return;
+  }
+
+  if (Number.isFinite(player.duration) && player.duration > 0) {
+    homeVideoDurationMs.value = player.duration * 1000;
+  }
+
+  if (Number.isFinite(player.currentTime) && player.currentTime >= 0) {
+    homeVideoCurrentTimeMs.value = player.currentTime * 1000;
+  }
+}
+
 function stopHomeVideoObserver(options: { clearVisibility?: boolean } = {}) {
   if (homeVideoObserver) {
     homeVideoObserver.disconnect();
@@ -722,6 +742,7 @@ async function syncHomeVideoPlayback() {
 
 function handleHomeVideoPlay() {
   isHomeVideoPaused.value = false;
+  syncHomeVideoTimelineState();
 
   if (!props.isActiveVideo && !isHomeVideoFullscreen.value) {
     void homePlayerElement.value?.pause().catch(() => {
@@ -732,6 +753,34 @@ function handleHomeVideoPlay() {
 
 function handleHomeVideoPause() {
   isHomeVideoPaused.value = showHomeVideoSurfaceControls.value;
+  syncHomeVideoTimelineState();
+}
+
+function handleHomeVideoDurationChange(event: Event) {
+  if (event instanceof CustomEvent && typeof event.detail === 'number' && event.detail > 0) {
+    homeVideoDurationMs.value = event.detail * 1000;
+  }
+
+  syncHomeVideoTimelineState();
+}
+
+function handleHomeVideoTimeUpdate(event: Event) {
+  if (
+    event instanceof CustomEvent &&
+    typeof event.detail === 'object' &&
+    event.detail !== null &&
+    'currentTime' in event.detail &&
+    typeof event.detail.currentTime === 'number'
+  ) {
+    homeVideoCurrentTimeMs.value = event.detail.currentTime * 1000;
+    return;
+  }
+
+  syncHomeVideoTimelineState();
+}
+
+function handleHomeVideoEnded() {
+  homeVideoCurrentTimeMs.value = homeVideoDurationMs.value;
 }
 
 async function handleHomeVideoSurfaceClick(event: MouseEvent) {
@@ -789,7 +838,10 @@ function handleHomeVideoFullscreenChange(event: Event) {
 
 function handleHomeVideoVolumeChange() {
   const player = homePlayerElement.value;
-  if (!player || homeVideoMuteSyncToken !== 0) {
+  // Ignore volume-change events that fire before the player has fully initialized.
+  // Vidstack can emit these during its own setup with muted=false, which would
+  // overwrite the persisted muted preference read from localStorage.
+  if (!player || !homePlayerReady || homeVideoMuteSyncToken !== 0) {
     return;
   }
 
@@ -807,7 +859,9 @@ function bindHomePlayerEventListeners(player: MediaPlayerElement | null) {
   }
 
   const handleReady = () => {
+    homePlayerReady = true;
     syncHomeVideoAspectRatio(player);
+    syncHomeVideoTimelineState(player);
     void syncHomeVideoPlayback();
   };
   const handleVolume = () => {
@@ -819,12 +873,24 @@ function bindHomePlayerEventListeners(player: MediaPlayerElement | null) {
   const handlePause = () => {
     handleHomeVideoPause();
   };
+  const handleDuration = (event: Event) => {
+    handleHomeVideoDurationChange(event);
+  };
+  const handleTimeUpdate = (event: Event) => {
+    handleHomeVideoTimeUpdate(event);
+  };
+  const handleEnded = () => {
+    handleHomeVideoEnded();
+  };
 
   player.addEventListener('loaded-metadata', handleReady);
   player.addEventListener('can-play', handleReady);
   player.addEventListener('volume-change', handleVolume);
   player.addEventListener('play', handlePlay);
   player.addEventListener('pause', handlePause);
+  player.addEventListener('duration-change', handleDuration);
+  player.addEventListener('time-update', handleTimeUpdate);
+  player.addEventListener('ended', handleEnded);
 
   removeHomePlayerEventListeners = () => {
     player.removeEventListener('loaded-metadata', handleReady);
@@ -832,6 +898,9 @@ function bindHomePlayerEventListeners(player: MediaPlayerElement | null) {
     player.removeEventListener('volume-change', handleVolume);
     player.removeEventListener('play', handlePlay);
     player.removeEventListener('pause', handlePause);
+    player.removeEventListener('duration-change', handleDuration);
+    player.removeEventListener('time-update', handleTimeUpdate);
+    player.removeEventListener('ended', handleEnded);
   };
 
   if (player.hasAttribute('data-can-play')) {
@@ -901,6 +970,8 @@ watch(
   () => {
     loadedHomeVideoAspectRatio.value = null;
     isHomeVideoPaused.value = false;
+    homeVideoDurationMs.value = props.item.durationMs ?? 0;
+    homeVideoCurrentTimeMs.value = 0;
   }
 );
 
@@ -930,6 +1001,9 @@ watch(
 watch(homePlayerElement, (player) => {
   loadedHomeVideoAspectRatio.value = null;
   isHomeVideoPaused.value = false;
+  homeVideoDurationMs.value = props.item.durationMs ?? 0;
+  homePlayerReady = false;
+  homeVideoCurrentTimeMs.value = 0;
   bindHomePlayerEventListeners(player);
 });
 

--- a/client/src/components/PostViewer.test.ts
+++ b/client/src/components/PostViewer.test.ts
@@ -32,6 +32,7 @@ class FakeMediaPlayerElement extends HTMLElement {
   playCallCount = 0;
   pauseCallCount = 0;
   currentTime = 0;
+  duration = 0;
 
   async play() {
     this.playCallCount += 1;
@@ -53,6 +54,7 @@ class FakeMediaControlsGroupElement extends HTMLElement {}
 class FakeMediaPlayButtonElement extends HTMLElement {}
 class FakeMediaMuteButtonElement extends HTMLElement {}
 class FakeMediaFullscreenButtonElement extends HTMLElement {}
+class FakeMediaTimeSliderElement extends HTMLElement {}
 
 if (!customElements.get('media-player')) {
   customElements.define('media-player', FakeMediaPlayerElement);
@@ -84,6 +86,10 @@ if (!customElements.get('media-mute-button')) {
 
 if (!customElements.get('media-fullscreen-button')) {
   customElements.define('media-fullscreen-button', FakeMediaFullscreenButtonElement);
+}
+
+if (!customElements.get('media-time-slider')) {
+  customElements.define('media-time-slider', FakeMediaTimeSliderElement);
 }
 
 function createFeedItem(id: number): FeedItem {
@@ -151,6 +157,13 @@ function createVideoDetail(id: number): ImageDetail {
     playbackStrategy: 'preview',
     previousImageId: null,
     nextImageId: null
+  };
+}
+
+function createHdVideoDetail(id: number): ImageDetail {
+  return {
+    ...createVideoDetail(id),
+    playbackStrategy: 'original'
   };
 }
 
@@ -279,6 +292,71 @@ describe('PostViewer', () => {
     expect(player.playCallCount).toBeGreaterThanOrEqual(2);
     expect(player.paused).toBe(false);
     expect(wrapper.find('.viewer__pause-indicator').exists()).toBe(false);
+  });
+
+  it('renders the bottom progress UI and keeps slider clicks from toggling viewer playback', async () => {
+    const wrapper = mount(PostViewer, {
+      props: {
+        image: createVideoDetail(24),
+        isModal: true
+      },
+      global: {
+        stubs: globalStubs
+      }
+    });
+
+    await flushPromises();
+
+    const player = wrapper.get('media-player').element as unknown as FakeMediaPlayerElement;
+    expect(wrapper.find('media-time-slider').exists()).toBe(true);
+    expect(wrapper.get('.video-progress-footer__time').text()).toBe('0:00 / 0:09');
+
+    await wrapper.get('media-time-slider').trigger('click');
+    await flushPromises();
+
+    expect(player.pauseCallCount).toBe(0);
+
+    player.dispatchEvent(new CustomEvent('time-update', {
+      detail: {
+        currentTime: 8,
+        played: { length: 0, start: () => 0, end: () => 0 }
+      }
+    }));
+    await flushPromises();
+
+    expect(wrapper.get('.video-progress-footer__time').text()).toBe('0:08 / 0:09');
+
+    player.dispatchEvent(new Event('ended'));
+    await flushPromises();
+
+    expect(wrapper.get('.video-progress-footer__time').text()).toBe('0:09 / 0:09');
+  });
+
+  it('preserves the playback position when switching between preview and HD sources', async () => {
+    const wrapper = mount(PostViewer, {
+      props: {
+        image: createHdVideoDetail(25),
+        isModal: true
+      },
+      global: {
+        stubs: globalStubs
+      }
+    });
+
+    await flushPromises();
+
+    const player = wrapper.get('media-player').element as unknown as FakeMediaPlayerElement;
+    player.currentTime = 4.25;
+    player.paused = false;
+
+    await wrapper.get('button[aria-label="Switch to HD original"]').trigger('click');
+    await flushPromises();
+
+    player.dispatchEvent(new Event('loaded-metadata'));
+    await flushPromises();
+
+    expect(player.currentTime).toBe(4.25);
+    expect(player.playCallCount).toBeGreaterThanOrEqual(2);
   });
 
   it('shows the paused indicator when autoplay is blocked on load', async () => {

--- a/client/src/components/PostViewer.vue
+++ b/client/src/components/PostViewer.vue
@@ -160,76 +160,84 @@
                 :src.prop="image.thumbnailUrl"
                 :alt.prop="image.filename"
               />
-              <media-controls class="viewer__player-controls" data-swipe-ignore="true">
-                <media-controls-group class="viewer__player-controls-group">
-                  <media-play-button
-                    class="viewer__player-control"
-                    aria-label="Toggle playback"
-                  >
-                    <span
-                      class="viewer__player-control-icon viewer__player-play-icon viewer__player-play-icon--play i-fluent-play-16-filled"
-                      aria-hidden="true"
-                    />
-                    <span
-                      class="viewer__player-control-icon viewer__player-play-icon viewer__player-play-icon--pause i-fluent-pause-16-filled"
-                      aria-hidden="true"
-                    />
-                  </media-play-button>
-                  <media-mute-button
-                    class="viewer__player-control"
-                    aria-label="Toggle sound"
-                  >
-                    <span
-                      class="viewer__player-control-icon viewer__player-mute-icon viewer__player-mute-icon--on i-fluent-speaker-2-16-regular"
-                      aria-hidden="true"
-                    />
-                    <span
-                      class="viewer__player-control-icon viewer__player-mute-icon viewer__player-mute-icon--off i-fluent-speaker-mute-16-regular"
-                      aria-hidden="true"
-                    />
-                  </media-mute-button>
-                </media-controls-group>
-                <media-controls-group class="viewer__player-controls-group">
-                  <button
-                    v-if="showHdButton"
-                    class="viewer__player-control"
-                    :class="{ 'viewer__player-control--active': isPlayingHd }"
-                    type="button"
-                    :aria-label="
-                      isPlayingHd
-                        ? 'Switch to preview quality'
-                        : 'Switch to HD original'
-                    "
-                    :aria-pressed="isPlayingHd"
-                    :title="isPlayingHd ? 'Preview quality' : 'HD original'"
-                    @click.stop="toggleHdSource"
-                  >
-                    <span
-                      class="viewer__player-control-icon"
-                      :class="
+              <VideoProgressFooter
+                variant="viewer"
+                :time-label="videoTimeLabel"
+                data-swipe-ignore="true"
+              >
+                <template #leading>
+                  <div class="viewer__player-controls-group">
+                    <media-play-button
+                      class="viewer__player-control"
+                      aria-label="Toggle playback"
+                    >
+                      <span
+                        class="viewer__player-control-icon viewer__player-play-icon viewer__player-play-icon--play i-fluent-play-16-filled"
+                        aria-hidden="true"
+                      />
+                      <span
+                        class="viewer__player-control-icon viewer__player-play-icon viewer__player-play-icon--pause i-fluent-pause-16-filled"
+                        aria-hidden="true"
+                      />
+                    </media-play-button>
+                  </div>
+                </template>
+                <template #trailing>
+                  <div class="viewer__player-controls-group">
+                    <media-mute-button
+                      class="viewer__player-control"
+                      aria-label="Toggle sound"
+                    >
+                      <span
+                        class="viewer__player-control-icon viewer__player-mute-icon viewer__player-mute-icon--on i-fluent-speaker-2-16-regular"
+                        aria-hidden="true"
+                      />
+                      <span
+                        class="viewer__player-control-icon viewer__player-mute-icon viewer__player-mute-icon--off i-fluent-speaker-mute-16-regular"
+                        aria-hidden="true"
+                      />
+                    </media-mute-button>
+                    <button
+                      v-if="showHdButton"
+                      class="viewer__player-control"
+                      :class="{ 'viewer__player-control--active': isPlayingHd }"
+                      type="button"
+                      :aria-label="
                         isPlayingHd
-                          ? 'i-fluent-hd-16-filled'
-                          : 'i-fluent-hd-16-regular'
+                          ? 'Switch to preview quality'
+                          : 'Switch to HD original'
                       "
-                      aria-hidden="true"
-                    />
-                  </button>
-                  <media-fullscreen-button
-                    class="viewer__player-control"
-                    aria-label="Toggle fullscreen"
-                    target="media"
-                  >
-                    <span
-                      class="viewer__player-control-icon viewer__player-fullscreen-icon viewer__player-fullscreen-icon--enter i-fluent-full-screen-maximize-16-regular"
-                      aria-hidden="true"
-                    />
-                    <span
-                      class="viewer__player-control-icon viewer__player-fullscreen-icon viewer__player-fullscreen-icon--exit i-fluent-full-screen-minimize-16-regular"
-                      aria-hidden="true"
-                    />
-                  </media-fullscreen-button>
-                </media-controls-group>
-              </media-controls>
+                      :aria-pressed="isPlayingHd"
+                      :title="isPlayingHd ? 'Preview quality' : 'HD original'"
+                      @click.stop="toggleHdSource"
+                    >
+                      <span
+                        class="viewer__player-control-icon"
+                        :class="
+                          isPlayingHd
+                            ? 'i-fluent-hd-16-filled'
+                            : 'i-fluent-hd-16-regular'
+                        "
+                        aria-hidden="true"
+                      />
+                    </button>
+                    <media-fullscreen-button
+                      class="viewer__player-control"
+                      aria-label="Toggle fullscreen"
+                      target="media"
+                    >
+                      <span
+                        class="viewer__player-control-icon viewer__player-fullscreen-icon viewer__player-fullscreen-icon--enter i-fluent-full-screen-maximize-16-regular"
+                        aria-hidden="true"
+                      />
+                      <span
+                        class="viewer__player-control-icon viewer__player-fullscreen-icon viewer__player-fullscreen-icon--exit i-fluent-full-screen-minimize-16-regular"
+                        aria-hidden="true"
+                      />
+                    </media-fullscreen-button>
+                  </div>
+                </template>
+              </VideoProgressFooter>
             </media-player>
             <div
               v-if="showVideoPausedIndicator"
@@ -570,7 +578,8 @@
   import Avatar from "./Avatar.vue"
   import CollectionBookmark from "./CollectionBookmark.vue"
   import ResilientImage from "./ResilientImage.vue"
-  import { formatMediaDuration, videoPreviewWouldDownscale } from "../utils/media"
+  import VideoProgressFooter from "./VideoProgressFooter.vue"
+  import { formatMediaDuration, formatVideoTimestamp, videoPreviewWouldDownscale } from "../utils/media"
 
   const props = defineProps<{
     image: ImageDetail | null
@@ -601,6 +610,8 @@
   const isSidebarSheetDragging = ref(false)
   const isPlayingHd = ref(false)
   const isVideoPaused = ref(false)
+  const videoDurationMs = ref(props.image?.durationMs ?? 0)
+  const videoCurrentTimeMs = ref(0)
   const sidebarSheetDragOffset = ref(0)
   const settingCover = ref(false)
 
@@ -620,6 +631,7 @@
   }
 
   let videoMuteSyncToken = 0
+  let playerReady = false
   let pendingVideoRestore: { currentTime: number; wasPaused: boolean } | null = null
   let removePlayerEventListeners: (() => void) | null = null
   let sidebarSheetPointerId: number | null = null
@@ -649,6 +661,12 @@
   )
   const showVideoPausedIndicator = computed(
     () => props.image?.mediaType === 'video' && isVideoPaused.value,
+  )
+  const videoTimeLabel = computed(() =>
+    formatVideoTimestamp(
+      videoDurationMs.value > 0 ? videoDurationMs.value : props.image?.durationMs,
+      videoCurrentTimeMs.value,
+    ),
   )
 
   const videoSrc = computed(() => {
@@ -893,10 +911,24 @@
           "media-play-button",
           "media-mute-button",
           "media-fullscreen-button",
-          "media-controls",
+          "media-time-slider",
         ].join(", "),
       ),
     )
+  }
+
+  function syncVideoTimelineState(player: MediaPlayerElement | null = playerElement.value) {
+    if (!player) {
+      return
+    }
+
+    if (Number.isFinite(player.duration) && player.duration > 0) {
+      videoDurationMs.value = player.duration * 1000
+    }
+
+    if (Number.isFinite(player.currentTime) && player.currentTime >= 0) {
+      videoCurrentTimeMs.value = player.currentTime * 1000
+    }
   }
 
   function formatExifNumber(
@@ -1359,7 +1391,10 @@
 
   function handlePlayerVolumeChange() {
     const player = playerElement.value
-    if (!player || videoMuteSyncToken !== 0) {
+    // Ignore volume-change events that fire before the player has fully initialized.
+    // Vidstack can emit these during its own setup with muted=false, which would
+    // overwrite the persisted muted preference read from localStorage.
+    if (!player || !playerReady || videoMuteSyncToken !== 0) {
       return
     }
 
@@ -1389,6 +1424,7 @@
       const restoreState = pendingVideoRestore
       pendingVideoRestore = null
       player.currentTime = restoreState.currentTime
+      syncVideoTimelineState(player)
 
       if (!restoreState.wasPaused) {
         void player.play().catch(() => { /* ignore */ })
@@ -1411,16 +1447,43 @@
     }
 
     const handleReady = () => {
+      playerReady = true
       void handlePlayerReadyForPlayback()
     }
     const handlePlay = () => {
       isVideoPaused.value = false
+      syncVideoTimelineState(player)
     }
     const handlePause = () => {
       isVideoPaused.value = props.image?.mediaType === "video"
+      syncVideoTimelineState(player)
     }
     const handleVolume = () => {
       handlePlayerVolumeChange()
+    }
+    const handleDuration = (event: Event) => {
+      if (event instanceof CustomEvent && typeof event.detail === "number" && event.detail > 0) {
+        videoDurationMs.value = event.detail * 1000
+      }
+
+      syncVideoTimelineState(player)
+    }
+    const handleTimeUpdate = (event: Event) => {
+      if (
+        event instanceof CustomEvent &&
+        typeof event.detail === "object" &&
+        event.detail !== null &&
+        "currentTime" in event.detail &&
+        typeof event.detail.currentTime === "number"
+      ) {
+        videoCurrentTimeMs.value = event.detail.currentTime * 1000
+        return
+      }
+
+      syncVideoTimelineState(player)
+    }
+    const handleEnded = () => {
+      videoCurrentTimeMs.value = videoDurationMs.value
     }
 
     player.addEventListener("loaded-metadata", handleReady)
@@ -1428,6 +1491,9 @@
     player.addEventListener("play", handlePlay)
     player.addEventListener("pause", handlePause)
     player.addEventListener("volume-change", handleVolume)
+    player.addEventListener("duration-change", handleDuration)
+    player.addEventListener("time-update", handleTimeUpdate)
+    player.addEventListener("ended", handleEnded)
 
     removePlayerEventListeners = () => {
       player.removeEventListener("loaded-metadata", handleReady)
@@ -1435,6 +1501,9 @@
       player.removeEventListener("play", handlePlay)
       player.removeEventListener("pause", handlePause)
       player.removeEventListener("volume-change", handleVolume)
+      player.removeEventListener("duration-change", handleDuration)
+      player.removeEventListener("time-update", handleTimeUpdate)
+      player.removeEventListener("ended", handleEnded)
     }
 
     if (player.hasAttribute("data-can-play")) {
@@ -1451,6 +1520,8 @@
       resetMediaSheetRevealGesture()
       isPlayingHd.value = false
       isVideoPaused.value = false
+      videoDurationMs.value = props.image?.durationMs ?? 0
+      videoCurrentTimeMs.value = 0
       pendingVideoRestore = null
       void attemptVideoPlayback()
     },
@@ -1469,6 +1540,9 @@
   )
 
   watch(playerElement, player => {
+    videoDurationMs.value = props.image?.durationMs ?? 0
+    videoCurrentTimeMs.value = 0
+    playerReady = false
     bindPlayerEventListeners(player)
   })
 

--- a/client/src/components/ReelPlayerCard.test.ts
+++ b/client/src/components/ReelPlayerCard.test.ts
@@ -37,6 +37,7 @@ class FakeMediaPlayerElement extends HTMLElement {
 
 class FakeMediaProviderElement extends HTMLElement {}
 class FakeMediaPosterElement extends HTMLElement {}
+class FakeMediaTimeSliderElement extends HTMLElement {}
 
 if (!customElements.get('media-player')) {
   customElements.define('media-player', FakeMediaPlayerElement);
@@ -48,6 +49,10 @@ if (!customElements.get('media-provider')) {
 
 if (!customElements.get('media-poster')) {
   customElements.define('media-poster', FakeMediaPosterElement);
+}
+
+if (!customElements.get('media-time-slider')) {
+  customElements.define('media-time-slider', FakeMediaTimeSliderElement);
 }
 
 function createFeedItem(id: number): FeedItem {
@@ -206,6 +211,31 @@ describe('ReelPlayerCard', () => {
     await flushPromises();
 
     expect(player.playCallCount).toBeGreaterThanOrEqual(2);
+    expect(player.paused).toBe(false);
+    expect(wrapper.find('.reel-player-card__pause-indicator').exists()).toBe(false);
+  });
+
+  it('keeps seek-bar interaction from toggling reel playback', async () => {
+    const wrapper = mount(ReelPlayerCard, {
+      props: {
+        item: createFeedItem(12),
+        folder: createFolder(),
+        active: true
+      },
+      global: {
+        stubs: globalStubs
+      }
+    });
+
+    await flushPromises();
+
+    const player = getPlayerElement(wrapper);
+    expect(player.pauseCallCount).toBe(0);
+
+    await wrapper.get('.reel-player-card__seekbar-track').trigger('click');
+    await flushPromises();
+
+    expect(player.pauseCallCount).toBe(0);
     expect(player.paused).toBe(false);
     expect(wrapper.find('.reel-player-card__pause-indicator').exists()).toBe(false);
   });

--- a/client/src/components/ReelPlayerCard.vue
+++ b/client/src/components/ReelPlayerCard.vue
@@ -26,6 +26,21 @@
             :src.prop="item.thumbnailUrl"
             :alt.prop="item.filename"
           />
+          <!-- TikTok-style bottom seek bar -->
+          <div class="reel-player-card__seekbar-shell">
+            <media-time-slider
+              class="reel-player-card__seekbar"
+              aria-label="Seek video"
+              @click.stop
+              @pointerdown.stop
+              @pointerup.stop
+            >
+              <div class="reel-player-card__seekbar-track" />
+              <div class="reel-player-card__seekbar-track reel-player-card__seekbar-progress" />
+              <div class="reel-player-card__seekbar-track reel-player-card__seekbar-fill" />
+              <div class="reel-player-card__seekbar-thumb" />
+            </media-time-slider>
+          </div>
         </media-player>
 
         <div
@@ -278,7 +293,11 @@ async function toggleSound() {
   }
 }
 
-async function handleSurfaceClick() {
+async function handleSurfaceClick(event?: MouseEvent) {
+  if (event && isInteractiveTarget(event.target)) {
+    return;
+  }
+
   const player = playerElement.value;
   if (!player || !props.active) {
     return;
@@ -296,7 +315,7 @@ async function handleSurfaceClick() {
 }
 
 function isInteractiveTarget(target: EventTarget | null): boolean {
-  return target instanceof HTMLElement && Boolean(target.closest('a, button'));
+  return target instanceof HTMLElement && Boolean(target.closest('a, button, media-time-slider'));
 }
 
 function handleSurfaceKeydown(event: KeyboardEvent) {
@@ -642,5 +661,102 @@ onBeforeUnmount(() => {
     width: 1.9rem;
     height: 1.9rem;
   }
+}
+
+/* ── Bottom seek bar ──────────────────────────────────────── */
+
+.reel-player-card__seekbar-shell {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 4;
+  pointer-events: none;
+}
+
+.reel-player-card__seekbar {
+  position: relative;
+  display: block;
+  width: 100%;
+  /* tall hit-target for comfortable scrubbing */
+  height: 1.25rem;
+  cursor: pointer;
+  touch-action: none;
+  pointer-events: auto;
+  outline: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* shared track base */
+.reel-player-card__seekbar-track {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  top: auto;
+  height: 2.5px;
+  border-radius: 0;
+  transform: none;
+  transition: height 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+/* expand on hover/drag */
+.reel-player-card__seekbar-shell:hover .reel-player-card__seekbar-track,
+.reel-player-card__seekbar[data-active] .reel-player-card__seekbar-track,
+.reel-player-card__seekbar[data-dragging] .reel-player-card__seekbar-track {
+  height: 6px;
+}
+
+/* track layers */
+.reel-player-card__seekbar .reel-player-card__seekbar-track:first-child {
+  z-index: 0;
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.reel-player-card__seekbar-progress {
+  z-index: 1;
+  width: var(--slider-progress, 0%);
+  background: rgba(255, 255, 255, 0.40);
+  will-change: width;
+}
+
+.reel-player-card__seekbar-fill {
+  z-index: 2;
+  width: var(--slider-fill, 0%);
+  background: #fff;
+  will-change: width;
+}
+
+/* thumb — only visible on hover/drag/focus */
+.reel-player-card__seekbar-thumb {
+  position: absolute;
+  bottom: 0;
+  top: auto;
+  left: var(--slider-fill, 0%);
+  z-index: 3;
+  width: 0.78rem;
+  height: 0.78rem;
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.32);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 50%);
+  transition:
+    opacity 0.18s ease,
+    transform 0.18s ease;
+  will-change: left;
+}
+
+.reel-player-card__seekbar-shell:hover .reel-player-card__seekbar-thumb,
+.reel-player-card__seekbar[data-active] .reel-player-card__seekbar-thumb,
+.reel-player-card__seekbar[data-dragging] .reel-player-card__seekbar-thumb,
+.reel-player-card__seekbar[data-focus] .reel-player-card__seekbar-thumb,
+.reel-player-card__seekbar:focus-visible .reel-player-card__seekbar-thumb {
+  opacity: 1;
+  transform: translate(-50%, 40%);
+}
+
+.reel-player-card__seekbar[data-focus] .reel-player-card__seekbar-track,
+.reel-player-card__seekbar:focus-visible .reel-player-card__seekbar-track {
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.16);
 }
 </style>

--- a/client/src/components/StoriesModal.test.ts
+++ b/client/src/components/StoriesModal.test.ts
@@ -7,6 +7,26 @@ import type { FeedItem, RailCapsule, RailViewerStoreContract } from '../types/ap
 import { useAppStore } from '../stores/app';
 import StoriesModal from './StoriesModal.vue';
 
+function createImageItem(id: number): FeedItem {
+  return {
+    id,
+    folderId: 91,
+    folderSlug: 'animal-planet',
+    folderName: 'Animal Planet',
+    folderPath: 'animal-planet',
+    folderBreadcrumb: null,
+    filename: `story-${id}.jpg`,
+    width: 1080,
+    height: 1920,
+    mediaType: 'image',
+    durationMs: null,
+    thumbnailUrl: `/thumbs/${id}.webp`,
+    previewUrl: `/previews/${id}.webp`,
+    sortTimestamp: 1_777_000_000_000 + id,
+    takenAt: 1_777_000_000_000 + id
+  };
+}
+
 function createVideoItem(id: number): FeedItem {
   return {
     id,
@@ -53,6 +73,62 @@ function createStore(capsules: RailCapsule[], imagesByCapsuleId: Record<string, 
       this.currentImages = imagesByCapsuleId[id] ?? [];
       this.currentHasMore = false;
     }
+  });
+}
+
+function readSegmentScaleX(wrapper: ReturnType<typeof mount>) {
+  const style = wrapper.get('.story-stage__progress-fill').attributes('style') ?? '';
+  const match = /scaleX\(([^)]+)\)/.exec(style);
+  return match ? Number(match[1]) : Number.NaN;
+}
+
+function getActiveStage(wrapper: ReturnType<typeof mount>) {
+  return wrapper.get('article.story-stage');
+}
+
+function getActiveStageTitle(wrapper: ReturnType<typeof mount>) {
+  return getActiveStage(wrapper).get('.story-stage__header-main strong').text();
+}
+
+function mockVideoPlaybackState(video: HTMLVideoElement, options: { duration: number; currentTime?: number }) {
+  let currentTime = options.currentTime ?? 0;
+  let duration = options.duration;
+
+  Object.defineProperty(video, 'currentTime', {
+    configurable: true,
+    get: () => currentTime,
+    set: (value: number) => {
+      currentTime = value;
+    }
+  });
+
+  Object.defineProperty(video, 'duration', {
+    configurable: true,
+    get: () => duration
+  });
+
+  return {
+    setCurrentTime(value: number) {
+      currentTime = value;
+    },
+    setDuration(value: number) {
+      duration = value;
+    }
+  };
+}
+
+function mockStoryAnimationFrames(stepMs: number) {
+  let autoplayNow = 0;
+
+  vi.spyOn(performance, 'now').mockImplementation(() => autoplayNow);
+  vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback) =>
+    window.setTimeout(() => {
+      autoplayNow += stepMs;
+      callback(autoplayNow);
+    }, 0)
+  );
+  vi.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation((handle: number) => {
+    window.clearTimeout(handle);
   });
 }
 
@@ -180,23 +256,16 @@ describe('StoriesModal', () => {
     await nextButton.trigger('click');
     await flushPromises();
 
-    expect(wrapper.text()).toContain('Second Stories');
-    expect(wrapper.get('video.story-stage__video').attributes('src')).toBe(secondItem.previewUrl);
+    expect(getActiveStageTitle(wrapper)).toBe('Second Stories');
+    expect(getActiveStage(wrapper).get('video.story-stage__video').attributes('src')).toBe(secondItem.previewUrl);
   });
 
-  it('autoplay advances into the next capsule when the current capsule finishes', async () => {
+  it('autoplay advances image stories into the next capsule when the current capsule finishes', async () => {
     vi.useFakeTimers();
+    mockStoryAnimationFrames(5_000);
 
-    let autoplayNow = 0;
-    vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback) =>
-      window.setTimeout(() => {
-        autoplayNow += 5_000;
-        callback(autoplayNow);
-      }, 0)
-    );
-
-    const firstItem = createVideoItem(601);
-    const secondItem = createVideoItem(602);
+    const firstItem = createImageItem(601);
+    const secondItem = createImageItem(602);
     const firstCapsule = createCapsule('capsule-autoplay-one', 'Autoplay One', firstItem);
     const secondCapsule = createCapsule('capsule-autoplay-two', 'Autoplay Two', secondItem);
     const store = createStore([firstCapsule, secondCapsule], {
@@ -227,8 +296,128 @@ describe('StoriesModal', () => {
     await vi.runAllTimersAsync();
     await flushPromises();
 
-    expect(wrapper.text()).toContain('Autoplay Two');
-    expect(wrapper.get('video.story-stage__video').attributes('src')).toBe(secondItem.previewUrl);
+    expect(getActiveStageTitle(wrapper)).toBe('Autoplay Two');
+    expect(getActiveStage(wrapper).find('video.story-stage__video').exists()).toBe(false);
+    expect(getActiveStage(wrapper).find('img[data-test="resilient-image"]').exists()).toBe(true);
+
+    vi.useRealTimers();
+  });
+
+  it('uses the active video duration for story progress and waits for ended before advancing', async () => {
+    vi.useFakeTimers();
+
+    const firstItem = createVideoItem(611);
+    const secondItem = createVideoItem(612);
+    const firstCapsule = createCapsule('capsule-video-one', 'Video One', firstItem);
+    const secondCapsule = createCapsule('capsule-video-two', 'Video Two', secondItem);
+    const store = createStore([firstCapsule, secondCapsule], {
+      [firstCapsule.id]: [firstItem],
+      [secondCapsule.id]: [secondItem]
+    });
+
+    const wrapper = mount(StoriesModal, {
+      props: {
+        items: [firstCapsule, secondCapsule],
+        initialId: firstCapsule.id,
+        railSingularLabel: 'Story',
+        store
+      },
+      global: {
+        stubs: {
+          Avatar: {
+            template: '<div data-test="avatar" />'
+          },
+          ResilientImage: {
+            template: '<img data-test="resilient-image" />'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    const video = wrapper.get('video.story-stage__video').element as HTMLVideoElement;
+    const playback = mockVideoPlaybackState(video, {
+      duration: 12,
+      currentTime: 0
+    });
+
+    video.dispatchEvent(new Event('loadedmetadata'));
+    await flushPromises();
+
+    playback.setCurrentTime(6);
+    video.dispatchEvent(new Event('timeupdate'));
+    await flushPromises();
+
+    expect(readSegmentScaleX(wrapper)).toBeCloseTo(0.5, 3);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await flushPromises();
+
+    expect(getActiveStageTitle(wrapper)).toBe('Video One');
+
+    video.dispatchEvent(new Event('ended'));
+    await flushPromises();
+
+    expect(getActiveStageTitle(wrapper)).toBe('Video Two');
+
+    vi.useRealTimers();
+  });
+
+  it('freezes and resumes image-story progress when playback is paused and resumed', async () => {
+    vi.useFakeTimers();
+    mockStoryAnimationFrames(1_000);
+
+    const imageItem = createImageItem(621);
+    const capsule = createCapsule('capsule-pause', 'Pause Stories', imageItem);
+    const store = createStore([capsule], {
+      [capsule.id]: [imageItem]
+    });
+
+    const wrapper = mount(StoriesModal, {
+      props: {
+        items: [capsule],
+        initialId: capsule.id,
+        railSingularLabel: 'Story',
+        store
+      },
+      global: {
+        stubs: {
+          Avatar: {
+            template: '<div data-test="avatar" />'
+          },
+          ResilientImage: {
+            template: '<img data-test="resilient-image" />'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+    await vi.runOnlyPendingTimersAsync();
+    await flushPromises();
+
+    await vi.runOnlyPendingTimersAsync();
+    await flushPromises();
+
+    const progressBeforePause = readSegmentScaleX(wrapper);
+    expect(progressBeforePause).toBeGreaterThan(0);
+
+    await wrapper.get('button[aria-label="Pause playback"]').trigger('click');
+    await flushPromises();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await flushPromises();
+
+    expect(readSegmentScaleX(wrapper)).toBeCloseTo(progressBeforePause, 3);
+
+    await wrapper.get('button[aria-label="Resume playback"]').trigger('click');
+    await flushPromises();
+
+    await vi.runOnlyPendingTimersAsync();
+    await flushPromises();
+
+    expect(readSegmentScaleX(wrapper)).toBeGreaterThan(progressBeforePause);
 
     vi.useRealTimers();
   });

--- a/client/src/components/StoriesModal.vue
+++ b/client/src/components/StoriesModal.vue
@@ -164,9 +164,13 @@
               :poster="displayImage.thumbnailUrl"
               :muted="appStore.videoMuted"
               autoplay
-              loop
               playsinline
               preload="metadata"
+              @ended="handleStoryVideoEnded"
+              @loadedmetadata="handleStoryVideoLoadedMetadata"
+              @pause="handleStoryVideoPause"
+              @play="handleStoryVideoPlay"
+              @timeupdate="handleStoryVideoTimeUpdate"
             />
             <ResilientImage
               v-else-if="displayImage"
@@ -260,7 +264,7 @@ import { getOriginalMediaDownloadUrl } from '../utils/original-media';
 import Avatar from './Avatar.vue';
 import ResilientImage from './ResilientImage.vue';
 
-const STORY_AUTO_ADVANCE_MS = 4200;
+const STORY_IMAGE_AUTO_ADVANCE_MS = 4200;
 const CAPSULE_SWITCH_ANIMATION_MS = 360;
 const CAPSULE_VIEW_TRANSITION_NAME = 'rail-highlight-stage';
 
@@ -278,7 +282,8 @@ const emit = defineEmits<{
 const appStore = useAppStore();
 const activeCapsuleId = ref(props.initialId);
 const activeImageIndex = ref(0);
-const autoplayProgress = ref(0);
+const activeSlideDurationMs = ref(STORY_IMAGE_AUTO_ADVANCE_MS);
+const activeSlideElapsedMs = ref(0);
 const isPaused = ref(false);
 const activeCapsuleTransitionId = ref<string | null>(null);
 const transitionPending = ref(false);
@@ -287,7 +292,7 @@ const videoElement = ref<HTMLVideoElement | null>(null);
 
 let previousBodyOverflow = '';
 let animationFrameId = 0;
-let autoplayStartedAt = 0;
+let imageAutoplayStartedAt = 0;
 
 const activeCapsuleIndex = computed(() => props.items.findIndex((item) => item.id === activeCapsuleId.value));
 const activeCapsule = computed(() => {
@@ -401,7 +406,11 @@ function segmentProgress(index: number) {
     return 0;
   }
 
-  return autoplayProgress.value;
+  if (activeSlideDurationMs.value <= 0) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(activeSlideElapsedMs.value / activeSlideDurationMs.value, 1));
 }
 
 function stopAutoplay() {
@@ -411,19 +420,47 @@ function stopAutoplay() {
   }
 }
 
-function startAutoplay() {
-  stopAutoplay();
+function resolveStoryDurationMs(image: FeedItem | null) {
+  if (!image) {
+    return STORY_IMAGE_AUTO_ADVANCE_MS;
+  }
 
-  if (!displayImage.value || isPaused.value) {
+  if (image.mediaType === 'video' && typeof image.durationMs === 'number' && image.durationMs > 0) {
+    return image.durationMs;
+  }
+
+  return STORY_IMAGE_AUTO_ADVANCE_MS;
+}
+
+function syncStoryVideoTiming(player: HTMLVideoElement | null = videoElement.value) {
+  if (!player || displayImage.value?.mediaType !== 'video') {
     return;
   }
 
-  autoplayStartedAt = performance.now() - autoplayProgress.value * STORY_AUTO_ADVANCE_MS;
+  const durationMs = Number.isFinite(player.duration) && player.duration > 0
+    ? player.duration * 1000
+    : resolveStoryDurationMs(displayImage.value);
+
+  activeSlideDurationMs.value = durationMs;
+
+  if (Number.isFinite(player.currentTime) && player.currentTime >= 0) {
+    activeSlideElapsedMs.value = Math.min(durationMs, player.currentTime * 1000);
+  }
+}
+
+function startImageAutoplay() {
+  stopAutoplay();
+
+  if (!displayImage.value || displayImage.value.mediaType !== 'image' || isPaused.value) {
+    return;
+  }
+
+  imageAutoplayStartedAt = performance.now() - activeSlideElapsedMs.value;
 
   const tick = async (now: number) => {
-    autoplayProgress.value = Math.min(1, (now - autoplayStartedAt) / STORY_AUTO_ADVANCE_MS);
+    activeSlideElapsedMs.value = Math.min(activeSlideDurationMs.value, now - imageAutoplayStartedAt);
 
-    if (autoplayProgress.value >= 1) {
+    if (activeSlideElapsedMs.value >= activeSlideDurationMs.value) {
       stopAutoplay();
       await showNextImageFromAutoplay();
       return;
@@ -436,8 +473,13 @@ function startAutoplay() {
 }
 
 function syncAutoplayForCurrentImage() {
-  autoplayProgress.value = 0;
-  startAutoplay();
+  stopAutoplay();
+  activeSlideElapsedMs.value = 0;
+  activeSlideDurationMs.value = resolveStoryDurationMs(displayImage.value);
+
+  if (displayImage.value?.mediaType === 'image') {
+    startImageAutoplay();
+  }
 }
 
 function togglePaused() {
@@ -453,7 +495,10 @@ function togglePaused() {
     return;
   }
 
-  startAutoplay();
+  if (displayImage.value.mediaType === 'image') {
+    startImageAutoplay();
+  }
+
   syncMediaPlayback();
 }
 
@@ -593,7 +638,7 @@ async function showNextImageInternal(fromAutoplay: boolean) {
   }
 
   if (fromAutoplay) {
-    autoplayProgress.value = 1;
+    activeSlideElapsedMs.value = activeSlideDurationMs.value;
   }
 }
 
@@ -656,6 +701,41 @@ function syncMediaPlayback() {
   void player.play().catch(() => {
     // Ignore autoplay rejections so the viewer can continue advancing.
   });
+}
+
+function handleStoryVideoLoadedMetadata() {
+  syncStoryVideoTiming();
+}
+
+function handleStoryVideoTimeUpdate() {
+  syncStoryVideoTiming();
+}
+
+function handleStoryVideoPlay() {
+  isPaused.value = false;
+  syncStoryVideoTiming();
+}
+
+function handleStoryVideoPause() {
+  if (displayImage.value?.mediaType !== 'video') {
+    return;
+  }
+
+  if (videoElement.value?.ended) {
+    return;
+  }
+
+  isPaused.value = true;
+  syncStoryVideoTiming();
+}
+
+async function handleStoryVideoEnded() {
+  if (displayImage.value?.mediaType !== 'video') {
+    return;
+  }
+
+  activeSlideElapsedMs.value = activeSlideDurationMs.value;
+  await showNextImageFromAutoplay();
 }
 
 function lockBodyScroll() {

--- a/client/src/components/TopNav.vue
+++ b/client/src/components/TopNav.vue
@@ -320,8 +320,8 @@ onUnmounted(() => {
     z-index: 30;
     display: block;
     padding:
-      0.5rem max(0.72rem, env(safe-area-inset-right))
-      calc(0.5rem + env(safe-area-inset-bottom))
+      0.22rem max(0.72rem, env(safe-area-inset-right))
+      calc(0.22rem + var(--mobile-safe-area-bottom, 0px))
       max(0.72rem, env(safe-area-inset-left));
     border-top: 1px solid var(--border);
     background: color-mix(in srgb, var(--bg) 92%, var(--surface) 8%);
@@ -340,9 +340,9 @@ onUnmounted(() => {
     z-index: 2;
     display: grid;
     grid-template-columns: 3rem minmax(0, 1fr);
-    gap: 0.4rem;
+    gap: 0.48rem;
     width: min(100%, 42rem);
-    min-height: 3.25rem;
+    min-height: 2.9rem;
     margin: 0 auto;
   }
 
@@ -350,14 +350,14 @@ onUnmounted(() => {
     display: flex;
     min-width: 0;
     align-items: center;
-    justify-content: flex-end;
-    gap: 0.18rem;
+    justify-content: center;
+    gap: 0.34rem;
   }
 
   .mobile-nav__item {
     display: inline-flex;
     width: 2.75rem;
-    height: 3.05rem;
+    height: 2.7rem;
     flex: 0 0 auto;
     align-items: center;
     justify-content: center;
@@ -484,11 +484,11 @@ onUnmounted(() => {
   @media (min-width: 360px) {
     .mobile-nav__bar {
       grid-template-columns: 2.8rem minmax(0, 1fr);
-      gap: 0.28rem;
+      gap: 0.38rem;
     }
 
     .mobile-nav__links {
-      gap: 0.12rem;
+      gap: 0.28rem;
     }
 
     .mobile-nav__item {

--- a/client/src/components/VideoProgressFooter.vue
+++ b/client/src/components/VideoProgressFooter.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="video-progress-footer" :class="`video-progress-footer--${variant}`">
+    <div class="video-progress-footer__meta">
+      <div class="video-progress-footer__slot video-progress-footer__slot--leading">
+        <slot name="leading" />
+        <span class="video-progress-footer__time">{{ timeLabel }}</span>
+      </div>
+      <div class="video-progress-footer__slot video-progress-footer__slot--trailing">
+        <slot name="trailing" />
+      </div>
+    </div>
+
+    <div class="video-progress-footer__timeline-shell">
+      <media-time-slider
+        class="vds-slider vds-time-slider video-progress-footer__slider"
+        aria-label="Seek video"
+      >
+        <div class="vds-slider-track video-progress-footer__track" />
+        <div class="vds-slider-track vds-slider-progress video-progress-footer__track-progress" />
+        <div class="vds-slider-track vds-slider-track-fill video-progress-footer__track-fill" />
+        <div class="vds-slider-thumb video-progress-footer__thumb" />
+      </media-time-slider>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    timeLabel: string;
+    variant?: 'feed' | 'viewer';
+  }>(),
+  {
+    variant: 'feed'
+  }
+);
+</script>

--- a/client/src/styles/base.css
+++ b/client/src/styles/base.css
@@ -747,6 +747,189 @@ img[data-loaded="true"] {
   height: 1.45rem;
 }
 
+/* ── TikTok-style bottom progress bar ─────────────────────── */
+
+.video-progress-footer {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  /* controls row gets padding; the progress bar sits at the very bottom edge */
+  padding: 0.4rem 0.72rem 0;
+  pointer-events: none;
+  background:
+    linear-gradient(180deg,
+      rgba(0, 0, 0, 0) 0%,
+      rgba(0, 0, 0, 0.38) 48%,
+      rgba(0, 0, 0, 0.78) 100%);
+}
+
+.video-progress-footer--viewer {
+  padding: 0.48rem 0.78rem 0;
+}
+
+/* ── meta row (controls + time label) ──────────────────────── */
+
+.video-progress-footer__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-height: 1.9rem;
+  pointer-events: none;
+  /* small bottom gap between controls and the progress bar */
+  margin-bottom: 0.28rem;
+}
+
+.video-progress-footer__slot {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.18rem;
+  pointer-events: none;
+}
+
+.video-progress-footer__slot--trailing {
+  margin-left: auto;
+  justify-content: flex-end;
+  gap: 0.32rem;
+}
+
+.video-progress-footer__slot > * {
+  pointer-events: auto;
+}
+
+.video-progress-footer__time {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.72rem;
+  font-weight: 400;
+  letter-spacing: 0.01em;
+  font-variant-numeric: tabular-nums;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.36);
+  white-space: nowrap;
+  /* small leading gap so it doesn't crowd the play button */
+  padding-left: 0.2rem;
+}
+
+.video-progress-footer--viewer .video-progress-footer__time {
+  font-size: 0.76rem;
+}
+
+/* ── timeline shell — flush to the bottom edge ─────────────── */
+
+.video-progress-footer__timeline-shell {
+  /* zero bottom padding so bar is truly flush */
+  margin-inline: -0.72rem;
+  pointer-events: none;
+}
+
+.video-progress-footer--viewer .video-progress-footer__timeline-shell {
+  margin-inline: -0.78rem;
+}
+
+/* ── slider ─────────────────────────────────────────────────── */
+
+.video-progress-footer__slider {
+  position: relative;
+  display: block;
+  /* hit-target stays tall for comfortable interaction */
+  width: 100%;
+  height: 1.25rem;
+  cursor: pointer;
+  touch-action: none;
+  pointer-events: auto;
+  outline: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* track base — thin by default, thicker on hover */
+.video-progress-footer__slider .vds-slider-track {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  top: auto;
+  height: 3px;
+  border-radius: 0;
+  transform: none;
+  transition: height 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+/* expand the visible bar on hover/interaction */
+.video-progress-footer__timeline-shell:hover .video-progress-footer__slider .vds-slider-track,
+.video-progress-footer__slider[data-active] .vds-slider-track,
+.video-progress-footer__slider[data-dragging] .vds-slider-track {
+  height: 7px;
+}
+
+/* slightly thinner track for the compact feed variant */
+.video-progress-footer--feed .video-progress-footer__slider .vds-slider-track {
+  height: 2.5px;
+}
+
+.video-progress-footer--feed .video-progress-footer__timeline-shell:hover .video-progress-footer__slider .vds-slider-track,
+.video-progress-footer--feed .video-progress-footer__slider[data-active] .vds-slider-track,
+.video-progress-footer--feed .video-progress-footer__slider[data-dragging] .vds-slider-track {
+  height: 6px;
+}
+
+.video-progress-footer__slider .video-progress-footer__track {
+  z-index: 0;
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.video-progress-footer__slider .video-progress-footer__track-progress {
+  z-index: 1;
+  width: var(--slider-progress, 0%);
+  background: rgba(255, 255, 255, 0.40);
+  will-change: width;
+}
+
+.video-progress-footer__slider .video-progress-footer__track-fill {
+  z-index: 2;
+  width: var(--slider-fill, 0%);
+  background: #fff;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.12);
+  will-change: width;
+}
+
+/* ── thumb ──────────────────────────────────────────────────── */
+
+.video-progress-footer__thumb {
+  position: absolute;
+  bottom: 0;
+  top: auto;
+  left: var(--slider-fill, 0%);
+  z-index: 3;
+  width: 0.78rem;
+  height: 0.78rem;
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.32);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 50%);
+  transition:
+    opacity 0.18s ease,
+    transform 0.18s ease;
+  will-change: left;
+}
+
+.video-progress-footer__timeline-shell:hover .video-progress-footer__thumb,
+.video-progress-footer__slider[data-active] .video-progress-footer__thumb,
+.video-progress-footer__slider[data-dragging] .video-progress-footer__thumb,
+.video-progress-footer__slider[data-focus] .video-progress-footer__thumb,
+.video-progress-footer__slider:focus-visible .video-progress-footer__thumb {
+  opacity: 1;
+  transform: translate(-50%, 40%);
+}
+
+.video-progress-footer__slider[data-focus] .video-progress-footer__track,
+.video-progress-footer__slider:focus-visible .video-progress-footer__track {
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.16);
+}
+
 .viewer__player-controls {
   position: absolute;
   inset-inline: 0;
@@ -903,6 +1086,10 @@ img[data-loaded="true"] {
   height: 1.45rem;
 }
 
+.feed-card__video-shell .video-progress-footer {
+  padding-top: 0.38rem;
+}
+
 .feed-card__player-controls {
   position: absolute;
   inset-inline: 0;
@@ -991,6 +1178,32 @@ img[data-loaded="true"] {
 }
 
 @media (max-width: 768px) {
+  .video-progress-footer {
+    gap: 0.24rem;
+    padding: 0.42rem 0.58rem 0;
+  }
+
+  .video-progress-footer--viewer {
+    padding: 0.48rem 0.62rem 0;
+  }
+
+  .video-progress-footer__timeline-shell {
+    margin-inline: -0.58rem;
+  }
+
+  .video-progress-footer--viewer .video-progress-footer__timeline-shell {
+    margin-inline: -0.62rem;
+  }
+
+  .video-progress-footer__slider {
+    width: 100%;
+    margin: 0;
+  }
+
+  .video-progress-footer__time {
+    font-size: 0.76rem;
+  }
+
   .feed-card__pause-indicator {
     width: 3.9rem;
     height: 3.9rem;

--- a/client/src/utils/media.ts
+++ b/client/src/utils/media.ts
@@ -3,7 +3,45 @@ export function formatMediaDuration(durationMs: number | null | undefined): stri
     return '';
   }
 
-  const totalSeconds = Math.max(1, Math.round(durationMs / 1000));
+  return formatClockSeconds(Math.max(1, Math.round(durationMs / 1000)));
+}
+
+export function formatRemainingMediaDuration(
+  durationMs: number | null | undefined,
+  currentTimeMs: number | null | undefined
+): string {
+  if (durationMs === null || durationMs === undefined || durationMs <= 0) {
+    return '0:00';
+  }
+
+  const safeCurrentTimeMs = currentTimeMs ?? 0;
+  const remainingMs = Math.max(0, durationMs - Math.max(0, safeCurrentTimeMs));
+
+  if (remainingMs === 0) {
+    return '0:00';
+  }
+
+  return `-${formatClockSeconds(Math.ceil(remainingMs / 1000))}`;
+}
+
+/**
+ * Formats playback position as "current / total", e.g. "0:42 / 0:58".
+ * Used in the in-player time label.
+ */
+export function formatVideoTimestamp(
+  durationMs: number | null | undefined,
+  currentTimeMs: number | null | undefined
+): string {
+  const safeDurationMs = (durationMs != null && durationMs > 0) ? durationMs : 0;
+  const safeCurrentMs = Math.max(0, Math.min(currentTimeMs ?? 0, safeDurationMs));
+
+  const current = formatClockSeconds(Math.floor(safeCurrentMs / 1000));
+  const total = safeDurationMs > 0 ? formatClockSeconds(Math.round(safeDurationMs / 1000)) : '0:00';
+
+  return `${current} / ${total}`;
+}
+
+function formatClockSeconds(totalSeconds: number): string {
   const hours = Math.floor(totalSeconds / 3600);
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const seconds = totalSeconds % 60;

--- a/client/src/views/SettingsView.vue
+++ b/client/src/views/SettingsView.vue
@@ -101,38 +101,86 @@
       </div>
     </section>
 
+    <nav
+      class="sticky top-3 z-20 grid w-full grid-cols-5 gap-1.5 rounded-[1.2rem] border border-border bg-[color-mix(in_srgb,var(--bg)_90%,var(--surface)_10%)] p-1.5 shadow-[0_12px_34px_rgba(15,20,25,0.08)] backdrop-blur-[18px] md:hidden"
+      aria-label="Settings sections"
+    >
+      <button
+        @click="currentCategory = 'library'"
+        class="flex min-h-[3.15rem] items-center justify-center rounded-[0.95rem] border-0 bg-transparent p-0 text-muted transition-colors duration-150 cursor-pointer"
+        :class="currentCategory === 'library' ? 'bg-surface-alt text-text' : 'hover:bg-surface-hover hover:text-text'"
+        aria-label="Scan and Library"
+      >
+        <span class="h-[1.55rem] w-[1.55rem]" :class="currentCategory === 'library' ? 'i-fluent-folder-sync-20-filled' : 'i-fluent-folder-sync-20-regular'" aria-hidden="true"></span>
+      </button>
+      <button
+        @click="currentCategory = 'general'"
+        class="flex min-h-[3.15rem] items-center justify-center rounded-[0.95rem] border-0 bg-transparent p-0 text-muted transition-colors duration-150 cursor-pointer"
+        :class="currentCategory === 'general' ? 'bg-surface-alt text-text' : 'hover:bg-surface-hover hover:text-text'"
+        aria-label="General Settings"
+      >
+        <span class="h-[1.55rem] w-[1.55rem]" :class="currentCategory === 'general' ? 'i-fluent-settings-20-filled' : 'i-fluent-settings-20-regular'" aria-hidden="true"></span>
+      </button>
+      <button
+        @click="currentCategory = 'places'"
+        class="flex min-h-[3.15rem] items-center justify-center rounded-[0.95rem] border-0 bg-transparent p-0 text-muted transition-colors duration-150 cursor-pointer"
+        :class="currentCategory === 'places' ? 'bg-surface-alt text-text' : 'hover:bg-surface-hover hover:text-text'"
+        aria-label="Places"
+      >
+        <span class="h-[1.55rem] w-[1.55rem]" :class="currentCategory === 'places' ? 'i-fluent-location-20-filled' : 'i-fluent-location-20-regular'" aria-hidden="true"></span>
+      </button>
+      <button
+        @click="currentCategory = 'access'"
+        class="flex min-h-[3.15rem] items-center justify-center rounded-[0.95rem] border-0 bg-transparent p-0 text-muted transition-colors duration-150 cursor-pointer"
+        :class="currentCategory === 'access' ? 'bg-surface-alt text-text' : 'hover:bg-surface-hover hover:text-text'"
+        aria-label="Security and Access"
+      >
+        <span class="h-[1.55rem] w-[1.55rem]" :class="currentCategory === 'access' ? 'i-fluent-lock-shield-20-filled' : 'i-fluent-lock-shield-20-regular'" aria-hidden="true"></span>
+      </button>
+      <button
+        @click="currentCategory = 'status'"
+        class="flex min-h-[3.15rem] items-center justify-center rounded-[0.95rem] border-0 bg-transparent p-0 text-muted transition-colors duration-150 cursor-pointer"
+        :class="currentCategory === 'status' ? 'bg-surface-alt text-text' : 'hover:bg-surface-hover hover:text-text'"
+        aria-label="System Status"
+      >
+        <span class="h-[1.55rem] w-[1.55rem]" :class="currentCategory === 'status' ? 'i-fluent-data-usage-20-filled' : 'i-fluent-data-usage-20-regular'" aria-hidden="true"></span>
+      </button>
+    </nav>
+
     <div class="flex flex-col md:flex-row gap-8 items-start mt-[0.5rem]">
       <!-- Navigation Sidebar -->
-      <nav class="flex flex-col gap-2 w-full md:w-[16rem] shrink-0 sticky top-[6.5rem]">
+      <nav
+        class="hidden w-full shrink-0 md:flex md:w-[16rem] md:flex-col md:gap-2 md:sticky md:top-[6.5rem]"
+        aria-label="Settings sections"
+      >
         <button
           @click="currentCategory = 'library'"
-          class="flex items-start gap-3 px-4 py-[0.85rem] rounded-[0.85rem] border-0 text-left transition-colors duration-150 cursor-pointer"
+          class="flex items-start gap-3 rounded-[0.85rem] border-0 px-4 py-[0.85rem] text-left text-[1rem] transition-colors duration-150 cursor-pointer"
           :class="currentCategory === 'library' ? 'bg-surface-alt font-bold text-text' : 'bg-transparent text-muted hover:bg-surface-hover hover:text-text'"
         >
-          <span class="w-[1.25rem] h-[1.25rem] shrink-0 mt-[0.1rem]" :class="currentCategory === 'library' ? 'i-fluent-folder-sync-20-filled' : 'i-fluent-folder-sync-20-regular'" aria-hidden="true"></span>
-          <span class="flex flex-col gap-[0.1rem]">
+          <span class="mt-[0.1rem] h-[1.25rem] w-[1.25rem] shrink-0" :class="currentCategory === 'library' ? 'i-fluent-folder-sync-20-filled' : 'i-fluent-folder-sync-20-regular'" aria-hidden="true"></span>
+          <span class="flex min-w-0 flex-col gap-[0.1rem]">
             <span>Scan & Library</span>
             <span class="text-[0.75rem] font-normal text-muted">Index media, rebuild thumbnails, and maintain the library index</span>
           </span>
         </button>
         <button
           @click="currentCategory = 'general'"
-          class="flex items-start gap-3 px-4 py-[0.85rem] rounded-[0.85rem] border-0 text-left transition-colors duration-150 cursor-pointer"
+          class="flex items-start gap-3 rounded-[0.85rem] border-0 px-4 py-[0.85rem] text-left text-[1rem] transition-colors duration-150 cursor-pointer"
           :class="currentCategory === 'general' ? 'bg-surface-alt font-bold text-text' : 'bg-transparent text-muted hover:bg-surface-hover hover:text-text'"
         >
-          <span class="w-[1.25rem] h-[1.25rem] shrink-0 mt-[0.1rem]" :class="currentCategory === 'general' ? 'i-fluent-settings-20-filled' : 'i-fluent-settings-20-regular'" aria-hidden="true"></span>
+          <span class="mt-[0.1rem] h-[1.25rem] w-[1.25rem] shrink-0" :class="currentCategory === 'general' ? 'i-fluent-settings-20-filled' : 'i-fluent-settings-20-regular'" aria-hidden="true"></span>
           <span class="flex flex-col gap-[0.1rem] min-w-0">
-
-              <span class="truncate">General Settings</span>
+            <span class="truncate">General Settings</span>
             <span class="text-[0.75rem] font-normal text-muted">Stories mode, excluded folders, and feed defaults</span>
           </span>
         </button>
         <button
           @click="currentCategory = 'places'"
-          class="flex items-start gap-3 px-4 py-[0.85rem] rounded-[0.85rem] border-0 text-left transition-colors duration-150 cursor-pointer"
+          class="flex items-start gap-3 rounded-[0.85rem] border-0 px-4 py-[0.85rem] text-left text-[1rem] transition-colors duration-150 cursor-pointer"
           :class="currentCategory === 'places' ? 'bg-surface-alt font-bold text-text' : 'bg-transparent text-muted hover:bg-surface-hover hover:text-text'"
         >
-          <span class="w-[1.25rem] h-[1.25rem] shrink-0 mt-[0.1rem]" :class="currentCategory === 'places' ? 'i-fluent-location-20-filled' : 'i-fluent-location-20-regular'" aria-hidden="true"></span>
+          <span class="mt-[0.1rem] h-[1.25rem] w-[1.25rem] shrink-0" :class="currentCategory === 'places' ? 'i-fluent-location-20-filled' : 'i-fluent-location-20-regular'" aria-hidden="true"></span>
           <span class="flex flex-col gap-[0.1rem] min-w-0">
             <span>Places</span>
             <span class="text-[0.75rem] font-normal text-muted">Offline city lookup and place assignment</span>
@@ -140,22 +188,22 @@
         </button>
         <button
           @click="currentCategory = 'access'"
-          class="flex items-start gap-3 px-4 py-[0.85rem] rounded-[0.85rem] border-0 text-left transition-colors duration-150 cursor-pointer"
+          class="flex items-start gap-3 rounded-[0.85rem] border-0 px-4 py-[0.85rem] text-left text-[1rem] transition-colors duration-150 cursor-pointer"
           :class="currentCategory === 'access' ? 'bg-surface-alt font-bold text-text' : 'bg-transparent text-muted hover:bg-surface-hover hover:text-text'"
         >
-          <span class="w-[1.25rem] h-[1.25rem] shrink-0 mt-[0.1rem]" :class="currentCategory === 'access' ? 'i-fluent-lock-shield-20-filled' : 'i-fluent-lock-shield-20-regular'" aria-hidden="true"></span>
-          <span class="flex flex-col gap-[0.1rem]">
+          <span class="mt-[0.1rem] h-[1.25rem] w-[1.25rem] shrink-0" :class="currentCategory === 'access' ? 'i-fluent-lock-shield-20-filled' : 'i-fluent-lock-shield-20-regular'" aria-hidden="true"></span>
+          <span class="flex flex-col gap-[0.1rem] min-w-0">
             <span>Security & Access</span>
             <span class="text-[0.75rem] font-normal text-muted">Password locks & viewer roles</span>
           </span>
         </button>
         <button
           @click="currentCategory = 'status'"
-          class="flex items-start gap-3 px-4 py-[0.85rem] rounded-[0.85rem] border-0 text-left transition-colors duration-150 cursor-pointer"
+          class="flex items-start gap-3 rounded-[0.85rem] border-0 px-4 py-[0.85rem] text-left text-[1rem] transition-colors duration-150 cursor-pointer"
           :class="currentCategory === 'status' ? 'bg-surface-alt font-bold text-text' : 'bg-transparent text-muted hover:bg-surface-hover hover:text-text'"
         >
-          <span class="w-[1.25rem] h-[1.25rem] shrink-0 mt-[0.1rem]" :class="currentCategory === 'status' ? 'i-fluent-data-usage-20-filled' : 'i-fluent-data-usage-20-regular'" aria-hidden="true"></span>
-          <span class="flex flex-col gap-[0.1rem]">
+          <span class="mt-[0.1rem] h-[1.25rem] w-[1.25rem] shrink-0" :class="currentCategory === 'status' ? 'i-fluent-data-usage-20-filled' : 'i-fluent-data-usage-20-regular'" aria-hidden="true"></span>
+          <span class="flex flex-col gap-[0.1rem] min-w-0">
             <span>System Status</span>
             <span class="text-[0.75rem] font-normal text-muted">Storage overview & scan history</span>
           </span>
@@ -190,23 +238,23 @@
             </div>
 
             <section v-if="!authStore.enabled" class="grid gap-[1rem]">
-              <div class="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
-                <label class="grid gap-[0.45rem]">
+              <div class="grid min-w-0 grid-cols-1 gap-4 md:grid-cols-2">
+                <label class="grid min-w-0 gap-[0.45rem]">
                   <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">Admin password</span>
                   <input
                     v-model="enablePassword"
-                    class="h-12 rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 text-[0.95rem] text-text outline-none transition-[border-color,box-shadow] duration-180 focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
+                    class="h-12 min-w-0 w-full rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 text-[0.95rem] text-text outline-none transition-[border-color,box-shadow] duration-180 focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
                     type="password"
                     autocomplete="new-password"
                     placeholder="Minimum 8 characters"
                     :disabled="authStore.loading"
                   />
                 </label>
-                <label class="grid gap-[0.45rem]">
+                <label class="grid min-w-0 gap-[0.45rem]">
                   <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">Confirm password</span>
                   <input
                     v-model="enablePasswordConfirmation"
-                    class="h-12 rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 text-[0.95rem] text-text outline-none transition-[border-color,box-shadow] duration-180 focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
+                    class="h-12 min-w-0 w-full rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 text-[0.95rem] text-text outline-none transition-[border-color,box-shadow] duration-180 focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
                     type="password"
                     autocomplete="new-password"
                     placeholder="Repeat the password"
@@ -217,7 +265,7 @@
 
               <div class="flex flex-col md:flex-row items-center gap-4 max-sm:items-stretch">
                 <p class="m-0 flex-1 text-muted">The admin password is stored as a one-way hash and unlocks this browser with a signed session cookie.</p>
-                <button class="btn-primary min-w-[13rem]" type="button" :disabled="authStore.loading" @click="enableAccessProtection">
+                <button class="btn-primary w-full sm:w-auto sm:min-w-[13rem]" type="button" :disabled="authStore.loading" @click="enableAccessProtection">
                   {{ authStore.loading ? 'Enabling...' : 'Enable Admin Password' }}
                 </button>
               </div>
@@ -880,9 +928,9 @@
               {{ placesStore.actionMessage }}
             </p>
 
-            <div class="flex flex-wrap items-center gap-3">
+            <div class="flex flex-col items-stretch gap-3 sm:flex-row sm:flex-wrap sm:items-center">
               <button
-                class="btn-primary min-w-[12rem]"
+                class="btn-primary w-full sm:w-auto sm:min-w-[12rem]"
                 type="button"
                 :disabled="placesStore.preparing"
                 @click="placesStore.prepareGeodata"
@@ -890,7 +938,7 @@
                 {{ placesStore.preparing ? 'Preparing...' : 'Prepare Geodata' }}
               </button>
               <button
-                class="inline-flex min-h-11 items-center justify-center rounded-[0.95rem] border border-border bg-surface-alt px-4 text-[0.9rem] font-semibold text-text transition-colors duration-180 hover:bg-surface-hover disabled:cursor-wait disabled:opacity-60"
+                class="inline-flex min-h-11 w-full items-center justify-center rounded-[0.95rem] border border-border bg-surface-alt px-4 text-center text-[0.9rem] font-semibold text-text transition-colors duration-180 hover:bg-surface-hover disabled:cursor-wait disabled:opacity-60 sm:w-auto"
                 type="button"
                 :disabled="placesStore.rebuilding || !placesStore.status?.prepared"
                 @click="placesStore.rebuildAssignments"


### PR DESCRIPTION
- Reworked `StoriesModal` timing so image stories keep fixed autoplay, while video stories follow real video playback duration and advance on `ended` instead of a fixed timeout.
- Added/updated bottom-edge seekable progress UI for feed and post video players, using the shared `VideoProgressFooter` component and preserving the intentional `current / total` label behavior.
- Applied the same bottom seek-bar treatment to reels without changing the rest of the reels layout.
- Updated shared player/footer styling so the progress bar stays flush to the bottom edge, including mobile.
- Cleaned up and expanded tests for stories timing, feed/post time labels, reel seek-bar behavior, and related playback regressions.
- Fixed mobile bottom-nav positioning in browser mode by removing unstable bottom inset behavior and only applying bottom safe-area padding in standalone/PWA mode.
- Reworked the Settings mobile section picker into a dedicated sticky top icon bar.
- Improved the Settings mobile layout under Places and Security page.

Closes #63 & #64 