### PR TITLE
Add automatic Dbmate migrations for SQLite startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,8 @@ DERIVATIVE_MODE=eager
 
 # Scan and logging
 LOG_VERBOSE=0
+# Controls scan-time supported-media failures: 'skip' (default, report and continue) or 'fail' (stop on first error)
+SCAN_MEDIA_ERROR_MODE=skip
 SCAN_DISCOVERY_CONCURRENCY=4
 SCAN_DERIVATIVE_CONCURRENCY=4
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ data/
   └─ previews/      # Generated previews, sharded by asset key
 ```
 
-`GALLERY_ROOT` only needs read access. `DB_DIR`, `THUMBNAILS_DIR`, and `PREVIEWS_DIR` must be writable.
+`GALLERY_ROOT` only needs read access. `DB_DIR`, `THUMBNAILS_DIR`, and
+`PREVIEWS_DIR` must be writable. `<DATA_ROOT>/scan-errors` is created on
+demand and must be writable when skip mode produces scan reports.
 
 | Variable                      | Default             | Description                                                               |
 | ----------------------------- | ------------------- | ------------------------------------------------------------------------- |
@@ -238,6 +240,7 @@ data/
 | `IMAGE_DETAIL_SOURCE`         | `preview`           | For image detail pages, use generated previews or stream originals.       |
 | `DERIVATIVE_MODE`             | `eager`             | Generate derivatives during scans or lazily on first request.             |
 | `LOG_VERBOSE`                 | `0`                 | Truthy values are `1`, `true`, `yes`, and `on`.                           |
+| `SCAN_MEDIA_ERROR_MODE`       | `skip`              | Use `skip` to report supported-media failures and continue, or `fail`.    |
 | `SCAN_DISCOVERY_CONCURRENCY`  | `4`                 | Folder discovery concurrency.                                             |
 | `SCAN_DERIVATIVE_CONCURRENCY` | `4`                 | Derivative generation concurrency.                                        |
 | `PUBLIC_DEMO_MODE`            | `0`                 | When enabled, all API mutations become read-only and return `403`.        |
@@ -248,6 +251,8 @@ only `DATA_ROOT`, Foldergram will default the other storage paths to
 `<DATA_ROOT>/gallery`, `<DATA_ROOT>/db`, `<DATA_ROOT>/thumbnails`, and
 `<DATA_ROOT>/previews`. Set `GALLERY_ROOT`, `DB_DIR`, `THUMBNAILS_DIR`, or
 `PREVIEWS_DIR` separately only when you need a non-standard layout.
+Per-run full scan error reports are written under `<DATA_ROOT>/scan-errors/`
+when a scan records supported-media failures.
 
 Docker uses the fixed internal container port `4141`, and other production
 runtimes continue to use `SERVER_PORT`, which defaults to `4141` in the Docker
@@ -272,6 +277,9 @@ not read directly by the container.
 - `IMAGE_DETAIL_SOURCE=original` makes image detail pages stream `/api/originals/:id`.
 - `DERIVATIVE_MODE=eager` generates thumbnails and previews during scans.
 - `DERIVATIVE_MODE=lazy` indexes metadata during scans, then generates missing files the first time `/thumbnails/...` or `/previews/...` is requested and caches them on disk.
+- `SCAN_MEDIA_ERROR_MODE=skip` reports supported image and video processing failures, skips those files, and lets the scan finish as `completed_with_errors`.
+- `SCAN_MEDIA_ERROR_MODE=fail` preserves fail-fast behavior for those same scan-time media errors.
+- When a scan records skipped media failures, Foldergram stores a short sample in SQLite, writes the full per-run report under `<DATA_ROOT>/scan-errors/`, and shows that report path in the admin Settings view.
 
 These flags are independent:
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ pnpm dev
 npm run dev
 ```
 
+`pnpm dev`, `pnpm dev:server`, and `pnpm start` now run versioned SQLite
+migrations automatically before the server boots. Use `pnpm migrate` if you
+want to apply pending migrations without starting the app.
+
 Development ports:
 
 - Client: prefers `http://localhost:4141` and automatically uses the next free port up to `4144`
@@ -234,7 +238,7 @@ demand and must be writable when skip mode produces scan reports.
 | `DATA_ROOT`                   | `./data`            | Root directory for app-managed storage.                                   |
 | `GALLERY_ROOT`                | `./data/gallery`    | Root directory scanned for App Folders.                                   |
 | `GALLERY_EXCLUDED_FOLDERS`    | empty               | Comma-separated folder exclusion rules such as `@eaDir,Archive/cache`.    |
-| `DB_DIR`                      | `./data/db`         | SQLite database directory.                                                |
+| `DB_DIR`                      | `./data/db`         | SQLite database directory. Startup migrations target `<DB_DIR>/gallery.sqlite`. |
 | `THUMBNAILS_DIR`              | `./data/thumbnails` | Generated thumbnail output directory.                                     |
 | `PREVIEWS_DIR`                | `./data/previews`   | Generated preview output directory.                                       |
 | `IMAGE_DETAIL_SOURCE`         | `preview`           | For image detail pages, use generated previews or stream originals.       |
@@ -347,6 +351,7 @@ only needed when the browser-visible origin differs from the upstream Node host 
 - `pnpm dev:client`
 - `pnpm dev:docs`
 - `pnpm build`
+- `pnpm migrate`
 - `pnpm start`
 - `pnpm test`
 - `pnpm rescan`

--- a/client/src/components/ReelInfoSidebar.test.ts
+++ b/client/src/components/ReelInfoSidebar.test.ts
@@ -132,4 +132,29 @@ describe('ReelInfoSidebar', () => {
 
     expect(fetchImageMock).toHaveBeenCalledTimes(1);
   });
+
+  it('applies the right-side anchor styling when requested', async () => {
+    const wrapper = mount(ReelInfoSidebar, {
+      props: {
+        item: createFeedItem(18),
+        folder: createFolder(),
+        open: false,
+        anchor: 'right'
+      },
+      global: {
+        stubs: {
+          Avatar: {
+            template: '<div data-test="avatar" />'
+          },
+          RouterLink: {
+            template: '<a><slot /></a>'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    expect(wrapper.get('.reels-info-sidebar').classes()).toContain('reels-info-sidebar--anchor-right');
+  });
 });

--- a/client/src/components/ReelInfoSidebar.vue
+++ b/client/src/components/ReelInfoSidebar.vue
@@ -1,5 +1,9 @@
 <template>
-  <aside class="reels-info-sidebar sidebar" aria-label="Reel details">
+  <aside
+    class="reels-info-sidebar sidebar"
+    :class="{ 'reels-info-sidebar--anchor-right': anchor === 'right' }"
+    aria-label="Reel details"
+  >
     <div class="reels-info-sidebar__header">
       <p class="reels-info-sidebar__eyebrow">Reel Details</p>
 
@@ -103,11 +107,14 @@ import type { FeedItem, FolderSummary, ImageDetail } from '../types/api';
 import { formatMediaDuration } from '../utils/media';
 import Avatar from './Avatar.vue';
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   item: FeedItem;
   folder: FolderSummary | null;
   open: boolean;
-}>();
+  anchor?: 'left' | 'right';
+}>(), {
+  anchor: 'left'
+});
 
 defineEmits<{
   close: [];
@@ -234,6 +241,13 @@ watch(
   border-left: 1px solid color-mix(in srgb, var(--border) 86%, transparent 14%);
   background: color-mix(in srgb, var(--surface) 96%, white 4%);
   transform: rotate(45deg);
+}
+
+.reels-info-sidebar--anchor-right::before {
+  right: -0.5rem;
+  left: auto;
+  border-right: 1px solid color-mix(in srgb, var(--border) 86%, transparent 14%);
+  border-left: 0;
 }
 
 .reels-info-sidebar__header {

--- a/client/src/components/ReelPlayerCard.vue
+++ b/client/src/components/ReelPlayerCard.vue
@@ -397,7 +397,8 @@ onBeforeUnmount(() => {
 
 <style scoped>
 .reel-player-card {
-  --reel-stage-gap: 1.25rem;
+  --reel-stage-gap: 0.75rem;
+  --reel-stage-inline-gap: 1.25rem;
   --reel-stage-max-width: 24.4rem;
   --reel-stage-max-height: calc(var(--reel-stage-max-width) * 16 / 9);
   display: grid;
@@ -412,12 +413,16 @@ onBeforeUnmount(() => {
   position: relative;
   justify-self: center;
   align-self: center;
-  width: auto;
-  max-width: min(100%, var(--reel-stage-max-width));
-  height: min(calc(100% - var(--reel-stage-gap)), var(--reel-stage-max-height));
+  width: min(100%, var(--reels-desktop-stage-width, var(--reel-stage-max-width)));
+  height: min(
+    calc(100% - var(--reel-stage-gap)),
+    var(--reels-desktop-stage-height, var(--reel-stage-max-height))
+  );
+  max-height: 100%;
+  max-width: calc(100% - var(--reel-stage-inline-gap));
   aspect-ratio: 9 / 16;
   overflow: hidden;
-  border-radius: 1.15rem;
+  border-radius: 0.6rem;
   background: #000;
   box-shadow: none;
 }

--- a/client/src/views/ReelsView.test.ts
+++ b/client/src/views/ReelsView.test.ts
@@ -119,11 +119,15 @@ vi.mock('../components/ReelInfoSidebar.vue', async () => {
         open: {
           type: Boolean,
           default: false
+        },
+        anchor: {
+          type: String,
+          default: 'left'
         }
       },
       emits: ['close'],
       template:
-        '<aside data-test="info-sidebar">{{ item.id }}<button data-test="close-info" @click="$emit(\'close\')">close</button></aside>'
+        '<aside data-test="info-sidebar" :data-anchor="anchor">{{ item.id }}<button data-test="close-info" @click="$emit(\'close\')">close</button></aside>'
     })
   };
 });
@@ -214,6 +218,11 @@ describe('ReelsView', () => {
       writable: true,
       value: 1280
     });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 720
+    });
     deckControls.goToPrevious.mockReset();
     deckControls.goToNext.mockReset();
     deckControls.navigateByWheel.mockReset();
@@ -282,6 +291,7 @@ describe('ReelsView', () => {
     expect(wrapper.get('.reels-view__action-rail--desktop').attributes('data-open')).toBe('true');
     expect(wrapper.find('[data-test="info-shell"]').exists()).toBe(true);
     expect(wrapper.get('[data-test="info-sidebar"]').text()).toContain('101');
+    expect(wrapper.get('[data-test="info-sidebar"]').attributes('data-anchor')).toBe('left');
     expect(wrapper.find('button[aria-label="Next reel"]').exists()).toBe(true);
 
     await wrapper.get('[data-test="close-info"]').trigger('click');
@@ -289,6 +299,30 @@ describe('ReelsView', () => {
 
     expect(wrapper.get('.reels-view__action-rail--desktop').attributes('data-open')).toBe('false');
     expect(wrapper.find('[data-test="info-shell"]').exists()).toBe(false);
+  });
+
+  it('opens desktop reel details back over the reel in portrait-style desktop viewports', async () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 920
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 1280
+    });
+
+    const reelsStore = useReelsStore();
+    vi.spyOn(reelsStore, 'loadInitial').mockResolvedValue(undefined);
+
+    const wrapper = mount(ReelsView);
+    await flushPromises();
+
+    await wrapper.get('.reels-view__action-rail--desktop [data-test="toggle-info"]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.get('[data-test="info-sidebar"]').attributes('data-anchor')).toBe('right');
   });
 
   it('renders the action rail inside the active reel on mobile viewports', async () => {

--- a/client/src/views/ReelsView.vue
+++ b/client/src/views/ReelsView.vue
@@ -49,6 +49,7 @@
                     <ReelInfoSidebar
                       :item="item"
                       :folder="activeFolder"
+                      anchor="right"
                       :open="isInfoSidebarOpen"
                       @close="closeInfoSidebar"
                     />
@@ -60,64 +61,68 @@
         </ReelDeck>
       </div>
 
-      <ReelActionRail
-        v-if="activeItem && !isMobileViewport"
-        class="reels-view__action-rail reels-view__action-rail--desktop"
-        :item="activeItem"
-        :info-open="isInfoSidebarOpen"
-        @toggle-info="handleInfoToggle"
-      >
-        <template #info-panel>
-          <Transition name="reels-info-popup">
-            <div v-if="isInfoSidebarOpen" data-test="info-shell" class="reels-view__info-shell">
-              <ReelInfoSidebar
-                :item="activeItem"
-                :folder="activeFolder"
-                :open="isInfoSidebarOpen"
-                @close="closeInfoSidebar"
+      <div v-if="!isMobileViewport" class="reels-view__right-column">
+        <div class="reels-view__nav-controls" aria-label="Reel navigation">
+          <button
+            class="reels-view__nav-button"
+            type="button"
+            aria-label="Previous reel"
+            :disabled="!canGoPrevious"
+            @click="goToPrevious"
+          >
+            <svg class="reels-view__nav-icon" viewBox="0 0 24 24" role="presentation">
+              <path
+                d="m6.75 14.75 5.25-5.25 5.25 5.25"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.9"
               />
-            </div>
-          </Transition>
-        </template>
-      </ReelActionRail>
+            </svg>
+          </button>
+          <button
+            class="reels-view__nav-button"
+            type="button"
+            aria-label="Next reel"
+            :disabled="!canGoNext"
+            @click="goToNext"
+          >
+            <svg class="reels-view__nav-icon" viewBox="0 0 24 24" role="presentation">
+              <path
+                d="m6.75 9.25 5.25 5.25 5.25-5.25"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.9"
+              />
+            </svg>
+          </button>
+        </div>
 
-      <div class="reels-view__nav-controls hidden md:grid" aria-label="Reel navigation">
-        <button
-          class="reels-view__nav-button"
-          type="button"
-          aria-label="Previous reel"
-          :disabled="!canGoPrevious"
-          @click="goToPrevious"
+        <ReelActionRail
+          v-if="activeItem"
+          class="reels-view__action-rail reels-view__action-rail--desktop"
+          :class="desktopInfoPanelSideClass"
+          :item="activeItem"
+          :info-open="isInfoSidebarOpen"
+          @toggle-info="handleInfoToggle"
         >
-          <svg class="reels-view__nav-icon" viewBox="0 0 24 24" role="presentation">
-            <path
-              d="m6.75 14.75 5.25-5.25 5.25 5.25"
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1.9"
-            />
-          </svg>
-        </button>
-        <button
-          class="reels-view__nav-button"
-          type="button"
-          aria-label="Next reel"
-          :disabled="!canGoNext"
-          @click="goToNext"
-        >
-          <svg class="reels-view__nav-icon" viewBox="0 0 24 24" role="presentation">
-            <path
-              d="m6.75 9.25 5.25 5.25 5.25-5.25"
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1.9"
-            />
-          </svg>
-        </button>
+          <template #info-panel>
+            <Transition name="reels-info-popup">
+              <div v-if="isInfoSidebarOpen" data-test="info-shell" class="reels-view__info-shell">
+                <ReelInfoSidebar
+                  :item="activeItem"
+                  :folder="activeFolder"
+                  :anchor="desktopInfoSidebarAnchor"
+                  :open="isInfoSidebarOpen"
+                  @close="closeInfoSidebar"
+                />
+              </div>
+            </Transition>
+          </template>
+        </ReelActionRail>
       </div>
     </div>
   </section>
@@ -138,7 +143,20 @@ const foldersStore = useFoldersStore();
 const reelsStore = useReelsStore();
 const deckElement = ref<InstanceType<typeof ReelDeck> | null>(null);
 const isInfoSidebarOpen = ref(false);
-const isMobileViewport = ref(typeof window !== 'undefined' ? window.innerWidth <= 768 : false);
+const viewportWidth = ref(typeof window !== 'undefined' ? window.innerWidth : 0);
+const viewportHeight = ref(typeof window !== 'undefined' ? window.innerHeight : 0);
+const isMobileViewport = computed(() => viewportWidth.value <= 768);
+const desktopInfoPanelSide = computed<'left' | 'right'>(() =>
+  !isMobileViewport.value && viewportWidth.value > viewportHeight.value ? 'right' : 'left'
+);
+const desktopInfoPanelSideClass = computed(() =>
+  desktopInfoPanelSide.value === 'right'
+    ? 'reels-view__action-rail--desktop-info-right'
+    : 'reels-view__action-rail--desktop-info-left'
+);
+const desktopInfoSidebarAnchor = computed<'left' | 'right'>(() =>
+  desktopInfoPanelSide.value === 'right' ? 'left' : 'right'
+);
 
 const activeItem = computed(() => reelsStore.activeItem);
 const activeFolder = computed(() =>
@@ -174,7 +192,8 @@ function closeInfoSidebar() {
 }
 
 function updateViewportMode() {
-  isMobileViewport.value = window.innerWidth <= 768;
+  viewportWidth.value = window.innerWidth;
+  viewportHeight.value = window.innerHeight;
 }
 
 function shouldCaptureGlobalWheel(event: WheelEvent) {
@@ -235,26 +254,86 @@ watch(activeItem, (item) => {
 }
 
 .reels-view__layout {
+  --reels-desktop-rail-width: 3.8rem;
+  --reels-desktop-column-gap: 0.85rem;
+  --reel-stage-block-gap: 0.75rem;
+  --reel-stage-inline-gap: 1.25rem;
+  --reels-desktop-stage-width: 24.4rem;
+  --reels-desktop-stage-height: calc(var(--reels-desktop-stage-width) * 16 / 9);
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 24.4rem) 3.4rem;
+  grid-template-columns: minmax(0, var(--reels-desktop-stage-width)) var(--reels-desktop-rail-width);
+  column-gap: var(--reels-desktop-column-gap);
   justify-content: center;
-  align-items: stretch;
-  column-gap: 1rem;
+  align-items: center;
   height: 100%;
   min-height: 100%;
   width: 100%;
-  padding: 0 1.25rem;
+  padding: 0 0.75rem;
+  container-type: size;
+}
+
+@supports (width: 1cqw) {
+  .reels-view__layout {
+    --reels-desktop-stage-width: min(
+      calc((100cqh - var(--reel-stage-block-gap)) * 9 / 16),
+      calc(100cqw - var(--reels-desktop-rail-width) - var(--reels-desktop-column-gap) - var(--reel-stage-inline-gap))
+    );
+    --reels-desktop-stage-height: calc(var(--reels-desktop-stage-width) * 16 / 9);
+  }
 }
 
 .reels-view__deck-shell {
   height: 100%;
   min-height: 0;
+  min-width: 0;
 }
 
-.reels-view__action-rail {
-  align-self: end;
-  margin-bottom: 4.8rem;
+/* ── Right column: nav arrows centered + action rail bottom-aligned ── */
+
+.reels-view__right-column {
+  width: var(--reels-desktop-rail-width);
+  height: var(--reels-desktop-stage-height);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  align-self: center;
+}
+
+.reels-view__action-rail--desktop {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.reels-view__action-rail--desktop :deep(.reel-action-rail__button) {
+  color: color-mix(in srgb, var(--text) 82%, transparent);
+}
+
+.reels-view__action-rail--desktop :deep(.reel-action-rail__button:hover:not(:disabled)) {
+  color: var(--text);
+}
+
+.reels-view__action-rail--desktop :deep(.reel-action-rail__icon) {
+  width: 1.6rem;
+  height: 1.6rem;
+}
+
+.reels-view__action-rail--desktop :deep(.reel-action-rail__info-panel) {
+  bottom: 0;
+}
+
+.reels-view__action-rail--desktop-info-left :deep(.reel-action-rail__info-panel) {
+  right: calc(100% + 0.9rem);
+  left: auto;
+}
+
+.reels-view__action-rail--desktop-info-right :deep(.reel-action-rail__info-panel) {
+  left: calc(100% + 0.9rem);
+  right: auto;
 }
 
 .reels-view__action-rail--mobile {
@@ -280,28 +359,26 @@ watch(activeItem, (item) => {
   left: auto;
 }
 
+/* ── Nav controls: centered in the right column ── */
+
 .reels-view__nav-controls {
-  position: fixed;
-  top: 50%;
-  right: max(1rem, env(safe-area-inset-right));
-  z-index: 12;
-  gap: 0.9rem;
-  transform: translateY(-50%);
+  display: grid;
+  gap: 0.75rem;
 }
 
 .reels-view__nav-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 3.35rem;
-  height: 3.35rem;
+  width: 2.8rem;
+  height: 2.8rem;
   padding: 0;
   border: 0;
   border-radius: 999px;
   background: color-mix(in srgb, var(--surface) 78%, var(--text) 22%);
   color: var(--text);
   cursor: pointer;
-  box-shadow: 0 10px 24px rgba(15, 20, 25, 0.16);
+  box-shadow: 0 8px 20px rgba(15, 20, 25, 0.14);
   transition:
     transform 0.16s ease,
     opacity 0.16s ease,
@@ -319,8 +396,8 @@ watch(activeItem, (item) => {
 }
 
 .reels-view__nav-icon {
-  width: 1.3rem;
-  height: 1.3rem;
+  width: 1.15rem;
+  height: 1.15rem;
 }
 
 .reels-view__message-card {
@@ -361,7 +438,7 @@ watch(activeItem, (item) => {
 
 @media (max-width: 768px) {
   .reels-view__layout {
-    grid-template-columns: minmax(0, 1fr);
+    display: block;
     padding: 0;
   }
 

--- a/client/src/views/SettingsView.vue
+++ b/client/src/views/SettingsView.vue
@@ -21,6 +21,9 @@
           <p v-if="scanErrorNoticeDetail" class="m-0 font-mono text-[0.8rem] leading-[1.5] text-[#7c5800] break-all">
             {{ scanErrorNoticeDetail }}
           </p>
+          <p v-if="scanErrorReportPath" class="m-0 font-mono text-[0.78rem] leading-[1.5] text-[#7c5800] break-all">
+            Full report: {{ scanErrorReportPath }}
+          </p>
         </div>
         <button
           class="inline-flex h-9 w-9 items-center justify-center rounded-full border-0 bg-[rgba(159,106,0,0.08)] text-[#9f6a00] cursor-pointer transition-colors duration-180 hover:bg-[rgba(159,106,0,0.14)]"
@@ -1980,7 +1983,16 @@ const scanErrorNoticeMessage = computed(() => {
     return 'Video processing tools are missing from the server environment. Install FFmpeg so scans can read video metadata and generate video derivatives.';
   }
 
+  if (scanErrorReportPath.value) {
+    return 'Some media failed during the last run. Review the sample error and full report path below, then scan the library again to retry failed media and derivative generation.';
+  }
+
   return 'Some media failed during the last run. Review the sample error below, then scan the library again to retry any missed files and derivative generation.';
+});
+const scanErrorReportPath = computed(() => {
+  const errorText = lastCompletedScan.value?.error_text?.trim() ?? '';
+  const match = errorText.match(/^Full error report: (.+)$/m);
+  return match?.[1]?.trim() || null;
 });
 const scanErrorNoticeDetail = computed(() => {
   const errorText = lastCompletedScan.value?.error_text?.trim() ?? '';

--- a/docs/api.md
+++ b/docs/api.md
@@ -660,7 +660,7 @@ Notable fields:
 | `folders` | Active indexed folders. |
 | `indexedImages` | Active indexed posts. The name is historical and still includes videos in the total feed count. |
 | `indexedVideos` | Active indexed videos only. |
-| `scan` | Viewer-safe live scan progress snapshot. It uses the same shape as `GET /api/scan-progress`, with `currentFolder` and `currentFile` redacted and `lastCompletedScan.error_text` forced to `null`. |
+| `scan` | Viewer-safe live scan progress snapshot. It uses the same shape as `GET /api/scan-progress`, with `currentFolder` and `currentFile` redacted and `lastCompletedScan.error_text` forced to `null`. Scan-report paths never appear here. |
 | `storage` | Availability with a generic unavailable message only. |
 | `libraryIndex` | Rebuild requirement plus ignored root-media count. Gallery-root paths are omitted. |
 | `preferences.defaultHomeFeedMode` | Current app-wide default home feed mode. |
@@ -694,7 +694,7 @@ Notable fields:
 | `queuedDerivativeJobs` / `processedDerivativeJobs` | Derivative job counters once the queue is known. |
 | `generatedThumbnails` / `generatedPreviews` | Completed derivative outputs in the current run. |
 | `currentFolder` / `currentFile` | Always `null` in this viewer-safe route. |
-| `lastCompletedScan` | Latest completed scan summary with `error_text` forced to `null`. |
+| `lastCompletedScan` | Latest completed scan summary with `error_text` forced to `null`. Runs can be `completed`, `completed_with_errors`, or `failed`. |
 
 Notes:
 
@@ -711,6 +711,7 @@ It uses the same overall shape as `GET /api/scan-progress`, with the following d
 
 - `currentFile` and `currentFolder` are populated when the active operation can identify a source path
 - `lastCompletedScan` is the full scan record, including `error_text`
+- when a run finishes as `completed_with_errors`, `error_text` contains a short sample plus the full report path under `<DATA_ROOT>/scan-errors/`
 
 ### `GET /api/admin/stats`
 
@@ -1342,6 +1343,10 @@ Success:
   }
 }
 ```
+
+Notes:
+
+- in `SCAN_MEDIA_ERROR_MODE=skip`, a successful rescan can also return `"status": "completed_with_errors"` when supported media was skipped and reported
 
 Errors:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ yourself.
 | `DATA_DIR` | unset | Optional alias that falls back into `DATA_ROOT` resolution when `DATA_ROOT` is absent. |
 | `GALLERY_ROOT` | `./data/gallery` | Source media root. Foldergram scans below this path. |
 | `GALLERY_EXCLUDED_FOLDERS` | unset | Comma-separated folder exclusion rules. Names match anywhere in the gallery tree; values with a slash match one exact relative path below `GALLERY_ROOT`. |
-| `DB_DIR` | `./data/db` | SQLite directory. Database file is `gallery.sqlite`. |
+| `DB_DIR` | `./data/db` | SQLite directory. Database file is `gallery.sqlite`, and startup Dbmate migrations run against it automatically when the directory is available. |
 | `THUMBNAILS_DIR` | `./data/thumbnails` | Generated thumbnail output root. |
 | `PREVIEWS_DIR` | `./data/previews` | Generated preview output root. |
 | `IMAGE_DETAIL_SOURCE` | `preview` | For image detail pages, use generated previews or stream originals. Videos ignore this flag. |
@@ -126,6 +126,9 @@ The Settings sidebar is split into:
 - `GALLERY_ROOT` only needs read access for scans and originals.
 - `DB_DIR`, `THUMBNAILS_DIR`, and `PREVIEWS_DIR` must be writable.
 - `<DATA_ROOT>/scan-errors` is created on demand and must be writable when skip mode produces scan reports.
+
+When `DB_DIR` cannot be created or written, Foldergram logs the reason, skips
+Dbmate for that process, and falls back to an in-memory SQLite database.
 
 Foldergram normalizes path separators so the same rules work with POSIX-style and
 Windows-style paths.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,7 @@ yourself.
 | `IMAGE_DETAIL_SOURCE` | `preview` | For image detail pages, use generated previews or stream originals. Videos ignore this flag. |
 | `DERIVATIVE_MODE` | `eager` | Generate derivatives during scans or lazily on the first protected derivative request. |
 | `LOG_VERBOSE` | `0` | Truthy values are `1`, `true`, `yes`, and `on`. |
+| `SCAN_MEDIA_ERROR_MODE` | `skip` | `skip` reports supported-media scan failures and continues. `fail` aborts on the first such error. |
 | `SCAN_DISCOVERY_CONCURRENCY` | `4` | Discovery concurrency, validated from `1` to `32`. |
 | `SCAN_DERIVATIVE_CONCURRENCY` | `4` | Derivative concurrency, validated from `1` to `32`. |
 | `PUBLIC_DEMO_MODE` | `0` | When enabled, mutating API routes return `403` for read-only demo deployments. |
@@ -117,11 +118,14 @@ The Settings sidebar is split into:
 - `DATA_DIR` is a legacy alias. It is used only when `DATA_ROOT` is unset.
 - Relative paths are resolved from the repository root.
 - Absolute paths are used as-is.
+- Foldergram reserves `<DATA_ROOT>/scan-errors` for per-run full scan error reports.
 - `THUMBNAILS_DIR` and `PREVIEWS_DIR` must be separate, non-overlapping directories.
+- The scan-error report directory must not overlap `THUMBNAILS_DIR` or `PREVIEWS_DIR`.
 - `THUMBNAILS_DIR` cannot contain `GALLERY_ROOT`.
 - `PREVIEWS_DIR` cannot contain `GALLERY_ROOT`.
 - `GALLERY_ROOT` only needs read access for scans and originals.
 - `DB_DIR`, `THUMBNAILS_DIR`, and `PREVIEWS_DIR` must be writable.
+- `<DATA_ROOT>/scan-errors` is created on demand and must be writable when skip mode produces scan reports.
 
 Foldergram normalizes path separators so the same rules work with POSIX-style and
 Windows-style paths.
@@ -164,12 +168,30 @@ Behavior:
 | Current behavior | `IMAGE_DETAIL_SOURCE=preview`, `DERIVATIVE_MODE=eager` |
 | Lowest upfront processing for large libraries | `IMAGE_DETAIL_SOURCE=original`, `DERIVATIVE_MODE=lazy` |
 
+### `SCAN_MEDIA_ERROR_MODE`
+
+Accepted values:
+
+- `skip`
+- `fail`
+
+Behavior:
+
+- `skip` is the default
+- `skip` reports supported-media failures during stat, metadata, derivative generation, and derivative-migration repair work, then continues scanning the rest of the library
+- scans with skipped media finish as `completed_with_errors` instead of `completed`
+- admin-facing scan details keep a short sample in SQLite and point to the full per-run report under `<DATA_ROOT>/scan-errors/`
+- `fail` preserves fail-fast behavior for those same scan-time media errors
+- this applies to supported media that actually reaches the scanner, including supported images and videos
+- unsupported extensions, hidden or excluded paths, and files placed directly in `GALLERY_ROOT` are still ignored earlier and do not produce scan error reports
+
 ### Settings actions and lazy mode
 
 - `Scan Library` always refreshes index metadata.
 - `Rebuild Library Index` resets and rebuilds the SQLite-backed index. Existing sharded derivatives remain reusable when the same indexed rows survive the upgrade path.
 - In `DERIVATIVE_MODE=lazy`, neither a normal scan nor `Rebuild Library Index` pre-generates missing thumbnails or previews.
 - `Regenerate Thumbnails` remains a manual thumbnail and video-poster rebuild only. It does not rebuild previews.
+- When `SCAN_MEDIA_ERROR_MODE=skip` records media failures, the admin Settings view shows the full report path for that scan.
 - Runtime-only app-wide controls such as stories mode and excluded folders live under `Settings -> General Settings`, while the scan and rebuild actions live under `Settings -> Scan & Library`.
 
 ## Derivative layout upgrade
@@ -198,12 +220,15 @@ Scan phases behave as follows:
 - `migration` is determinate and reports checked rows, moved files, repaired files, missing files, and asset-key backfills
 - `discovery` reports discovered and processed folders and posts, but remains open-ended while the scanner is still finding additional folders
 - `derivatives` is determinate and reports queued-versus-completed jobs plus generated thumbnails and previews
+- completed runs can finish as `completed_with_errors` when `SCAN_MEDIA_ERROR_MODE=skip` records supported-media failures
 
 ## Managed path ignores
 
 If your configured database, thumbnails, or previews directories live inside the
 gallery tree, Foldergram computes their relative paths and excludes them from
-discovery. That prevents generated files from being re-indexed as source media.
+discovery. The same ignore protection applies to `<DATA_ROOT>/scan-errors`.
+That prevents generated files and scan reports from being re-indexed as source
+media.
 
 ## Recommended local `.env`
 
@@ -225,6 +250,7 @@ PREVIEWS_DIR=./data/previews
 IMAGE_DETAIL_SOURCE=preview
 DERIVATIVE_MODE=eager
 LOG_VERBOSE=0
+SCAN_MEDIA_ERROR_MODE=skip
 SCAN_DISCOVERY_CONCURRENCY=4
 SCAN_DERIVATIVE_CONCURRENCY=4
 PUBLIC_DEMO_MODE=0

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,6 +27,7 @@ description: Workspace scripts, local ports, watcher behavior, tests, and docs d
 | `pnpm dev:client` | Client only |
 | `pnpm dev:docs` | VitePress docs only |
 | `pnpm build` | Server build plus client build |
+| `pnpm migrate` | Run pending server database migrations without starting the app |
 | `pnpm start` | Production server start |
 | `pnpm build:docs` | VitePress docs build |
 | `pnpm rescan` | Manual server rescan script |
@@ -56,11 +57,15 @@ lets it move off `4141` without stepping onto the backend or docs ports.
 
 ## Startup sequence
 
-At boot, the server:
+At boot, the server process:
 
-1. creates the Express app
-2. listens on `DEV_SERVER_PORT`
-3. asks the scanner whether startup should scan, stay idle, or block for rebuild
+1. runs Dbmate migrations for `gallery.sqlite`
+2. creates the Express app
+3. listens on `DEV_SERVER_PORT`
+4. asks the scanner whether startup should scan, stay idle, or block for rebuild
+
+If `DB_DIR` is unavailable, Foldergram keeps the existing fallback behavior:
+it skips Dbmate for that run and uses an in-memory SQLite database instead.
 
 If the scanner decides startup should be blocked because the gallery root
 changed and relocation validation failed, Foldergram defers scanning until the
@@ -95,6 +100,21 @@ Run them with:
 ```bash
 pnpm test
 ```
+
+## Schema migrations
+
+Foldergram keeps two schema references in sync:
+
+- `server/src/db/schema.ts` for the current readable schema snapshot
+- `server/db/migrations/*.sql` for ordered Dbmate migrations
+
+When you change the schema:
+
+- update `server/src/db/schema.ts`
+- add a new SQL migration under `server/db/migrations`
+- do not edit an already released migration; add a new one instead
+
+Use `pnpm migrate` to apply pending migrations without starting the app.
 
 ## Client behavior worth knowing
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -232,11 +232,11 @@ Its left sidebar is split into:
 
 | Section | What it contains |
 | --- | --- |
-| `Scan & Library` | Phase-aware live scan state, manual scan, thumbnail-only rebuild, and library-index rebuild actions. |
+| `Scan & Library` | Phase-aware live scan state, manual scan, thumbnail-only rebuild, and library-index rebuild actions. Admins also see the full report path when a scan finishes with skipped media errors. |
 | `General Settings` | Home and Reels default feed modes, the default App Folder photo order, stories-folders mode, excluded-folder rules, migration notices, and save-and-rescan prompts for those app-wide changes. |
 | `Places` | Offline GeoNames preparation status plus place-assignment rebuild actions for GPS-tagged photos. |
 | `Security & Access` | Admin password, viewer password, public mode, sign-out, and related auth controls. |
-| `System Status` | Storage and index state plus last completed scan details. |
+| `System Status` | Storage and index state plus last completed scan details, including whether the last run completed with errors. |
 
 In `General Settings`, env-backed excluded-folder rules are shown read-only and
 custom rules are saved at runtime. Changing stories mode or excluded folders
@@ -274,7 +274,7 @@ Current non-admin behavior:
 
 | Action | What changes |
 | --- | --- |
-| Scan Library | Runs a normal scan against the current gallery root. |
+| Scan Library | Runs a normal scan against the current gallery root. In `SCAN_MEDIA_ERROR_MODE=skip`, supported-media failures are reported, skipped, and the run finishes as `completed_with_errors`. |
 | Regenerate Thumbnails | Clears generated thumbnails and video poster images, then rebuilds them from indexed media only. |
 | Rebuild Library Index | Clears indexed folders, posts, likes, folder scan state, and scan history, then rescans the active gallery root and reuses matching cached derivatives when possible. In lazy derivative mode it does not pre-generate missing thumbnails or previews. |
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -71,6 +71,7 @@ data/
     gallery.sqlite
   thumbnails/    # asset-key-sharded thumbnail derivatives
   previews/      # asset-key-sharded preview derivatives
+  scan-errors/   # created on demand for full scan error reports
 ```
 
 The database schema includes:
@@ -164,8 +165,9 @@ During a full scan, Foldergram:
 6. Reconciles eligible file moves so the same row, likes, and derivative paths can survive path changes.
 7. Marks missing indexed rows as deleted.
 8. Queues derivative work for changed or missing outputs.
-9. Performs deferred stale-derivative cleanup after successful scans.
-10. Writes scan status to `scan_runs`.
+9. Depending on `SCAN_MEDIA_ERROR_MODE`, either records and skips supported-media failures or fails fast on the first one.
+10. Performs deferred stale-derivative cleanup after successful scans.
+11. Writes scan status to `scan_runs` and, when needed, a per-run full scan error report.
 
 ## Scan progress phases
 
@@ -174,6 +176,7 @@ Foldergram reports long-running scans in three phases:
 - `migration` checks previously indexed rows, backfills missing `asset_key` values, and moves, repairs, or regenerates legacy derivatives before fresh indexing begins
 - `discovery` walks the gallery tree, resolves folders, refreshes metadata, and reconciles safe file moves
 - `derivatives` processes queued thumbnail and preview jobs after discovery has identified the required work
+- completed runs can finish as `completed_with_errors` when skip mode records supported-media failures
 
 Only migration and derivative work have a fixed total upfront. Discovery still
 reports discovered and processed folder and post counts, but the client keeps

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -193,10 +193,13 @@ The shipped `.env.example` points at:
 | `DB_DIR` | `./data/db` |
 | `THUMBNAILS_DIR` | `./data/thumbnails` |
 | `PREVIEWS_DIR` | `./data/previews` |
+| `SCAN_MEDIA_ERROR_MODE` | `skip` |
 
 `DATA_ROOT` is the base path for this layout. If you change only `DATA_ROOT`,
 Foldergram will look for `gallery`, `db`, `thumbnails`, and `previews`
 under that directory unless you override those paths individually.
+Full scan error reports are written under `<DATA_ROOT>/scan-errors/` when skip
+mode records supported-media failures.
 
 `GALLERY_EXCLUDED_FOLDERS` accepts comma-separated folder rules. Names match
 any folder with that name anywhere in the gallery tree; values with a slash

--- a/docs/media-processing.md
+++ b/docs/media-processing.md
@@ -52,6 +52,23 @@ directories, so subsequent requests use the cached file on disk. It also uses
 the same media-specific generation rules as eager mode, including animated AVIF
 preview generation.
 
+## Scan-time media failures
+
+`SCAN_MEDIA_ERROR_MODE` controls what happens when supported media reaches scan
+processing but fails during stat, metadata, derivative generation, or
+derivative-repair work.
+
+| Mode | Behavior |
+| --- | --- |
+| `skip` | Report the failure, skip that file, continue scanning, and finish the run as `completed_with_errors`. |
+| `fail` | Stop on the first such failure and mark the run as failed. |
+
+In skip mode, Foldergram keeps a short admin-visible sample in SQLite and
+writes the full per-run report under `<DATA_ROOT>/scan-errors/`.
+
+This applies to supported image and video files that actually reach scan
+processing. Unsupported extensions are still ignored earlier during discovery.
+
 ## Derivative mapping
 
 Foldergram stores derivatives by stable asset key, not by source-relative path.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -141,6 +141,11 @@ Inside Settings:
 - `Places` contains offline place-data preparation and place-assignment rebuilds for GPS-tagged photos
 - `Scan & Library` contains manual scan plus rebuild actions
 
+If a scan finishes with skipped corrupt or unreadable supported media, the
+admin scan panel shows the full report path for that run. Foldergram writes
+those per-run reports under `<DATA_ROOT>/scan-errors/` and marks the run
+`completed_with_errors`.
+
 Until you enable password protection, Foldergram starts without an auth gate,
 so Settings and the library-maintenance controls are available immediately to
 whoever can reach the app.

--- a/docs/security.md
+++ b/docs/security.md
@@ -92,6 +92,15 @@ Foldergram does not serve arbitrary filesystem paths from the client.
 - confirms that path is still within `GALLERY_ROOT`
 - confirms the file still exists
 
+### Scan error reports
+
+Per-run full scan error reports are written under `<DATA_ROOT>/scan-errors/`
+when skip mode records supported-media failures.
+
+- report paths are surfaced through admin-only scan details
+- viewer-safe scan responses force `error_text` to `null`
+- the report directory is kept separate from `/thumbnails` and `/previews`, so those files are not exposed through derivative static serving
+
 ### Delete actions
 
 Delete flows resolve target files and directories inside configured roots before

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,6 +21,7 @@ Check:
 - the configured paths in `.env`
 - whether those paths exist
 - whether `DB_DIR`, `THUMBNAILS_DIR`, and `PREVIEWS_DIR` are writable by the current process
+- whether `<DATA_ROOT>/scan-errors` is writable if you use `SCAN_MEDIA_ERROR_MODE=skip`
 
 `GALLERY_ROOT` is scanned read-only. It does not need write access unless you
 use delete actions that remove originals from the gallery.
@@ -105,6 +106,27 @@ after the retention window on a later successful full scan.
 
 That is intentional so temporary share outages or accidental moves do not
 immediately delete cached derivatives.
+
+## A scan failed or completed with errors on a corrupt or unreadable media file
+
+Foldergram can now handle this in two different ways, depending on
+`SCAN_MEDIA_ERROR_MODE`.
+
+Default behavior:
+
+- `SCAN_MEDIA_ERROR_MODE=skip` reports supported-media failures and continues scanning the rest of the library
+- the completed run is marked `completed_with_errors`
+- `Settings -> Scan & Library` shows the admin-only report path for that run
+- the full per-run report is written under `<DATA_ROOT>/scan-errors/`
+
+Strict behavior:
+
+- `SCAN_MEDIA_ERROR_MODE=fail` stops on the first supported-media failure and marks the scan as failed
+
+This applies to supported media that reaches scan processing, including
+supported images and videos. Unsupported extensions, excluded folders, hidden
+paths, and files placed directly in `GALLERY_ROOT` are still ignored before
+this stage.
 
 ## Moments are missing and highlights appear instead
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev:docs": "node scripts/run-workspace-script.mjs docs dev",
     "build": "node scripts/run-workspace-script.mjs server build && node scripts/run-workspace-script.mjs client build",
     "start": "cross-env NODE_ENV=production node scripts/run-workspace-script.mjs server start",
+    "migrate": "node scripts/run-workspace-script.mjs server migrate",
     "build:server": "node scripts/run-workspace-script.mjs server build",
     "build:client": "node scripts/run-workspace-script.mjs client build",
     "build:docs": "node scripts/run-workspace-script.mjs docs build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
+      dbmate:
+        specifier: ^2.33.0
+        version: 2.33.0
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
@@ -238,6 +241,41 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dbmate/darwin-arm64@2.33.0':
+    resolution: {integrity: sha512-YbB2IYigcHV+5qo35wvHoKdRXPQdtXv+tUoiEEhXX9gmJm8t/OqsPguR5m7+6rRHE7hsBEtxruykBOKVArqc0A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@dbmate/darwin-x64@2.33.0':
+    resolution: {integrity: sha512-6y4BSqUj6m9halhUi6PNVOUBmsciRjCFAlXWk0WFu35Eg7ojZWWW3BRD7bRcQwZcsmjKn6uCb/k5hFci5/gkxQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@dbmate/linux-arm64@2.33.0':
+    resolution: {integrity: sha512-HFYIGBKTI+BQC8Ps6nzj1Zb8w7I61IGstveNeEQYKTxkV1CPDMajYX52heJ7Jv3ignOrzzy054YhV+z+j6xV8g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@dbmate/linux-arm@2.33.0':
+    resolution: {integrity: sha512-Xm6w63BjPtab0LgAleDqzhSDIvFJOqN7v8RMJaydPlrPNIBauJwEOWKu5nSnUGNKi9PHZXIHCu0hI8m0fAI6eQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@dbmate/linux-ia32@2.33.0':
+    resolution: {integrity: sha512-tyVbpGPRds5Rf5AbP5W1+ip319GZTWqy+jjMWKVyAuEbH/6Kjn88RhVqG6f7NsOvHgS3aekOQIBW6ZMkm0crEw==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@dbmate/linux-x64@2.33.0':
+    resolution: {integrity: sha512-SxzgU1TzWA37N2GuOUCcV2JjQKiEdzQzfI7k15YRxPw2K3UZc2hueFtF1l2HAoilDi8ekOV2JFUb9XmfqhgSrA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@dbmate/win32-x64@2.33.0':
+    resolution: {integrity: sha512-1axw11wBuJ6mLByBtJg4o7fxUkyX+Vz435N3vfdH8OdSPWnpygp/nVyo3iz58SR7XnJkCJBzoKjtsRONeAsO2g==}
+    cpu: [x64]
+    os: [win32]
 
   '@docsearch/css@3.8.2':
     resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
@@ -1659,6 +1697,10 @@ packages:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
 
+  dbmate@2.33.0:
+    resolution: {integrity: sha512-UNyMVmEt+AS0xXrcPIHtSRF8eMgh9YJDUyW2S/l8QO/yB8uGT4eO1g18g+4GKdkPWVY9NHUTA1584jvWHK57JQ==}
+    hasBin: true
+
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
 
@@ -2920,6 +2962,27 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
+  '@dbmate/darwin-arm64@2.33.0':
+    optional: true
+
+  '@dbmate/darwin-x64@2.33.0':
+    optional: true
+
+  '@dbmate/linux-arm64@2.33.0':
+    optional: true
+
+  '@dbmate/linux-arm@2.33.0':
+    optional: true
+
+  '@dbmate/linux-ia32@2.33.0':
+    optional: true
+
+  '@dbmate/linux-x64@2.33.0':
+    optional: true
+
+  '@dbmate/win32-x64@2.33.0':
+    optional: true
+
   '@docsearch/css@3.8.2': {}
 
   '@docsearch/js@3.8.2(@algolia/client-search@5.49.2)(search-insights@2.17.3)':
@@ -4114,6 +4177,16 @@ snapshots:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
+
+  dbmate@2.33.0:
+    optionalDependencies:
+      '@dbmate/darwin-arm64': 2.33.0
+      '@dbmate/darwin-x64': 2.33.0
+      '@dbmate/linux-arm': 2.33.0
+      '@dbmate/linux-arm64': 2.33.0
+      '@dbmate/linux-ia32': 2.33.0
+      '@dbmate/linux-x64': 2.33.0
+      '@dbmate/win32-x64': 2.33.0
 
   de-indent@1.0.2: {}
 

--- a/server/db/migrations/000001_baseline.sql
+++ b/server/db/migrations/000001_baseline.sql
@@ -1,0 +1,165 @@
+-- migrate:up
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS folders (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  folder_path TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'normal',
+  story_owner_folder_id INTEGER NULL,
+  description TEXT NULL,
+  avatar_image_id INTEGER NULL,
+  avatar_source TEXT NOT NULL DEFAULT 'auto',
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (avatar_image_id) REFERENCES images(id),
+  FOREIGN KEY (story_owner_folder_id) REFERENCES folders(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS images (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  folder_id INTEGER NOT NULL,
+  place_id INTEGER NULL,
+  asset_key TEXT NULL,
+  filename TEXT NOT NULL,
+  extension TEXT NOT NULL,
+  relative_path TEXT NOT NULL UNIQUE,
+  absolute_path TEXT NOT NULL,
+  file_size INTEGER NOT NULL,
+  width INTEGER NOT NULL,
+  height INTEGER NOT NULL,
+  display_orientation INTEGER NULL,
+  media_type TEXT NOT NULL DEFAULT 'image',
+  mime_type TEXT NOT NULL,
+  duration_ms REAL NULL,
+  is_animated INTEGER NULL,
+  checksum_or_fingerprint TEXT NOT NULL,
+  mtime_ms REAL NOT NULL,
+  first_seen_at TEXT NOT NULL,
+  sort_timestamp INTEGER NOT NULL,
+  taken_at INTEGER NULL,
+  taken_at_source TEXT NULL,
+  exif_json TEXT NULL,
+  thumbnail_path TEXT NOT NULL,
+  preview_path TEXT NOT NULL,
+  playback_strategy TEXT NOT NULL DEFAULT 'preview',
+  is_deleted INTEGER NOT NULL DEFAULT 0,
+  deleted_at TEXT NULL,
+  is_trashed INTEGER NOT NULL DEFAULT 0,
+  trashed_at TEXT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (folder_id) REFERENCES folders(id) ON DELETE CASCADE,
+  FOREIGN KEY (place_id) REFERENCES places(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS places (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug TEXT NOT NULL UNIQUE,
+  display_name TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  source TEXT NOT NULL,
+  source_confidence REAL NULL,
+  provider TEXT NULL,
+  provider_place_id TEXT NULL,
+  latitude REAL NULL,
+  longitude REAL NULL,
+  city_name TEXT NULL,
+  admin1_name TEXT NULL,
+  country_name TEXT NULL,
+  country_code TEXT NULL,
+  geonames_id INTEGER NULL,
+  is_approximate INTEGER NOT NULL DEFAULT 1,
+  name_override TEXT NULL,
+  description TEXT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS scan_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  started_at TEXT NOT NULL,
+  finished_at TEXT NULL,
+  status TEXT NOT NULL,
+  scanned_files INTEGER NOT NULL DEFAULT 0,
+  new_files INTEGER NOT NULL DEFAULT 0,
+  updated_files INTEGER NOT NULL DEFAULT 0,
+  removed_files INTEGER NOT NULL DEFAULT 0,
+  error_text TEXT NULL
+);
+
+CREATE TABLE IF NOT EXISTS app_settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS folder_scan_state (
+  folder_path TEXT PRIMARY KEY,
+  signature TEXT NOT NULL,
+  file_count INTEGER NOT NULL,
+  max_mtime_ms REAL NOT NULL,
+  total_size INTEGER NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS likes (
+  image_id INTEGER PRIMARY KEY,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS collections (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  is_default INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS collection_items (
+  collection_id INTEGER NOT NULL,
+  image_id INTEGER NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (collection_id, image_id),
+  FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE CASCADE,
+  FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_folders_slug ON folders(slug);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_folders_folder_path ON folders(folder_path);
+CREATE INDEX IF NOT EXISTS idx_folders_role ON folders(role);
+CREATE INDEX IF NOT EXISTS idx_folders_story_owner_role ON folders(story_owner_folder_id, role, folder_path COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_images_folder_id ON images(folder_id);
+CREATE INDEX IF NOT EXISTS idx_images_place_id ON images(place_id);
+CREATE INDEX IF NOT EXISTS idx_images_sort_timestamp ON images(sort_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_images_taken_at ON images(taken_at DESC);
+CREATE INDEX IF NOT EXISTS idx_images_taken_at_source ON images(is_deleted, taken_at_source);
+CREATE INDEX IF NOT EXISTS idx_images_folder_sort ON images(folder_id, is_deleted, sort_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_images_folder_media_sort ON images(folder_id, media_type, is_deleted, sort_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_images_is_deleted ON images(is_deleted);
+CREATE INDEX IF NOT EXISTS idx_images_media_type ON images(media_type, is_deleted, sort_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_images_visibility_flags ON images(is_deleted, is_trashed);
+CREATE INDEX IF NOT EXISTS idx_images_taken_at_source_visibility ON images(is_deleted, is_trashed, taken_at_source);
+CREATE INDEX IF NOT EXISTS idx_images_folder_visible_sort ON images(folder_id, is_deleted, is_trashed, sort_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_images_folder_media_visible_sort ON images(folder_id, media_type, is_deleted, is_trashed, sort_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_images_media_visible_sort ON images(media_type, is_deleted, is_trashed, sort_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_images_trashed_listing ON images(is_trashed, is_deleted, trashed_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_images_relative_path ON images(relative_path);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_images_asset_key ON images(asset_key) WHERE asset_key IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_images_deleted_at ON images(deleted_at);
+CREATE INDEX IF NOT EXISTS idx_places_slug ON places(slug);
+CREATE INDEX IF NOT EXISTS idx_places_display_name ON places(display_name);
+CREATE INDEX IF NOT EXISTS idx_places_geonames_id ON places(geonames_id);
+CREATE INDEX IF NOT EXISTS idx_folder_scan_state_updated_at ON folder_scan_state(updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_likes_created_at ON likes(created_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_collections_single_default ON collections(is_default) WHERE is_default = 1;
+CREATE INDEX IF NOT EXISTS idx_collections_updated_at ON collections(updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_collection_items_image ON collection_items(image_id);
+CREATE INDEX IF NOT EXISTS idx_collection_items_created ON collection_items(collection_id, created_at DESC, image_id DESC);
+
+-- migrate:down
+
+-- Forward-only. Foldergram does not automatically roll back local user data migrations.

--- a/server/package.json
+++ b/server/package.json
@@ -5,14 +5,17 @@
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx src/scripts/migrate.ts && tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/index.js",
+    "migrate": "tsx src/scripts/migrate.ts",
+    "migrate:prod": "node dist/scripts/migrate.js",
+    "start": "node dist/scripts/migrate.js && node dist/index.js",
     "rescan": "tsx src/scripts/rescan.ts",
     "test": "vitest run"
   },
   "dependencies": {
     "chokidar": "^4.0.3",
+    "dbmate": "^2.33.0",
     "dotenv": "^16.4.7",
     "exifr": "^7.1.3",
     "express": "^5.1.0",

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -23,6 +23,7 @@ const envSchema = z.object({
   THUMBNAILS_DIR: z.string().optional(),
   PREVIEWS_DIR: z.string().optional(),
   LOG_VERBOSE: z.string().optional(),
+  SCAN_MEDIA_ERROR_MODE: z.enum(['skip', 'fail']).default('skip'),
   SCAN_DISCOVERY_CONCURRENCY: z.coerce.number().int().min(1).max(32).default(4),
   SCAN_DERIVATIVE_CONCURRENCY: z.coerce.number().int().min(1).max(32).default(4),
   PUBLIC_DEMO_MODE: z.string().optional(),
@@ -97,6 +98,7 @@ const dbDir = resolveConfiguredPath(parsed.DB_DIR, path.join(dataRoot, 'db'));
 const geodataDir = path.join(dataRoot, 'geodata');
 const thumbnailsDir = resolveConfiguredPath(parsed.THUMBNAILS_DIR, path.join(dataRoot, 'thumbnails'));
 const previewsDir = resolveConfiguredPath(parsed.PREVIEWS_DIR, path.join(dataRoot, 'previews'));
+const scanErrorReportDir = path.join(dataRoot, 'scan-errors');
 const logVerbose = parseBooleanFlag(parsed.LOG_VERBOSE);
 const publicDemoMode = parseBooleanFlag(parsed.PUBLIC_DEMO_MODE);
 const csrfTrustedOrigins = parseConfiguredOrigins(parsed.CSRF_TRUSTED_ORIGINS);
@@ -109,6 +111,16 @@ if (derivativeDirectoriesOverlap) {
   throw new Error('Invalid storage configuration: THUMBNAILS_DIR and PREVIEWS_DIR must point to separate non-overlapping directories.');
 }
 
+const scanErrorReportDirectoryOverlapsServedMedia =
+  isSameOrWithinPath(scanErrorReportDir, thumbnailsDir) ||
+  isSameOrWithinPath(thumbnailsDir, scanErrorReportDir) ||
+  isSameOrWithinPath(scanErrorReportDir, previewsDir) ||
+  isSameOrWithinPath(previewsDir, scanErrorReportDir);
+
+if (scanErrorReportDirectoryOverlapsServedMedia) {
+  throw new Error('Invalid storage configuration: scan error reports must not overlap THUMBNAILS_DIR or PREVIEWS_DIR.');
+}
+
 if (isSameOrWithinPath(thumbnailsDir, galleryRoot)) {
   throw new Error('Invalid storage configuration: THUMBNAILS_DIR cannot contain GALLERY_ROOT.');
 }
@@ -118,7 +130,7 @@ if (isSameOrWithinPath(previewsDir, galleryRoot)) {
 }
 
 const managedGalleryRelativeIgnores = uniq(
-  [dbDir, thumbnailsDir, previewsDir]
+  [dbDir, thumbnailsDir, previewsDir, scanErrorReportDir]
     .map((directoryPath) => getRelativePathWithinRoot(galleryRoot, directoryPath))
     .filter((value): value is string => typeof value === 'string' && value.length > 0)
     .map((value) => normalizePath(value))
@@ -136,9 +148,11 @@ export const appConfig = {
   geodataDir,
   thumbnailsDir,
   previewsDir,
+  scanErrorReportDir,
   managedGalleryRelativeIgnores,
   galleryExcludedFolders,
   logVerbose,
+  scanMediaErrorMode: parsed.SCAN_MEDIA_ERROR_MODE,
   publicDemoMode,
   csrfTrustedOrigins,
   scanDiscoveryConcurrency: parsed.SCAN_DISCOVERY_CONCURRENCY,

--- a/server/src/db/database.ts
+++ b/server/src/db/database.ts
@@ -1,167 +1,34 @@
 import { DatabaseSync } from 'node:sqlite';
 
+import { runStartupMigrations } from './migration.js';
+import { assertNoLegacySchema } from './schema-compat.js';
 import { schemaSql } from './schema.js';
 import { storageService } from '../services/storage-service.js';
 
-class DatabaseManager {
-  private database: DatabaseSync;
+function initializeTransientDatabase(database: DatabaseSync): DatabaseSync {
+  database.exec(schemaSql);
+  return database;
+}
 
-  constructor() {
-    this.database = new DatabaseSync(storageService.getDatabasePath());
-    this.assertNoLegacySchema();
-    this.applyCompatColumnMigrations();
-    this.database.exec(schemaSql);
-    this.applyCompatIndexes();
-  }
+class DatabaseManager {
+  private database: DatabaseSync | null = null;
 
   get connection(): DatabaseSync {
+    if (this.database) {
+      return this.database;
+    }
+
+    const databasePath = storageService.getDatabasePath();
+
+    if (databasePath === ':memory:') {
+      this.database = initializeTransientDatabase(new DatabaseSync(databasePath));
+      return this.database;
+    }
+
+    runStartupMigrations({ databasePath });
+    this.database = new DatabaseSync(databasePath);
+    assertNoLegacySchema(this.database);
     return this.database;
-  }
-
-  private tableExists(name: string): boolean {
-    const row = this.database
-      .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`)
-      .get(name) as { name: string } | undefined;
-
-    return row?.name === name;
-  }
-
-  private tableHasColumn(tableName: string, columnName: string): boolean {
-    if (!this.tableExists(tableName)) {
-      return false;
-    }
-
-    const columns = this.database.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
-    return columns.some((column) => column.name === columnName);
-  }
-
-  private assertNoLegacySchema(): void {
-    const hasLegacyProfilesTable = this.tableExists('profiles');
-    const imagesUseLegacyProfileId = this.tableHasColumn('images', 'profile_id');
-
-    if (!hasLegacyProfilesTable && !imagesUseLegacyProfileId) {
-      return;
-    }
-
-    throw new Error('Legacy database schema detected. Delete the SQLite file and restart the app to rebuild the database with folders/folder_id tables.');
-  }
-
-  private applyCompatColumnMigrations(): void {
-    if (this.tableExists('folders') && !this.tableHasColumn('folders', 'description')) {
-      this.database.exec('ALTER TABLE folders ADD COLUMN description TEXT NULL');
-    }
-
-    if (this.tableExists('folders') && !this.tableHasColumn('folders', 'avatar_source')) {
-      this.database.exec("ALTER TABLE folders ADD COLUMN avatar_source TEXT NOT NULL DEFAULT 'auto'");
-    }
-
-    if (this.tableExists('folders') && !this.tableHasColumn('folders', 'role')) {
-      this.database.exec("ALTER TABLE folders ADD COLUMN role TEXT NOT NULL DEFAULT 'normal'");
-    }
-
-    if (this.tableExists('folders') && !this.tableHasColumn('folders', 'story_owner_folder_id')) {
-      this.database.exec('ALTER TABLE folders ADD COLUMN story_owner_folder_id INTEGER NULL');
-    }
-
-    if (this.tableExists('images') && !this.tableHasColumn('images', 'media_type')) {
-      this.database.exec("ALTER TABLE images ADD COLUMN media_type TEXT NOT NULL DEFAULT 'image'");
-    }
-
-    if (this.tableExists('images') && !this.tableHasColumn('images', 'duration_ms')) {
-      this.database.exec('ALTER TABLE images ADD COLUMN duration_ms REAL NULL');
-    }
-
-    if (this.tableExists('images') && !this.tableHasColumn('images', 'display_orientation')) {
-      this.database.exec('ALTER TABLE images ADD COLUMN display_orientation INTEGER NULL');
-    }
-
-    if (this.tableExists('images') && !this.tableHasColumn('images', 'is_animated')) {
-      this.database.exec('ALTER TABLE images ADD COLUMN is_animated INTEGER NULL');
-    }
-
-    if (this.tableExists('images') && !this.tableHasColumn('images', 'taken_at')) {
-      this.database.exec('ALTER TABLE images ADD COLUMN taken_at INTEGER NULL');
-    }
-
-    if (this.tableExists('images') && !this.tableHasColumn('images', 'taken_at_source')) {
-      this.database.exec('ALTER TABLE images ADD COLUMN taken_at_source TEXT NULL');
-    }
-
-    if (this.tableExists('images') && !this.tableHasColumn('images', 'exif_json')) {
-      this.database.exec('ALTER TABLE images ADD COLUMN exif_json TEXT NULL');
-    }
-
-    if (this.tableExists('images') && !this.tableHasColumn('images', 'playback_strategy')) {
-      this.database.exec("ALTER TABLE images ADD COLUMN playback_strategy TEXT NULL");
-    }
-
-    if (this.tableExists('images') && this.tableHasColumn('images', 'playback_strategy')) {
-      this.database.exec("UPDATE images SET playback_strategy = 'preview' WHERE media_type != 'video' AND playback_strategy IS NULL");
-    }
-
-    if (this.tableExists('images') && this.tableHasColumn('images', 'is_animated')) {
-      this.database.exec("UPDATE images SET is_animated = 0 WHERE media_type = 'video' AND is_animated IS NULL");
-    }
-
-    if (this.tableExists('images') && !this.tableHasColumn('images', 'is_trashed')) {
-      this.database.exec('ALTER TABLE images ADD COLUMN is_trashed INTEGER NOT NULL DEFAULT 0');
-    }
-
-    if (this.tableExists('images') && !this.tableHasColumn('images', 'asset_key')) {
-      this.database.exec('ALTER TABLE images ADD COLUMN asset_key TEXT NULL');
-    }
-
-    if (this.tableExists('images') && !this.tableHasColumn('images', 'place_id')) {
-      this.database.exec('ALTER TABLE images ADD COLUMN place_id INTEGER NULL');
-    }
-
-    if (this.tableExists('images') && !this.tableHasColumn('images', 'deleted_at')) {
-      this.database.exec('ALTER TABLE images ADD COLUMN deleted_at TEXT NULL');
-    }
-
-    if (this.tableExists('images') && !this.tableHasColumn('images', 'trashed_at')) {
-      this.database.exec('ALTER TABLE images ADD COLUMN trashed_at TEXT NULL');
-    }
-
-    if (this.tableExists('images') && this.tableHasColumn('images', 'deleted_at')) {
-      this.database.exec("UPDATE images SET deleted_at = updated_at WHERE is_deleted = 1 AND deleted_at IS NULL");
-      this.database.exec('UPDATE images SET deleted_at = NULL WHERE is_deleted = 0');
-    }
-
-    if (this.tableExists('images') && this.tableHasColumn('images', 'is_trashed') && this.tableHasColumn('images', 'trashed_at')) {
-      this.database.exec('UPDATE images SET trashed_at = NULL WHERE is_trashed = 0');
-    }
-  }
-
-  private applyCompatIndexes(): void {
-    this.database.exec("CREATE INDEX IF NOT EXISTS idx_folders_role ON folders(role)");
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_folders_story_owner_role ON folders(story_owner_folder_id, role, folder_path COLLATE NOCASE)');
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_images_taken_at ON images(taken_at DESC)');
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_images_taken_at_source ON images(is_deleted, taken_at_source)');
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_images_media_type ON images(media_type, is_deleted, sort_timestamp DESC)');
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_images_folder_media_sort ON images(folder_id, media_type, is_deleted, sort_timestamp DESC)');
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_images_visibility_flags ON images(is_deleted, is_trashed)');
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_images_taken_at_source_visibility ON images(is_deleted, is_trashed, taken_at_source)');
-    this.database.exec(
-      'CREATE INDEX IF NOT EXISTS idx_images_folder_visible_sort ON images(folder_id, is_deleted, is_trashed, sort_timestamp DESC)'
-    );
-    this.database.exec(
-      'CREATE INDEX IF NOT EXISTS idx_images_folder_media_visible_sort ON images(folder_id, media_type, is_deleted, is_trashed, sort_timestamp DESC)'
-    );
-    this.database.exec(
-      'CREATE INDEX IF NOT EXISTS idx_images_media_visible_sort ON images(media_type, is_deleted, is_trashed, sort_timestamp DESC)'
-    );
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_images_trashed_listing ON images(is_trashed, is_deleted, trashed_at DESC, id DESC)');
-    this.database.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_images_asset_key ON images(asset_key) WHERE asset_key IS NOT NULL');
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_images_deleted_at ON images(deleted_at)');
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_images_place_id ON images(place_id)');
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_places_slug ON places(slug)');
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_places_display_name ON places(display_name)');
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_places_geonames_id ON places(geonames_id)');
-    this.database.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_collections_single_default ON collections(is_default) WHERE is_default = 1');
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_collections_updated_at ON collections(updated_at DESC)');
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_collection_items_image ON collection_items(image_id)');
-    this.database.exec('CREATE INDEX IF NOT EXISTS idx_collection_items_created ON collection_items(collection_id, created_at DESC, image_id DESC)');
   }
 }
 

--- a/server/src/db/migration.ts
+++ b/server/src/db/migration.ts
@@ -1,0 +1,190 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { resolveBinary } from 'dbmate';
+
+import { repositoryRoot } from '../config/env.js';
+import {
+  applyBaselineCompatMigrations,
+  assertNoLegacySchema,
+  rebuildBaselineForeignKeys,
+  tableExists
+} from './schema-compat.js';
+import { log } from '../services/log-service.js';
+import { storageService } from '../services/storage-service.js';
+
+export const BASELINE_MIGRATION_VERSION = '000001';
+const SCHEMA_MIGRATIONS_TABLE_SQL = 'CREATE TABLE IF NOT EXISTS schema_migrations (version TEXT PRIMARY KEY)';
+const APP_SCHEMA_TABLES = [
+  'folders',
+  'images',
+  'places',
+  'scan_runs',
+  'app_settings',
+  'folder_scan_state',
+  'likes',
+  'collections',
+  'collection_items'
+] as const;
+
+export interface BaselineResult {
+  baselineInserted: boolean;
+  existingSchemaDetected: boolean;
+}
+
+export interface StartupMigrationResult {
+  baselineInserted: boolean;
+  databasePath: string;
+  usedInMemoryDatabase: boolean;
+}
+
+export interface StartupMigrationOptions {
+  databasePath?: string;
+  migrationsDirectory?: string;
+  spawnSyncImpl?: typeof spawnSync;
+}
+
+function defaultMigrationsDirectory(): string {
+  return path.join(repositoryRoot, 'server', 'db', 'migrations');
+}
+
+function baselineMigrationPath(migrationsDirectory: string): string {
+  return path.join(migrationsDirectory, `${BASELINE_MIGRATION_VERSION}_baseline.sql`);
+}
+
+function extractMigrationUpSql(migrationSql: string): string {
+  const lines = migrationSql.split(/\r?\n/);
+  const upLines: string[] = [];
+  let inUpSection = false;
+
+  for (const line of lines) {
+    if (/^\s*--\s*migrate:up\b/i.test(line)) {
+      inUpSection = true;
+      continue;
+    }
+
+    if (/^\s*--\s*migrate:down\b/i.test(line)) {
+      break;
+    }
+
+    if (inUpSection) {
+      upLines.push(line);
+    }
+  }
+
+  if (!inUpSection || upLines.length === 0) {
+    throw new Error(`Baseline migration is missing an up section: ${migrationSql}`);
+  }
+
+  return upLines.join('\n').trim();
+}
+
+function applyBaselineSchema(database: DatabaseSync, migrationsDirectory: string): void {
+  const migrationSql = fs.readFileSync(baselineMigrationPath(migrationsDirectory), 'utf8');
+  database.exec(extractMigrationUpSql(migrationSql));
+}
+
+function buildSqliteDatabaseUrl(databasePath: string): string {
+  return `sqlite:${pathToFileURL(databasePath).pathname}`;
+}
+
+function hasExistingAppSchema(database: DatabaseSync): boolean {
+  return APP_SCHEMA_TABLES.some((tableName) => tableExists(database, tableName));
+}
+
+function migrationVersionExists(database: DatabaseSync, version: string): boolean {
+  if (!tableExists(database, 'schema_migrations')) {
+    return false;
+  }
+
+  const row = database
+    .prepare('SELECT version FROM schema_migrations WHERE version = ? LIMIT 1')
+    .get(version) as { version: string } | undefined;
+
+  return row?.version === version;
+}
+
+export function baselineExistingDatabaseIfNeeded(databasePath: string, options: StartupMigrationOptions = {}): BaselineResult {
+  const database = new DatabaseSync(databasePath);
+  const migrationsDirectory = options.migrationsDirectory ?? defaultMigrationsDirectory();
+
+  try {
+    assertNoLegacySchema(database);
+
+    const existingSchemaDetected = hasExistingAppSchema(database);
+    if (!existingSchemaDetected || migrationVersionExists(database, BASELINE_MIGRATION_VERSION)) {
+      return {
+        baselineInserted: false,
+        existingSchemaDetected
+      };
+    }
+
+    applyBaselineCompatMigrations(database);
+    applyBaselineSchema(database, migrationsDirectory);
+    const rebuiltForeignKeys = rebuildBaselineForeignKeys(database);
+    if (rebuiltForeignKeys) {
+      applyBaselineSchema(database, migrationsDirectory);
+    }
+    database.exec(SCHEMA_MIGRATIONS_TABLE_SQL);
+    database.prepare('INSERT OR IGNORE INTO schema_migrations(version) VALUES (?)').run(BASELINE_MIGRATION_VERSION);
+
+    return {
+      baselineInserted: true,
+      existingSchemaDetected
+    };
+  } finally {
+    database.close();
+  }
+}
+
+function runDbmateUp(databasePath: string, options: StartupMigrationOptions = {}): void {
+  const spawnSyncImpl = options.spawnSyncImpl ?? spawnSync;
+  const result = spawnSyncImpl(
+    resolveBinary(),
+    [
+      '--url',
+      buildSqliteDatabaseUrl(databasePath),
+      '--migrations-dir',
+      options.migrationsDirectory ?? defaultMigrationsDirectory(),
+      '--no-dump-schema',
+      'up'
+    ],
+    {
+      cwd: repositoryRoot,
+      env: process.env,
+      stdio: 'inherit'
+    }
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`Dbmate exited with status ${result.status ?? 'unknown'}`);
+  }
+}
+
+export function runStartupMigrations(options: StartupMigrationOptions = {}): StartupMigrationResult {
+  const databasePath = options.databasePath ?? storageService.getDatabasePath();
+  if (databasePath === ':memory:') {
+    log.info('Skipping Dbmate migrations because the configured database directory is unavailable');
+    return {
+      baselineInserted: false,
+      databasePath,
+      usedInMemoryDatabase: true
+    };
+  }
+
+  const baselineResult = baselineExistingDatabaseIfNeeded(databasePath, options);
+  runDbmateUp(databasePath, options);
+
+  return {
+    baselineInserted: baselineResult.baselineInserted,
+    databasePath,
+    usedInMemoryDatabase: false
+  };
+}

--- a/server/src/db/schema-compat.ts
+++ b/server/src/db/schema-compat.ts
@@ -1,0 +1,400 @@
+import { DatabaseSync } from 'node:sqlite';
+
+interface ForeignKeyRecord {
+  table: string;
+  from: string;
+  to: string;
+  on_delete: string;
+}
+
+export function tableExists(database: DatabaseSync, name: string): boolean {
+  const row = database
+    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`)
+    .get(name) as { name: string } | undefined;
+
+  return row?.name === name;
+}
+
+export function tableHasColumn(database: DatabaseSync, tableName: string, columnName: string): boolean {
+  if (!tableExists(database, tableName)) {
+    return false;
+  }
+
+  const columns = database.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
+  return columns.some((column) => column.name === columnName);
+}
+
+function tableHasForeignKey(database: DatabaseSync, tableName: string, options: {
+  from: string;
+  toTable: string;
+  toColumn: string;
+  onDelete: string;
+}): boolean {
+  if (!tableExists(database, tableName)) {
+    return false;
+  }
+
+  const foreignKeys = database.prepare(`PRAGMA foreign_key_list(${tableName})`).all() as unknown as ForeignKeyRecord[];
+  return foreignKeys.some((foreignKey) =>
+    foreignKey.from === options.from &&
+    foreignKey.table === options.toTable &&
+    foreignKey.to === options.toColumn &&
+    foreignKey.on_delete.toUpperCase() === options.onDelete.toUpperCase()
+  );
+}
+
+export function assertNoLegacySchema(database: DatabaseSync): void {
+  const hasLegacyProfilesTable = tableExists(database, 'profiles');
+  const imagesUseLegacyProfileId = tableHasColumn(database, 'images', 'profile_id');
+
+  if (!hasLegacyProfilesTable && !imagesUseLegacyProfileId) {
+    return;
+  }
+
+  throw new Error('Legacy database schema detected. Delete the SQLite file and restart the app to rebuild the database with folders/folder_id tables.');
+}
+
+export function applyBaselineCompatMigrations(database: DatabaseSync): void {
+  if (tableExists(database, 'folders') && !tableHasColumn(database, 'folders', 'description')) {
+    database.exec('ALTER TABLE folders ADD COLUMN description TEXT NULL');
+  }
+
+  if (tableExists(database, 'folders') && !tableHasColumn(database, 'folders', 'avatar_image_id')) {
+    database.exec('ALTER TABLE folders ADD COLUMN avatar_image_id INTEGER NULL');
+  }
+
+  if (tableExists(database, 'folders') && !tableHasColumn(database, 'folders', 'avatar_source')) {
+    database.exec("ALTER TABLE folders ADD COLUMN avatar_source TEXT NOT NULL DEFAULT 'auto'");
+  }
+
+  if (tableExists(database, 'folders') && !tableHasColumn(database, 'folders', 'role')) {
+    database.exec("ALTER TABLE folders ADD COLUMN role TEXT NOT NULL DEFAULT 'normal'");
+  }
+
+  if (tableExists(database, 'folders') && !tableHasColumn(database, 'folders', 'story_owner_folder_id')) {
+    database.exec('ALTER TABLE folders ADD COLUMN story_owner_folder_id INTEGER NULL');
+  }
+
+  if (tableExists(database, 'images') && !tableHasColumn(database, 'images', 'media_type')) {
+    database.exec("ALTER TABLE images ADD COLUMN media_type TEXT NOT NULL DEFAULT 'image'");
+  }
+
+  if (tableExists(database, 'images') && !tableHasColumn(database, 'images', 'duration_ms')) {
+    database.exec('ALTER TABLE images ADD COLUMN duration_ms REAL NULL');
+  }
+
+  if (tableExists(database, 'images') && !tableHasColumn(database, 'images', 'display_orientation')) {
+    database.exec('ALTER TABLE images ADD COLUMN display_orientation INTEGER NULL');
+  }
+
+  if (tableExists(database, 'images') && !tableHasColumn(database, 'images', 'is_animated')) {
+    database.exec('ALTER TABLE images ADD COLUMN is_animated INTEGER NULL');
+  }
+
+  if (tableExists(database, 'images') && !tableHasColumn(database, 'images', 'taken_at')) {
+    database.exec('ALTER TABLE images ADD COLUMN taken_at INTEGER NULL');
+  }
+
+  if (tableExists(database, 'images') && !tableHasColumn(database, 'images', 'taken_at_source')) {
+    database.exec('ALTER TABLE images ADD COLUMN taken_at_source TEXT NULL');
+  }
+
+  if (tableExists(database, 'images') && !tableHasColumn(database, 'images', 'exif_json')) {
+    database.exec('ALTER TABLE images ADD COLUMN exif_json TEXT NULL');
+  }
+
+  if (tableExists(database, 'images') && !tableHasColumn(database, 'images', 'playback_strategy')) {
+    database.exec("ALTER TABLE images ADD COLUMN playback_strategy TEXT NOT NULL DEFAULT 'preview'");
+  }
+
+  if (tableExists(database, 'images') && tableHasColumn(database, 'images', 'playback_strategy')) {
+    database.exec("UPDATE images SET playback_strategy = 'preview' WHERE playback_strategy IS NULL OR playback_strategy = ''");
+  }
+
+  if (tableExists(database, 'images') && tableHasColumn(database, 'images', 'is_animated')) {
+    database.exec("UPDATE images SET is_animated = 0 WHERE media_type = 'video' AND is_animated IS NULL");
+  }
+
+  if (tableExists(database, 'images') && !tableHasColumn(database, 'images', 'is_trashed')) {
+    database.exec('ALTER TABLE images ADD COLUMN is_trashed INTEGER NOT NULL DEFAULT 0');
+  }
+
+  if (tableExists(database, 'images') && !tableHasColumn(database, 'images', 'asset_key')) {
+    database.exec('ALTER TABLE images ADD COLUMN asset_key TEXT NULL');
+  }
+
+  if (tableExists(database, 'images') && !tableHasColumn(database, 'images', 'place_id')) {
+    database.exec('ALTER TABLE images ADD COLUMN place_id INTEGER NULL');
+  }
+
+  if (tableExists(database, 'images') && !tableHasColumn(database, 'images', 'deleted_at')) {
+    database.exec('ALTER TABLE images ADD COLUMN deleted_at TEXT NULL');
+  }
+
+  if (tableExists(database, 'images') && !tableHasColumn(database, 'images', 'trashed_at')) {
+    database.exec('ALTER TABLE images ADD COLUMN trashed_at TEXT NULL');
+  }
+
+  if (tableExists(database, 'images') && tableHasColumn(database, 'images', 'deleted_at')) {
+    database.exec("UPDATE images SET deleted_at = updated_at WHERE is_deleted = 1 AND deleted_at IS NULL");
+    database.exec('UPDATE images SET deleted_at = NULL WHERE is_deleted = 0');
+  }
+
+  if (tableExists(database, 'images') && tableHasColumn(database, 'images', 'is_trashed') && tableHasColumn(database, 'images', 'trashed_at')) {
+    database.exec('UPDATE images SET trashed_at = NULL WHERE is_trashed = 0');
+  }
+}
+
+function foldersNeedBaselineForeignKeyRebuild(database: DatabaseSync): boolean {
+  return tableExists(database, 'folders') && (
+    !tableHasForeignKey(database, 'folders', {
+      from: 'avatar_image_id',
+      toTable: 'images',
+      toColumn: 'id',
+      onDelete: 'NO ACTION'
+    }) ||
+    !tableHasForeignKey(database, 'folders', {
+      from: 'story_owner_folder_id',
+      toTable: 'folders',
+      toColumn: 'id',
+      onDelete: 'SET NULL'
+    })
+  );
+}
+
+function imagesNeedBaselineForeignKeyRebuild(database: DatabaseSync): boolean {
+  return tableExists(database, 'images') && (
+    !tableHasForeignKey(database, 'images', {
+      from: 'folder_id',
+      toTable: 'folders',
+      toColumn: 'id',
+      onDelete: 'CASCADE'
+    }) ||
+    !tableHasForeignKey(database, 'images', {
+      from: 'place_id',
+      toTable: 'places',
+      toColumn: 'id',
+      onDelete: 'SET NULL'
+    })
+  );
+}
+
+function cleanOptionalBaselineForeignKeys(database: DatabaseSync): void {
+  database.exec(`
+    UPDATE folders
+    SET avatar_image_id = NULL
+    WHERE avatar_image_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM images WHERE images.id = folders.avatar_image_id);
+
+    UPDATE folders
+    SET story_owner_folder_id = NULL
+    WHERE story_owner_folder_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM folders AS owner_folders WHERE owner_folders.id = folders.story_owner_folder_id);
+
+    UPDATE images
+    SET place_id = NULL
+    WHERE place_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM places WHERE places.id = images.place_id);
+  `);
+}
+
+function rebuildFoldersWithBaselineForeignKeys(database: DatabaseSync): void {
+  database.exec(`
+    DROP TABLE IF EXISTS __foldergram_baseline_folders;
+
+    CREATE TABLE __foldergram_baseline_folders (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      slug TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
+      folder_path TEXT NOT NULL,
+      role TEXT NOT NULL DEFAULT 'normal',
+      story_owner_folder_id INTEGER NULL,
+      description TEXT NULL,
+      avatar_image_id INTEGER NULL,
+      avatar_source TEXT NOT NULL DEFAULT 'auto',
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (avatar_image_id) REFERENCES images(id),
+      FOREIGN KEY (story_owner_folder_id) REFERENCES __foldergram_baseline_folders(id) ON DELETE SET NULL
+    );
+
+    INSERT INTO __foldergram_baseline_folders(
+      id,
+      slug,
+      name,
+      folder_path,
+      role,
+      story_owner_folder_id,
+      description,
+      avatar_image_id,
+      avatar_source,
+      created_at,
+      updated_at
+    )
+    SELECT
+      id,
+      slug,
+      name,
+      folder_path,
+      role,
+      story_owner_folder_id,
+      description,
+      avatar_image_id,
+      avatar_source,
+      created_at,
+      updated_at
+    FROM folders;
+
+    DROP TABLE folders;
+    ALTER TABLE __foldergram_baseline_folders RENAME TO folders;
+  `);
+}
+
+function rebuildImagesWithBaselineForeignKeys(database: DatabaseSync): void {
+  database.exec(`
+    DROP TABLE IF EXISTS __foldergram_baseline_images;
+
+    CREATE TABLE __foldergram_baseline_images (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      folder_id INTEGER NOT NULL,
+      place_id INTEGER NULL,
+      asset_key TEXT NULL,
+      filename TEXT NOT NULL,
+      extension TEXT NOT NULL,
+      relative_path TEXT NOT NULL UNIQUE,
+      absolute_path TEXT NOT NULL,
+      file_size INTEGER NOT NULL,
+      width INTEGER NOT NULL,
+      height INTEGER NOT NULL,
+      display_orientation INTEGER NULL,
+      media_type TEXT NOT NULL DEFAULT 'image',
+      mime_type TEXT NOT NULL,
+      duration_ms REAL NULL,
+      is_animated INTEGER NULL,
+      checksum_or_fingerprint TEXT NOT NULL,
+      mtime_ms REAL NOT NULL,
+      first_seen_at TEXT NOT NULL,
+      sort_timestamp INTEGER NOT NULL,
+      taken_at INTEGER NULL,
+      taken_at_source TEXT NULL,
+      exif_json TEXT NULL,
+      thumbnail_path TEXT NOT NULL,
+      preview_path TEXT NOT NULL,
+      playback_strategy TEXT NOT NULL DEFAULT 'preview',
+      is_deleted INTEGER NOT NULL DEFAULT 0,
+      deleted_at TEXT NULL,
+      is_trashed INTEGER NOT NULL DEFAULT 0,
+      trashed_at TEXT NULL,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (folder_id) REFERENCES folders(id) ON DELETE CASCADE,
+      FOREIGN KEY (place_id) REFERENCES places(id) ON DELETE SET NULL
+    );
+
+    INSERT INTO __foldergram_baseline_images(
+      id,
+      folder_id,
+      place_id,
+      asset_key,
+      filename,
+      extension,
+      relative_path,
+      absolute_path,
+      file_size,
+      width,
+      height,
+      display_orientation,
+      media_type,
+      mime_type,
+      duration_ms,
+      is_animated,
+      checksum_or_fingerprint,
+      mtime_ms,
+      first_seen_at,
+      sort_timestamp,
+      taken_at,
+      taken_at_source,
+      exif_json,
+      thumbnail_path,
+      preview_path,
+      playback_strategy,
+      is_deleted,
+      deleted_at,
+      is_trashed,
+      trashed_at,
+      created_at,
+      updated_at
+    )
+    SELECT
+      id,
+      folder_id,
+      place_id,
+      asset_key,
+      filename,
+      extension,
+      relative_path,
+      absolute_path,
+      file_size,
+      width,
+      height,
+      display_orientation,
+      media_type,
+      mime_type,
+      duration_ms,
+      is_animated,
+      checksum_or_fingerprint,
+      mtime_ms,
+      first_seen_at,
+      sort_timestamp,
+      taken_at,
+      taken_at_source,
+      exif_json,
+      thumbnail_path,
+      preview_path,
+      playback_strategy,
+      is_deleted,
+      deleted_at,
+      is_trashed,
+      trashed_at,
+      created_at,
+      updated_at
+    FROM images;
+
+    DROP TABLE images;
+    ALTER TABLE __foldergram_baseline_images RENAME TO images;
+  `);
+}
+
+export function rebuildBaselineForeignKeys(database: DatabaseSync): boolean {
+  const shouldRebuildFolders = foldersNeedBaselineForeignKeyRebuild(database);
+  const shouldRebuildImages = imagesNeedBaselineForeignKeyRebuild(database);
+
+  if (!shouldRebuildFolders && !shouldRebuildImages) {
+    return false;
+  }
+
+  const foreignKeyState = database.prepare('PRAGMA foreign_keys').get() as { foreign_keys: number };
+  database.exec('PRAGMA foreign_keys = OFF');
+
+  try {
+    database.exec('BEGIN');
+    cleanOptionalBaselineForeignKeys(database);
+
+    if (shouldRebuildFolders) {
+      rebuildFoldersWithBaselineForeignKeys(database);
+    }
+
+    if (shouldRebuildImages) {
+      rebuildImagesWithBaselineForeignKeys(database);
+    }
+
+    database.exec('COMMIT');
+  } catch (error) {
+    database.exec('ROLLBACK');
+    throw error;
+  } finally {
+    database.exec(`PRAGMA foreign_keys = ${foreignKeyState.foreign_keys === 1 ? 'ON' : 'OFF'}`);
+  }
+
+  return true;
+}

--- a/server/src/scripts/migrate.ts
+++ b/server/src/scripts/migrate.ts
@@ -1,0 +1,32 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { log } from '../services/log-service.js';
+import { runStartupMigrations } from '../db/migration.js';
+
+export async function main(): Promise<void> {
+  const result = runStartupMigrations();
+
+  if (!result.usedInMemoryDatabase && result.baselineInserted) {
+    log.info('Marked existing SQLite database as Dbmate baseline');
+  }
+}
+
+function isDirectExecution(): boolean {
+  const entryPoint = process.argv[1];
+  if (typeof entryPoint !== 'string' || entryPoint.length === 0) {
+    return false;
+  }
+
+  return pathToFileURL(path.resolve(entryPoint)).href === import.meta.url;
+}
+
+if (isDirectExecution()) {
+  try {
+    await main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error('Database migration failed. Foldergram will not start until the issue is resolved.', message);
+    process.exit(1);
+  }
+}

--- a/server/src/scripts/rescan.ts
+++ b/server/src/scripts/rescan.ts
@@ -1,4 +1,6 @@
-import { scannerService } from '../services/scanner-service.js';
+import { main as migrate } from './migrate.js';
 
+await migrate();
+const { scannerService } = await import('../services/scanner-service.js');
 const result = await scannerService.scanAll('script');
 console.log(JSON.stringify(result, null, 2));

--- a/server/src/services/derivative-migration-service.ts
+++ b/server/src/services/derivative-migration-service.ts
@@ -51,12 +51,21 @@ export interface DerivativeMigrationProgress {
 
 interface EnsureMigratedOptions {
   onProgress?: (progress: DerivativeMigrationProgress) => void;
+  onError?: (error: DerivativeMigrationRepairError) => void | Promise<void>;
 }
 
 export interface DerivativeMigrationSummary extends DerivativeMigrationProgress {
   migratedRows: number;
   repairedRows: number;
+  repairErrors: number;
   complete: boolean;
+}
+
+interface DerivativeMigrationRepairError {
+  currentFile: string;
+  operation: DerivativeMigrationOperation;
+  message: string;
+  sourcePath: string | null;
 }
 
 interface DerivativeCleanupSummary {
@@ -73,10 +82,46 @@ interface MissingDerivativeRepairSummary {
   repairedFiles: number;
   repairedRows: number;
   missingFiles: number;
+  repairErrors: number;
+}
+
+interface RepairRowError {
+  message: string;
+  sourcePath: string | null;
+  error: unknown;
 }
 
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function formatStep(label: string, value: string | number): string {
+  return `${label} ${value}`;
+}
+
+function joinLogParts(parts: Array<string | null | undefined>): string {
+  return parts.filter((part): part is string => Boolean(part)).join(' | ');
+}
+
+function logDerivativeRepairFailure(
+  currentFile: string,
+  sourcePath: string | null,
+  message: string,
+  error: unknown
+): void {
+  log.error(
+    joinLogParts([
+      'Derivative repair skipped',
+      formatStep('file', currentFile),
+      sourcePath ? formatStep('source', normalizePath(sourcePath)) : null,
+      message
+    ]),
+    appConfig.logVerbose ? error : undefined
+  );
 }
 
 async function fileExists(targetPath: string): Promise<boolean> {
@@ -188,6 +233,7 @@ class DerivativeMigrationService {
         currentPhaseMessage: MIGRATION_PHASE_MESSAGE,
         migratedRows: 0,
         repairedRows: 0,
+        repairErrors: 0,
         complete: true
       };
     }
@@ -199,6 +245,7 @@ class DerivativeMigrationService {
 
     const totalRows = imageRepository.countAll();
     let repairedRows = 0;
+    let repairErrors = 0;
     let migratedRows = 0;
     const progress: DerivativeMigrationProgress = {
       totalRows,
@@ -302,9 +349,18 @@ class DerivativeMigrationService {
           emitProgress({
             missingFiles: progress.missingFiles + missingFiles
           });
+        },
+        onRepairError: async (currentFile, message, sourcePath) => {
+          await options.onError?.({
+            currentFile,
+            operation: 'regenerating_derivatives',
+            message,
+            sourcePath
+          });
         }
       });
       repairedRows = repairSummary.repairedRows;
+      repairErrors = repairSummary.repairErrors;
     }
 
     appSettingsRepository.set(DERIVATIVE_STORAGE_LAYOUT_VERSION_SETTING_KEY, DERIVATIVE_STORAGE_LAYOUT_VERSION);
@@ -316,23 +372,33 @@ class DerivativeMigrationService {
       progress.backfilledAssetKeys > 0 ||
       progress.movedFiles > 0 ||
       progress.repairedFiles > 0 ||
-      progress.missingFiles > 0
+      progress.missingFiles > 0 ||
+      repairErrors > 0
     ) {
-      log.table('Derivative storage migration complete', [
+      const rows: Array<[label: string, value: unknown]> = [
         ['Rows', migratedRows],
         ['Asset keys backfilled', progress.backfilledAssetKeys],
         ['Derivative files moved', progress.movedFiles],
         ['Derivative files repaired', progress.repairedFiles],
         ['Rows repaired', repairedRows],
         ['Missing derivative files', progress.missingFiles]
-      ], 'success');
+      ];
+
+      if (repairErrors > 0) {
+        rows.push(['Derivative repair errors', repairErrors]);
+      }
+
+      log.table('Derivative storage migration complete', rows, repairErrors > 0 ? 'warning' : 'success');
     }
+
+    const complete = repairErrors === 0 && this.isMigrationComplete();
 
     return {
       ...progress,
       migratedRows,
       repairedRows,
-      complete: true
+      repairErrors,
+      complete
     };
   }
 
@@ -443,35 +509,76 @@ class DerivativeMigrationService {
       onRepairingPreview?: (currentFile: string) => void;
       onRegeneratingDerivatives?: (currentFile: string, repairedFiles: number) => void;
       onMissingFilesCounted?: (missingFiles: number) => void;
+      onRepairError?: (currentFile: string, message: string, sourcePath: string | null) => void | Promise<void>;
     } = {}
   ): Promise<MissingDerivativeRepairSummary> {
     let repairedFiles = 0;
     let repairedRows = 0;
     let missingFiles = 0;
+    let repairErrors = 0;
 
     for (const row of imageRepository.listActive()) {
       const currentFile = normalizePath(row.relative_path);
-      const repairSummary = await this.repairRow(row, {
-        onRepairingThumbnail: () => {
-          callbacks.onRepairingThumbnail?.(currentFile);
-        },
-        onRepairingPreview: () => {
-          callbacks.onRepairingPreview?.(currentFile);
-        },
-        onRegeneratingDerivatives: (repairedFiles) => {
-          callbacks.onRegeneratingDerivatives?.(currentFile, repairedFiles);
+      let fatalRepairError: string | null = null;
+
+      try {
+        const repairSummary = await this.repairRow(row, {
+          onRepairingThumbnail: () => {
+            callbacks.onRepairingThumbnail?.(currentFile);
+          },
+          onRepairingPreview: () => {
+            callbacks.onRepairingPreview?.(currentFile);
+          },
+          onRegeneratingDerivatives: (repairedFiles) => {
+            callbacks.onRegeneratingDerivatives?.(currentFile, repairedFiles);
+          }
+        });
+
+        if (repairSummary.regenerationError) {
+          repairErrors += 1;
+          await callbacks.onRepairError?.(
+            currentFile,
+            repairSummary.regenerationError.message,
+            repairSummary.regenerationError.sourcePath
+          );
+          logDerivativeRepairFailure(
+            currentFile,
+            repairSummary.regenerationError.sourcePath,
+            repairSummary.regenerationError.message,
+            repairSummary.regenerationError.error
+          );
+
+          if (appConfig.scanMediaErrorMode === 'fail') {
+            fatalRepairError = `${currentFile}: ${repairSummary.regenerationError.message}`;
+          }
         }
-      });
-      repairedFiles += repairSummary.repairedFiles;
-      repairedRows += repairSummary.repaired ? 1 : 0;
-      missingFiles += repairSummary.missingFiles;
-      callbacks.onMissingFilesCounted?.(repairSummary.missingFiles);
+
+        repairedFiles += repairSummary.repairedFiles;
+        repairedRows += repairSummary.repaired ? 1 : 0;
+        missingFiles += repairSummary.missingFiles;
+        callbacks.onMissingFilesCounted?.(repairSummary.missingFiles);
+      } catch (error) {
+        const message = getErrorMessage(error);
+
+        repairErrors += 1;
+        await callbacks.onRepairError?.(currentFile, message, null);
+        logDerivativeRepairFailure(currentFile, null, message, error);
+
+        if (appConfig.scanMediaErrorMode === 'fail') {
+          throw new Error(`${currentFile}: ${message}`);
+        }
+      }
+
+      if (fatalRepairError) {
+        throw new Error(fatalRepairError);
+      }
     }
 
     return {
       repairedFiles,
       repairedRows,
-      missingFiles
+      missingFiles,
+      repairErrors
     };
   }
 
@@ -482,9 +589,10 @@ class DerivativeMigrationService {
       onRepairingPreview?: () => void;
       onRegeneratingDerivatives?: (repairedFiles: number) => void;
     } = {}
-  ): Promise<{ repairedFiles: number; missingFiles: number; repaired: boolean }> {
+  ): Promise<{ repairedFiles: number; missingFiles: number; repaired: boolean; regenerationError: RepairRowError | null }> {
     let assetKey = row.asset_key;
     let repairedFiles = 0;
+    let regenerationError: RepairRowError | null = null;
 
     if (!assetKey) {
       assetKey = generateAssetKey();
@@ -537,14 +645,22 @@ class DerivativeMigrationService {
     const previewExistsBeforeGenerate = await fileExists(previewAbsolutePath);
 
     if ((!thumbnailExistsBeforeGenerate || !previewExistsBeforeGenerate) && sourcePath && sourceExists) {
-      const derivatives = await generateDerivatives(sourcePath, row.relative_path, false, {
-        thumbnailPath: targetThumbnailPath,
-        previewPath: targetPreviewPath
-      });
-      const regeneratedFiles = Number(derivatives.generatedThumbnail) + Number(derivatives.generatedPreview);
-      if (regeneratedFiles > 0) {
-        repairedFiles += regeneratedFiles;
-        callbacks.onRegeneratingDerivatives?.(regeneratedFiles);
+      try {
+        const derivatives = await generateDerivatives(sourcePath, row.relative_path, false, {
+          thumbnailPath: targetThumbnailPath,
+          previewPath: targetPreviewPath
+        });
+        const regeneratedFiles = Number(derivatives.generatedThumbnail) + Number(derivatives.generatedPreview);
+        if (regeneratedFiles > 0) {
+          repairedFiles += regeneratedFiles;
+          callbacks.onRegeneratingDerivatives?.(regeneratedFiles);
+        }
+      } catch (error) {
+        regenerationError = {
+          message: getErrorMessage(error),
+          sourcePath,
+          error
+        };
       }
     }
 
@@ -569,6 +685,7 @@ class DerivativeMigrationService {
     return {
       repairedFiles,
       missingFiles,
+      regenerationError,
       repaired:
         repairedFiles > 0 ||
         row.thumbnail_path !== resolvedThumbnailPath ||

--- a/server/src/services/scanner-service.ts
+++ b/server/src/services/scanner-service.ts
@@ -1,4 +1,5 @@
 import type { Stats } from 'node:fs';
+import fsSync from 'node:fs';
 import fs from 'node:fs/promises';
 import { performance } from 'node:perf_hooks';
 import path from 'node:path';
@@ -128,7 +129,7 @@ interface IndexedFolderScanOptions {
   usedSlugs: Set<string>;
   folderScanStates: Map<string, FolderScanStateRecord>;
   derivativeJobs: Map<string, DerivativeJob>;
-  errors: string[];
+  errors: ScanErrorCollector;
   options: FullScanOptions;
   context: ImageProcessingContext;
   logLabel: string;
@@ -247,6 +248,8 @@ const HEARTBEAT_INTERVAL_MS = 5000;
 const DERIVATIVE_CACHE_KEEP_FILE = '.gitkeep';
 const ROOT_DISCOVERY_LABEL = '(root)';
 const CURRENT_AVIF_METADATA_REPAIR_VERSION = '1';
+const MAX_SCAN_ERROR_TEXT_LENGTH = 8000;
+const MAX_SCAN_ERROR_LINE_LENGTH = 2000;
 export const LIBRARY_REBUILD_REQUIRED_MESSAGE =
   'Library rebuild required before scanning because the configured gallery root changed.';
 
@@ -366,6 +369,166 @@ function joinLogParts(parts: Array<string | null | undefined>): string {
 
 function createReusableDerivativeSignature(fileSize: number, mtimeMs: number, extension: string): string {
   return `${fileSize}:${Math.round(mtimeMs)}:${extension.toLowerCase()}`;
+}
+
+function sanitizeReportFilenamePart(value: string): string {
+  const sanitized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return sanitized.length > 0 ? sanitized.slice(0, 48) : 'scan';
+}
+
+function formatScanError(relativePath: string, message: string, options: { sourcePath?: string | null } = {}): string {
+  const sourcePath = options.sourcePath ? normalizePath(options.sourcePath) : null;
+  return sourcePath ? `${relativePath}: ${message} (source: ${sourcePath})` : `${relativePath}: ${message}`;
+}
+
+function truncateScanErrorLine(value: string): string {
+  if (value.length <= MAX_SCAN_ERROR_LINE_LENGTH) {
+    return value;
+  }
+
+  return `${value.slice(0, MAX_SCAN_ERROR_LINE_LENGTH - 15)}...[truncated]`;
+}
+
+class ScanErrorCollector {
+  private readonly reportPath: string;
+  private readonly sampleLines: string[] = [];
+  private sampleLength = 0;
+  private stream: fsSync.WriteStream | null = null;
+  private reportError: string | null = null;
+  count = 0;
+
+  constructor(
+    private readonly runId: number,
+    private readonly reason: string
+  ) {
+    this.reportPath = path.join(
+      appConfig.scanErrorReportDir,
+      `scan-${runId}-${sanitizeReportFilenamePart(reason)}.log`
+    );
+  }
+
+  get hasErrors(): boolean {
+    return this.count > 0;
+  }
+
+  get sampleText(): string {
+    return this.sampleLines.join('\n');
+  }
+
+  async add(error: string): Promise<string> {
+    const normalizedError = truncateScanErrorLine(error.replace(/\s+/g, ' ').trim());
+    this.count += 1;
+    this.rememberSample(normalizedError);
+    await this.write(`${this.count}. ${normalizedError}\n`);
+    return normalizedError;
+  }
+
+  async finalize(summary: ScanSummary): Promise<{ reportPath: string | null; errorMessage: string | null } | null> {
+    if (!this.hasErrors) {
+      return null;
+    }
+
+    await this.write([
+      '',
+      'Summary:',
+      `Status: ${summary.status}`,
+      `Error count: ${this.count}`,
+      `Scanned files: ${summary.scanned_files}`,
+      `New files: ${summary.new_files}`,
+      `Updated files: ${summary.updated_files}`,
+      `Removed files: ${summary.removed_files}`,
+      ''
+    ].join('\n'));
+
+    if (this.stream) {
+      await new Promise<void>((resolve) => {
+        this.stream?.end(resolve);
+      });
+    }
+
+    if (this.reportError) {
+      return {
+        reportPath: null,
+        errorMessage: this.reportError
+      };
+    }
+
+    return {
+      reportPath: this.reportPath,
+      errorMessage: null
+    };
+  }
+
+  private rememberSample(error: string): void {
+    if (this.sampleLength >= MAX_SCAN_ERROR_TEXT_LENGTH) {
+      return;
+    }
+
+    const nextLineLength = error.length + (this.sampleLines.length > 0 ? 1 : 0);
+    if (this.sampleLength + nextLineLength > MAX_SCAN_ERROR_TEXT_LENGTH) {
+      const remaining = MAX_SCAN_ERROR_TEXT_LENGTH - this.sampleLength - (this.sampleLines.length > 0 ? 1 : 0);
+      if (remaining > 0) {
+        this.sampleLines.push(error.slice(0, remaining));
+        this.sampleLength = MAX_SCAN_ERROR_TEXT_LENGTH;
+      }
+      return;
+    }
+
+    this.sampleLines.push(error);
+    this.sampleLength += nextLineLength;
+  }
+
+  private ensureStream(): fsSync.WriteStream | null {
+    if (this.stream || this.reportError) {
+      return this.stream;
+    }
+
+    try {
+      fsSync.mkdirSync(appConfig.scanErrorReportDir, { recursive: true });
+      this.stream = fsSync.createWriteStream(this.reportPath, {
+        flags: 'w',
+        mode: 0o600
+      });
+      this.stream.on('error', (error) => {
+        this.reportError = error.message;
+      });
+      this.stream.write([
+        'Foldergram scan error report',
+        `Generated at: ${new Date().toISOString()}`,
+        `Run ID: ${this.runId}`,
+        `Reason: ${this.reason}`,
+        `Gallery root: ${normalizePath(appConfig.galleryRoot)}`,
+        '',
+        'Errors:',
+        ''
+      ].join('\n'));
+    } catch (error) {
+      this.reportError = error instanceof Error ? error.message : String(error);
+      this.stream = null;
+    }
+
+    return this.stream;
+  }
+
+  private async write(value: string): Promise<void> {
+    const stream = this.ensureStream();
+    if (!stream || this.reportError) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      stream.write(value, (error?: Error | null) => {
+        if (error) {
+          this.reportError = error.message;
+        }
+        resolve();
+      });
+    });
+  }
 }
 
 class ScannerService {
@@ -641,6 +804,36 @@ class ScannerService {
     });
   }
 
+  private async applyScanErrors(summary: ScanSummary, errors: ScanErrorCollector): Promise<void> {
+    if (!errors.hasErrors) {
+      return;
+    }
+
+    if (summary.status !== 'failed') {
+      summary.status = 'completed_with_errors';
+    }
+
+    let reportNotice = '';
+    const reportResult = await errors.finalize(summary);
+
+    if (reportResult?.reportPath) {
+      reportNotice = `\n\nFull error report: ${normalizePath(reportResult.reportPath)}`;
+      log.info(
+        joinLogParts([
+          'Scan error report written',
+          formatStep('errors', errors.count),
+          formatStep('path', normalizePath(reportResult.reportPath))
+        ])
+      );
+    } else if (reportResult?.errorMessage) {
+      reportNotice = `\n\nUnable to write full error report: ${reportResult.errorMessage}`;
+      log.error('Failed to write scan error report', reportResult.errorMessage);
+    }
+
+    const sampleLimit = Math.max(0, MAX_SCAN_ERROR_TEXT_LENGTH - reportNotice.length);
+    summary.error_text = `${errors.sampleText.slice(0, sampleLimit)}${reportNotice}`;
+  }
+
   private finishUnavailableRun(runId: number, reason: string): ScanSummary {
     const storageState = storageService.refreshAvailability();
     const summary = {
@@ -827,7 +1020,7 @@ class ScannerService {
     usedSlugs: Set<string>,
     folderScanStates: Map<string, FolderScanStateRecord>,
     derivativeJobs: Map<string, DerivativeJob>,
-    errors: string[],
+    errors: ScanErrorCollector,
     options: FullScanOptions,
     context: ImageProcessingContext
   ): Promise<SourceFolderScanResult> {
@@ -904,35 +1097,46 @@ class ScannerService {
     return result;
   }
 
-  private async statIndexedFiles(files: IndexedFileReference[], errors: string[]): Promise<StatIndexedFilesResult> {
+  private async statIndexedFiles(files: IndexedFileReference[], errors: ScanErrorCollector): Promise<StatIndexedFilesResult> {
     const activeRelativePaths: string[] = [];
     const discoveredFiles: IndexedFileCandidate[] = [];
     let folderHadErrors = false;
 
-    await Promise.all(
-      files.map((file) =>
-        discoveryLimit(async () => {
-          activeRelativePaths.push(file.relativePath);
+    const statFile = async (file: IndexedFileReference) => {
+      activeRelativePaths.push(file.relativePath);
 
-          try {
-            const stats = await fs.stat(file.absolutePath);
-            discoveredFiles.push({
-              absolutePath: file.absolutePath,
-              relativePath: file.relativePath,
-              stats
-            });
-          } catch (error) {
-            folderHadErrors = true;
-            const message = error instanceof Error ? error.message : String(error);
-            errors.push(`${file.relativePath}: ${message}`);
-            this.setProgress({
-              processedImages: this.progress.processedImages + 1
-            });
-            log.error(joinLogParts(['Failed to stat media during discovery', formatStep('file', file.relativePath), message]));
-          }
-        })
-      )
-    );
+      try {
+        const stats = await fs.stat(file.absolutePath);
+        discoveredFiles.push({
+          absolutePath: file.absolutePath,
+          relativePath: file.relativePath,
+          stats
+        });
+      } catch (error) {
+        folderHadErrors = true;
+        const message = error instanceof Error ? error.message : String(error);
+        const detail = formatScanError(file.relativePath, message, {
+          sourcePath: file.absolutePath
+        });
+        await errors.add(detail);
+        this.setProgress({
+          processedImages: this.progress.processedImages + 1
+        });
+        log.error(joinLogParts(['Failed to stat media during discovery', formatStep('file', file.relativePath), message]));
+
+        if (appConfig.scanMediaErrorMode === 'fail') {
+          throw new Error(detail);
+        }
+      }
+    };
+
+    if (appConfig.scanMediaErrorMode === 'fail') {
+      for (const file of files) {
+        await statFile(file);
+      }
+    } else {
+      await Promise.all(files.map((file) => discoveryLimit(() => statFile(file))));
+    }
 
     return {
       activeRelativePaths,
@@ -1000,7 +1204,7 @@ class ScannerService {
     usedSlugs: Set<string>,
     folderScanStates: Map<string, FolderScanStateRecord>,
     derivativeJobs: Map<string, DerivativeJob>,
-    errors: string[],
+    errors: ScanErrorCollector,
     options: FullScanOptions,
     context: ImageProcessingContext,
     excludedFolderRules: string[]
@@ -1278,45 +1482,56 @@ class ScannerService {
       };
     }
 
-    await Promise.all(
-      discoveredFiles.map((file) =>
-        discoveryLimit(async () => {
-          try {
-            const result = await this.processImageFile(folder, file, options, context);
+    const scanFile = async (file: IndexedFileCandidate) => {
+      try {
+        const result = await this.processImageFile(folder, file, options, context);
 
-            if (result.status === 'new') {
-              newFiles += 1;
-            }
+        if (result.status === 'new') {
+          newFiles += 1;
+        }
 
-            if (result.status === 'updated') {
-              updatedFiles += 1;
-            }
+        if (result.status === 'updated') {
+          updatedFiles += 1;
+        }
 
-            if (result.status === 'unchanged') {
-              unchangedFiles += 1;
-              if (result.refreshedIndexedRow) {
-                refreshedUnchangedRows += 1;
-              } else {
-                skippedUnchangedRows += 1;
-              }
-            }
-
-            if (result.derivativeJob) {
-              this.queueDerivativeJob(derivativeJobs, result.derivativeJob);
-            }
-          } catch (error) {
-            folderHadErrors = true;
-            const message = error instanceof Error ? error.message : String(error);
-            errors.push(`${file.relativePath}: ${message}`);
-            log.error(joinLogParts(['Failed to index media', formatStep('file', file.relativePath), message]));
-          } finally {
-            this.setProgress({
-              processedImages: this.progress.processedImages + 1
-            });
+        if (result.status === 'unchanged') {
+          unchangedFiles += 1;
+          if (result.refreshedIndexedRow) {
+            refreshedUnchangedRows += 1;
+          } else {
+            skippedUnchangedRows += 1;
           }
-        })
-      )
-    );
+        }
+
+        if (result.derivativeJob) {
+          this.queueDerivativeJob(derivativeJobs, result.derivativeJob);
+        }
+      } catch (error) {
+        folderHadErrors = true;
+        const message = error instanceof Error ? error.message : String(error);
+        const detail = formatScanError(file.relativePath, message, {
+          sourcePath: file.absolutePath
+        });
+        await errors.add(detail);
+        log.error(joinLogParts(['Failed to index media', formatStep('file', file.relativePath), message]));
+
+        if (appConfig.scanMediaErrorMode === 'fail') {
+          throw new Error(detail);
+        }
+      } finally {
+        this.setProgress({
+          processedImages: this.progress.processedImages + 1
+        });
+      }
+    };
+
+    if (appConfig.scanMediaErrorMode === 'fail') {
+      for (const file of discoveredFiles) {
+        await scanFile(file);
+      }
+    } else {
+      await Promise.all(discoveredFiles.map((file) => discoveryLimit(() => scanFile(file))));
+    }
 
     const removedFiles = imageRepository.markFolderImagesDeleted(folder.id, activeRelativePaths);
     folderRepository.syncAvatarSelection(folder.id);
@@ -1390,7 +1605,7 @@ class ScannerService {
 
     const runId = scanRunRepository.start();
     const summary = createEmptySummary();
-    const errors: string[] = [];
+    const errors = new ScanErrorCollector(runId, reason);
     let derivativeSummary: DerivativeProcessingSummary = {
       durationMs: 0,
       generatedPreviews: 0,
@@ -1408,7 +1623,8 @@ class ScannerService {
       joinLogParts([
         'Rebuild thumbnails',
         formatStep('reason', reason),
-        formatStep('root', normalizePath(appConfig.galleryRoot))
+        formatStep('root', normalizePath(appConfig.galleryRoot)),
+        formatStep('media-errors', appConfig.scanMediaErrorMode)
       ])
     );
 
@@ -1452,12 +1668,7 @@ class ScannerService {
       log.error('Thumbnail rebuild failed', summary.error_text);
     }
 
-    if (errors.length > 0) {
-      summary.error_text = errors.join('\n').slice(0, 8000);
-      if (summary.status !== 'failed') {
-        summary.status = 'completed_with_errors';
-      }
-    }
+    await this.applyScanErrors(summary, errors);
 
     this.finishRun(runId, summary);
     log.table(
@@ -1483,7 +1694,7 @@ class ScannerService {
   ): Promise<ScanSummary> {
     const runId = scanRunRepository.start();
     const summary = createEmptySummary();
-    const errors: string[] = [];
+    const errors = new ScanErrorCollector(runId, reason);
     const derivativeJobs = new Map<string, DerivativeJob>();
     const metrics: FullScanMetrics = {
       folderShortcutHits: 0,
@@ -1537,6 +1748,7 @@ class ScannerService {
         formatStep('root-changed', formatToggle(galleryRootChanged)),
         formatStep('stored-root', formatToggle(hasStoredGalleryRoot)),
         formatStep('avif-repair', formatToggle(avifMetadataRepairPending)),
+        formatStep('media-errors', appConfig.scanMediaErrorMode),
         formatStep('stories-as-folders', formatToggle(treatStoriesAsFolders)),
         excludedFolderRules.length > 0 ? formatStep('excluded-folders', excludedFolderRules.join(',')) : null,
         appConfig.managedGalleryRelativeIgnores.length > 0
@@ -1594,12 +1806,18 @@ class ScannerService {
         currentPhaseMessage: getMigrationPhaseMessage(),
         migratedRows: 0,
         repairedRows: 0,
+        repairErrors: 0,
         complete: derivativeMigrationService.isMigrationComplete()
       };
       if (requiresDerivativeMigration) {
         migrationSummary = await derivativeMigrationService.ensureMigrated({
           onProgress: (progress) => {
             this.updateMigrationProgress(progress);
+          },
+          onError: async (error) => {
+            await errors.add(formatScanError(error.currentFile, error.message, {
+              sourcePath: error.sourcePath
+            }));
           }
         });
       }
@@ -1743,7 +1961,7 @@ class ScannerService {
 
       derivativeSummary = await this.processDerivativeJobs([...derivativeJobs.values()], errors);
 
-      if (summary.status !== 'failed' && errors.length === 0 && derivativeMigrationService.isMigrationComplete()) {
+      if (summary.status !== 'failed' && !errors.hasErrors && derivativeMigrationService.isMigrationComplete()) {
         await derivativeMigrationService.cleanupStaleDerivatives();
       }
     } catch (error) {
@@ -1752,12 +1970,7 @@ class ScannerService {
       log.error('Full scan failed', summary.error_text);
     }
 
-    if (errors.length > 0) {
-      summary.error_text = errors.join('\n').slice(0, 8000);
-      if (summary.status !== 'failed') {
-        summary.status = 'completed_with_errors';
-      }
-    }
+    await this.applyScanErrors(summary, errors);
 
     if (summary.status !== 'failed') {
       appSettingsRepository.set(LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY, currentGalleryRoot);
@@ -1786,7 +1999,7 @@ class ScannerService {
   private async performIncrementalScan(relativePaths: string[], reason: string): Promise<ScanSummary> {
     const runId = scanRunRepository.start();
     const summary = createEmptySummary();
-    const errors: string[] = [];
+    const errors = new ScanErrorCollector(runId, reason);
     const derivativeJobs = new Map<string, DerivativeJob>();
     let fallbackReason: string | null = null;
 
@@ -1841,7 +2054,8 @@ class ScannerService {
       joinLogParts([
         `Starting incremental scan (${reason})`,
         formatStep('files', normalizedPaths.length),
-        formatStep('source-folders', impactedSourceFolders.size)
+        formatStep('source-folders', impactedSourceFolders.size),
+        formatStep('media-errors', appConfig.scanMediaErrorMode)
       ])
     );
 
@@ -1898,12 +2112,7 @@ class ScannerService {
       log.error('Incremental scan failed', summary.error_text);
     }
 
-    if (errors.length > 0) {
-      summary.error_text = errors.join('\n').slice(0, 8000);
-      if (summary.status !== 'failed') {
-        summary.status = 'completed_with_errors';
-      }
-    }
+    await this.applyScanErrors(summary, errors);
 
     this.finishRun(runId, summary);
     log.table(`Finished incremental scan (${reason})`, [
@@ -1942,7 +2151,7 @@ class ScannerService {
     });
   }
 
-  private async processDerivativeJobs(jobs: DerivativeJob[], errors: string[]): Promise<DerivativeProcessingSummary> {
+  private async processDerivativeJobs(jobs: DerivativeJob[], errors: ScanErrorCollector): Promise<DerivativeProcessingSummary> {
     const startedAt = performance.now();
     let generatedThumbnails = 0;
     let generatedPreviews = 0;
@@ -1979,63 +2188,75 @@ class ScannerService {
       joinLogParts([
         'Starting derivative phase',
         formatStep('jobs', jobs.length),
-        formatStep('concurrency', appConfig.scanDerivativeConcurrency)
+        formatStep('concurrency', appConfig.scanDerivativeConcurrency),
+        formatStep('media-errors', appConfig.scanMediaErrorMode)
       ])
     );
 
-    await Promise.all(
-      jobs.map((job) =>
-        derivativeLimit(async () => {
-          try {
+    const processJob = async (job: DerivativeJob) => {
+      try {
+        this.setProgress({
+          currentOperation: getDerivativeOperationForJob(job),
+          currentFile: job.relativePath,
+          currentFolder: getSourceFolderPathFromRelativePath(job.relativePath)
+        });
+
+        if (job.kind === 'thumbnail') {
+          const thumbnail = await generateThumbnailDerivative(job.absolutePath, job.relativePath, job.force, {
+            thumbnailPath: job.thumbnailPath
+          });
+
+          if (thumbnail.generatedThumbnail) {
+            generatedThumbnails += 1;
             this.setProgress({
-              currentOperation: getDerivativeOperationForJob(job),
-              currentFile: job.relativePath,
-              currentFolder: getSourceFolderPathFromRelativePath(job.relativePath)
-            });
-
-            if (job.kind === 'thumbnail') {
-              const thumbnail = await generateThumbnailDerivative(job.absolutePath, job.relativePath, job.force, {
-                thumbnailPath: job.thumbnailPath
-              });
-
-              if (thumbnail.generatedThumbnail) {
-                generatedThumbnails += 1;
-                this.setProgress({
-                  generatedThumbnails: this.progress.generatedThumbnails + 1
-                });
-              }
-            } else {
-              const derivatives = await generateDerivatives(job.absolutePath, job.relativePath, job.force, {
-                thumbnailPath: job.thumbnailPath,
-                previewPath: job.previewPath
-              });
-
-              if (derivatives.generatedThumbnail) {
-                generatedThumbnails += 1;
-                this.setProgress({
-                  generatedThumbnails: this.progress.generatedThumbnails + 1
-                });
-              }
-
-              if (derivatives.generatedPreview) {
-                generatedPreviews += 1;
-                this.setProgress({
-                  generatedPreviews: this.progress.generatedPreviews + 1
-                });
-              }
-            }
-          } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            errors.push(`${job.relativePath}: ${message}`);
-            log.error(joinLogParts(['Derivative generation failed', formatStep('file', job.relativePath), message]));
-          } finally {
-            this.setProgress({
-              processedDerivativeJobs: this.progress.processedDerivativeJobs + 1
+              generatedThumbnails: this.progress.generatedThumbnails + 1
             });
           }
-        })
-      )
-    );
+        } else {
+          const derivatives = await generateDerivatives(job.absolutePath, job.relativePath, job.force, {
+            thumbnailPath: job.thumbnailPath,
+            previewPath: job.previewPath
+          });
+
+          if (derivatives.generatedThumbnail) {
+            generatedThumbnails += 1;
+            this.setProgress({
+              generatedThumbnails: this.progress.generatedThumbnails + 1
+            });
+          }
+
+          if (derivatives.generatedPreview) {
+            generatedPreviews += 1;
+            this.setProgress({
+              generatedPreviews: this.progress.generatedPreviews + 1
+            });
+          }
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const detail = formatScanError(job.relativePath, message, {
+          sourcePath: job.absolutePath
+        });
+        await errors.add(detail);
+        log.error(joinLogParts(['Derivative generation failed', formatStep('file', job.relativePath), message]));
+
+        if (appConfig.scanMediaErrorMode === 'fail') {
+          throw new Error(detail);
+        }
+      } finally {
+        this.setProgress({
+          processedDerivativeJobs: this.progress.processedDerivativeJobs + 1
+        });
+      }
+    };
+
+    if (appConfig.scanMediaErrorMode === 'fail') {
+      for (const job of jobs) {
+        await processJob(job);
+      }
+    } else {
+      await Promise.all(jobs.map((job) => derivativeLimit(() => processJob(job))));
+    }
 
     const summary = {
       durationMs: elapsedMilliseconds(startedAt),

--- a/server/test/derivative-layout-upgrade.test.ts
+++ b/server/test/derivative-layout-upgrade.test.ts
@@ -338,6 +338,7 @@ describe.sequential('derivative layout upgrade', () => {
       currentPhaseMessage: 'Upgrading legacy thumbnails and previews before indexing starts.',
       migratedRows: 1,
       repairedRows: 0,
+      repairErrors: 0,
       complete: true
     });
 
@@ -509,6 +510,70 @@ describe.sequential('derivative layout upgrade', () => {
     expect(summary.missingFiles).toBe(2);
     expect(migrated?.thumbnail_path).toBe(legacyThumbnailPath);
     expect(migrated?.preview_path).toBe(legacyPreviewPath);
+  });
+
+  it('skips corrupt sources during derivative repair and reports the failing file', async () => {
+    const folder = folderRepository.upsert({
+      slug: 'corrupt-repair',
+      name: 'corrupt-repair',
+      folderPath: 'corrupt-repair'
+    });
+    const relativePath = 'corrupt-repair/photo.jpg';
+    const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+    const legacyThumbnailPath = getThumbnailRelativePath(relativePath);
+    const legacyPreviewPath = getPreviewRelativePath(relativePath, 'image');
+    const sourceContents = `source:${relativePath}`;
+    const mtimeMs = Date.parse('2026-03-05T12:00:00.000Z');
+
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, sourceContents);
+    await fs.utimes(absolutePath, mtimeMs / 1000, mtimeMs / 1000);
+
+    imageRepository.upsert({
+      folderId: folder.id,
+      filename: 'photo.jpg',
+      extension: '.jpg',
+      relativePath,
+      absolutePath,
+      fileSize: Buffer.byteLength(sourceContents),
+      width: 1200,
+      height: 800,
+      mediaType: 'image',
+      mimeType: getMimeTypeFromExtension('.jpg'),
+      durationMs: null,
+      fingerprint: createFingerprint(relativePath, Buffer.byteLength(sourceContents), mtimeMs),
+      mtimeMs,
+      firstSeenAt: '2026-03-05T12:00:00.000Z',
+      sortTimestamp: mtimeMs,
+      takenAt: mtimeMs,
+      takenAtSource: 'mtime',
+      exifJson: '{}',
+      thumbnailPath: legacyThumbnailPath,
+      previewPath: legacyPreviewPath
+    });
+
+    generateDerivativesMock.mockRejectedValueOnce(new Error('VipsJpeg: premature end of JPEG image'));
+
+    const lastScan = await scannerService.scanAll('manual', {
+      repairUnchangedDerivatives: false
+    });
+    const migrated = imageRepository.getByRelativePath(relativePath);
+
+    expect(lastScan?.status).toBe('completed_with_errors');
+    expect(lastScan?.error_text).toContain(relativePath);
+    expect(lastScan?.error_text).toContain('VipsJpeg: premature end of JPEG image');
+    expect(lastScan?.error_text).toContain('Full error report:');
+    const reportPath = lastScan?.error_text?.match(/Full error report: (.+)$/m)?.[1];
+    expect(reportPath).toBeTruthy();
+    await expect(fs.readFile(reportPath!, 'utf8')).resolves.toContain(relativePath);
+    await expect(fs.readFile(reportPath!, 'utf8')).resolves.toContain('Error count: 1');
+    expect(migrated?.asset_key).toMatch(/^[a-f0-9]{32}$/);
+    expect(migrated?.thumbnail_path).toBe(legacyThumbnailPath);
+    expect(migrated?.preview_path).toBe(legacyPreviewPath);
+    expect(generateDerivativesMock).toHaveBeenCalledWith(absolutePath, relativePath, false, {
+      thumbnailPath: getThumbnailPathForAssetKey(migrated!.asset_key!),
+      previewPath: getPreviewPathForAssetKey(migrated!.asset_key!, 'image')
+    });
   });
 
   it('repairs broken rows by moving legacy mirrored derivatives into the current asset-key layout', async () => {

--- a/server/test/env-config.test.ts
+++ b/server/test/env-config.test.ts
@@ -45,7 +45,23 @@ describe.sequential('derivative mode env config', () => {
 
     expect(appConfig.imageDetailSource).toBe('preview');
     expect(appConfig.derivativeMode).toBe('eager');
+    expect(appConfig.scanMediaErrorMode).toBe('skip');
+    expect(appConfig.scanErrorReportDir).toBe(path.join(tempRoot, 'data', 'scan-errors'));
     expect(appConfig.galleryExcludedFolders).toEqual([]);
+  });
+
+  it('allows strict scan failure on media errors when requested', async () => {
+    await stubBaseEnv();
+    vi.stubEnv('SCAN_MEDIA_ERROR_MODE', 'fail');
+    vi.doMock('dotenv', () => ({
+      default: {
+        config: vi.fn()
+      }
+    }));
+
+    const { appConfig } = await import('../src/config/env.js') as EnvModule;
+
+    expect(appConfig.scanMediaErrorMode).toBe('fail');
   });
 
   it('parses excluded folder env rules with trimming and dedupe', async () => {
@@ -85,5 +101,17 @@ describe.sequential('derivative mode env config', () => {
     }));
 
     await expect(import('../src/config/env.js')).rejects.toThrow();
+  });
+
+  it('rejects derivative directories that overlap scan error reports', async () => {
+    await stubBaseEnv();
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'data'));
+    vi.doMock('dotenv', () => ({
+      default: {
+        config: vi.fn()
+      }
+    }));
+
+    await expect(import('../src/config/env.js')).rejects.toThrow(/scan error reports/i);
   });
 });

--- a/server/test/migration-bootstrap.test.ts
+++ b/server/test/migration-bootstrap.test.ts
@@ -1,0 +1,522 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MigrationModule = typeof import('../src/db/migration.js');
+type DatabaseModule = typeof import('../src/db/database.js');
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const serverRoot = path.resolve(testDirectory, '..');
+const bundledMigrationsDirectory = path.join(serverRoot, 'db', 'migrations');
+
+function listAppliedVersions(database: DatabaseSync): string[] {
+  if (!tableExists(database, 'schema_migrations')) {
+    return [];
+  }
+
+  return (database.prepare('SELECT version FROM schema_migrations ORDER BY version').all() as Array<{ version: string }>)
+    .map((row) => row.version);
+}
+
+function tableExists(database: DatabaseSync, name: string): boolean {
+  const row = database
+    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`)
+    .get(name) as { name: string } | undefined;
+
+  return row?.name === name;
+}
+
+function tableHasColumn(database: DatabaseSync, tableName: string, columnName: string): boolean {
+  if (!tableExists(database, tableName)) {
+    return false;
+  }
+
+  const rows = database.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
+  return rows.some((row) => row.name === columnName);
+}
+
+function getColumnInfo(database: DatabaseSync, tableName: string, columnName: string): { notnull: number; dflt_value: string | null } | null {
+  if (!tableExists(database, tableName)) {
+    return null;
+  }
+
+  const rows = database.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{
+    name: string;
+    notnull: number;
+    dflt_value: string | null;
+  }>;
+  const row = rows.find((entry) => entry.name === columnName);
+  return row ? { notnull: row.notnull, dflt_value: row.dflt_value } : null;
+}
+
+function listForeignKeySignatures(database: DatabaseSync, tableName: string): string[] {
+  if (!tableExists(database, tableName)) {
+    return [];
+  }
+
+  const rows = database.prepare(`PRAGMA foreign_key_list(${tableName})`).all() as Array<{
+    table: string;
+    from: string;
+    to: string;
+    on_delete: string;
+  }>;
+
+  return rows
+    .map((row) => `${row.from}->${row.table}.${row.to}:${row.on_delete}`)
+    .sort();
+}
+
+async function createTestMigrationsDirectory(rootDirectory: string, extraMigrations: Array<[filename: string, sql: string]> = []): Promise<string> {
+  const targetDirectory = path.join(rootDirectory, 'migrations');
+  await fs.mkdir(targetDirectory, { recursive: true });
+  const bundledFiles = await fs.readdir(bundledMigrationsDirectory);
+
+  for (const bundledFile of bundledFiles) {
+    await fs.copyFile(path.join(bundledMigrationsDirectory, bundledFile), path.join(targetDirectory, bundledFile));
+  }
+
+  for (const [filename, sql] of extraMigrations) {
+    await fs.writeFile(path.join(targetDirectory, filename), sql);
+  }
+
+  return targetDirectory;
+}
+
+describe.sequential('dbmate startup migrations', () => {
+  let tempRoot = '';
+
+  function stubBaseEnv(): void {
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  }
+
+  async function importMigrationModule(): Promise<MigrationModule> {
+    return import('../src/db/migration.js');
+  }
+
+  async function importDatabaseModule(): Promise<DatabaseModule> {
+    return import('../src/db/database.js');
+  }
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'foldergram-migrations-'));
+  });
+
+  beforeEach(async () => {
+    vi.unstubAllEnvs();
+    vi.doUnmock('../src/db/migration.js');
+    vi.doUnmock('../src/services/log-service.js');
+    vi.resetModules();
+    vi.restoreAllMocks();
+
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+    stubBaseEnv();
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    vi.restoreAllMocks();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('runs the baseline migration for a fresh database', async () => {
+    const { BASELINE_MIGRATION_VERSION, runStartupMigrations } = await importMigrationModule();
+
+    const result = runStartupMigrations();
+
+    expect(result.usedInMemoryDatabase).toBe(false);
+
+    const database = new DatabaseSync(path.join(tempRoot, 'db', 'gallery.sqlite'));
+
+    try {
+      expect(tableExists(database, 'folders')).toBe(true);
+      expect(tableExists(database, 'images')).toBe(true);
+      expect(tableExists(database, 'collections')).toBe(true);
+      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION]);
+    } finally {
+      database.close();
+    }
+  });
+
+  it('marks an existing pre-dbmate database as baseline without dropping indexed data', async () => {
+    const databasePath = path.join(tempRoot, 'db', 'gallery.sqlite');
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+
+    const legacyDatabase = new DatabaseSync(databasePath);
+
+    try {
+      legacyDatabase.exec(`
+        CREATE TABLE folders (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          slug TEXT NOT NULL UNIQUE,
+          name TEXT NOT NULL,
+          folder_path TEXT NOT NULL,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE images (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          folder_id INTEGER NOT NULL,
+          filename TEXT NOT NULL,
+          extension TEXT NOT NULL,
+          relative_path TEXT NOT NULL UNIQUE,
+          absolute_path TEXT NOT NULL,
+          file_size INTEGER NOT NULL,
+          width INTEGER NOT NULL,
+          height INTEGER NOT NULL,
+          mime_type TEXT NOT NULL,
+          checksum_or_fingerprint TEXT NOT NULL,
+          mtime_ms REAL NOT NULL,
+          first_seen_at TEXT NOT NULL,
+          sort_timestamp INTEGER NOT NULL,
+          thumbnail_path TEXT NOT NULL,
+          preview_path TEXT NOT NULL,
+          is_deleted INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          FOREIGN KEY (folder_id) REFERENCES folders(id) ON DELETE CASCADE
+        );
+      `);
+
+      legacyDatabase
+        .prepare('INSERT INTO folders(slug, name, folder_path) VALUES (?, ?, ?)')
+        .run('legacy-folder', 'Legacy Folder', 'legacy-folder');
+      legacyDatabase.prepare(`
+        INSERT INTO images(
+          folder_id,
+          filename,
+          extension,
+          relative_path,
+          absolute_path,
+          file_size,
+          width,
+          height,
+          mime_type,
+          checksum_or_fingerprint,
+          mtime_ms,
+          first_seen_at,
+          sort_timestamp,
+          thumbnail_path,
+          preview_path
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        1,
+        'photo-1.jpg',
+        '.jpg',
+        'legacy-folder/photo-1.jpg',
+        path.join(tempRoot, 'gallery', 'legacy-folder', 'photo-1.jpg'),
+        1234,
+        1200,
+        900,
+        'image/jpeg',
+        'legacy-folder/photo-1.jpg:1234',
+        Date.parse('2026-05-01T10:00:00.000Z'),
+        '2026-05-01T10:00:00.000Z',
+        Date.parse('2026-05-01T10:00:00.000Z'),
+        'legacy-folder/photo-1.webp',
+        'legacy-folder/photo-1.webp'
+      );
+    } finally {
+      legacyDatabase.close();
+    }
+
+    const { BASELINE_MIGRATION_VERSION, runStartupMigrations } = await importMigrationModule();
+    runStartupMigrations({ databasePath });
+
+    const database = new DatabaseSync(databasePath);
+
+    try {
+      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION]);
+      expect(tableExists(database, 'collections')).toBe(true);
+      expect(tableHasColumn(database, 'folders', 'avatar_image_id')).toBe(true);
+      expect(tableHasColumn(database, 'folders', 'avatar_source')).toBe(true);
+      expect(tableHasColumn(database, 'images', 'playback_strategy')).toBe(true);
+      expect(listForeignKeySignatures(database, 'folders')).toEqual([
+        'avatar_image_id->images.id:NO ACTION',
+        'story_owner_folder_id->folders.id:SET NULL'
+      ]);
+      expect(listForeignKeySignatures(database, 'images')).toEqual([
+        'folder_id->folders.id:CASCADE',
+        'place_id->places.id:SET NULL'
+      ]);
+      expect(getColumnInfo(database, 'images', 'playback_strategy')).toEqual({
+        notnull: 1,
+        dflt_value: "'preview'"
+      });
+      expect(database.prepare('SELECT COUNT(*) AS count FROM images').get()).toEqual({ count: 1 });
+      expect(database.prepare('SELECT playback_strategy AS playbackStrategy FROM images WHERE id = 1').get()).toEqual({
+        playbackStrategy: 'preview'
+      });
+    } finally {
+      database.close();
+    }
+  });
+
+  it('runs a pending migration once and records its version', async () => {
+    const { BASELINE_MIGRATION_VERSION, runStartupMigrations } = await importMigrationModule();
+    const databasePath = path.join(tempRoot, 'db', 'gallery.sqlite');
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    const migrationsDirectory = await createTestMigrationsDirectory(tempRoot, [
+      [
+        '000002_add_test_note.sql',
+        `-- migrate:up
+
+ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
+
+-- migrate:down
+
+-- Forward-only for test coverage.
+`
+      ]
+    ]);
+
+    runStartupMigrations({
+      databasePath,
+      migrationsDirectory
+    });
+
+    const database = new DatabaseSync(databasePath);
+
+    try {
+      expect(tableHasColumn(database, 'images', 'migration_note')).toBe(true);
+      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002']);
+    } finally {
+      database.close();
+    }
+  });
+
+  it('baselines an existing pre-dbmate database before applying later migrations', async () => {
+    const databasePath = path.join(tempRoot, 'db', 'gallery.sqlite');
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    const legacyDatabase = new DatabaseSync(databasePath);
+
+    try {
+      legacyDatabase.exec(`
+        CREATE TABLE folders (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          slug TEXT NOT NULL UNIQUE,
+          name TEXT NOT NULL,
+          folder_path TEXT NOT NULL,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE images (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          folder_id INTEGER NOT NULL,
+          filename TEXT NOT NULL,
+          extension TEXT NOT NULL,
+          relative_path TEXT NOT NULL UNIQUE,
+          absolute_path TEXT NOT NULL,
+          file_size INTEGER NOT NULL,
+          width INTEGER NOT NULL,
+          height INTEGER NOT NULL,
+          mime_type TEXT NOT NULL,
+          checksum_or_fingerprint TEXT NOT NULL,
+          mtime_ms REAL NOT NULL,
+          first_seen_at TEXT NOT NULL,
+          sort_timestamp INTEGER NOT NULL,
+          thumbnail_path TEXT NOT NULL,
+          preview_path TEXT NOT NULL,
+          is_deleted INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          FOREIGN KEY (folder_id) REFERENCES folders(id) ON DELETE CASCADE
+        );
+      `);
+
+      legacyDatabase
+        .prepare('INSERT INTO folders(slug, name, folder_path) VALUES (?, ?, ?)')
+        .run('legacy-folder', 'Legacy Folder', 'legacy-folder');
+      legacyDatabase.prepare(`
+        INSERT INTO images(
+          folder_id,
+          filename,
+          extension,
+          relative_path,
+          absolute_path,
+          file_size,
+          width,
+          height,
+          mime_type,
+          checksum_or_fingerprint,
+          mtime_ms,
+          first_seen_at,
+          sort_timestamp,
+          thumbnail_path,
+          preview_path
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        1,
+        'photo-1.jpg',
+        '.jpg',
+        'legacy-folder/photo-1.jpg',
+        path.join(tempRoot, 'gallery', 'legacy-folder', 'photo-1.jpg'),
+        1234,
+        1200,
+        900,
+        'image/jpeg',
+        'legacy-folder/photo-1.jpg:1234',
+        Date.parse('2026-05-01T10:00:00.000Z'),
+        '2026-05-01T10:00:00.000Z',
+        Date.parse('2026-05-01T10:00:00.000Z'),
+        'legacy-folder/photo-1.webp',
+        'legacy-folder/photo-1.webp'
+      );
+    } finally {
+      legacyDatabase.close();
+    }
+
+    const { runStartupMigrations } = await importMigrationModule();
+    const migrationsDirectory = await createTestMigrationsDirectory(tempRoot, [
+      [
+        '000002_add_test_note.sql',
+        `-- migrate:up
+
+ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
+
+-- migrate:down
+
+-- Forward-only for test coverage.
+`
+      ]
+    ]);
+
+    runStartupMigrations({ databasePath, migrationsDirectory });
+
+    const database = new DatabaseSync(databasePath);
+
+    try {
+      expect(listAppliedVersions(database)).toEqual(['000001', '000002']);
+      expect(tableHasColumn(database, 'images', 'migration_note')).toBe(true);
+      expect(database.prepare('SELECT playback_strategy AS playbackStrategy FROM images WHERE id = 1').get()).toEqual({
+        playbackStrategy: 'preview'
+      });
+    } finally {
+      database.close();
+    }
+  });
+
+  it('is idempotent on a second migration run', async () => {
+    const { runStartupMigrations } = await importMigrationModule();
+    const databasePath = path.join(tempRoot, 'db', 'gallery.sqlite');
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    const migrationsDirectory = await createTestMigrationsDirectory(tempRoot, [
+      [
+        '000002_add_test_note.sql',
+        `-- migrate:up
+
+ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
+
+-- migrate:down
+
+        -- Forward-only for test coverage.
+`
+      ]
+    ]);
+
+    runStartupMigrations({ databasePath, migrationsDirectory });
+    runStartupMigrations({ databasePath, migrationsDirectory });
+
+    const database = new DatabaseSync(databasePath);
+
+    try {
+      expect(listAppliedVersions(database)).toEqual(['000001', '000002']);
+      expect(database.prepare('SELECT COUNT(*) AS count FROM schema_migrations').get()).toEqual({ count: 2 });
+    } finally {
+      database.close();
+    }
+  });
+
+  it('throws when a pending migration fails', async () => {
+    const { runStartupMigrations } = await importMigrationModule();
+    const databasePath = path.join(tempRoot, 'db', 'gallery.sqlite');
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    const migrationsDirectory = await createTestMigrationsDirectory(tempRoot, [
+      [
+        '000002_broken.sql',
+        `-- migrate:up
+
+THIS IS NOT VALID SQL;
+
+-- migrate:down
+
+-- Forward-only for test coverage.
+`
+      ]
+    ]);
+
+    expect(() =>
+      runStartupMigrations({
+        databasePath,
+        migrationsDirectory
+      })
+    ).toThrow(/Dbmate exited with status/i);
+  });
+
+  it('exits the migration script when startup migrations fail', async () => {
+    const exitError = new Error('process.exit:1');
+    const scriptPath = path.join(serverRoot, 'src', 'scripts', 'migrate.ts');
+    const originalArgv1 = process.argv[1];
+    const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: string | number | null) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+    const logErrorMock = vi.fn();
+
+    try {
+      process.argv[1] = scriptPath;
+
+      vi.doMock('../src/db/migration.js', () => ({
+        runStartupMigrations: () => {
+          throw exitError;
+        }
+      }));
+      vi.doMock('../src/services/log-service.js', () => ({
+        log: {
+          info: vi.fn(),
+          error: logErrorMock,
+          table: vi.fn()
+        }
+      }));
+
+      await expect(import('../src/scripts/migrate.js')).rejects.toThrow('process.exit:1');
+
+      expect(logErrorMock).toHaveBeenCalledWith(
+        'Database migration failed. Foldergram will not start until the issue is resolved.',
+        'process.exit:1'
+      );
+    } finally {
+      process.argv[1] = originalArgv1;
+      processExitSpy.mockRestore();
+      vi.doUnmock('../src/db/migration.js');
+      vi.doUnmock('../src/services/log-service.js');
+      vi.resetModules();
+    }
+  });
+
+  it('keeps the in-memory fallback when the database directory is unavailable', async () => {
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'occupied-file'));
+    await fs.writeFile(path.join(tempRoot, 'occupied-file'), 'not-a-directory');
+    vi.resetModules();
+
+    const { runStartupMigrations } = await importMigrationModule();
+    const result = runStartupMigrations();
+
+    expect(result.usedInMemoryDatabase).toBe(true);
+    expect(result.databasePath).toBe(':memory:');
+
+    const { databaseManager } = await importDatabaseModule();
+    expect(tableExists(databaseManager.connection, 'folders')).toBe(true);
+  });
+});

--- a/server/test/rescan-script.test.ts
+++ b/server/test/rescan-script.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { migrateMock, scanAllMock } = vi.hoisted(() => ({
+  migrateMock: vi.fn(),
+  scanAllMock: vi.fn()
+}));
+
+describe.sequential('rescan script', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    migrateMock.mockReset();
+    scanAllMock.mockReset();
+  });
+
+  it('runs migrations before scanning', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    migrateMock.mockResolvedValue(undefined);
+    scanAllMock.mockResolvedValue({ status: 'completed' });
+
+    vi.doMock('../src/scripts/migrate.js', () => ({
+      main: migrateMock
+    }));
+    vi.doMock('../src/services/scanner-service.js', () => ({
+      scannerService: {
+        scanAll: scanAllMock
+      }
+    }));
+
+    await import('../src/scripts/rescan.js');
+
+    expect(migrateMock).toHaveBeenCalledTimes(1);
+    expect(scanAllMock).toHaveBeenCalledWith('script');
+    expect(migrateMock.mock.invocationCallOrder[0]).toBeLessThan(scanAllMock.mock.invocationCallOrder[0]);
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ status: 'completed' }, null, 2));
+  });
+});

--- a/server/test/scan-media-error-mode.test.ts
+++ b/server/test/scan-media-error-mode.test.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type ScannerServiceModule = typeof import('../src/services/scanner-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+
+const generateThumbnailDerivativeMock = vi.fn();
+const generateDerivativesMock = vi.fn();
+const readMediaMetadataMock = vi.fn();
+
+describe.sequential('scan media error mode', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let scannerService: ScannerServiceModule['scannerService'];
+  let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-scan-media-errors-'));
+  });
+
+  beforeEach(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    generateThumbnailDerivativeMock.mockReset();
+    generateDerivativesMock.mockReset();
+    readMediaMetadataMock.mockReset();
+
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('SCAN_MEDIA_ERROR_MODE', 'fail');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+
+    vi.doMock('../src/services/derivative-service.js', () => ({
+      generateDerivatives: generateDerivativesMock,
+      generateThumbnailDerivative: generateThumbnailDerivativeMock,
+      readMediaMetadata: readMediaMetadataMock
+    }));
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ scannerService } = await import('../src/services/scanner-service.js'));
+    ({ maintenanceRepository } = await import('../src/db/repositories.js'));
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+    maintenanceRepository.resetLibraryIndex();
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('stops same-folder indexing after the first media error in strict mode', async () => {
+    await fs.mkdir(path.join(appConfig.galleryRoot, 'album'), { recursive: true });
+    await fs.writeFile(path.join(appConfig.galleryRoot, 'album', 'a-broken.jpg'), 'broken');
+    await fs.writeFile(path.join(appConfig.galleryRoot, 'album', 'z-also-broken.jpg'), 'also-broken');
+    readMediaMetadataMock.mockRejectedValue(new Error('metadata failed'));
+
+    const lastScan = await scannerService.scanAll('manual', {
+      repairUnchangedDerivatives: false
+    });
+
+    expect(lastScan?.status).toBe('failed');
+    expect(lastScan?.error_text).toContain('metadata failed');
+    expect(lastScan?.error_text).toContain('Full error report:');
+    expect(readMediaMetadataMock).toHaveBeenCalledTimes(1);
+    expect(generateDerivativesMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This PR adds Dbmate-backed SQLite migrations that run before the server opens the app database. Existing databases are normalized and marked at the baseline migration, fresh databases are created from the baseline SQL, and future migrations will apply automatically during pnpm dev, pnpm start, Docker startup, manual migration runs, and rescan scripts.

It also keeps the in-memory fallback behavior when DB_DIR is unavailable and adds migration bootstrap tests for fresh installs, existing database baselining, idempotency, failed migrations, and future migration upgrades.

Closes #69 