### PR TITLE
Add editable post captions and sync caption state across the app

### DIFF
--- a/client/src/api/gallery.ts
+++ b/client/src/api/gallery.ts
@@ -21,6 +21,7 @@ import type {
   FeedMode,
   FolderImageOrder,
   FolderImageOrderDefaultSetting,
+  ImageCaptionMutationResult,
   ImageDetail,
   ImageCollectionsPayload,
   LikeMutationResult,
@@ -187,6 +188,16 @@ export function fetchImage(id: number, mediaType?: 'image' | 'video') {
 
   const suffix = params.size > 0 ? `?${params.toString()}` : '';
   return requestJson<ImageDetail>(`/api/images/${id}${suffix}`);
+}
+
+export async function updateImageCaption(id: number, caption: string | null) {
+  const payload = await requestJson<ImageCaptionMutationResult>(`/api/images/${id}/caption`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ caption })
+  });
+
+  return payload.image;
 }
 
 export function fetchLikes() {

--- a/client/src/components/FeedCard.test.ts
+++ b/client/src/components/FeedCard.test.ts
@@ -2,6 +2,7 @@ import { flushPromises, mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useAuthStore } from '../stores/auth';
 import type { FeedItem } from '../types/api';
 import FeedCard from './FeedCard.vue';
 
@@ -330,5 +331,80 @@ describe('FeedCard', () => {
 
     expect(originalLink.attributes('href')).toBe('/api/originals/807');
     expect(originalLink.attributes('title')).toBe('Open original file');
+  });
+
+  it('falls back to a readable filename when the caption is not customized', () => {
+    const wrapper = mount(FeedCard, {
+      props: {
+        item: {
+          ...createImageItem(808),
+          filename: 'road_trip-shot.jpg',
+          caption: null
+        },
+        avatarUrl: null
+      },
+      global: {
+        stubs: globalStubs
+      }
+    });
+
+    expect(wrapper.text()).toContain('road trip shot');
+  });
+
+  it('renders a custom caption when present', () => {
+    const wrapper = mount(FeedCard, {
+      props: {
+        item: {
+          ...createImageItem(809),
+          caption: 'Sunrise over the bay'
+        },
+        avatarUrl: null
+      },
+      global: {
+        stubs: globalStubs
+      }
+    });
+
+    expect(wrapper.text()).toContain('Sunrise over the bay');
+    expect(wrapper.text()).not.toContain('photo 809');
+  });
+
+  it('shows the edit-caption menu action only for library managers', async () => {
+    const authStore = useAuthStore();
+    const wrapper = mount(FeedCard, {
+      props: {
+        item: createImageItem(810),
+        avatarUrl: null
+      },
+      global: {
+        stubs: globalStubs
+      }
+    });
+
+    await wrapper.get('button[aria-label="More options"]').trigger('click');
+    expect(wrapper.text()).toContain('Edit caption');
+
+    authStore.capabilities = {
+      canManageLibrary: false,
+      canDeleteMedia: false,
+      canAccessSettings: false,
+      canUseSharedLikes: true,
+      canUseLocalFavorites: false,
+      canUseSharedCollections: true,
+      canUseLocalCollections: false
+    };
+
+    const restrictedWrapper = mount(FeedCard, {
+      props: {
+        item: createImageItem(811),
+        avatarUrl: null
+      },
+      global: {
+        stubs: globalStubs
+      }
+    });
+
+    await restrictedWrapper.get('button[aria-label="More options"]').trigger('click');
+    expect(restrictedWrapper.text()).not.toContain('Edit caption');
   });
 });

--- a/client/src/components/FeedCard.vue
+++ b/client/src/components/FeedCard.vue
@@ -301,6 +301,15 @@
     <div v-if="menuOpen" class="fixed inset-0 z-50 flex items-center justify-center p-6 bg-black/48" @click.self="menuOpen = false">
       <div class="w-[min(100%,22rem)] overflow-hidden bg-surface border border-border rounded-[1rem] shadow-[var(--shadow)]">
         <button
+          v-if="authStore.canManageLibrary"
+          class="flex items-center gap-[0.8rem] w-full px-4 py-[0.95rem] border-0 border-b border-border text-text bg-transparent cursor-pointer text-left"
+          type="button"
+          @click="openCaptionEditor"
+        >
+          <span class="i-fluent-edit-16-regular w-[1.15rem] h-[1.15rem] shrink-0" aria-hidden="true" />
+          <span>Edit caption</span>
+        </button>
+        <button
           class="flex items-center gap-[0.8rem] w-full px-4 py-[0.95rem] border-0 border-b border-border text-text bg-transparent cursor-pointer text-left"
           type="button"
           @click="openOriginal"
@@ -355,6 +364,18 @@
       </div>
     </div>
 
+    <Teleport to="body">
+      <PostCaptionModal
+        v-if="isEditingCaption"
+        :filename="item.filename"
+        :caption="item.caption"
+        :error="captionError"
+        :loading="captionSaving"
+        @cancel="closeCaptionEditor"
+        @save="handleCaptionSave"
+      />
+    </Teleport>
+
     <ConfirmDialog
       v-if="confirmDeleteOpen"
       title="Delete this post?"
@@ -397,12 +418,13 @@
 <script setup lang="ts">
 import 'vidstack/bundle';
 
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { RouterLink, useRoute } from 'vue-router';
 import type { PlayerSrc } from 'vidstack';
 import type { MediaPlayerElement } from 'vidstack/elements';
 
 import { deleteImage, trashImage } from '../api/gallery';
+import { useImageCaptionEditor } from '../composables/useImageCaptionEditor';
 import { useAppStore } from '../stores/app';
 import { useAuthStore } from '../stores/auth';
 import { useFeedStore } from '../stores/feed';
@@ -410,12 +432,14 @@ import { useFoldersStore } from '../stores/folders';
 import { useLikesStore } from '../stores/likes';
 import { useMomentsStore } from '../stores/moments';
 import type { FeedItem } from '../types/api';
+import { resolveDisplayCaption } from '../utils/caption';
 import { formatMediaDuration, formatVideoTimestamp } from '../utils/media';
 import { resolveFeedAspectRatio } from '../utils/media-layout';
 import { getOriginalMediaDownloadUrl, getOriginalMediaUrl } from '../utils/original-media';
 import Avatar from './Avatar.vue';
 import CollectionBookmark from './CollectionBookmark.vue';
 import ConfirmDialog from './ConfirmDialog.vue';
+import PostCaptionModal from './PostCaptionModal.vue';
 import ResilientImage from './ResilientImage.vue';
 import VideoProgressFooter from './VideoProgressFooter.vue';
 
@@ -460,6 +484,7 @@ const deleting = ref(false);
 const confirmDeleteOpen = ref(false);
 const deleteOriginalFromDisk = ref(false);
 const deleteError = ref<string | null>(null);
+const isEditingCaption = ref(false);
 const homeVideoTarget = ref<HTMLElement | null>(null);
 const homePlayerElement = ref<MediaPlayerElement | null>(null);
 const loadedHomeVideoAspectRatio = ref<string | null>(null);
@@ -475,6 +500,12 @@ let homeVideoObserver: IntersectionObserver | null = null;
 let homeVideoMuteSyncToken = 0;
 let homePlayerReady = false;
 let removeHomePlayerEventListeners: (() => void) | null = null;
+const {
+  saving: captionSaving,
+  error: captionError,
+  saveCaption,
+  clearError: clearCaptionError
+} = useImageCaptionEditor();
 
 const imageRoute = computed(() => ({
   name: 'image',
@@ -488,13 +519,7 @@ const folderStoriesLabel = computed(() => `Open ${props.item.folderName} stories
 const folderAvatarLabel = computed(() => `Open ${props.item.folderName}`);
 const likeActionLabel = computed(() => likesStore.toggleAriaLabel(likesStore.isLiked(props.item.id)));
 const openMediaLabel = computed(() => (props.item.mediaType === 'video' ? 'Open reel' : 'Open post'));
-const caption = computed(() =>
-  props.item.filename
-    .replace(/\.[^.]+$/, '')
-    .replace(/[_-]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-);
+const caption = computed(() => resolveDisplayCaption(props.item));
 const formattedDate = computed(() =>
   new Date(props.item.takenAt ?? props.item.sortTimestamp).toLocaleDateString(undefined, {
     month: 'short',
@@ -912,6 +937,27 @@ function bindHomePlayerEventListeners(player: MediaPlayerElement | null) {
 function openOriginal() {
   menuOpen.value = false;
   window.open(getOriginalMediaUrl(props.item.id), '_blank', 'noopener,noreferrer');
+}
+
+async function openCaptionEditor() {
+  menuOpen.value = false;
+  clearCaptionError();
+  await nextTick();
+  isEditingCaption.value = true;
+}
+
+function closeCaptionEditor() {
+  clearCaptionError();
+  isEditingCaption.value = false;
+}
+
+async function handleCaptionSave(nextCaption: string | null) {
+  try {
+    await saveCaption(props.item, nextCaption);
+    closeCaptionEditor();
+  } catch {
+    // The modal surfaces the current error state.
+  }
 }
 
 function handleDelete() {

--- a/client/src/components/FolderHeader.test.ts
+++ b/client/src/components/FolderHeader.test.ts
@@ -1,0 +1,95 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { FolderSummary } from '../types/api';
+import FolderHeader from './FolderHeader.vue';
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router');
+
+  return {
+    ...actual,
+    useRoute: () => ({
+      fullPath: '/folders/animal-planet',
+      query: {}
+    })
+  };
+});
+
+function createFolder(overrides: Partial<FolderSummary> = {}): FolderSummary {
+  return {
+    id: 7,
+    slug: 'animal-planet',
+    name: 'Animal Planet',
+    description: 'Wildlife notes from the ridge line.',
+    folderPath: 'animals/big-cats',
+    breadcrumb: 'Animals / Big Cats',
+    imageCount: 3,
+    videoCount: 1,
+    latestImageMtimeMs: 1_777_000_000_000,
+    avatarImageId: null,
+    avatarUrl: null,
+    ...overrides
+  };
+}
+
+describe('FolderHeader', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('keeps the description expanded during same-folder description edits', async () => {
+    const wrapper = mount(FolderHeader, {
+      props: {
+        folder: createFolder()
+      },
+      global: {
+        stubs: {
+          Avatar: {
+            template: '<div data-test="avatar" />'
+          },
+          FolderProfileModal: {
+            template: '<div data-test="folder-profile-modal" />'
+          },
+          RouterLink: {
+            template: '<a><slot /></a>'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    const description = wrapper.get('p[id^="folder-description-"]').element as HTMLParagraphElement;
+    Object.defineProperty(description, 'clientHeight', {
+      configurable: true,
+      get: () => 40
+    });
+    Object.defineProperty(description, 'scrollHeight', {
+      configurable: true,
+      get: () => 80
+    });
+
+    await wrapper.setProps({
+      folder: createFolder({
+        description: 'Wildlife notes from the ridge line. Updated with a second sentence.'
+      })
+    });
+    await flushPromises();
+
+    const toggle = wrapper.get('button[aria-label="Expand description"]');
+    await toggle.trigger('click');
+    expect(toggle.attributes('aria-expanded')).toBe('true');
+
+    await wrapper.setProps({
+      folder: createFolder({
+        description: 'Wildlife notes from the ridge line. Updated again without navigating away.'
+      })
+    });
+    await flushPromises();
+
+    expect(wrapper.get('button[aria-label="Collapse description"]').attributes('aria-expanded')).toBe('true');
+    expect(wrapper.find('.folder-description--collapsed').exists()).toBe(false);
+  });
+});

--- a/client/src/components/FolderHeader.vue
+++ b/client/src/components/FolderHeader.vue
@@ -57,7 +57,33 @@
         <p class="m-0 font-mono text-[0.8rem] leading-[1.5] text-muted break-all">{{ folder.folderPath }}</p>
       </div>
       <div v-if="folder.description" class="max-w-[34rem] pt-[0.25rem]">
-        <p class="m-0 text-[0.95rem] leading-[1.4] whitespace-pre-wrap">{{ folder.description }}</p>
+        <div class="flex items-start gap-[0.35rem]">
+          <p
+            :id="descriptionId"
+            ref="descriptionElement"
+            :class="[
+              'm-0 text-[0.95rem] leading-[1.4] whitespace-pre-wrap',
+              { 'folder-description--collapsed': !isDescriptionExpanded }
+            ]"
+          >
+            {{ folder.description }}
+          </p>
+          <button
+            v-if="isDescriptionOverflowing"
+            class="inline-flex items-center justify-center mt-[0.05rem] w-6 h-6 p-0 border-0 rounded-full bg-transparent text-muted cursor-pointer transition-colors hover:text-text"
+            type="button"
+            :aria-expanded="isDescriptionExpanded"
+            :aria-controls="descriptionId"
+            :aria-label="isDescriptionExpanded ? 'Collapse description' : 'Expand description'"
+            @click="isDescriptionExpanded = !isDescriptionExpanded"
+          >
+            <span
+              :class="isDescriptionExpanded ? 'i-fluent-chevron-up-16-regular' : 'i-fluent-chevron-down-16-regular'"
+              class="w-4 h-4"
+              aria-hidden="true"
+            />
+          </button>
+        </div>
       </div>
     </div>
 
@@ -76,7 +102,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { RouterLink, useRoute } from 'vue-router';
 import type { FolderSummary } from '../types/api';
 import Avatar from './Avatar.vue';
@@ -102,6 +128,13 @@ const route = useRoute();
 const isEditingProfile = ref(false);
 const savingProfile = ref(false);
 const profileError = ref<string | null>(null);
+const descriptionElement = ref<HTMLElement | null>(null);
+const isDescriptionExpanded = ref(false);
+const isDescriptionOverflowing = ref(false);
+const descriptionId = `folder-description-${Math.random().toString(36).slice(2, 10)}`;
+
+let descriptionResizeObserver: ResizeObserver | null = null;
+let syncingDescriptionOverflow = false;
 
 const formattedUpdatedDate = computed(() =>
   props.folder.latestImageMtimeMs
@@ -136,6 +169,55 @@ function closeProfileEditor() {
   isEditingProfile.value = false;
 }
 
+function disconnectDescriptionObserver() {
+  if (!descriptionResizeObserver) {
+    return;
+  }
+
+  descriptionResizeObserver.disconnect();
+  descriptionResizeObserver = null;
+}
+
+function observeDescriptionElement() {
+  disconnectDescriptionObserver();
+
+  if (!descriptionElement.value || !props.folder.description) {
+    return;
+  }
+
+  descriptionResizeObserver = new ResizeObserver(() => {
+    if (syncingDescriptionOverflow) {
+      return;
+    }
+
+    void syncDescriptionOverflow();
+  });
+  descriptionResizeObserver.observe(descriptionElement.value);
+}
+
+async function syncDescriptionOverflow() {
+  await nextTick();
+
+  const element = descriptionElement.value;
+  if (!element) {
+    isDescriptionOverflowing.value = false;
+    return;
+  }
+
+  syncingDescriptionOverflow = true;
+
+  element.classList.add('folder-description--measure');
+  const isOverflowing = element.scrollHeight > element.clientHeight + 1;
+  element.classList.remove('folder-description--measure');
+
+  isDescriptionOverflowing.value = isOverflowing;
+  if (!isOverflowing) {
+    isDescriptionExpanded.value = false;
+  }
+
+  syncingDescriptionOverflow = false;
+}
+
 function buildAvatarRoute(id: number) {
   return {
     name: 'image',
@@ -153,4 +235,48 @@ function handleAvatarNavigation(event: MouseEvent, navigate: () => void) {
   appStore.setImageModalBackground(route.fullPath);
   navigate();
 }
+
+watch(
+  () => props.folder.slug,
+  async () => {
+    isDescriptionExpanded.value = false;
+    await nextTick();
+    observeDescriptionElement();
+    void syncDescriptionOverflow();
+  },
+  { immediate: true }
+);
+
+watch(
+  () => props.folder.description,
+  async () => {
+    await nextTick();
+    observeDescriptionElement();
+    void syncDescriptionOverflow();
+  }
+);
+
+watch(descriptionElement, () => {
+  observeDescriptionElement();
+  void syncDescriptionOverflow();
+});
+
+onMounted(() => {
+  observeDescriptionElement();
+  void syncDescriptionOverflow();
+});
+
+onBeforeUnmount(() => {
+  disconnectDescriptionObserver();
+});
 </script>
+
+<style scoped>
+.folder-description--collapsed,
+.folder-description--measure {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+</style>

--- a/client/src/components/PostCaptionModal.test.ts
+++ b/client/src/components/PostCaptionModal.test.ts
@@ -1,0 +1,62 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import PostCaptionModal from './PostCaptionModal.vue';
+
+describe('PostCaptionModal', () => {
+  it('emits a trimmed caption when saving', async () => {
+    const wrapper = mount(PostCaptionModal, {
+      props: {
+        filename: 'road-trip_001.jpg',
+        caption: null
+      }
+    });
+
+    await wrapper.get('textarea').setValue('  New caption  ');
+    await wrapper.get('form').trigger('submit.prevent');
+
+    expect(wrapper.emitted('save')).toEqual([['New caption']]);
+  });
+
+  it('resets to the filename fallback when saving the unchanged default caption', async () => {
+    const wrapper = mount(PostCaptionModal, {
+      props: {
+        filename: 'road-trip_001.jpg',
+        caption: null
+      }
+    });
+
+    await wrapper.get('form').trigger('submit.prevent');
+
+    expect(wrapper.emitted('save')).toEqual([[null]]);
+  });
+
+  it('emits null from the reset action when a custom caption exists', async () => {
+    const wrapper = mount(PostCaptionModal, {
+      props: {
+        filename: 'road-trip_001.jpg',
+        caption: 'Golden hour'
+      }
+    });
+
+    await wrapper.get('button[type="button"]').trigger('click');
+
+    expect(wrapper.emitted('save')).toEqual([[null]]);
+  });
+
+  it('refreshes the draft when the modal props change to a different post', async () => {
+    const wrapper = mount(PostCaptionModal, {
+      props: {
+        filename: 'road-trip_001.jpg',
+        caption: 'Golden hour'
+      }
+    });
+
+    await wrapper.setProps({
+      filename: 'city-walk_002.jpg',
+      caption: null
+    });
+
+    expect((wrapper.get('textarea').element as HTMLTextAreaElement).value).toBe('city walk 002');
+  });
+});

--- a/client/src/components/PostCaptionModal.vue
+++ b/client/src/components/PostCaptionModal.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="fixed inset-0 z-60 flex items-center justify-center p-6 bg-black/55" @click.self="$emit('cancel')">
+    <section
+      class="w-[min(100%,32rem)] p-[1.4rem] bg-surface border border-border rounded-[1.2rem] shadow-[var(--shadow)]"
+      role="dialog"
+      aria-modal="true"
+      :aria-labelledby="titleId"
+    >
+      <div class="grid gap-[1.2rem]">
+        <h2 :id="titleId" class="m-0 text-[1.25rem] font-semibold">Edit caption</h2>
+
+        <form class="grid gap-[1.1rem]" @submit.prevent="submit">
+          <div class="grid gap-[0.35rem]">
+            <div class="flex items-center justify-between gap-4">
+              <label for="post-caption" class="text-[0.85rem] font-semibold text-text">Caption</label>
+              <span class="text-[0.75rem] text-muted">{{ formData.caption.length }} / 300</span>
+            </div>
+            <textarea
+              id="post-caption"
+              v-model="formData.caption"
+              class="w-full min-h-[7rem] rounded-lg border border-border bg-surface px-[0.75rem] py-[0.6rem] text-[0.95rem] text-text placeholder-muted resize-y focus:border-text focus:outline-none focus:ring-1 focus:ring-text"
+              maxlength="300"
+              placeholder="Write a caption..."
+            />
+          </div>
+
+          <p
+            v-if="error"
+            class="m-0 rounded-[0.95rem] border border-[rgba(214,48,49,0.24)] bg-[rgba(214,48,49,0.08)] px-4 py-3 text-[0.88rem] text-[#c0392b]"
+          >
+            {{ error }}
+          </p>
+
+          <div class="flex flex-wrap items-center justify-between gap-3 mt-2">
+            <button
+              v-if="hasCustomCaption"
+              class="min-h-[2.5rem] px-4 py-[0.6rem] border border-transparent rounded-[0.75rem] font-semibold cursor-pointer bg-surface-hover text-text disabled:opacity-70 disabled:cursor-wait"
+              type="button"
+              :disabled="loading"
+              @click="resetToFilename"
+            >
+              Reset to filename
+            </button>
+            <div class="flex items-center gap-3 ml-auto">
+              <button
+                class="min-h-[2.5rem] px-4 py-[0.6rem] border border-transparent rounded-[0.75rem] font-semibold cursor-pointer bg-surface-hover text-text disabled:opacity-70 disabled:cursor-wait"
+                type="button"
+                :disabled="loading"
+                @click="$emit('cancel')"
+              >
+                Cancel
+              </button>
+              <button
+                class="min-h-[2.5rem] px-4 py-[0.6rem] border border-transparent rounded-[0.75rem] font-semibold cursor-pointer bg-text text-bg disabled:opacity-70 disabled:cursor-wait"
+                type="submit"
+                :disabled="loading"
+              >
+                {{ loading ? 'Saving...' : 'Save' }}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, watch } from 'vue';
+
+import { normalizeCaptionInput, resolveDisplayCaption } from '../utils/caption';
+
+const props = defineProps<{
+  filename: string;
+  caption?: string | null;
+  error?: string | null;
+  loading?: boolean;
+}>();
+
+const emit = defineEmits<{
+  cancel: [];
+  save: [caption: string | null];
+}>();
+
+const titleId = `caption-dialog-title-${Math.random().toString(36).slice(2, 10)}`;
+const hasCustomCaption = computed(() => props.caption !== null && props.caption !== undefined);
+const formData = reactive({
+  caption: resolveDisplayCaption({
+    filename: props.filename,
+    caption: props.caption
+  })
+});
+
+watch(
+  () => [props.filename, props.caption] as const,
+  ([filename, caption]) => {
+    formData.caption = resolveDisplayCaption({ filename, caption });
+  }
+);
+
+function submit() {
+  emit('save', normalizeCaptionInput({ filename: props.filename }, formData.caption));
+}
+
+function resetToFilename() {
+  emit('save', null);
+}
+</script>

--- a/client/src/components/PostViewer.test.ts
+++ b/client/src/components/PostViewer.test.ts
@@ -1,6 +1,6 @@
-import { flushPromises, mount } from '@vue/test-utils';
+import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { FeedItem, ImageDetail } from '../types/api';
 import { useAppStore } from '../stores/app';
@@ -8,6 +8,7 @@ import { useFoldersStore } from '../stores/folders';
 import { useLikesStore } from '../stores/likes';
 import PostViewer from './PostViewer.vue';
 
+const mockRouterPush = vi.fn();
 const mockRouterResolve = vi.fn();
 
 vi.mock('vidstack/bundle', () => ({}));
@@ -20,7 +21,7 @@ vi.mock('vue-router', async () => {
       query: {}
     }),
     useRouter: () => ({
-      push: vi.fn(),
+      push: mockRouterPush,
       resolve: mockRouterResolve
     })
   };
@@ -182,12 +183,19 @@ const globalStubs = {
 };
 
 describe('PostViewer', () => {
+  enableAutoUnmount(afterEach);
+
   beforeEach(() => {
     setActivePinia(createPinia());
+    mockRouterPush.mockReset();
     mockRouterResolve.mockReset();
     mockRouterResolve.mockImplementation((path: string) => ({
       name: path === '/likes/posts' ? 'likes' : 'folder'
     }));
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
   });
 
   it('uses likes-page neighbors instead of folder neighbors when opened from likes', () => {
@@ -382,5 +390,60 @@ describe('PostViewer', () => {
     expect(player.playCallCount).toBeGreaterThanOrEqual(1);
     expect(player.paused).toBe(true);
     expect(wrapper.find('.viewer__pause-indicator').exists()).toBe(true);
+  });
+
+  it('shows an inline caption edit button in the summary instead of the footer actions', () => {
+    const wrapper = mount(PostViewer, {
+      props: {
+        image: {
+          ...createImageDetail(26, {
+            previousImageId: null,
+            nextImageId: null
+          }),
+          caption: 'Custom field note'
+        },
+        isModal: true
+      },
+      global: {
+        stubs: globalStubs
+      }
+    });
+
+    expect(wrapper.get('.viewer__sidebar-summary button[aria-label="Edit caption"]').exists()).toBe(true);
+    expect(wrapper.find('.viewer__sidebar-actions button[aria-label="Edit caption"]').exists()).toBe(false);
+    expect(wrapper.text()).toContain('Custom field note');
+  });
+
+  it('does not navigate to another image when arrow keys are pressed inside the caption editor', async () => {
+    const wrapper = mount(PostViewer, {
+      props: {
+        image: {
+          ...createImageDetail(27, {
+            previousImageId: 26,
+            nextImageId: 28
+          }),
+          caption: 'Night market notes'
+        },
+        isModal: true
+      },
+      attachTo: document.body,
+      global: {
+        stubs: globalStubs
+      }
+    });
+
+    await wrapper.get('.viewer__sidebar-summary button[aria-label="Edit caption"]').trigger('click');
+    await flushPromises();
+
+    const textarea = document.getElementById('post-caption');
+    expect(textarea).not.toBeNull();
+
+    textarea!.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'ArrowRight',
+      bubbles: true
+    }));
+    await flushPromises();
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/PostViewer.vue
+++ b/client/src/components/PostViewer.vue
@@ -335,10 +335,22 @@
 
         <!-- Description -->
         <div class="viewer__sidebar-summary grid gap-[0.3rem] px-5 pt-[1.1rem]">
-          <p class="viewer__sidebar-caption m-0 text-text">
-            <strong class="mr-[0.35rem]">{{ image.folderName }}</strong>
-            {{ readableFilename }}
-          </p>
+          <div class="flex items-start gap-[0.35rem]">
+            <p class="viewer__sidebar-caption m-0 text-text">
+              <strong class="mr-[0.35rem]">{{ image.folderName }}</strong>
+              {{ caption }}
+            </p>
+            <button
+              v-if="authStore.canManageLibrary"
+              class="inline-flex items-center justify-center mt-[0.05rem] w-6 h-6 p-0 border-0 rounded-full bg-transparent text-muted cursor-pointer transition-colors hover:text-text"
+              type="button"
+              aria-label="Edit caption"
+              title="Edit caption"
+              @click="openCaptionEditor"
+            >
+              <span class="i-fluent-edit-16-regular w-4 h-4" aria-hidden="true" />
+            </button>
+          </div>
           <p class="viewer__sidebar-path mt-3 text-muted">
             <span class="viewer__sidebar-path-label">Folder Path</span>
             <span class="viewer__sidebar-path-value">{{ image.relativePath }}</span>
@@ -557,6 +569,18 @@
         </div>
       </aside>
     </div>
+
+    <Teleport to="body">
+      <PostCaptionModal
+        v-if="isEditingCaption && image"
+        :filename="image.filename"
+        :caption="image.caption"
+        :error="captionError"
+        :loading="captionSaving"
+        @cancel="closeCaptionEditor"
+        @save="handleCaptionSave"
+      />
+    </Teleport>
   </section>
 </template>
 
@@ -569,14 +593,17 @@
   import type { MediaPlayerElement } from "vidstack/elements"
 
   import { useHorizontalSwipe } from "../composables/useHorizontalSwipe"
+  import { useImageCaptionEditor } from "../composables/useImageCaptionEditor"
   import type { ImageDetail, FolderSummary } from "../types/api"
   import { useAppStore } from "../stores/app"
   import { useAuthStore } from "../stores/auth"
   import { useLikesStore } from "../stores/likes"
   import { useFoldersStore } from "../stores/folders"
+  import { resolveDisplayCaption } from "../utils/caption"
   import { getOriginalMediaDownloadUrl, getOriginalMediaUrl } from "../utils/original-media"
   import Avatar from "./Avatar.vue"
   import CollectionBookmark from "./CollectionBookmark.vue"
+  import PostCaptionModal from "./PostCaptionModal.vue"
   import ResilientImage from "./ResilientImage.vue"
   import VideoProgressFooter from "./VideoProgressFooter.vue"
   import { formatMediaDuration, formatVideoTimestamp, videoPreviewWouldDownscale } from "../utils/media"
@@ -614,6 +641,13 @@
   const videoCurrentTimeMs = ref(0)
   const sidebarSheetDragOffset = ref(0)
   const settingCover = ref(false)
+  const isEditingCaption = ref(false)
+  const {
+    saving: captionSaving,
+    error: captionError,
+    saveCaption,
+    clearError: clearCaptionError,
+  } = useImageCaptionEditor()
 
   const WHEEL_NAVIGATION_THRESHOLD = 72
   const NAVIGATION_COOLDOWN_MS = 320
@@ -719,15 +753,7 @@
   })
 
   const folderAvatar = computed(() => props.folder?.avatarUrl ?? null)
-  const readableFilename = computed(() =>
-    props.image
-      ? props.image.filename
-          .replace(/\.[^.]+$/, "")
-          .replace(/[_-]+/g, " ")
-          .replace(/\s+/g, " ")
-          .trim()
-      : "",
-  )
+  const caption = computed(() => (props.image ? resolveDisplayCaption(props.image) : ""))
   const formattedDate = computed(() =>
     props.image
       ? new Date(
@@ -820,6 +846,29 @@
 
     return details
   })
+
+  function openCaptionEditor() {
+    clearCaptionError()
+    isEditingCaption.value = true
+  }
+
+  function closeCaptionEditor() {
+    clearCaptionError()
+    isEditingCaption.value = false
+  }
+
+  async function handleCaptionSave(nextCaption: string | null) {
+    if (!props.image) {
+      return
+    }
+
+    try {
+      await saveCaption(props.image, nextCaption)
+      closeCaptionEditor()
+    } catch {
+      // The modal surfaces the current error state.
+    }
+  }
   const isModalSidebarCollapsible = computed(
     () => props.isModal === true && isSidebarCollapsible.value,
   )
@@ -1609,6 +1658,10 @@
       return
     }
 
+    if (isEditingCaption.value) {
+      return
+    }
+
     if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
       return
     }
@@ -1703,4 +1756,15 @@
     removePlayerEventListeners = null
     void playerElement.value?.pause().catch(() => { /* ignore */ })
   })
+
+  watch(
+    () => props.image?.id,
+    (nextImageId, previousImageId) => {
+      if (!nextImageId || nextImageId === previousImageId) {
+        return
+      }
+
+      closeCaptionEditor()
+    },
+  )
 </script>

--- a/client/src/components/ReelInfoSidebar.test.ts
+++ b/client/src/components/ReelInfoSidebar.test.ts
@@ -25,7 +25,8 @@ function createFeedItem(id: number): FeedItem {
     thumbnailUrl: `/thumbs/${id}.webp`,
     previewUrl: `/previews/${id}.mp4`,
     sortTimestamp: 1_777_000_000_000 + id,
-    takenAt: 1_777_000_000_000 + id
+    takenAt: 1_777_000_000_000 + id,
+    caption: null
   };
 }
 
@@ -48,6 +49,7 @@ function createFolder(): FolderSummary {
 function createImageDetail(id: number): ImageDetail {
   return {
     ...createFeedItem(id),
+    caption: 'Snow leopard sprint',
     folderAvatarImageId: null,
     relativePath: `animals/big-cats/snow-leopard-${id}.mp4`,
     mimeType: 'video/mp4',
@@ -156,5 +158,44 @@ describe('ReelInfoSidebar', () => {
     await flushPromises();
 
     expect(wrapper.get('.reels-info-sidebar').classes()).toContain('reels-info-sidebar--anchor-right');
+  });
+
+  it('falls back to the filename when a cleared caption should override cached detail text', async () => {
+    fetchImageMock.mockResolvedValue(createImageDetail(21));
+
+    const wrapper = mount(ReelInfoSidebar, {
+      props: {
+        item: {
+          ...createFeedItem(21),
+          caption: 'Snow leopard sprint'
+        },
+        folder: createFolder(),
+        open: true
+      },
+      global: {
+        stubs: {
+          Avatar: {
+            template: '<div data-test="avatar" />'
+          },
+          RouterLink: {
+            template: '<a><slot /></a>'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+    expect(wrapper.text()).toContain('Snow leopard sprint');
+
+    await wrapper.setProps({
+      item: {
+        ...createFeedItem(21),
+        caption: null
+      }
+    });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('snow leopard 21');
+    expect(wrapper.text()).not.toContain('Snow leopard sprint');
   });
 });

--- a/client/src/components/ReelInfoSidebar.vue
+++ b/client/src/components/ReelInfoSidebar.vue
@@ -50,7 +50,7 @@
       <span class="reels-info-sidebar__date">{{ formattedDate }}</span>
     </div>
 
-    <p class="reels-info-sidebar__caption">{{ readableFilename }}</p>
+    <p class="reels-info-sidebar__caption">{{ caption }}</p>
 
     <dl class="reels-info-sidebar__stats">
       <div class="reels-info-sidebar__stat">
@@ -104,6 +104,7 @@ import { RouterLink } from 'vue-router';
 
 import { fetchImage } from '../api/gallery';
 import type { FeedItem, FolderSummary, ImageDetail } from '../types/api';
+import { resolveDisplayCaption } from '../utils/caption';
 import { formatMediaDuration } from '../utils/media';
 import Avatar from './Avatar.vue';
 
@@ -127,12 +128,12 @@ const error = ref<string | null>(null);
 const detailCache = new Map<number, ImageDetail>();
 let requestToken = 0;
 
-const readableFilename = computed(() =>
-  props.item.filename
-    .replace(/\.[^.]+$/, '')
-    .replace(/[_-]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
+const hasExplicitItemCaption = computed(() => Object.hasOwn(props.item, 'caption'));
+const caption = computed(() =>
+  resolveDisplayCaption({
+    filename: props.item.filename,
+    caption: hasExplicitItemCaption.value ? props.item.caption ?? null : detail.value?.caption
+  })
 );
 const formattedDate = computed(() =>
   new Date(detail.value?.takenAt ?? detail.value?.sortTimestamp ?? props.item.takenAt ?? props.item.sortTimestamp).toLocaleDateString(

--- a/client/src/composables/useImageCaptionEditor.ts
+++ b/client/src/composables/useImageCaptionEditor.ts
@@ -1,0 +1,78 @@
+import { ref } from 'vue';
+
+import { updateImageCaption as updateImageCaptionRequest } from '../api/gallery';
+import { useCollectionsStore } from '../stores/collections';
+import { useExploreStore } from '../stores/explore';
+import { useFeedStore } from '../stores/feed';
+import { useFolderStoriesStore } from '../stores/folder-stories';
+import { useFoldersStore } from '../stores/folders';
+import { useLikesStore } from '../stores/likes';
+import { useMomentsStore } from '../stores/moments';
+import { usePlacesStore } from '../stores/places';
+import { useReelsStore } from '../stores/reels';
+import { useTrashStore } from '../stores/trash';
+import { useViewerStore } from '../stores/viewer';
+import type { ImageDetail } from '../types/api';
+import { normalizeCaptionInput } from '../utils/caption';
+
+export function useImageCaptionEditor() {
+  const saving = ref(false);
+  const error = ref<string | null>(null);
+
+  const feedStore = useFeedStore();
+  const foldersStore = useFoldersStore();
+  const viewerStore = useViewerStore();
+  const likesStore = useLikesStore();
+  const collectionsStore = useCollectionsStore();
+  const momentsStore = useMomentsStore();
+  const placesStore = usePlacesStore();
+  const reelsStore = useReelsStore();
+  const trashStore = useTrashStore();
+  const folderStoriesStore = useFolderStoriesStore();
+  const exploreStore = useExploreStore();
+
+  function applyCaption(id: number, caption: string | null) {
+    feedStore.updateImageCaption(id, caption);
+    foldersStore.updateImageCaption(id, caption);
+    viewerStore.updateCaption(id, caption);
+    likesStore.updateImageCaption(id, caption);
+    collectionsStore.updateImageCaption(id, caption);
+    momentsStore.updateImageCaption(id, caption);
+    placesStore.updateImageCaption(id, caption);
+    reelsStore.updateImageCaption(id, caption);
+    trashStore.updateImageCaption(id, caption);
+    folderStoriesStore.updateImageCaption(id, caption);
+    exploreStore.updateImageCaption(id, caption);
+  }
+
+  async function saveCaption(
+    image: Pick<ImageDetail, 'id' | 'filename'> | { id: number; filename: string },
+    caption: string | null
+  ) {
+    saving.value = true;
+    error.value = null;
+
+    try {
+      const normalizedCaption = normalizeCaptionInput(image, caption);
+      const updatedImage = await updateImageCaptionRequest(image.id, normalizedCaption);
+      applyCaption(updatedImage.id, updatedImage.caption ?? null);
+      return updatedImage;
+    } catch (saveError) {
+      error.value = saveError instanceof Error ? saveError.message : 'Unable to update caption';
+      throw saveError;
+    } finally {
+      saving.value = false;
+    }
+  }
+
+  function clearError() {
+    error.value = null;
+  }
+
+  return {
+    saving,
+    error,
+    saveCaption,
+    clearError
+  };
+}

--- a/client/src/stores/collections.ts
+++ b/client/src/stores/collections.ts
@@ -19,6 +19,7 @@ import type {
   FeedItem,
   ImageCollectionsPayload
 } from '../types/api';
+import { updateCaptionInItems } from '../utils/caption';
 import { useAuthStore } from './auth';
 
 type CollectionsMode = 'shared' | 'local';
@@ -634,6 +635,10 @@ export const useCollectionsStore = defineStore('collections', {
       this.setBookmarkedState(id, false);
       this.currentImages = this.currentImages.filter((item) => item.id !== id);
       delete this.membershipByImageId[id];
+    },
+
+    updateImageCaption(id: number, caption: string | null) {
+      this.currentImages = updateCaptionInItems(this.currentImages, id, caption);
     },
 
     removeFolderItems(folderSlug: string) {

--- a/client/src/stores/explore.ts
+++ b/client/src/stores/explore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 
 import { fetchFeed, fetchFeedSearch } from '../api/gallery';
 import type { FeedItem } from '../types/api';
+import { updateCaptionInItems } from '../utils/caption';
 
 interface ExploreState {
   items: FeedItem[];
@@ -188,6 +189,11 @@ export const useExploreStore = defineStore('explore', {
       this.initializeRecentSearches();
       this.recentSearchQueries = [];
       window.localStorage.removeItem(RECENT_SEARCHES_STORAGE_KEY);
+    },
+
+    updateImageCaption(id: number, caption: string | null) {
+      this.items = updateCaptionInItems(this.items, id, caption);
+      this.searchItems = updateCaptionInItems(this.searchItems, id, caption);
     },
 
     async loadInitial(force = false) {

--- a/client/src/stores/feed.ts
+++ b/client/src/stores/feed.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 
 import { fetchFeed } from '../api/gallery';
 import type { FeedItem, FeedMode } from '../types/api';
+import { updateCaptionInItems } from '../utils/caption';
 
 interface FeedState {
   mode: FeedMode;
@@ -72,6 +73,10 @@ export const useFeedStore = defineStore('feed', {
 
     removeFolderItems(folderSlug: string) {
       this.items = this.items.filter((item) => item.folderSlug !== folderSlug);
+    },
+
+    updateImageCaption(id: number, caption: string | null) {
+      this.items = updateCaptionInItems(this.items, id, caption);
     },
 
     resetForRebuild() {

--- a/client/src/stores/folder-stories.ts
+++ b/client/src/stores/folder-stories.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 
 import { fetchFolderStories, fetchFolderStoryFeed } from '../api/gallery';
 import type { FeedItem, FolderStoriesPayload, RailCapsule } from '../types/api';
+import { updateCaptionInItems } from '../utils/caption';
 
 interface FolderStoriesState {
   currentFolderSlug: string | null;
@@ -138,6 +139,10 @@ export const useFolderStoriesStore = defineStore('folderStories', {
       } finally {
         this.loadingStory = false;
       }
+    },
+
+    updateImageCaption(id: number, caption: string | null) {
+      this.currentImages = updateCaptionInItems(this.currentImages, id, caption);
     }
   }
 });

--- a/client/src/stores/folders.ts
+++ b/client/src/stores/folders.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 
 import { fetchFolderImages, fetchFolders, updateFolderProfile, setFolderCover } from '../api/gallery';
 import type { FeedItem, FolderSummary } from '../types/api';
+import { updateCaptionInItems } from '../utils/caption';
 
 type FolderMediaFilter = 'all' | 'video';
 
@@ -90,6 +91,10 @@ export const useFoldersStore = defineStore('folders', {
         this.currentPage = 1;
         this.currentHasMore = false;
       }
+    },
+
+    updateImageCaption(id: number, caption: string | null) {
+      this.currentImages = updateCaptionInItems(this.currentImages, id, caption);
     },
 
     resetForRebuild() {

--- a/client/src/stores/likes.ts
+++ b/client/src/stores/likes.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 
 import { fetchLikes, likeImage, unlikeImage } from '../api/gallery';
 import type { FeedItem, LikesMode } from '../types/api';
+import { updateCaptionInItems } from '../utils/caption';
 import { useAuthStore } from './auth';
 
 interface LikesState {
@@ -221,6 +222,14 @@ export const useLikesStore = defineStore('likes', {
       this.items = this.items.filter((item) => item.folderSlug !== folderSlug);
       this.likedIds = this.likedIds.filter((id) => !removedIds.has(id));
       this.pendingIds = this.pendingIds.filter((id) => !removedIds.has(id));
+
+      if (this.mode === 'local') {
+        writeLocalFavorites(this.items);
+      }
+    },
+
+    updateImageCaption(id: number, caption: string | null) {
+      this.items = updateCaptionInItems(this.items, id, caption);
 
       if (this.mode === 'local') {
         writeLocalFavorites(this.items);

--- a/client/src/stores/moments.ts
+++ b/client/src/stores/moments.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 
 import { fetchMomentFeed, fetchMoments } from '../api/gallery';
 import type { FeedItem, FeedRailKind, MomentCapsule } from '../types/api';
+import { updateCaptionInItems } from '../utils/caption';
 
 interface MomentsState {
   railKind: FeedRailKind;
@@ -132,6 +133,10 @@ export const useMomentsStore = defineStore('moments', {
 
     async loadCapsule(id: string, reset = true) {
       await this.loadMoment(id, reset);
+    },
+
+    updateImageCaption(id: number, caption: string | null) {
+      this.currentImages = updateCaptionInItems(this.currentImages, id, caption);
     }
   }
 });

--- a/client/src/stores/places.ts
+++ b/client/src/stores/places.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 
 import { fetchPlaceImages, fetchPlaces, fetchPlacesStatus, preparePlacesGeodata, rebuildPlaces } from '../api/gallery';
 import type { FeedItem, PlaceDetail, PlacesStatus } from '../types/api';
+import { updateCaptionInItems } from '../utils/caption';
 
 interface PlacesState {
   items: PlaceDetail[];
@@ -147,6 +148,10 @@ export const usePlacesStore = defineStore('places', {
       } finally {
         this.rebuilding = false;
       }
+    },
+
+    updateImageCaption(id: number, caption: string | null) {
+      this.currentImages = updateCaptionInItems(this.currentImages, id, caption);
     }
   }
 });

--- a/client/src/stores/reels.ts
+++ b/client/src/stores/reels.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 
 import { fetchReels } from '../api/gallery';
 import type { FeedItem, ReelsFeedMode } from '../types/api';
+import { updateCaptionInItems } from '../utils/caption';
 import { resolveReelsAffinitySnapshot, type ReelsAffinitySnapshot } from '../utils/reels';
 import { useAppStore } from './app';
 
@@ -170,6 +171,10 @@ export const useReelsStore = defineStore('reels', {
       if (activeIndex >= this.items.length - 3) {
         await this.loadMore();
       }
+    },
+
+    updateImageCaption(id: number, caption: string | null) {
+      this.items = updateCaptionInItems(this.items, id, caption);
     }
   }
 });

--- a/client/src/stores/trash.ts
+++ b/client/src/stores/trash.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 
 import { fetchTrashImages } from '../api/gallery';
 import type { TrashItem } from '../types/api';
+import { updateCaptionInItems } from '../utils/caption';
 
 interface TrashState {
   items: TrashItem[];
@@ -97,6 +98,10 @@ export const useTrashStore = defineStore('trash', {
       } finally {
         this.loading = false;
       }
+    },
+
+    updateImageCaption(id: number, caption: string | null) {
+      this.items = updateCaptionInItems(this.items, id, caption);
     }
   }
 });

--- a/client/src/stores/viewer.ts
+++ b/client/src/stores/viewer.ts
@@ -54,6 +54,17 @@ export const useViewerStore = defineStore('viewer', {
       }
     },
 
+    updateCaption(id: number, caption: string | null) {
+      if (this.image?.id !== id) {
+        return;
+      }
+
+      this.image = {
+        ...this.image,
+        caption
+      };
+    },
+
     async deleteImage(id: number, options: { permanent?: boolean } = {}): Promise<DeleteImageResult> {
       this.deleting = true;
       this.error = null;

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -50,6 +50,7 @@ export interface FeedItem {
   folderPath: string;
   folderBreadcrumb: string | null;
   filename: string;
+  caption?: string | null;
   width: number;
   height: number;
   mediaType: 'image' | 'video';
@@ -297,6 +298,11 @@ export interface DeleteImageResult {
 
 export type TrashImageResult = DeleteImageResult;
 export type RestoreImageResult = DeleteImageResult;
+
+export interface ImageCaptionMutationResult {
+  ok: boolean;
+  image: ImageDetail;
+}
 
 export interface DeleteFolderResult {
   slug: string;

--- a/client/src/utils/caption.ts
+++ b/client/src/utils/caption.ts
@@ -1,0 +1,36 @@
+export function readableFilename(filename: string): string {
+  return filename
+    .replace(/\.[^.]+$/, '')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function resolveDisplayCaption(item: { filename: string; caption?: string | null }): string {
+  if (typeof item.caption === 'string' && item.caption.trim().length > 0) {
+    return item.caption;
+  }
+
+  return readableFilename(item.filename);
+}
+
+export function normalizeCaptionInput(item: { filename: string }, caption: string | null): string | null {
+  if (caption === null) {
+    return null;
+  }
+
+  const trimmedCaption = caption.trim();
+  if (!trimmedCaption || trimmedCaption === readableFilename(item.filename)) {
+    return null;
+  }
+
+  return trimmedCaption;
+}
+
+export function updateCaptionInItems<T extends { id: number; caption?: string | null }>(
+  items: T[],
+  id: number,
+  caption: string | null
+): T[] {
+  return items.map((item) => (item.id === id ? { ...item, caption } : item));
+}

--- a/client/src/views/TrashView.test.ts
+++ b/client/src/views/TrashView.test.ts
@@ -95,6 +95,7 @@ function createTrashItem(id: number): TrashItem {
     previewUrl: `/previews/${id}.webp`,
     sortTimestamp: 1_777_000_000_000 + id,
     takenAt: 1_777_000_000_000 + id,
+    caption: null,
     trashedAt: '2026-04-04T12:00:00.000Z'
   };
 }
@@ -269,5 +270,68 @@ describe('TrashView', () => {
 
     expect(wrapper.find('[data-test="empty-state"]').exists()).toBe(true);
     expect(wrapper.text()).not.toContain('Loading trash...');
+  });
+
+  it('renders custom captions in trash cards instead of always falling back to filenames', async () => {
+    const appStore = useAppStore();
+    const trashStore = useTrashStore();
+
+    appStore.$patch({
+      stats: {
+        folders: 1,
+        indexedImages: 1,
+        indexedVideos: 0,
+        scan: {
+          isScanning: false,
+          lastCompletedScan: null
+        },
+        storage: {
+          available: true,
+          reason: null
+        },
+        libraryIndex: {
+          rebuildRequired: false,
+          reason: null,
+          ignoredRootMediaCount: 0
+        },
+        preferences: {
+          defaultHomeFeedMode: 'random',
+          defaultReelsFeedMode: 'recommended',
+          treatStoriesAsFolders: false
+        },
+        storiesMigration: {
+          hasLegacyStoriesCandidates: false,
+          decisionPending: false
+        }
+      } as never
+    });
+
+    trashStore.$patch({
+      items: [{
+        ...createTrashItem(52),
+        caption: 'Fog lifting over the ridge'
+      }],
+      initialized: true,
+      loading: false,
+      hasMore: false,
+      error: null
+    });
+
+    vi.spyOn(trashStore, 'loadInitial').mockResolvedValue(undefined);
+
+    const wrapper = mount(TrashView, {
+      global: {
+        stubs: {
+          RouterLink: {
+            template: '<a><slot /></a>'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Fog lifting over the ridge');
+    expect(wrapper.text()).not.toContain('photo 52');
   });
 });

--- a/client/src/views/TrashView.vue
+++ b/client/src/views/TrashView.vue
@@ -83,7 +83,7 @@
               class="relative block w-full aspect-square overflow-hidden border-0 p-0 text-left cursor-pointer bg-surface-alt"
               type="button"
               :aria-pressed="isSelected(item.id)"
-              :aria-label="`${isSelected(item.id) ? 'Deselect' : 'Select'} ${readableFilename(item.filename)}`"
+              :aria-label="`${isSelected(item.id) ? 'Deselect' : 'Select'} ${displayCaption(item)}`"
               @click="toggleSelected(item.id)"
             >
               <ResilientImage
@@ -124,7 +124,7 @@
             </button>
 
             <div class="grid gap-[0.35rem] px-3 py-3">
-              <p class="m-0 text-[0.84rem] truncate">{{ readableFilename(item.filename) }}</p>
+              <p class="m-0 text-[0.84rem] truncate">{{ displayCaption(item) }}</p>
               <p class="m-0 text-[0.74rem] text-muted">Trashed {{ formatTrashedAt(item.trashedAt) }}</p>
               <RouterLink class="text-[0.74rem] font-semibold text-accent-strong" :to="{ name: 'folder', params: { slug: item.folderSlug } }">
                 Open folder
@@ -183,6 +183,7 @@ import { useFoldersStore } from '../stores/folders';
 import { useLikesStore } from '../stores/likes';
 import { useMomentsStore } from '../stores/moments';
 import { useTrashStore } from '../stores/trash';
+import { resolveDisplayCaption } from '../utils/caption';
 
 const appStore = useAppStore();
 const feedStore = useFeedStore();
@@ -211,12 +212,8 @@ function toggleSelected(id: number) {
   selectedIds.value = [...selectedIds.value, id];
 }
 
-function readableFilename(filename: string) {
-  return filename
-    .replace(/\.[^.]+$/, '')
-    .replace(/[_-]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
+function displayCaption(item: { filename: string; caption?: string | null }) {
+  return resolveDisplayCaption(item);
 }
 
 function formatTrashedAt(value: string | null) {

--- a/server/db/migrations/000002_add_image_caption.sql
+++ b/server/db/migrations/000002_add_image_caption.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+
+ALTER TABLE images ADD COLUMN caption TEXT NULL;
+
+-- migrate:down
+
+-- Forward-only. Foldergram does not automatically roll back local user data migrations.

--- a/server/src/db/repositories.ts
+++ b/server/src/db/repositories.ts
@@ -148,6 +148,7 @@ const FEED_IMAGE_SELECT_SQL = `
     folders.name AS folderName,
     folders.folder_path AS folderPath,
     images.filename,
+    images.caption AS caption,
     images.width,
     images.height,
     images.media_type AS mediaType,
@@ -949,6 +950,10 @@ export const imageRepository = {
       .run(thumbnailPath, previewPath, nowIso(), id);
   },
 
+  updateCaption(id: number, caption: string | null): void {
+    database.prepare('UPDATE images SET caption = ?, updated_at = ? WHERE id = ?').run(caption, nowIso(), id);
+  },
+
   assignPlace(id: number, placeId: number | null): void {
     database.prepare('UPDATE images SET place_id = ?, updated_at = ? WHERE id = ?').run(placeId, nowIso(), id);
   },
@@ -1139,6 +1144,7 @@ export const imageRepository = {
         folders.name AS folderName,
         folders.folder_path AS folderPath,
         images.filename,
+        images.caption AS caption,
         images.width,
         images.height,
         images.media_type AS mediaType,
@@ -1182,6 +1188,7 @@ export const imageRepository = {
         search_results.folderName,
         search_results.folderPath,
         search_results.filename,
+        search_results.caption,
         search_results.width,
         search_results.height,
         search_results.mediaType,
@@ -1206,6 +1213,7 @@ export const imageRepository = {
           folders.name AS folderName,
           folders.folder_path AS folderPath,
           images.filename,
+          images.caption AS caption,
           images.width,
           images.height,
           images.media_type AS mediaType,
@@ -1380,6 +1388,7 @@ export const imageRepository = {
         folders.name AS folderName,
         folders.folder_path AS folderPath,
         images.filename,
+        images.caption AS caption,
         images.width,
         images.height,
         images.media_type AS mediaType,
@@ -1665,6 +1674,7 @@ export const imageRepository = {
         folders.folder_path AS folderPath,
         folders.avatar_image_id AS folderAvatarImageId,
         images.filename,
+        images.caption AS caption,
         images.width,
         images.height,
         images.media_type AS mediaType,
@@ -1830,6 +1840,7 @@ export const likeRepository = {
         folders.name AS folderName,
         folders.folder_path AS folderPath,
         images.filename,
+        images.caption AS caption,
         images.width,
         images.height,
         images.media_type AS mediaType,
@@ -1880,6 +1891,7 @@ export const likeRepository = {
         folders.name AS folderName,
         folders.folder_path AS folderPath,
         images.filename,
+        images.caption AS caption,
         images.width,
         images.height,
         images.media_type AS mediaType,

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS images (
   sort_timestamp INTEGER NOT NULL,
   taken_at INTEGER NULL,
   taken_at_source TEXT NULL,
+  caption TEXT NULL,
   exif_json TEXT NULL,
   thumbnail_path TEXT NOT NULL,
   preview_path TEXT NOT NULL,

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -103,6 +103,17 @@ export const patchFolderBodySchema = z.object({
   description: z.string().max(300).nullable().optional()
 });
 
+export const patchImageCaptionBodySchema = z
+  .object({
+    caption: z.preprocess(
+      (value) => (typeof value === 'string' ? value.trim() : value),
+      z.string().max(300).nullable().optional()
+    )
+  })
+  .transform((body) => ({
+    caption: body.caption === '' ? null : body.caption ?? null
+  }));
+
 export const folderCoverBodySchema = z.object({
   imageId: z.coerce.number().int().positive()
 });
@@ -674,6 +685,22 @@ router.get('/images/:id', (request, response) => {
   }
 
   response.json(image);
+});
+
+router.patch('/images/:id/caption', requireCapability('canManageLibrary', 'Admin access is required.'), (request, response) => {
+  const params = imageIdSchema.parse(request.params);
+  const body = patchImageCaptionBodySchema.parse(request.body);
+  const image = galleryService.updateImageCaption(params.id, body.caption);
+
+  if (!image) {
+    response.status(404).json({ message: 'Post not found' });
+    return;
+  }
+
+  response.json({
+    ok: true,
+    image
+  });
 });
 
 router.get('/images/:id/collections', requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -1273,6 +1273,23 @@ export const galleryService = {
     return buildFolderSummary(folder);
   },
 
+  updateImageCaption(id: number, caption: string | null) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const defaultFolderImageOrder = getDefaultFolderImageOrder();
+    const existing = imageRepository.getImageDetail(id, undefined, false, defaultFolderImageOrder);
+    if (!existing) {
+      return null;
+    }
+
+    imageRepository.updateCaption(id, caption);
+
+    const updated = imageRepository.getImageDetail(id, undefined, false, defaultFolderImageOrder);
+    return updated ? mapImageDetail(updated, getDerivativeAssetVersion()) : null;
+  },
+
   setFolderAvatar(slug: string, imageId: number) {
     if (!storageService.getState().libraryAvailable) {
       return null;

--- a/server/src/types/models.ts
+++ b/server/src/types/models.ts
@@ -89,6 +89,7 @@ export interface ImageRecord {
   sort_timestamp: number;
   taken_at: number | null;
   taken_at_source: TakenAtSource | null;
+  caption: string | null;
   exif_json: string | null;
   thumbnail_path: string;
   preview_path: string;
@@ -168,6 +169,7 @@ export interface FeedImage {
   folderPath: string;
   folderBreadcrumb?: string | null;
   filename: string;
+  caption: string | null;
   width: number;
   height: number;
   mediaType: MediaType;

--- a/server/test/folder-customization-scan-behavior.test.ts
+++ b/server/test/folder-customization-scan-behavior.test.ts
@@ -133,6 +133,25 @@ describe.sequential('folder customization scan behavior', () => {
     expect(rescannedFolder?.avatar_source).toBe('manual');
   });
 
+  it('preserves a custom caption across normal rescans', async () => {
+    maintenanceRepository.resetLibraryIndex();
+
+    await createSourceFile('albums/photo-1.jpg');
+    await scannerService.scanAll('manual');
+
+    const image = imageRepository.getByRelativePath('albums/photo-1.jpg');
+    expect(image).toBeDefined();
+
+    const updated = galleryService.updateImageCaption(image!.id, 'Golden hour on the ridge');
+    expect(updated?.caption).toBe('Golden hour on the ridge');
+
+    await createSourceFile('albums/photo-2.jpg');
+    await scannerService.scanAll('manual');
+
+    expect(imageRepository.getById(image!.id)?.caption).toBe('Golden hour on the ridge');
+    expect(galleryService.getImageDetail(image!.id)?.caption).toBe('Golden hour on the ridge');
+  });
+
   it('detects case-insensitive cover files in child albums and hides them from the feed, folder grid, and detail view', async () => {
     maintenanceRepository.resetLibraryIndex();
 

--- a/server/test/folder-customization.test.ts
+++ b/server/test/folder-customization.test.ts
@@ -101,6 +101,22 @@ describe.sequential('folder customization', () => {
       expect(() => folderCoverBodySchema.parse({ imageId: -1 })).toThrowError();
       expect(() => folderCoverBodySchema.parse({ imageId: 'abc' })).toThrowError();
     });
+
+    it('validates PATCH image caption body correctly', () => {
+      const { patchImageCaptionBodySchema } = apiModule;
+
+      expect(patchImageCaptionBodySchema.parse({ caption: '  New caption  ' })).toEqual({
+        caption: 'New caption'
+      });
+      expect(patchImageCaptionBodySchema.parse({ caption: '   ' })).toEqual({
+        caption: null
+      });
+      expect(patchImageCaptionBodySchema.parse({})).toEqual({
+        caption: null
+      });
+
+      expect(() => patchImageCaptionBodySchema.parse({ caption: 'x'.repeat(301) })).toThrowError();
+    });
   });
 
   describe('gallery service operations', () => {
@@ -143,6 +159,41 @@ describe.sequential('folder customization', () => {
 
     it('returns null updating non-existent metadata', () => {
       expect(galleryService.updateFolderMetadata('non-existent', 'Name', null)).toBeFalsy();
+    });
+
+    it('updates an image caption and clears it back to the filename fallback', () => {
+      const folder = folderRepository.upsert({ slug: 'caption-folder', name: 'Caption Folder', folderPath: 'caption-folder' });
+      const image = imageRepository.upsert({
+        folderId: folder.id,
+        filename: 'photo-1.jpg',
+        relativePath: 'caption-folder/photo-1.jpg',
+        absolutePath: '/dummy/caption-folder/photo-1.jpg',
+        fileSize: 100,
+        mtimeMs: 1000,
+        width: 100,
+        height: 100,
+        mediaType: 'image',
+        mimeType: 'image/jpeg',
+        fingerprint: 'caption-fingerprint-1',
+        sortTimestamp: 1000,
+        takenAt: 1000,
+        takenAtSource: 'mtime',
+        extension: '.jpg',
+        firstSeenAt: new Date().toISOString(),
+        thumbnailPath: 't/photo-1.webp',
+        previewPath: 'p/photo-1.webp',
+        playbackStrategy: 'preview',
+        durationMs: null,
+        exifJson: null
+      });
+
+      const updated = galleryService.updateImageCaption(image.id, 'Custom caption');
+      expect(updated?.caption).toBe('Custom caption');
+      expect(imageRepository.getById(image.id)?.caption).toBe('Custom caption');
+
+      const cleared = galleryService.updateImageCaption(image.id, null);
+      expect(cleared?.caption).toBeNull();
+      expect(imageRepository.getById(image.id)?.caption).toBeNull();
     });
 
     it('sets folder cover avatar', () => {

--- a/server/test/media-search.test.ts
+++ b/server/test/media-search.test.ts
@@ -88,6 +88,16 @@ describe.sequential('media search', () => {
     expect(new Set(payload.items.map((item) => item.id))).toEqual(new Set([compact.id, underscored.id]));
   });
 
+  it('returns saved custom captions in search results', async () => {
+    const compact = await createIndexedMedia('wildlife', 'redpanda.jpg', 1_777_100_010_000);
+    const updated = galleryService.updateImageCaption(compact.id, 'Red panda at dusk');
+
+    expect(updated?.caption).toBe('Red panda at dusk');
+
+    const payload = galleryService.searchMedia('red panda', 1, 20);
+    expect(payload.items.find((item) => item.id === compact.id)?.caption).toBe('Red panda at dusk');
+  });
+
   it('excludes deleted, trashed, and hidden cover media from search results', async () => {
     const visible = await createIndexedMedia('travel/sunrise', 'sunrise-visible.jpg', 1_777_200_000_000);
     const deleted = await createIndexedMedia('travel/sunrise', 'sunrise-deleted.jpg', 1_777_200_000_500);

--- a/server/test/migration-bootstrap.test.ts
+++ b/server/test/migration-bootstrap.test.ts
@@ -142,7 +142,8 @@ describe.sequential('dbmate startup migrations', () => {
       expect(tableExists(database, 'folders')).toBe(true);
       expect(tableExists(database, 'images')).toBe(true);
       expect(tableExists(database, 'collections')).toBe(true);
-      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION]);
+      expect(tableHasColumn(database, 'images', 'caption')).toBe(true);
+      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002']);
     } finally {
       database.close();
     }
@@ -237,11 +238,12 @@ describe.sequential('dbmate startup migrations', () => {
     const database = new DatabaseSync(databasePath);
 
     try {
-      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION]);
+      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002']);
       expect(tableExists(database, 'collections')).toBe(true);
       expect(tableHasColumn(database, 'folders', 'avatar_image_id')).toBe(true);
       expect(tableHasColumn(database, 'folders', 'avatar_source')).toBe(true);
       expect(tableHasColumn(database, 'images', 'playback_strategy')).toBe(true);
+      expect(tableHasColumn(database, 'images', 'caption')).toBe(true);
       expect(listForeignKeySignatures(database, 'folders')).toEqual([
         'avatar_image_id->images.id:NO ACTION',
         'story_owner_folder_id->folders.id:SET NULL'
@@ -269,7 +271,7 @@ describe.sequential('dbmate startup migrations', () => {
     await fs.mkdir(path.dirname(databasePath), { recursive: true });
     const migrationsDirectory = await createTestMigrationsDirectory(tempRoot, [
       [
-        '000002_add_test_note.sql',
+        '000003_add_test_note.sql',
         `-- migrate:up
 
 ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
@@ -290,7 +292,7 @@ ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
 
     try {
       expect(tableHasColumn(database, 'images', 'migration_note')).toBe(true);
-      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002']);
+      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002', '000003']);
     } finally {
       database.close();
     }
@@ -381,7 +383,7 @@ ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
     const { runStartupMigrations } = await importMigrationModule();
     const migrationsDirectory = await createTestMigrationsDirectory(tempRoot, [
       [
-        '000002_add_test_note.sql',
+        '000003_add_test_note.sql',
         `-- migrate:up
 
 ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
@@ -398,8 +400,9 @@ ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
     const database = new DatabaseSync(databasePath);
 
     try {
-      expect(listAppliedVersions(database)).toEqual(['000001', '000002']);
+      expect(listAppliedVersions(database)).toEqual(['000001', '000002', '000003']);
       expect(tableHasColumn(database, 'images', 'migration_note')).toBe(true);
+      expect(tableHasColumn(database, 'images', 'caption')).toBe(true);
       expect(database.prepare('SELECT playback_strategy AS playbackStrategy FROM images WHERE id = 1').get()).toEqual({
         playbackStrategy: 'preview'
       });
@@ -414,7 +417,7 @@ ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
     await fs.mkdir(path.dirname(databasePath), { recursive: true });
     const migrationsDirectory = await createTestMigrationsDirectory(tempRoot, [
       [
-        '000002_add_test_note.sql',
+        '000003_add_test_note.sql',
         `-- migrate:up
 
 ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
@@ -432,8 +435,8 @@ ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
     const database = new DatabaseSync(databasePath);
 
     try {
-      expect(listAppliedVersions(database)).toEqual(['000001', '000002']);
-      expect(database.prepare('SELECT COUNT(*) AS count FROM schema_migrations').get()).toEqual({ count: 2 });
+      expect(listAppliedVersions(database)).toEqual(['000001', '000002', '000003']);
+      expect(database.prepare('SELECT COUNT(*) AS count FROM schema_migrations').get()).toEqual({ count: 3 });
     } finally {
       database.close();
     }
@@ -445,7 +448,7 @@ ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
     await fs.mkdir(path.dirname(databasePath), { recursive: true });
     const migrationsDirectory = await createTestMigrationsDirectory(tempRoot, [
       [
-        '000002_broken.sql',
+        '000003_broken.sql',
         `-- migrate:up
 
 THIS IS NOT VALID SQL;

--- a/server/test/trash-flow.test.ts
+++ b/server/test/trash-flow.test.ts
@@ -190,6 +190,23 @@ describe.sequential('trash flow', () => {
     expect(galleryService.getFeed(1, 20, 'recent').items.map((item) => item.id)).not.toContain(image.id);
   });
 
+  it('preserves custom captions in likes and trash payloads', async () => {
+    await createSourceFile('captions/photo-a.jpg');
+    await scanAll('initial');
+
+    const image = mustGetImage('captions/photo-a.jpg');
+    expect(galleryService.updateImageCaption(image.id, 'Misty morning by the lake')).toMatchObject({
+      id: image.id,
+      caption: 'Misty morning by the lake'
+    });
+
+    expect(galleryService.likeImage(image.id)).toMatchObject({ id: image.id, liked: true });
+    expect(galleryService.getLikes().items.find((item) => item.id === image.id)?.caption).toBe('Misty morning by the lake');
+
+    expect(galleryService.trashImage(image.id)).toMatchObject({ id: image.id });
+    expect(galleryService.getTrashImages(1, 20).items.find((item) => item.id === image.id)?.caption).toBe('Misty morning by the lake');
+  });
+
   it('permanently deletes rows and derivatives and still succeeds when original files are already missing', async () => {
     await createSourceFile('cleanup/photo-a.jpg');
     await scanAll('initial');


### PR DESCRIPTION
- Adds admin-only post caption editing from both the feed card menu and the post viewer, with trimmed input, a 300-character limit, and filename fallback when no custom caption is set.
- Persists captions in SQLite with a new migration and keeps them stable across rescans and follow-up index refreshes.
- Synchronizes caption changes across viewer state, feed surfaces, search, likes, trash, reels, and other in-memory collections so edits appear immediately.
- Fixes stale caption edge cases, including cleared captions reappearing from cached reel detail state and modal viewer navigation interfering while caption editing is open.
- Improves folder descriptions with overflow-aware two-line collapse and local expand/collapse behavior that resets on folder navigation.

Closes #61 