### PR TITLE
Add static and animated AVIF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ Runtime reads come from SQLite and generated derivatives, not from live filesyst
 
 ### Supported Formats
 
-- **Images:** `.jpg`, `.jpeg`, `.png`, `.webp`, `.gif`
+- **Images:** `.jpg`, `.jpeg`, `.png`, `.webp`, `.gif`, `.avif`
 - **Videos:** `.mp4`, `.mov`, `.m4v`, `.webm`, `.mkv`
 
-Animated image files keep animation in the post viewer preview and home feed cards. Folder/profile grids and other thumbnail surfaces remain static.
+Animated image files keep animation in the post viewer preview and home feed cards. Folder/profile grids and other thumbnail surfaces remain static. Static AVIF files stay on the normal image pipeline; animated AVIF image sequences generate static WebP thumbnails and animated WebP previews.
 
-For source installs, video support requires `ffmpeg` and `ffprobe`. The Docker image installs them inside the container.
+For source installs, video support and animated AVIF image-sequence processing require `ffmpeg` and `ffprobe`. The Docker image installs them inside the container.
 
 ## Installation
 
@@ -151,7 +151,7 @@ Requirements:
 
 - Node.js 22
 - `npm` or `pnpm`
-- `ffmpeg` and `ffprobe` if you want video support outside Docker
+- `ffmpeg` and `ffprobe` if you want video support or animated AVIF image-sequence processing outside Docker
 
 1. Clone the repository:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -29,10 +29,10 @@ media.
 
 ## How does the app select a folder's avatar or cover image?
 
-By default, Foldergram automatically selects a `cover.jpg` (or `.png`, `.webp`, `.avif`, `.gif`) file within the folder if one exists.
+By default, Foldergram automatically selects a `cover.jpg` (or `.jpeg`, `.png`, `.webp`, `.avif`, `.gif`) file within the folder if one exists.
 If no explicit cover file is found, it falls back to the most recent (newest) supported media file in that folder.
 Admins can also use the "Set as Cover" action from the detail view of any image to set it as the cover without renaming files.
-Any explicit `cover.*` files, or any files manually set as the cover via the UI, are hidden from the normal folder grid so they don't appear as duplicate posts.
+Any explicit `cover.*` files are hidden from the normal folder grid so they don't appear as duplicate posts. Images manually set as the cover via the UI remain visible in the folder grid.
 
 ## How do reserved stories folders work?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ features:
       width: "36"
       height: "36"
     title: Photos and videos
-    details: Indexes JPEG, PNG, WebP, GIF, MP4, MOV, M4V, WebM, and MKV. Thumbnails and previews are generated automatically. Videos get a full reels view with scroll-snap playback.
+    details: Indexes JPEG, PNG, WebP, GIF, AVIF, MP4, MOV, M4V, WebM, and MKV. Thumbnails and previews are generated automatically during scans or on demand in lazy mode. Videos get a full reels view with scroll-snap playback.
   - icon:
       src: /icons/access-control.svg
       width: "36"
@@ -71,7 +71,7 @@ features:
 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
 </div>
 <h3>Formats and storage</h3>
-<p>Images: <code>.jpg</code>, <code>.png</code>, <code>.webp</code>, <code>.gif</code>. Videos: <code>.mp4</code>, <code>.mov</code>, <code>.m4v</code>, <code>.webm</code>, <code>.mkv</code>. Originals are never moved. SQLite stores metadata. Thumbnails and previews are written under <code>thumbnails/</code> and <code>previews/</code>.</p>
+<p>Images: <code>.jpg</code>, <code>.jpeg</code>, <code>.png</code>, <code>.webp</code>, <code>.gif</code>, <code>.avif</code>. Videos: <code>.mp4</code>, <code>.mov</code>, <code>.m4v</code>, <code>.webm</code>, <code>.mkv</code>. Originals are never moved. SQLite stores metadata. Thumbnails and previews are written under <code>thumbnails/</code> and <code>previews/</code>.</p>
 </div>
 
 <div class="cs-feature">

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -160,7 +160,7 @@ The shipped `.env.example` keeps the development ports aligned like this:
 | Node.js 22 | Used across the workspace and CI configuration. |
 | `pnpm` | Matches the workspace scripts and lockfile. |
 | Writable local storage | Foldergram creates and maintains the gallery, database, thumbnails, and previews directories. |
-| FFmpeg and FFprobe | Needed only when you run the app outside Docker and want supported video processing. The backend calls `ffprobe` for metadata and `ffmpeg` for video thumbnails and previews. |
+| FFmpeg and FFprobe | Needed only when you run the app outside Docker and want supported video processing or animated AVIF image-sequence processing. The backend calls `ffprobe` for metadata and `ffmpeg` for video thumbnails, video previews, and animated AVIF derivatives. |
 
 ## Supported media
 
@@ -171,6 +171,7 @@ The shipped `.env.example` keeps the development ports aligned like this:
 - `.png`
 - `.webp`
 - `.gif`
+- `.avif`
 
 ### Videos
 

--- a/docs/media-processing.md
+++ b/docs/media-processing.md
@@ -19,6 +19,7 @@ cached on disk.
 - `.png`
 - `.webp`
 - `.gif`
+- `.avif`
 
 ### Videos
 
@@ -47,7 +48,9 @@ These values are defined in `server/src/utils/image-utils.ts`.
 | `lazy` | Scans index metadata only. Missing thumbnails and previews are generated when `/thumbnails/...` or `/previews/...` is first requested. |
 
 Lazy mode still writes the generated files to the configured derivative
-directories, so subsequent requests use the cached file on disk.
+directories, so subsequent requests use the cached file on disk. It also uses
+the same media-specific generation rules as eager mode, including animated AVIF
+preview generation.
 
 ## Derivative mapping
 
@@ -76,7 +79,7 @@ keeps the last known-good path until the new target is repaired or regenerated.
 
 ## Image derivatives
 
-Images are processed with Sharp.
+Most images are processed with Sharp. Static AVIF files also stay on the Sharp path so transparency and regular image behavior are preserved.
 
 ### Thumbnail
 
@@ -89,6 +92,23 @@ Images are processed with Sharp.
 - auto-rotated
 - resized to width `1500` without enlargement
 - encoded as WebP with `quality: 86`
+
+## Animated AVIF handling
+
+Animated AVIF image sequences are treated as images in the UI, not videos.
+
+Foldergram uses:
+
+- Sharp first for normal static AVIF image metadata
+- `ffprobe` to identify animated AVIF image sequences when Sharp cannot decode them reliably
+- `ffmpeg` to generate static WebP thumbnails and animated WebP previews for animated AVIF files
+
+This hybrid path keeps static AVIF on the normal Sharp image pipeline while still supporting animated AVIF sequences that Sharp cannot decode reliably in the current runtime.
+
+Existing libraries with already indexed AVIF files receive a one-time AVIF
+metadata repair on the next successful full scan after upgrade. That pass
+refreshes legacy animated flags and AVIF timestamp fallbacks for stored rows,
+then stops re-reading unchanged AVIF files on later scans.
 
 ## Image detail source
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -8,8 +8,8 @@ description: Get Foldergram running locally with a real gallery structure and ve
 Docker Compose is the recommended way to run Foldergram.
 
 It gives you the quickest path to a working install and includes the media
-tooling needed for video support, so you do not need to set up Node.js,
-`pnpm`, or `ffmpeg` on the host first.
+tooling needed for video support and animated AVIF processing, so you do not
+need to set up Node.js, `pnpm`, or `ffmpeg` on the host first.
 
 ## Preferred: Docker Compose
 
@@ -83,7 +83,7 @@ The included compose file:
 - mounts `./data/gallery`, `./data/db`, `./data/thumbnails`, and `./data/previews`
 - runs the app in production mode
 - uses internal container paths under `/app/data`
-- relies on the image's bundled `ffmpeg`
+- relies on the image's bundled `ffmpeg` and `ffprobe`
 
 For the default Docker Compose setup, the container uses the image's built-in
 production defaults plus the mounted `./data/...` volumes. The source-install

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -147,14 +147,16 @@ Check:
 If the folder was already indexed before the rule existed, it will stay visible
 until that scan finishes and soft-removes it from the index.
 
-## Videos fail to index or generate previews
+## Videos or animated AVIF files fail to index or generate previews
 
 Check that both tools are installed and available on `PATH`:
 
 - `ffprobe`
 - `ffmpeg`
 
-Foldergram uses them directly for supported video files.
+Foldergram uses them directly for supported video files and animated AVIF
+image-sequence processing. Static AVIF files use the normal image path and do
+not require these tools.
 
 ## A video opens from the original file instead of a generated preview
 

--- a/server/src/constants/app-setting-keys.ts
+++ b/server/src/constants/app-setting-keys.ts
@@ -5,6 +5,7 @@ export const DERIVATIVE_STORAGE_LAYOUT_VERSION_SETTING_KEY = 'derivatives.storag
 export const DERIVATIVE_STORAGE_MIGRATION_CURSOR_SETTING_KEY = 'derivatives.storage_migration_cursor';
 export const DERIVATIVE_STORAGE_MIGRATION_COMPLETE_AT_SETTING_KEY = 'derivatives.storage_migration_complete_at';
 export const STALE_DERIVATIVE_GC_LAST_RUN_AT_SETTING_KEY = 'derivatives.stale_gc_last_run_at';
+export const AVIF_METADATA_REPAIR_VERSION_SETTING_KEY = 'library.avif_metadata_repair_version';
 export const TREAT_STORIES_AS_FOLDERS_SETTING_KEY = 'library.treat_stories_as_folders';
 export const EXCLUDED_FOLDERS_SETTING_KEY = 'library.excluded_folders';
 export const STORIES_MIGRATION_DECISION_SETTING_KEY = 'library.stories_migration_decision';

--- a/server/src/db/repositories.ts
+++ b/server/src/db/repositories.ts
@@ -30,7 +30,7 @@ const database = databaseManager.connection;
 const EFFECTIVE_FEED_TIME_SQL = 'COALESCE(images.taken_at, images.sort_timestamp)';
 const DEFAULT_COLLECTION_SLUG = 'saved';
 const DEFAULT_COLLECTION_NAME = 'Saved';
-const COVER_FILENAMES = ['cover.jpg', 'cover.jpeg', 'cover.png', 'cover.webp', 'cover.gif'] as const;
+const COVER_FILENAMES = ['cover.jpg', 'cover.jpeg', 'cover.png', 'cover.webp', 'cover.avif', 'cover.gif'] as const;
 const COVER_FILENAME_SQL = COVER_FILENAMES.map((name) => `'${name}'`).join(', ');
 const NORMAL_FOLDER_ROLE_SQL = "folders.role = 'normal'";
 const NORMAL_FOLDER_ID_SUBQUERY_SQL = "SELECT id FROM folders WHERE role = 'normal'";
@@ -1628,8 +1628,9 @@ export const imageRepository = {
           WHEN 'cover.jpeg' THEN 2
           WHEN 'cover.png' THEN 3
           WHEN 'cover.webp' THEN 4
-          WHEN 'cover.gif' THEN 5
-          ELSE 6
+          WHEN 'cover.avif' THEN 5
+          WHEN 'cover.gif' THEN 6
+          ELSE 7
         END,
         id ASC
       LIMIT 1

--- a/server/src/routes/lazy-derivatives.ts
+++ b/server/src/routes/lazy-derivatives.ts
@@ -6,7 +6,7 @@ import pLimit from 'p-limit';
 import { appConfig } from '../config/env.js';
 import { imageRepository } from '../db/repositories.js';
 import { log } from '../services/log-service.js';
-import { generateThumbnailDerivative, writeImagePreview, writeVideoPreview } from '../services/derivative-service.js';
+import { generatePreviewDerivative, generateThumbnailDerivative } from '../services/derivative-service.js';
 import { scannerService } from '../services/scanner-service.js';
 import { resolveOriginalPath } from '../utils/media-paths.js';
 import { applyDerivativeErrorHeaders, applyProtectedMediaHeaders } from '../utils/media-response.js';
@@ -122,7 +122,6 @@ async function serveOrGenerate(
     return;
   }
 
-  const mediaType = imageRecord.media_type;
   let generationPromise = inflightGenerations.get(absoluteOutputPath);
 
   if (!generationPromise) {
@@ -142,23 +141,9 @@ async function serveOrGenerate(
           });
           return;
         }
-
-        if (mediaType === 'video') {
-          const previewAbsolutePath = resolveDerivativePath(appConfig.previewsDir, requestedPath);
-          if (!previewAbsolutePath) {
-            throw new Error('Invalid derivative path.');
-          }
-
-          await writeVideoPreview(sourcePath, previewAbsolutePath);
-          return;
-        }
-
-        const previewAbsolutePath = resolveDerivativePath(appConfig.previewsDir, requestedPath);
-        if (!previewAbsolutePath) {
-          throw new Error('Invalid derivative path.');
-        }
-
-        await writeImagePreview(sourcePath, previewAbsolutePath);
+        await generatePreviewDerivative(sourcePath, imageRecord.relative_path, false, {
+          previewPath: imageRecord.preview_path
+        });
       } finally {
         inflightGenerations.delete(absoluteOutputPath);
       }

--- a/server/src/services/derivative-service.ts
+++ b/server/src/services/derivative-service.ts
@@ -29,9 +29,13 @@ interface FfprobeStream {
   width?: number;
   height?: number;
   pix_fmt?: string;
+  duration?: string;
+  nb_frames?: string;
   tags?: {
     creation_time?: string;
     rotate?: string;
+    title?: string;
+    handler_name?: string;
   };
   side_data_list?: Array<{
     rotation?: number;
@@ -41,8 +45,11 @@ interface FfprobeStream {
 interface FfprobeFormat {
   duration?: string;
   format_name?: string;
+  nb_streams?: number;
   tags?: {
     creation_time?: string;
+    major_brand?: string;
+    compatible_brands?: string;
   };
 }
 
@@ -75,6 +82,11 @@ export interface ThumbnailDerivativeResult {
   generatedThumbnail: boolean;
 }
 
+export interface PreviewDerivativeResult {
+  previewPath: string;
+  generatedPreview: boolean;
+}
+
 export interface DerivativePathOverrides {
   thumbnailPath?: string;
   previewPath?: string;
@@ -103,14 +115,14 @@ async function runBinary(command: string, args: string[]): Promise<void> {
   });
 }
 
-async function readVideoProbe(sourcePath: string): Promise<FfprobePayload> {
+async function readMediaProbe(sourcePath: string): Promise<FfprobePayload> {
   const { stdout } = await execFileAsync(
     'ffprobe',
     [
       '-v',
       'error',
       '-show_entries',
-      'format=duration,format_name:format_tags=creation_time:stream=codec_type,codec_name,width,height,pix_fmt:stream_tags=creation_time,rotate:stream_side_data=rotation',
+      'format=duration,format_name,nb_streams:format_tags=creation_time,major_brand,compatible_brands:stream=codec_type,codec_name,width,height,pix_fmt,duration,nb_frames:stream_tags=creation_time,rotate,title,handler_name:stream_side_data=rotation',
       '-of',
       'json',
       sourcePath
@@ -121,6 +133,32 @@ async function readVideoProbe(sourcePath: string): Promise<FfprobePayload> {
   );
 
   return JSON.parse(stdout) as FfprobePayload;
+}
+
+function parseFfprobeFloat(value: string | number | null | undefined): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseFfprobeInteger(value: string | number | null | undefined): number | null {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? value : null;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) ? parsed : null;
 }
 
 function normalizeVideoRotation(rotation: number | string | null | undefined): number {
@@ -206,6 +244,133 @@ async function readImageMetadata(sourcePath: string): Promise<MediaMetadata> {
   };
 }
 
+interface AvifAnimatedSource {
+  stream: FfprobeStream;
+  videoStreamIndex: number;
+}
+
+interface AvifSourceDescriptor {
+  metadata: MediaMetadata;
+  animatedVideoStreamIndex: number | null;
+}
+
+function getVideoStreams(payload: FfprobePayload): FfprobeStream[] {
+  return payload.streams?.filter((stream) => stream.codec_type === 'video') ?? [];
+}
+
+function getAvifMajorBrand(payload: FfprobePayload): string {
+  return payload.format?.tags?.major_brand?.toLowerCase() ?? '';
+}
+
+function getAvifCompatibleBrands(payload: FfprobePayload): string {
+  return payload.format?.tags?.compatible_brands?.toLowerCase() ?? '';
+}
+
+function resolveAnimatedAvifSource(payload: FfprobePayload): AvifAnimatedSource | null {
+  const videoStreams = getVideoStreams(payload);
+  if (videoStreams.length === 0) {
+    return null;
+  }
+
+  const animatedStream = videoStreams.find((stream) => {
+    const frameCount = parseFfprobeInteger(stream.nb_frames);
+    if (frameCount !== null && frameCount > 1) {
+      return true;
+    }
+
+    const durationSeconds = parseFfprobeFloat(stream.duration);
+    return durationSeconds !== null && durationSeconds > 0;
+  });
+
+  if (animatedStream) {
+    return {
+      stream: animatedStream,
+      videoStreamIndex: videoStreams.indexOf(animatedStream)
+    };
+  }
+
+  const majorBrand = getAvifMajorBrand(payload);
+  const compatibleBrands = getAvifCompatibleBrands(payload);
+  const isSequenceContainer = majorBrand === 'avis' || compatibleBrands.includes('avis');
+
+  if (!isSequenceContainer) {
+    return null;
+  }
+
+  const fallbackStream = videoStreams.at(-1);
+  if (!fallbackStream) {
+    return null;
+  }
+
+  return {
+    stream: fallbackStream,
+    videoStreamIndex: videoStreams.length - 1
+  };
+}
+
+async function createAnimatedAvifMetadata(
+  sourcePath: string,
+  animatedSource: AvifAnimatedSource
+): Promise<MediaMetadata> {
+  const imageExif = await extractImageExif(sourcePath);
+  const displayDimensions = resolveVideoDisplayDimensions(animatedSource.stream);
+
+  return {
+    width: displayDimensions.width,
+    height: displayDimensions.height,
+    takenAt: imageExif.takenAt,
+    exif: imageExif.exif,
+    durationMs: null,
+    mediaType: 'image',
+    playbackStrategy: 'preview',
+    isAnimated: true
+  };
+}
+
+async function inspectAvifSource(
+  sourcePath: string,
+  options: {
+    requireAnimatedVideoStreamIndex?: boolean;
+  } = {}
+): Promise<AvifSourceDescriptor> {
+  let sharpMetadataError: unknown = null;
+
+  try {
+    const sharpMetadata = await readImageMetadata(sourcePath);
+    if (!sharpMetadata.isAnimated || !options.requireAnimatedVideoStreamIndex) {
+      return {
+        metadata: sharpMetadata,
+        animatedVideoStreamIndex: null
+      };
+    }
+  } catch (error) {
+    sharpMetadataError = error;
+  }
+
+  const payload = await readMediaProbe(sourcePath);
+  const animatedSource = resolveAnimatedAvifSource(payload);
+
+  if (!animatedSource) {
+    if (sharpMetadataError) {
+      throw sharpMetadataError;
+    }
+
+    return {
+      metadata: await readImageMetadata(sourcePath),
+      animatedVideoStreamIndex: null
+    };
+  }
+
+  return {
+    metadata: await createAnimatedAvifMetadata(sourcePath, animatedSource),
+    animatedVideoStreamIndex: animatedSource.videoStreamIndex
+  };
+}
+
+async function readAvifMetadata(sourcePath: string): Promise<MediaMetadata> {
+  return (await inspectAvifSource(sourcePath)).metadata;
+}
+
 async function resolveVideoPlaybackStrategy(
   sourcePath: string,
   payload: FfprobePayload
@@ -236,10 +401,10 @@ async function resolveVideoPlaybackStrategy(
 }
 
 async function readVideoMetadata(sourcePath: string, options: ReadMediaMetadataOptions = {}): Promise<MediaMetadata> {
-  const payload = await readVideoProbe(sourcePath);
+  const payload = await readMediaProbe(sourcePath);
   const videoStream = payload.streams?.find((stream) => stream.codec_type === 'video');
-  const durationSeconds = payload.format?.duration ? Number.parseFloat(payload.format.duration) : Number.NaN;
-  const durationMs = Number.isFinite(durationSeconds) ? Math.round(durationSeconds * 1000) : null;
+  const durationSeconds = parseFfprobeFloat(payload.format?.duration);
+  const durationMs = durationSeconds !== null ? Math.round(durationSeconds * 1000) : null;
   const takenAt = normalizeTakenAtValue(videoStream?.tags?.creation_time ?? payload.format?.tags?.creation_time ?? null);
   const displayDimensions = resolveVideoDisplayDimensions(videoStream);
 
@@ -260,7 +425,13 @@ export async function readMediaMetadata(
   mediaType: MediaType,
   options: ReadMediaMetadataOptions = {}
 ): Promise<MediaMetadata> {
-  return mediaType === 'video' ? readVideoMetadata(sourcePath, options) : readImageMetadata(sourcePath);
+  if (mediaType === 'video') {
+    return readVideoMetadata(sourcePath, options);
+  }
+
+  return path.extname(sourcePath).toLowerCase() === '.avif'
+    ? readAvifMetadata(sourcePath)
+    : readImageMetadata(sourcePath);
 }
 
 async function writeImageThumbnail(sourcePath: string, thumbnailAbsolutePath: string): Promise<void> {
@@ -285,6 +456,64 @@ export async function writeImagePreview(sourcePath: string, previewAbsolutePath:
     })
     .webp({ quality: 86, effort: 4 })
     .toFile(previewAbsolutePath);
+}
+
+async function writeAnimatedAvifThumbnail(
+  sourcePath: string,
+  thumbnailAbsolutePath: string,
+  videoStreamIndex: number
+): Promise<void> {
+  await ensureParentDirectory(thumbnailAbsolutePath);
+
+  await runBinary('ffmpeg', [
+    '-y',
+    '-v',
+    'error',
+    '-i',
+    sourcePath,
+    '-map',
+    `0:v:${videoStreamIndex}`,
+    '-vf',
+    `thumbnail,scale='min(${THUMBNAIL_SIZE},iw)':-2:flags=lanczos`,
+    '-frames:v',
+    '1',
+    '-c:v',
+    'libwebp',
+    '-quality',
+    '82',
+    '-compression_level',
+    '4',
+    thumbnailAbsolutePath
+  ]);
+}
+
+async function writeAnimatedAvifPreview(
+  sourcePath: string,
+  previewAbsolutePath: string,
+  videoStreamIndex: number
+): Promise<void> {
+  await ensureParentDirectory(previewAbsolutePath);
+
+  await runBinary('ffmpeg', [
+    '-y',
+    '-v',
+    'error',
+    '-i',
+    sourcePath,
+    '-map',
+    `0:v:${videoStreamIndex}`,
+    '-vf',
+    `scale='min(${PREVIEW_MAX_WIDTH},iw)':-2:flags=lanczos`,
+    '-c:v',
+    'libwebp',
+    '-quality',
+    '86',
+    '-compression_level',
+    '4',
+    '-loop',
+    '0',
+    previewAbsolutePath
+  ]);
 }
 
 async function writeVideoThumbnail(sourcePath: string, thumbnailAbsolutePath: string): Promise<void> {
@@ -371,6 +600,38 @@ async function generateImageDerivatives(
   };
 }
 
+async function generateAnimatedAvifDerivatives(
+  sourcePath: string,
+  thumbnailAbsolutePath: string,
+  previewAbsolutePath: string,
+  force: boolean,
+  videoStreamIndex: number
+): Promise<Pick<DerivativeResult, 'generatedThumbnail' | 'generatedPreview'>> {
+  const shouldWriteThumbnail = force || !(await fileExists(thumbnailAbsolutePath));
+  const shouldWritePreview = force || !(await fileExists(previewAbsolutePath));
+
+  if (shouldWriteThumbnail) {
+    await writeAnimatedAvifThumbnail(sourcePath, thumbnailAbsolutePath, videoStreamIndex);
+  }
+
+  if (shouldWritePreview) {
+    await writeAnimatedAvifPreview(sourcePath, previewAbsolutePath, videoStreamIndex);
+  }
+
+  return {
+    generatedThumbnail: shouldWriteThumbnail,
+    generatedPreview: shouldWritePreview
+  };
+}
+
+function requireAnimatedAvifVideoStreamIndex(descriptor: AvifSourceDescriptor): number {
+  if (descriptor.animatedVideoStreamIndex === null) {
+    throw new Error('Animated AVIF source stream not found.');
+  }
+
+  return descriptor.animatedVideoStreamIndex;
+}
+
 async function generateVideoDerivatives(
   sourcePath: string,
   thumbnailAbsolutePath: string,
@@ -401,6 +662,7 @@ export async function generateThumbnailDerivative(
   overrides: DerivativePathOverrides = {}
 ): Promise<ThumbnailDerivativeResult> {
   const mediaType = getMediaTypeFromExtension(path.extname(relativePath));
+  const isAvif = path.extname(relativePath).toLowerCase() === '.avif';
   const thumbnailPath = overrides.thumbnailPath ?? getThumbnailRelativePath(relativePath);
   const thumbnailAbsolutePath = safeJoin(appConfig.thumbnailsDir, thumbnailPath);
   const shouldWriteThumbnail = force || !(await fileExists(thumbnailAbsolutePath));
@@ -408,6 +670,20 @@ export async function generateThumbnailDerivative(
   if (shouldWriteThumbnail) {
     if (mediaType === 'video') {
       await writeVideoThumbnail(sourcePath, thumbnailAbsolutePath);
+    } else if (isAvif) {
+      const avifSource = await inspectAvifSource(sourcePath, {
+        requireAnimatedVideoStreamIndex: true
+      });
+
+      if (avifSource.metadata.isAnimated) {
+        await writeAnimatedAvifThumbnail(
+          sourcePath,
+          thumbnailAbsolutePath,
+          requireAnimatedAvifVideoStreamIndex(avifSource)
+        );
+      } else {
+        await writeImageThumbnail(sourcePath, thumbnailAbsolutePath);
+      }
     } else {
       await writeImageThumbnail(sourcePath, thumbnailAbsolutePath);
     }
@@ -419,6 +695,46 @@ export async function generateThumbnailDerivative(
   };
 }
 
+export async function generatePreviewDerivative(
+  sourcePath: string,
+  relativePath: string,
+  force = false,
+  overrides: DerivativePathOverrides = {}
+): Promise<PreviewDerivativeResult> {
+  const mediaType = getMediaTypeFromExtension(path.extname(relativePath));
+  const isAvif = path.extname(relativePath).toLowerCase() === '.avif';
+  const previewPath = overrides.previewPath ?? getPreviewRelativePath(relativePath, mediaType);
+  const previewAbsolutePath = safeJoin(appConfig.previewsDir, previewPath);
+  const shouldWritePreview = force || !(await fileExists(previewAbsolutePath));
+
+  if (shouldWritePreview) {
+    if (mediaType === 'video') {
+      await writeVideoPreview(sourcePath, previewAbsolutePath);
+    } else if (isAvif) {
+      const avifSource = await inspectAvifSource(sourcePath, {
+        requireAnimatedVideoStreamIndex: true
+      });
+
+      if (avifSource.metadata.isAnimated) {
+        await writeAnimatedAvifPreview(
+          sourcePath,
+          previewAbsolutePath,
+          requireAnimatedAvifVideoStreamIndex(avifSource)
+        );
+      } else {
+        await writeImagePreview(sourcePath, previewAbsolutePath);
+      }
+    } else {
+      await writeImagePreview(sourcePath, previewAbsolutePath);
+    }
+  }
+
+  return {
+    previewPath,
+    generatedPreview: shouldWritePreview
+  };
+}
+
 export async function generateDerivatives(
   sourcePath: string,
   relativePath: string,
@@ -426,15 +742,35 @@ export async function generateDerivatives(
   overrides: DerivativePathOverrides = {}
 ): Promise<DerivativeResult> {
   const mediaType = getMediaTypeFromExtension(path.extname(relativePath));
+  const isAvif = path.extname(relativePath).toLowerCase() === '.avif';
   const thumbnailPath = overrides.thumbnailPath ?? getThumbnailRelativePath(relativePath);
   const previewPath = overrides.previewPath ?? getPreviewRelativePath(relativePath, mediaType);
   const thumbnailAbsolutePath = safeJoin(appConfig.thumbnailsDir, thumbnailPath);
   const previewAbsolutePath = safeJoin(appConfig.previewsDir, previewPath);
-  const metadata = await readMediaMetadata(sourcePath, mediaType);
-  const generated =
-    mediaType === 'video'
-      ? await generateVideoDerivatives(sourcePath, thumbnailAbsolutePath, previewAbsolutePath, force)
+  let metadata: MediaMetadata;
+  let generated: Pick<DerivativeResult, 'generatedThumbnail' | 'generatedPreview'>;
+
+  if (mediaType === 'video') {
+    metadata = await readVideoMetadata(sourcePath);
+    generated = await generateVideoDerivatives(sourcePath, thumbnailAbsolutePath, previewAbsolutePath, force);
+  } else if (isAvif) {
+    const avifSource = await inspectAvifSource(sourcePath, {
+      requireAnimatedVideoStreamIndex: true
+    });
+    metadata = avifSource.metadata;
+    generated = metadata.isAnimated
+      ? await generateAnimatedAvifDerivatives(
+          sourcePath,
+          thumbnailAbsolutePath,
+          previewAbsolutePath,
+          force,
+          requireAnimatedAvifVideoStreamIndex(avifSource)
+        )
       : await generateImageDerivatives(sourcePath, thumbnailAbsolutePath, previewAbsolutePath, force);
+  } else {
+    metadata = await readImageMetadata(sourcePath);
+    generated = await generateImageDerivatives(sourcePath, thumbnailAbsolutePath, previewAbsolutePath, force);
+  }
 
   return {
     ...metadata,

--- a/server/src/services/scanner-service.ts
+++ b/server/src/services/scanner-service.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import pLimit from 'p-limit';
 
 import {
+  AVIF_METADATA_REPAIR_VERSION_SETTING_KEY,
   EXCLUDED_FOLDERS_SETTING_KEY,
   LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY,
   LIBRARY_REBUILD_REQUIRED_SETTING_KEY,
@@ -165,6 +166,7 @@ interface SourceFolderScanResult {
 interface ImageProcessingContext {
   galleryRootChanged: boolean;
   hasStoredGalleryRoot: boolean;
+  avifMetadataRepairPending: boolean;
   moveReconciliationEnabled: boolean;
   claimedMoveImageIds: Set<number>;
   rebuildDerivativeReuseIndex?: RebuildDerivativeReuseIndex;
@@ -244,6 +246,7 @@ const derivativeLimit = pLimit(appConfig.scanDerivativeConcurrency);
 const HEARTBEAT_INTERVAL_MS = 5000;
 const DERIVATIVE_CACHE_KEEP_FILE = '.gitkeep';
 const ROOT_DISCOVERY_LABEL = '(root)';
+const CURRENT_AVIF_METADATA_REPAIR_VERSION = '1';
 export const LIBRARY_REBUILD_REQUIRED_MESSAGE =
   'Library rebuild required before scanning because the configured gallery root changed.';
 
@@ -668,6 +671,14 @@ class ScannerService {
   private clearLibraryRebuildRequirement(): void {
     appSettingsRepository.remove(LIBRARY_REBUILD_REQUIRED_SETTING_KEY);
     appSettingsRepository.remove(PREVIOUS_GALLERY_ROOT_SETTING_KEY);
+  }
+
+  private isAvifMetadataRepairPending(): boolean {
+    return appSettingsRepository.get(AVIF_METADATA_REPAIR_VERSION_SETTING_KEY) !== CURRENT_AVIF_METADATA_REPAIR_VERSION;
+  }
+
+  private markAvifMetadataRepairComplete(): void {
+    appSettingsRepository.set(AVIF_METADATA_REPAIR_VERSION_SETTING_KEY, CURRENT_AVIF_METADATA_REPAIR_VERSION);
   }
 
   private async resetDerivativeDirectory(targetDirectory: string): Promise<void> {
@@ -1501,9 +1512,11 @@ class ScannerService {
     const normalizedStoredGalleryRoot = storedGalleryRoot ? normalizePath(storedGalleryRoot) : null;
     const hasStoredGalleryRoot = normalizedStoredGalleryRoot !== null;
     const galleryRootChanged = normalizedStoredGalleryRoot !== currentGalleryRoot;
+    const avifMetadataRepairPending = this.isAvifMetadataRepairPending();
     const imageProcessingContext: ImageProcessingContext = {
       galleryRootChanged,
       hasStoredGalleryRoot,
+      avifMetadataRepairPending,
       moveReconciliationEnabled: false,
       claimedMoveImageIds: new Set<number>(),
       rebuildDerivativeReuseIndex: contextOptions.rebuildDerivativeReuseIndex
@@ -1523,6 +1536,7 @@ class ScannerService {
         formatStep('storage-migration', formatToggle(options.allowDerivativeMigration)),
         formatStep('root-changed', formatToggle(galleryRootChanged)),
         formatStep('stored-root', formatToggle(hasStoredGalleryRoot)),
+        formatStep('avif-repair', formatToggle(avifMetadataRepairPending)),
         formatStep('stories-as-folders', formatToggle(treatStoriesAsFolders)),
         excludedFolderRules.length > 0 ? formatStep('excluded-folders', excludedFolderRules.join(',')) : null,
         appConfig.managedGalleryRelativeIgnores.length > 0
@@ -1749,6 +1763,10 @@ class ScannerService {
       appSettingsRepository.set(LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY, currentGalleryRoot);
     }
 
+    if (summary.status === 'completed' && avifMetadataRepairPending) {
+      this.markAvifMetadataRepairComplete();
+    }
+
     this.finishRun(runId, summary);
     log.table(`Finished full scan (${reason})`, [
       ['Status', summary.status],
@@ -1836,6 +1854,7 @@ class ScannerService {
       const imageProcessingContext: ImageProcessingContext = {
         galleryRootChanged: false,
         hasStoredGalleryRoot: appSettingsRepository.get(LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY) !== null,
+        avifMetadataRepairPending: false,
         moveReconciliationEnabled: false,
         claimedMoveImageIds: new Set<number>()
       };
@@ -2212,6 +2231,7 @@ class ScannerService {
     context: ImageProcessingContext = {
       galleryRootChanged: false,
       hasStoredGalleryRoot: false,
+      avifMetadataRepairPending: false,
       moveReconciliationEnabled: false,
       claimedMoveImageIds: new Set<number>()
     }
@@ -2239,6 +2259,10 @@ class ScannerService {
     const needsPlaybackStrategyBackfill = mediaType === 'video' && existing?.playback_strategy === null;
     const needsAnimatedBackfill = mediaType === 'image' && existing?.is_animated === null;
     const needsExifBackfill = mediaType === 'image' && existing?.exif_json === null;
+    const needsAvifMetadataRepair = context.avifMetadataRepairPending
+      && mediaType === 'image'
+      && extension === '.avif'
+      && existingByPath !== undefined;
 
     if (existingByPath && existingByPath.checksum_or_fingerprint === fingerprint) {
       const refreshedIndexedRow = shouldRefreshUnchangedImage({
@@ -2257,7 +2281,15 @@ class ScannerService {
       let metadataIsAnimated = existingByPath.is_animated === 1;
       let metadataExifJson = existingByPath.exif_json;
 
-      if (needsTakenAtBackfill || needsMediaBackfill || needsOrientationBackfill || needsPlaybackStrategyBackfill || needsAnimatedBackfill || needsExifBackfill) {
+      if (
+        needsTakenAtBackfill
+        || needsMediaBackfill
+        || needsOrientationBackfill
+        || needsPlaybackStrategyBackfill
+        || needsAnimatedBackfill
+        || needsExifBackfill
+        || needsAvifMetadataRepair
+      ) {
         const metadata = await readMediaMetadata(file.absolutePath, mediaType, {
           fileSize: file.stats.size
         });
@@ -2275,11 +2307,25 @@ class ScannerService {
           : null;
       }
 
-      if (refreshedIndexedRow || needsTakenAtBackfill || needsMediaBackfill || needsOrientationBackfill || needsPlaybackStrategyBackfill || needsAnimatedBackfill || needsExifBackfill) {
+      const shouldResetLegacyAnimatedAvifTakenAt = needsAvifMetadataRepair
+        && existingByPath.taken_at_source === 'exif'
+        && metadataIsAnimated
+        && metadataTakenAt !== existingByPath.taken_at;
+
+      if (
+        refreshedIndexedRow
+        || needsTakenAtBackfill
+        || needsMediaBackfill
+        || needsOrientationBackfill
+        || needsPlaybackStrategyBackfill
+        || needsAnimatedBackfill
+        || needsExifBackfill
+        || needsAvifMetadataRepair
+      ) {
         const resolvedTakenAt = resolveTakenAt({
           exifTakenAt: metadataTakenAt,
-          existingTakenAt: existingByPath.taken_at,
-          existingTakenAtSource: existingByPath.taken_at_source,
+          existingTakenAt: shouldResetLegacyAnimatedAvifTakenAt ? null : existingByPath.taken_at,
+          existingTakenAtSource: shouldResetLegacyAnimatedAvifTakenAt ? null : existingByPath.taken_at_source,
           existingSortTimestamp: existingByPath.sort_timestamp,
           existingFirstSeenAt: existingByPath.first_seen_at,
           existingMtimeMs: existingByPath.mtime_ms,
@@ -2349,10 +2395,16 @@ class ScannerService {
       file.stats.mtimeMs
     );
     const firstSeenAt = existing?.first_seen_at ?? new Date().toISOString();
+    const shouldResetLegacyAnimatedAvifTakenAt = context.avifMetadataRepairPending
+      && mediaType === 'image'
+      && extension === '.avif'
+      && existing?.taken_at_source === 'exif'
+      && metadata.isAnimated
+      && metadata.takenAt !== existing.taken_at;
     const resolvedTakenAt = resolveTakenAt({
       exifTakenAt: metadata.takenAt,
-      existingTakenAt: existing?.taken_at,
-      existingTakenAtSource: existing?.taken_at_source,
+      existingTakenAt: shouldResetLegacyAnimatedAvifTakenAt ? null : existing?.taken_at,
+      existingTakenAtSource: shouldResetLegacyAnimatedAvifTakenAt ? null : existing?.taken_at_source,
       existingSortTimestamp: existing?.sort_timestamp,
       existingFirstSeenAt: existing?.first_seen_at,
       existingMtimeMs: existing?.mtime_ms,

--- a/server/src/utils/image-utils.ts
+++ b/server/src/utils/image-utils.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type { MediaType } from '../types/models.js';
 import { normalizePath } from './path-utils.js';
 
-export const SUPPORTED_IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.gif']);
+export const SUPPORTED_IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.gif', '.avif']);
 export const SUPPORTED_VIDEO_EXTENSIONS = new Set(['.mp4', '.mov', '.m4v', '.webm', '.mkv']);
 
 export const THUMBNAIL_SIZE = 640;
@@ -58,6 +58,8 @@ export function getMimeTypeFromExtension(extension: string): string {
       return 'image/webp';
     case '.gif':
       return 'image/gif';
+    case '.avif':
+      return 'image/avif';
     case '.mp4':
       return 'video/mp4';
     case '.mov':

--- a/server/test/animated-avif-feed-support.test.ts
+++ b/server/test/animated-avif-feed-support.test.ts
@@ -1,0 +1,354 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createFingerprint,
+  getMimeTypeFromExtension,
+  getPreviewRelativePath,
+  getThumbnailRelativePath
+} from '../src/utils/image-utils.js';
+import { AVIF_METADATA_REPAIR_VERSION_SETTING_KEY } from '../src/constants/app-setting-keys.js';
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type ScannerServiceModule = typeof import('../src/services/scanner-service.js');
+type GalleryServiceModule = typeof import('../src/services/gallery-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type ModelsModule = typeof import('../src/types/models.js');
+
+type FolderRecord = ModelsModule['FolderRecord'];
+
+const generateDerivativesMock = vi.fn();
+const generateThumbnailDerivativeMock = vi.fn();
+const readMediaMetadataMock = vi.fn();
+
+describe.sequential('animated AVIF feed support', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let scannerService: ScannerServiceModule['scannerService'];
+  let galleryService: GalleryServiceModule['galleryService'];
+  let folderRepository: RepositoriesModule['folderRepository'];
+  let imageRepository: RepositoriesModule['imageRepository'];
+  let appSettingsRepository: RepositoriesModule['appSettingsRepository'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-animated-avif-feed-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    generateDerivativesMock.mockReset();
+    generateThumbnailDerivativeMock.mockReset();
+    readMediaMetadataMock.mockReset();
+
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.resetModules();
+    vi.doMock('../src/services/derivative-service.js', () => ({
+      generateDerivatives: generateDerivativesMock,
+      generateThumbnailDerivative: generateThumbnailDerivativeMock,
+      readMediaMetadata: readMediaMetadataMock
+    }));
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ scannerService } = await import('../src/services/scanner-service.js'));
+    ({ galleryService } = await import('../src/services/gallery-service.js'));
+    ({ folderRepository, imageRepository, appSettingsRepository } = await import('../src/db/repositories.js'));
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+
+    readMediaMetadataMock.mockImplementation(async (sourcePath: string) => {
+      const extension = path.extname(sourcePath).toLowerCase();
+
+      if (extension === '.avif') {
+        return {
+          width: 800,
+          height: 450,
+          displayOrientation: 1,
+          takenAt: null,
+          exif: null,
+          durationMs: null,
+          mediaType: 'image',
+          playbackStrategy: 'preview',
+          isAnimated: true
+        };
+      }
+
+      return {
+        width: 1600,
+        height: 1200,
+        displayOrientation: 1,
+        takenAt: null,
+        exif: null,
+        durationMs: null,
+        mediaType: 'image',
+        playbackStrategy: 'preview',
+        isAnimated: false
+      };
+    });
+
+    generateThumbnailDerivativeMock.mockResolvedValue({
+      thumbnailPath: 'unused.webp',
+      generatedThumbnail: true
+    });
+
+    generateDerivativesMock.mockImplementation(async (_sourcePath: string, relativePath: string) => ({
+      width: path.extname(relativePath).toLowerCase() === '.avif' ? 800 : 1600,
+      height: path.extname(relativePath).toLowerCase() === '.avif' ? 450 : 1200,
+      displayOrientation: 1,
+      takenAt: null,
+      exif: null,
+      durationMs: null,
+      mediaType: 'image',
+      playbackStrategy: 'preview',
+      isAnimated: path.extname(relativePath).toLowerCase() === '.avif',
+      thumbnailPath: getThumbnailRelativePath(relativePath),
+      previewPath: getPreviewRelativePath(relativePath, 'image'),
+      generatedThumbnail: true,
+      generatedPreview: true
+    }));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('repairs legacy animated AVIF timestamps so recent feed ordering follows scan-time fallback values', async () => {
+    const folder = createFolder('albums');
+    const recentRelativePath = 'albums/recent.jpg';
+    const avifRelativePath = 'albums/animated.avif';
+    const recentAbsolutePath = await createSourceFile(recentRelativePath, 'recent-jpg');
+    const avifAbsolutePath = await createSourceFile(avifRelativePath, 'animated-avif');
+    const recentTimestamp = Date.parse('2025-04-01T08:30:00.000Z');
+    const avifTimestamp = Date.parse('2026-05-21T15:05:24.146Z');
+
+    await Promise.all([
+      fs.utimes(recentAbsolutePath, recentTimestamp / 1000, recentTimestamp / 1000),
+      fs.utimes(avifAbsolutePath, avifTimestamp / 1000, avifTimestamp / 1000)
+    ]);
+
+    const recentStats = await fs.stat(recentAbsolutePath);
+    const avifStats = await fs.stat(avifAbsolutePath);
+
+    const recentImage = imageRepository.upsert({
+      folderId: folder.id,
+      filename: 'recent.jpg',
+      extension: '.jpg',
+      relativePath: recentRelativePath,
+      absolutePath: recentAbsolutePath,
+      fileSize: recentStats.size,
+      width: 1600,
+      height: 1200,
+      displayOrientation: 1,
+      mediaType: 'image',
+      mimeType: getMimeTypeFromExtension('.jpg'),
+      durationMs: null,
+      isAnimated: false,
+      fingerprint: createFingerprint(recentRelativePath, recentStats.size, recentStats.mtimeMs),
+      mtimeMs: recentStats.mtimeMs,
+      firstSeenAt: new Date(recentTimestamp + 2_000).toISOString(),
+      sortTimestamp: Math.round(recentStats.mtimeMs),
+      takenAt: Math.round(recentStats.mtimeMs),
+      takenAtSource: 'mtime',
+      exifJson: '{}',
+      thumbnailPath: getThumbnailRelativePath(recentRelativePath),
+      previewPath: getPreviewRelativePath(recentRelativePath, 'image'),
+      playbackStrategy: 'preview'
+    });
+
+    const avifImage = imageRepository.upsert({
+      folderId: folder.id,
+      filename: 'animated.avif',
+      extension: '.avif',
+      relativePath: avifRelativePath,
+      absolutePath: avifAbsolutePath,
+      fileSize: avifStats.size,
+      width: 800,
+      height: 450,
+      displayOrientation: 1,
+      mediaType: 'image',
+      mimeType: getMimeTypeFromExtension('.avif'),
+      durationMs: null,
+      isAnimated: true,
+      fingerprint: createFingerprint(avifRelativePath, avifStats.size, avifStats.mtimeMs),
+      mtimeMs: avifStats.mtimeMs,
+      firstSeenAt: new Date(avifTimestamp + 5_000).toISOString(),
+      sortTimestamp: Math.round(avifStats.mtimeMs),
+      takenAt: Date.parse('2020-09-13T22:30:13.000Z'),
+      takenAtSource: 'exif',
+      exifJson: '{}',
+      thumbnailPath: getThumbnailRelativePath(avifRelativePath),
+      previewPath: getPreviewRelativePath(avifRelativePath, 'image'),
+      playbackStrategy: 'preview'
+    });
+
+    expect(galleryService.getFeed(1, 10, 'recent').items.map((item) => item.id)).toEqual([recentImage.id, avifImage.id]);
+
+    await scannerService.scanAll('manual');
+
+    expect(readMediaMetadataMock).toHaveBeenCalledTimes(1);
+    expect(readMediaMetadataMock).toHaveBeenCalledWith(avifAbsolutePath, 'image', {
+      fileSize: avifStats.size
+    });
+
+    const refreshedAvif = imageRepository.getByRelativePath(avifRelativePath);
+    expect(refreshedAvif?.taken_at).toBe(Math.round(avifStats.mtimeMs));
+    expect(refreshedAvif?.taken_at_source).toBe('mtime');
+    expect(appSettingsRepository.get(AVIF_METADATA_REPAIR_VERSION_SETTING_KEY)).toBe('1');
+
+    expect(galleryService.getFeed(1, 10, 'recent').items.map((item) => item.id)).toEqual([avifImage.id, recentImage.id]);
+
+    readMediaMetadataMock.mockClear();
+
+    await scannerService.scanAll('manual');
+
+    expect(readMediaMetadataMock).not.toHaveBeenCalled();
+  });
+
+  it('repairs stale animated AVIF flags stored as non-animated rows during the one-time AVIF metadata repair scan', async () => {
+    const folder = createFolder('legacy');
+    const relativePath = 'legacy/animated.avif';
+    const absolutePath = await createSourceFile(relativePath, 'legacy-animated-avif');
+    const timestamp = Date.parse('2026-05-21T16:40:00.000Z');
+
+    await fs.utimes(absolutePath, timestamp / 1000, timestamp / 1000);
+
+    const stats = await fs.stat(absolutePath);
+    const image = imageRepository.upsert({
+      folderId: folder.id,
+      filename: 'animated.avif',
+      extension: '.avif',
+      relativePath,
+      absolutePath,
+      fileSize: stats.size,
+      width: 800,
+      height: 450,
+      displayOrientation: 1,
+      mediaType: 'image',
+      mimeType: getMimeTypeFromExtension('.avif'),
+      durationMs: null,
+      isAnimated: false,
+      fingerprint: createFingerprint(relativePath, stats.size, stats.mtimeMs),
+      mtimeMs: stats.mtimeMs,
+      firstSeenAt: new Date(timestamp).toISOString(),
+      sortTimestamp: Math.round(stats.mtimeMs),
+      takenAt: Math.round(stats.mtimeMs),
+      takenAtSource: 'mtime',
+      exifJson: '{}',
+      thumbnailPath: getThumbnailRelativePath(relativePath),
+      previewPath: getPreviewRelativePath(relativePath, 'image'),
+      playbackStrategy: 'preview'
+    });
+
+    expect(image.is_animated).toBe(0);
+
+    await scannerService.scanAll('manual');
+
+    const refreshed = imageRepository.getByRelativePath(relativePath);
+    expect(refreshed?.is_animated).toBe(1);
+  });
+
+  it('does not keep re-reading unchanged animated AVIF rows that legitimately retain EXIF timestamps after the one-time repair pass', async () => {
+    readMediaMetadataMock.mockImplementation(async (sourcePath: string) => {
+      const extension = path.extname(sourcePath).toLowerCase();
+
+      if (extension === '.avif') {
+        return {
+          width: 800,
+          height: 450,
+          displayOrientation: 1,
+          takenAt: Date.parse('2024-07-10T08:30:00.000Z'),
+          exif: null,
+          durationMs: null,
+          mediaType: 'image',
+          playbackStrategy: 'preview',
+          isAnimated: true
+        };
+      }
+
+      return {
+        width: 1600,
+        height: 1200,
+        displayOrientation: 1,
+        takenAt: null,
+        exif: null,
+        durationMs: null,
+        mediaType: 'image',
+        playbackStrategy: 'preview',
+        isAnimated: false
+      };
+    });
+
+    const folder = createFolder('exif-album');
+    const relativePath = 'exif-album/animated.avif';
+    const absolutePath = await createSourceFile(relativePath, 'exif-animated-avif');
+    const timestamp = Date.parse('2026-05-21T17:05:00.000Z');
+
+    await fs.utimes(absolutePath, timestamp / 1000, timestamp / 1000);
+
+    const stats = await fs.stat(absolutePath);
+    imageRepository.upsert({
+      folderId: folder.id,
+      filename: 'animated.avif',
+      extension: '.avif',
+      relativePath,
+      absolutePath,
+      fileSize: stats.size,
+      width: 800,
+      height: 450,
+      displayOrientation: 1,
+      mediaType: 'image',
+      mimeType: getMimeTypeFromExtension('.avif'),
+      durationMs: null,
+      isAnimated: true,
+      fingerprint: createFingerprint(relativePath, stats.size, stats.mtimeMs),
+      mtimeMs: stats.mtimeMs,
+      firstSeenAt: new Date(timestamp).toISOString(),
+      sortTimestamp: Math.round(stats.mtimeMs),
+      takenAt: Date.parse('2024-07-10T08:30:00.000Z'),
+      takenAtSource: 'exif',
+      exifJson: '{}',
+      thumbnailPath: getThumbnailRelativePath(relativePath),
+      previewPath: getPreviewRelativePath(relativePath, 'image'),
+      playbackStrategy: 'preview'
+    });
+
+    await scannerService.scanAll('manual');
+    expect(readMediaMetadataMock).toHaveBeenCalledTimes(1);
+
+    readMediaMetadataMock.mockClear();
+
+    await scannerService.scanAll('manual');
+    expect(readMediaMetadataMock).not.toHaveBeenCalled();
+  });
+
+  function createFolder(folderPath: string): FolderRecord {
+    return folderRepository.upsert({
+      slug: folderPath,
+      name: path.posix.basename(folderPath),
+      folderPath
+    });
+  }
+
+  async function createSourceFile(relativePath: string, contents: string): Promise<string> {
+    const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, contents);
+    return absolutePath;
+  }
+});

--- a/server/test/avif-support.test.ts
+++ b/server/test/avif-support.test.ts
@@ -1,0 +1,262 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import sharp from 'sharp';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const PROMISIFY_CUSTOM = Symbol.for('nodejs.util.promisify.custom');
+const { execFileMock, execFileAsyncMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  execFileAsyncMock: vi.fn()
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: Object.assign(execFileMock, {
+    [PROMISIFY_CUSTOM]: execFileAsyncMock
+  })
+}));
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type DerivativeServiceModule = typeof import('../src/services/derivative-service.js');
+
+describe.sequential('AVIF derivative strategy', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let generateDerivatives: DerivativeServiceModule['generateDerivatives'];
+  let generateThumbnailDerivative: DerivativeServiceModule['generateThumbnailDerivative'];
+  let generatePreviewDerivative: DerivativeServiceModule['generatePreviewDerivative'];
+  let readMediaMetadata: DerivativeServiceModule['readMediaMetadata'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'foldergram-avif-derivatives-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+
+    vi.resetModules();
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ generateDerivatives, generatePreviewDerivative, generateThumbnailDerivative, readMediaMetadata } = await import('../src/services/derivative-service.js'));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    execFileMock.mockReset();
+    execFileAsyncMock.mockReset();
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+  });
+
+  it('keeps static AVIF images on the Sharp image path so alpha survives in derivatives', async () => {
+    execFileAsyncMock.mockImplementation(async (command: string) => {
+      if (command === 'ffprobe') {
+        throw new Error('ffprobe should not be called for static AVIF');
+      }
+
+      return {
+        stdout: '',
+        stderr: ''
+      };
+    });
+
+    const sourcePath = path.join(appConfig.galleryRoot, 'albums', 'transparent.avif');
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await sharp({
+      create: {
+        width: 24,
+        height: 12,
+        channels: 4,
+        background: { r: 255, g: 88, b: 88, alpha: 0.5 }
+      }
+    })
+      .avif({ effort: 4 })
+      .toFile(sourcePath);
+
+    const result = await generateDerivatives(sourcePath, 'albums/transparent.avif', true);
+
+    expect(result.mediaType).toBe('image');
+    expect(result.isAnimated).toBe(false);
+    expect(result.generatedPreview).toBe(true);
+    expect(result.generatedThumbnail).toBe(true);
+
+    const ffmpegCalls = execFileAsyncMock.mock.calls.filter(([command]) => command === 'ffmpeg');
+    expect(ffmpegCalls).toHaveLength(0);
+
+    const previewMetadata = await sharp(path.join(appConfig.previewsDir, result.previewPath)).metadata();
+    const thumbnailMetadata = await sharp(path.join(appConfig.thumbnailsDir, result.thumbnailPath)).metadata();
+
+    expect(previewMetadata.hasAlpha).toBe(true);
+    expect(thumbnailMetadata.hasAlpha).toBe(true);
+    expect(execFileAsyncMock.mock.calls.filter(([command]) => command === 'ffprobe')).toHaveLength(0);
+  });
+
+  it('reads static AVIF metadata without requiring ffprobe', async () => {
+    execFileAsyncMock.mockImplementation(async (command: string) => {
+      if (command === 'ffprobe') {
+        throw new Error('ffprobe should not be called for static AVIF metadata');
+      }
+
+      return {
+        stdout: '',
+        stderr: ''
+      };
+    });
+
+    const sourcePath = path.join(appConfig.galleryRoot, 'albums', 'metadata-only.avif');
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await sharp({
+      create: {
+        width: 20,
+        height: 10,
+        channels: 4,
+        background: { r: 12, g: 34, b: 56, alpha: 0.8 }
+      }
+    })
+      .avif({ effort: 4 })
+      .toFile(sourcePath);
+
+    const metadata = await readMediaMetadata(sourcePath, 'image');
+
+    expect(metadata.mediaType).toBe('image');
+    expect(metadata.isAnimated).toBe(false);
+    expect(metadata.width).toBe(20);
+    expect(metadata.height).toBe(10);
+    expect(execFileAsyncMock.mock.calls.filter(([command]) => command === 'ffprobe')).toHaveLength(0);
+  });
+
+  it('routes animated AVIF image sequences through ffmpeg while keeping image semantics', async () => {
+    execFileAsyncMock.mockImplementation(createExecFileAsyncMock(animatedAvifProbePayload()));
+
+    const sourcePath = path.join(appConfig.galleryRoot, 'albums', 'animated.avif');
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, Buffer.from('animated-avif'));
+
+    const result = await generateDerivatives(sourcePath, 'albums/animated.avif', true);
+
+    expect(result.mediaType).toBe('image');
+    expect(result.isAnimated).toBe(true);
+    expect(result.durationMs).toBeNull();
+    expect(result.takenAt).toBeNull();
+    expect(result.generatedPreview).toBe(true);
+    expect(result.generatedThumbnail).toBe(true);
+    expect(result.previewPath).toBe('albums/animated.webp');
+    expect(result.thumbnailPath).toBe('albums/animated.webp');
+
+    const ffprobeCalls = execFileAsyncMock.mock.calls.filter(([command]) => command === 'ffprobe');
+    const ffmpegCalls = execFileAsyncMock.mock.calls.filter(([command]) => command === 'ffmpeg');
+    expect(ffprobeCalls).toHaveLength(1);
+    expect(ffmpegCalls).toHaveLength(2);
+    expect(ffmpegCalls[0]?.[1]).toContain('0:v:1');
+    expect(ffmpegCalls[0]?.[1].some((arg: string) => arg.includes('thumbnail'))).toBe(true);
+    expect(ffmpegCalls[1]?.[1]).toContain('0:v:1');
+    expect(ffmpegCalls[1]?.[1].some((arg: string) => arg.includes("scale='min(1500,iw)':-2:flags=lanczos"))).toBe(true);
+    expect(ffmpegCalls[1]?.[1]).toContain('-loop');
+  });
+
+  it('uses the animated AVIF ffmpeg thumbnail path during thumbnail-only rebuilds', async () => {
+    execFileAsyncMock.mockImplementation(createExecFileAsyncMock(animatedAvifProbePayload()));
+
+    const sourcePath = path.join(appConfig.galleryRoot, 'albums', 'animated-thumb.avif');
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, Buffer.from('animated-avif-thumb'));
+
+    const result = await generateThumbnailDerivative(sourcePath, 'albums/animated-thumb.avif', true);
+
+    expect(result.generatedThumbnail).toBe(true);
+    expect(result.thumbnailPath).toBe('albums/animated-thumb.webp');
+
+    const ffprobeCalls = execFileAsyncMock.mock.calls.filter(([command]) => command === 'ffprobe');
+    const ffmpegCalls = execFileAsyncMock.mock.calls.filter(([command]) => command === 'ffmpeg');
+    expect(ffprobeCalls).toHaveLength(1);
+    expect(ffmpegCalls).toHaveLength(1);
+    expect(ffmpegCalls[0]?.[1]).toContain('0:v:1');
+    expect(ffmpegCalls[0]?.[1].some((arg: string) => arg.includes('thumbnail'))).toBe(true);
+  });
+
+  it('uses the animated AVIF ffmpeg preview path during preview-only generation', async () => {
+    execFileAsyncMock.mockImplementation(createExecFileAsyncMock(animatedAvifProbePayload()));
+
+    const sourcePath = path.join(appConfig.galleryRoot, 'albums', 'animated-preview.avif');
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, Buffer.from('animated-avif-preview'));
+
+    const result = await generatePreviewDerivative(sourcePath, 'albums/animated-preview.avif', true);
+
+    expect(result.generatedPreview).toBe(true);
+    expect(result.previewPath).toBe('albums/animated-preview.webp');
+
+    const ffprobeCalls = execFileAsyncMock.mock.calls.filter(([command]) => command === 'ffprobe');
+    const ffmpegCalls = execFileAsyncMock.mock.calls.filter(([command]) => command === 'ffmpeg');
+    expect(ffprobeCalls).toHaveLength(1);
+    expect(ffmpegCalls).toHaveLength(1);
+    expect(ffmpegCalls[0]?.[1]).toContain('0:v:1');
+    expect(ffmpegCalls[0]?.[1].some((arg: string) => arg.includes("scale='min(1500,iw)':-2:flags=lanczos"))).toBe(true);
+  });
+});
+
+function createExecFileAsyncMock(payload: unknown) {
+  return async (command: string) => {
+    if (command === 'ffprobe') {
+      return {
+        stdout: JSON.stringify(payload),
+        stderr: ''
+      };
+    }
+
+    return {
+      stdout: '',
+      stderr: ''
+    };
+  };
+}
+
+function animatedAvifProbePayload() {
+  return {
+    format: {
+      format_name: 'mov,mp4,m4a,3gp,3g2,mj2',
+      tags: {
+        major_brand: 'avis',
+        compatible_brands: 'avismsf1miafMA1B',
+        creation_time: '2020-09-13T22:30:30.000000Z'
+      }
+    },
+    streams: [
+      {
+        codec_type: 'video',
+        codec_name: 'av1',
+        width: 800,
+        height: 450,
+        pix_fmt: 'yuv420p',
+        nb_frames: '1',
+        tags: {
+          title: 'Image'
+        }
+      },
+      {
+        codec_type: 'video',
+        codec_name: 'av1',
+        width: 800,
+        height: 450,
+        pix_fmt: 'yuv420p',
+        duration: '10.844167',
+        nb_frames: '325',
+        tags: {
+          handler_name: 'GPAC avifs'
+        }
+      }
+    ]
+  };
+}

--- a/server/test/folder-cover-scanner.test.ts
+++ b/server/test/folder-cover-scanner.test.ts
@@ -124,6 +124,19 @@ describe.sequential('folder cover scanner', () => {
     expect(avatarImage!.filename).toBe('cover.png');
   });
 
+  it('respects cover.avif when higher-priority cover files are absent', async () => {
+    maintenanceRepository.resetLibraryIndex();
+
+    await createSourceFile('nature/photo-1.jpg');
+    await createSourceFile('nature/cover.avif');
+
+    await scannerService.scanAll('manual');
+
+    const folder = folderRepository.getBySlug('nature');
+    const avatarImage = imageRepository.getById(folder!.avatar_image_id!);
+    expect(avatarImage!.filename).toBe('cover.avif');
+  });
+
   async function createSourceFile(relativePath: string, mtimeOffsetMs = 0): Promise<void> {
     const absolutePath = path.join(appConfig.galleryRoot, relativePath);
     await fs.mkdir(path.dirname(absolutePath), { recursive: true });

--- a/server/test/image-utils.test.ts
+++ b/server/test/image-utils.test.ts
@@ -7,6 +7,7 @@ import {
   getPreviewRelativePath,
   getStableSortTimestamp,
   getThumbnailRelativePath,
+  isSupportedImageFile,
   isSupportedMediaFile,
   isSupportedVideoFile
 } from '../src/utils/image-utils.js';
@@ -38,6 +39,12 @@ describe('scanner utilities', () => {
     expect(isSupportedVideoFile('clip.mp4')).toBe(true);
     expect(isSupportedMediaFile('clip.webm')).toBe(true);
     expect(getMediaTypeFromExtension('.mov')).toBe('video');
+  });
+
+  it('detects supported AVIF image files', () => {
+    expect(isSupportedImageFile('poster.avif')).toBe(true);
+    expect(isSupportedMediaFile('poster.avif')).toBe(true);
+    expect(getMediaTypeFromExtension('.avif')).toBe('image');
   });
 
   it('preserves existing sort timestamps before mtime fallback', () => {

--- a/server/test/lazy-derivatives.test.ts
+++ b/server/test/lazy-derivatives.test.ts
@@ -26,9 +26,8 @@ type PlaybackStrategy = ModelsModule['PlaybackStrategy'];
 
 const generateThumbnailDerivativeMock = vi.fn();
 const generateDerivativesMock = vi.fn();
+const generatePreviewDerivativeMock = vi.fn();
 const readMediaMetadataMock = vi.fn();
-const writeImagePreviewMock = vi.fn();
-const writeVideoPreviewMock = vi.fn();
 
 describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
   let tempRoot = '';
@@ -45,9 +44,8 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
   async function reset(derivativeMode = 'lazy', scanDerivativeConcurrency = 4) {
     generateThumbnailDerivativeMock.mockReset();
     generateDerivativesMock.mockReset();
+    generatePreviewDerivativeMock.mockReset();
     readMediaMetadataMock.mockReset();
-    writeImagePreviewMock.mockReset();
-    writeVideoPreviewMock.mockReset();
 
     await fs.rm(tempRoot, { recursive: true, force: true });
     await fs.mkdir(tempRoot, { recursive: true });
@@ -55,10 +53,9 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
     vi.resetModules();
     vi.doMock('../src/services/derivative-service.js', () => ({
       generateDerivatives: generateDerivativesMock,
+      generatePreviewDerivative: generatePreviewDerivativeMock,
       generateThumbnailDerivative: generateThumbnailDerivativeMock,
-      readMediaMetadata: readMediaMetadataMock,
-      writeImagePreview: writeImagePreviewMock,
-      writeVideoPreview: writeVideoPreviewMock
+      readMediaMetadata: readMediaMetadataMock
     }));
 
     vi.stubEnv('DERIVATIVE_MODE', derivativeMode);
@@ -123,14 +120,20 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
       };
     });
 
-    writeImagePreviewMock.mockImplementation(async (_src: string, previewAbsolutePath: string) => {
+    generatePreviewDerivativeMock.mockImplementation(async (_src: string, relativePath: string, _force = false, overrides?: { previewPath?: string }) => {
+      const previewPath = overrides?.previewPath ?? getPreviewRelativePath(relativePath, getMediaTypeFromExtension(path.extname(relativePath)));
+      const previewAbsolutePath = path.join(appConfig.previewsDir, previewPath);
       await fs.mkdir(path.dirname(previewAbsolutePath), { recursive: true });
-      await fs.writeFile(previewAbsolutePath, `image-preview:${path.basename(previewAbsolutePath)}`);
-    });
-
-    writeVideoPreviewMock.mockImplementation(async (_src: string, previewAbsolutePath: string) => {
-      await fs.mkdir(path.dirname(previewAbsolutePath), { recursive: true });
-      await fs.writeFile(previewAbsolutePath, `video-preview:${path.basename(previewAbsolutePath)}`);
+      const suffix = path.extname(relativePath).toLowerCase() === '.mp4'
+        ? 'video-preview'
+        : path.extname(relativePath).toLowerCase() === '.avif'
+          ? 'animated-avif-preview'
+          : 'image-preview';
+      await fs.writeFile(previewAbsolutePath, `${suffix}:${path.basename(previewAbsolutePath)}`);
+      return {
+        previewPath,
+        generatedPreview: true
+      };
     });
   }
 
@@ -254,7 +257,7 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
     mtimeMs: number,
     playbackStrategy: PlaybackStrategy,
     durationMs: number | null = null,
-    options: { storedGalleryRoot?: string } = {}
+    options: { storedGalleryRoot?: string; isAnimated?: boolean | null } = {}
   ) {
     const relativePath = `${folder.folder_path}/${filename}`;
     const absolutePath = options.storedGalleryRoot
@@ -278,6 +281,7 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
       mediaType,
       mimeType: getMimeTypeFromExtension(extension),
       durationMs,
+      isAnimated: options.isAnimated ?? false,
       fingerprint: createFingerprint(relativePath, fileSize, mtimeMs),
       mtimeMs,
       firstSeenAt: '2026-01-01T00:00:00.000Z',
@@ -419,8 +423,7 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
     const response = await dispatchRoute(lazyPreviewsRouter, `/${encodeRelativePath(image.preview_path)}`);
     expect(response.statusCode).toBe(200);
     expect(response.body).toBe('image-preview:photo.webp');
-    expect(writeImagePreviewMock).toHaveBeenCalledOnce();
-    expect(writeVideoPreviewMock).not.toHaveBeenCalled();
+    expect(generatePreviewDerivativeMock).toHaveBeenCalledOnce();
   });
 
   it('generates a missing image preview from the current gallery root when the cached absolute path is stale', async () => {
@@ -436,9 +439,32 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
     const response = await dispatchRoute(lazyPreviewsRouter, `/${encodeRelativePath(image.preview_path)}`);
 
     expect(response.statusCode).toBe(200);
-    expect(writeImagePreviewMock).toHaveBeenCalledWith(
+    expect(generatePreviewDerivativeMock).toHaveBeenCalledWith(
       path.join(appConfig.galleryRoot, image.relative_path),
-      path.join(appConfig.previewsDir, image.preview_path)
+      image.relative_path,
+      false,
+      { previewPath: image.preview_path }
+    );
+  });
+
+  it('generates a missing animated AVIF preview through the AVIF-aware preview generator', async () => {
+    await reset('lazy');
+
+    maintenanceRepository.resetLibraryIndex();
+    const folder = folderRepository.upsert({ slug: 'animated-avif', name: 'Animated AVIF', folderPath: 'animated-avif' });
+    const image = createIndexedMedia(folder, 'clip.avif', 3_400, 'preview', null, {
+      isAnimated: true
+    });
+
+    const response = await dispatchRoute(lazyPreviewsRouter, `/${encodeRelativePath(image.preview_path)}`);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe('animated-avif-preview:clip.webp');
+    expect(generatePreviewDerivativeMock).toHaveBeenCalledWith(
+      path.join(appConfig.galleryRoot, image.relative_path),
+      image.relative_path,
+      false,
+      { previewPath: image.preview_path }
     );
   });
 
@@ -450,7 +476,9 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
     const video = createIndexedMedia(folder, 'clip.mp4', 4000, 'original', 5000);
     let releaseGeneration: (() => void) | null = null;
     const generationStarted = new Promise<void>((resolve) => {
-      writeVideoPreviewMock.mockImplementationOnce(async (_src: string, previewAbsolutePath: string) => {
+      generatePreviewDerivativeMock.mockImplementationOnce(async (_src: string, relativePath: string, _force = false, overrides?: { previewPath?: string }) => {
+        const previewPath = overrides?.previewPath ?? getPreviewRelativePath(relativePath, 'video');
+        const previewAbsolutePath = path.join(appConfig.previewsDir, previewPath);
         resolve();
         await new Promise<void>((generationResolve) => {
           releaseGeneration = generationResolve;
@@ -471,7 +499,7 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
     expect(secondResponse.statusCode).toBe(200);
     expect(firstResponse.body).toBe('video-preview:clip.mp4');
     expect(secondResponse.body).toBe('video-preview:clip.mp4');
-    expect(writeVideoPreviewMock).toHaveBeenCalledOnce();
+    expect(generatePreviewDerivativeMock).toHaveBeenCalledOnce();
   });
 
   it('limits concurrent generation for different missing derivatives', async () => {


### PR DESCRIPTION
This PR adds full AVIF support to Foldergram, including both static AVIF images and animated AVIF image sequences.

Static AVIF files now behave like normal images throughout the app. They are indexed as images, use the regular Sharp-based image path, preserve expected image behavior such as transparency, and do not require `ffprobe` for normal metadata handling.

Animated AVIF files are now detected during scanning and kept in the image flow instead of being treated like videos. Foldergram generates static WebP thumbnails for grid-style surfaces and animated WebP previews for feed/detail viewing, so animated AVIF content displays like an image post rather than going through the video player.

Folder cover support now includes `cover.avif`.

Closes #67 