### PR TITLE
Add app-wide localization foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Generated derivatives are now stored under stable asset-key shards instead of mi
 - Image and video support with configurable eager or lazy derivative generation for fast browsing.
 - Original-media download controls on home feed cards, post detail, and stories, alongside open-original actions.
 - Optional role-based local access with admin, viewer, and public browse modes.
-- Settings split into `General Settings` for Home/Reels defaults, stories mode, and excluded folders, plus `Scan & Library` for scan and rebuild actions.
+- Settings split into `General Settings` for Home/Reels defaults, language selection, stories mode, and excluded folders, plus `Scan & Library` for scan and rebuild actions.
 - Phase-aware scan progress for first indexing, derivative migration, and rebuilds.
 - A web app manifest plus production service worker registration.
 - A debounced filesystem watcher in development mode only.
@@ -278,7 +278,7 @@ not read directly by the container.
 - Use `GALLERY_EXCLUDED_FOLDERS` to skip unwanted source folders during discovery and rescans.
 - Rules without a slash match a folder name anywhere in the gallery tree, such as `@eaDir` or `thumbnails`.
 - Rules with a slash match one exact relative folder path beneath `GALLERY_ROOT`, such as `Archive/cache`.
-- The Settings sidebar now separates app-wide preferences into `General Settings`. That section includes the stories-folders toggle, Home/Reels defaults, and the excluded-folder editor.
+- The Settings sidebar now separates app-wide preferences into `General Settings`. That section includes the client-side language selector, the stories-folders toggle, Home/Reels defaults, and the excluded-folder editor.
 - `General Settings` can add or remove custom exclusion rules at runtime. Env-backed rules stay read-only there and still require a restart to change.
 - After changing excluded folders or stories mode in `General Settings`, run a full library scan from `Scan & Library` so previously indexed folders are soft-removed or reclassified correctly.
 
@@ -343,6 +343,7 @@ only needed when the browser-visible origin differs from the upstream Node host 
 
 - Vue 3
 - Vite
+- Vue I18n
 - Vue Router 4
 - Pinia
 - UnoCSS
@@ -350,6 +351,15 @@ only needed when the browser-visible origin differs from the upstream Node host 
 **Workspace**
 
 - `pnpm` monorepo
+
+## Localization
+
+Client translations live under `client/src/locales/`.
+
+- `en.json` is the canonical source locale and the first place new UI copy should be added.
+- `es.json` and `zh.json` are the shipped Spanish and Chinese translations for the client.
+- `client/src/locales/index.ts` wires locale resolution and the Vue I18n runtime.
+- `pnpm --filter @foldergram/client test` includes a locale validation test that checks locale keys against `en.json`.
 
 ## Scripts
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ not read directly by the container.
 - Use `GALLERY_EXCLUDED_FOLDERS` to skip unwanted source folders during discovery and rescans.
 - Rules without a slash match a folder name anywhere in the gallery tree, such as `@eaDir` or `thumbnails`.
 - Rules with a slash match one exact relative folder path beneath `GALLERY_ROOT`, such as `Archive/cache`.
-- The Settings sidebar now separates app-wide preferences into `General Settings`. That section includes the client-side language selector, the stories-folders toggle, Home/Reels defaults, and the excluded-folder editor.
+- The Settings sidebar now separates app-wide preferences into `General Settings`. That section includes the instant language selector plus saved app-language default, the stories-folders toggle, Home/Reels defaults, and the excluded-folder editor.
 - `General Settings` can add or remove custom exclusion rules at runtime. Env-backed rules stay read-only there and still require a restart to change.
 - After changing excluded folders or stories mode in `General Settings`, run a full library scan from `Scan & Library` so previously indexed folders are soft-removed or reclassified correctly.
 

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
     "pinia": "^3.0.1",
     "vidstack": "^1.12.13",
     "vue": "^3.5.13",
+    "vue-i18n": "^11.1.11",
     "vue-router": "^4.5.0"
   },
   "devDependencies": {

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -181,6 +181,16 @@ onUnmounted(() => {
 });
 
 watch(
+  () => authStore.defaultLocale,
+  (defaultLocale) => {
+    appStore.syncLocaleFromAuthStatus(defaultLocale);
+  },
+  {
+    immediate: true
+  }
+);
+
+watch(
   () => appStore.stats?.folders ?? 0,
   async (folderCount) => {
     if (appStore.isLibraryUnavailable || folderCount === 0 || folderCount === foldersStore.items.length) {

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -5,9 +5,9 @@
     style="background: radial-gradient(circle at top, rgba(0,149,246,0.1), transparent 34%), linear-gradient(180deg, color-mix(in srgb, var(--bg) 90%, #ffffff 10%) 0%, var(--bg) 100%);"
   >
     <div class="card w-full max-w-[24rem] p-8 text-center">
-      <p class="m-0 text-[0.78rem] font-bold uppercase tracking-[0.08em] text-accent-strong">Access Protection</p>
-      <h1 class="mt-3 mb-2 text-[1.45rem] font-semibold tracking-[-0.04em]">Checking access</h1>
-      <p class="m-0 text-muted">Loading the current password protection status.</p>
+      <p class="m-0 text-[0.78rem] font-bold uppercase tracking-[0.08em] text-accent-strong">{{ t('app.authLoading.eyebrow') }}</p>
+      <h1 class="mt-3 mb-2 text-[1.45rem] font-semibold tracking-[-0.04em]">{{ t('app.authLoading.title') }}</h1>
+      <p class="m-0 text-muted">{{ t('app.authLoading.description') }}</p>
     </div>
   </section>
   <AuthGate v-else-if="authStore.requiresLogin" />
@@ -22,6 +22,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onUnmounted, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { RouterView, useRoute, useRouter, type RouteLocationNormalizedLoaded } from 'vue-router';
 
 import AppShell from './components/AppShell.vue';
@@ -41,6 +42,7 @@ import { useReelsStore } from './stores/reels';
 import { useTrashStore } from './stores/trash';
 import { useViewerStore } from './stores/viewer';
 
+const { t } = useI18n();
 const appStore = useAppStore();
 const authStore = useAuthStore();
 const collectionsStore = useCollectionsStore();

--- a/client/src/api/gallery.ts
+++ b/client/src/api/gallery.ts
@@ -1,4 +1,5 @@
 import type {
+  AppLocaleSetting,
   AppStatus,
   AppStats,
   AuthMutationResult,
@@ -436,6 +437,14 @@ export function updateHomeFeedDefault(defaultMode: FeedMode) {
     method: 'PUT',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ defaultMode })
+  });
+}
+
+export function updateAppLocale(defaultLocale: AppLocaleSetting['defaultLocale']) {
+  return requestJson<AppLocaleSetting>('/api/admin/settings/app-locale', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ defaultLocale })
   });
 }
 

--- a/client/src/components/AdminUnlockDialog.vue
+++ b/client/src/components/AdminUnlockDialog.vue
@@ -3,13 +3,13 @@
     <div class="w-full max-w-[27rem] rounded-[1.5rem] border border-border bg-surface p-8 shadow-[var(--shadow)]">
       <div class="flex items-start justify-between gap-4">
         <div class="grid gap-[0.28rem]">
-          <p class="m-0 text-[0.74rem] font-bold uppercase tracking-[0.08em] text-accent-strong">Admin Unlock</p>
-          <h2 class="m-0 text-[1.5rem] font-semibold tracking-[-0.04em]">Unlock admin access</h2>
+          <p class="m-0 text-[0.74rem] font-bold uppercase tracking-[0.08em] text-accent-strong">{{ t('auth.adminUnlock.eyebrow') }}</p>
+          <h2 class="m-0 text-[1.5rem] font-semibold tracking-[-0.04em]">{{ t('auth.adminUnlock.title') }}</h2>
         </div>
         <button
           class="inline-flex h-10 w-10 items-center justify-center rounded-full border-0 bg-transparent text-muted transition-colors duration-150 hover:bg-surface-alt hover:text-text"
           type="button"
-          aria-label="Close admin unlock dialog"
+          :aria-label="t('auth.adminUnlock.closeAria')"
           @click="closeDialog"
         >
           <span class="i-fluent-dismiss-20-filled h-5 w-5" aria-hidden="true" />
@@ -17,18 +17,18 @@
       </div>
 
       <p class="mt-5 mb-0 text-[0.95rem] leading-[1.65] text-muted">
-        Enter the admin password to open Settings, Trash, scans, rebuild tools, and other admin-only actions.
+        {{ t('auth.adminUnlock.description') }}
       </p>
 
       <form class="mt-6 grid gap-4" @submit.prevent="submitUnlock">
         <label class="grid gap-[0.45rem]">
-          <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">Admin password</span>
+          <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('auth.adminUnlock.passwordLabel') }}</span>
           <input
             v-model="password"
             class="h-12 rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 text-[0.95rem] text-text outline-none transition-[border-color,box-shadow] duration-180 focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
             type="password"
             autocomplete="current-password"
-            placeholder="Enter the admin password"
+            :placeholder="t('auth.adminUnlock.placeholder')"
             :disabled="submitting"
           />
         </label>
@@ -39,7 +39,7 @@
 
         <div class="flex items-center gap-3 max-sm:flex-col max-sm:items-stretch">
           <button class="btn-primary min-h-12 flex-1 justify-center" type="submit" :disabled="submitting || password.length === 0">
-            {{ submitting ? 'Unlocking...' : 'Unlock Admin' }}
+            {{ submitting ? t('auth.adminUnlock.unlocking') : t('auth.adminUnlock.unlock') }}
           </button>
           <button
             class="inline-flex min-h-12 items-center justify-center rounded-[0.95rem] border border-border bg-transparent px-4 text-[0.92rem] font-semibold text-text transition-colors duration-180 hover:bg-surface-alt disabled:cursor-wait disabled:opacity-60"
@@ -47,7 +47,7 @@
             :disabled="submitting"
             @click="closeDialog"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
         </div>
       </form>
@@ -57,9 +57,11 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import { useAuthStore } from '../stores/auth';
 
+const { t } = useI18n();
 const authStore = useAuthStore();
 const password = ref('');
 const submitting = ref(false);
@@ -85,7 +87,7 @@ async function submitUnlock() {
     await authStore.unlockAdmin(password.value);
     closeDialog();
   } catch (error) {
-    localError.value = error instanceof Error ? error.message : 'Unable to unlock admin access.';
+    localError.value = error instanceof Error ? error.message : t('auth.adminUnlock.unableToUnlock');
   } finally {
     submitting.value = false;
   }

--- a/client/src/components/AuthGate.vue
+++ b/client/src/components/AuthGate.vue
@@ -6,8 +6,8 @@
           <BrandMark />
         </div>
         <div>
-          <p class="m-0 text-[0.74rem] font-bold uppercase tracking-[0.08em] text-accent-strong">Shared Password</p>
-          <h1 class="m-0 text-[1.5rem] font-semibold tracking-[-0.04em]">Unlock Foldergram</h1>
+          <p class="m-0 text-[0.74rem] font-bold uppercase tracking-[0.08em] text-accent-strong">{{ t('auth.gate.eyebrow') }}</p>
+          <h1 class="m-0 text-[1.5rem] font-semibold tracking-[-0.04em]">{{ t('auth.gate.title') }}</h1>
         </div>
       </div>
 
@@ -17,7 +17,7 @@
 
       <form class="mt-6 grid gap-4" @submit.prevent="submitLogin">
         <label class="grid gap-[0.45rem]">
-          <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">Password</span>
+          <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('auth.gate.passwordLabel') }}</span>
           <input
             v-model="password"
             class="h-12 rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 text-[0.95rem] text-text outline-none transition-[border-color,box-shadow] duration-180 focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
@@ -33,7 +33,7 @@
         </p>
 
         <button class="btn-primary min-h-12 justify-center" type="submit" :disabled="submitting || password.length === 0">
-          {{ submitting ? 'Unlocking...' : 'Unlock Library' }}
+          {{ submitting ? t('auth.gate.unlocking') : t('auth.gate.unlock') }}
         </button>
       </form>
     </div>
@@ -42,10 +42,12 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import BrandMark from './BrandMark.vue';
 import { useAuthStore } from '../stores/auth';
 
+const { t } = useI18n();
 const authStore = useAuthStore();
 const password = ref('');
 const submitting = ref(false);
@@ -53,11 +55,11 @@ const localError = ref<string | null>(null);
 const errorMessage = computed(() => localError.value ?? authStore.error);
 const description = computed(() =>
   authStore.accessMode === 'password'
-    ? 'This library accepts either the admin password or the viewer password for local access.'
-    : 'This library is protected with the admin password for local and homelab access.'
+    ? t('auth.gate.descriptionPassword')
+    : t('auth.gate.descriptionAdmin')
 );
 const placeholder = computed(() =>
-  authStore.accessMode === 'password' ? 'Enter the admin or viewer password' : 'Enter the admin password'
+  authStore.accessMode === 'password' ? t('auth.gate.placeholderPassword') : t('auth.gate.placeholderAdmin')
 );
 
 async function submitLogin() {
@@ -73,7 +75,7 @@ async function submitLogin() {
     await authStore.login(password.value);
     password.value = '';
   } catch (error) {
-    localError.value = error instanceof Error ? error.message : 'Unable to sign in.';
+    localError.value = error instanceof Error ? error.message : t('auth.gate.unableToSignIn');
   } finally {
     submitting.value = false;
   }

--- a/client/src/components/CollectionBookmark.vue
+++ b/client/src/components/CollectionBookmark.vue
@@ -40,7 +40,7 @@
         :data-placement="popoverPlacement"
         :style="popoverStyle"
         role="dialog"
-        aria-label="Collections"
+        :aria-label="t('collections.bookmark.dialogLabel')"
         @click.stop
         @focusout="handleFocusOut"
         @keydown.esc.stop.prevent="closePopover"
@@ -48,12 +48,12 @@
         @pointerleave="handlePointerLeave"
       >
         <div class="collection-bookmark__header">
-          <strong>Collections</strong>
+          <strong>{{ t('collections.bookmark.title') }}</strong>
           <button
             class="collection-bookmark__create-button"
             type="button"
-            aria-label="Create collection"
-            title="Create collection"
+            :aria-label="t('collections.bookmark.createCollection')"
+            :title="t('collections.bookmark.createCollection')"
             @click="startCreating"
           >
             <span class="i-fluent-add-16-filled" aria-hidden="true" />
@@ -67,7 +67,7 @@
             class="collection-bookmark__input"
             type="text"
             maxlength="80"
-            placeholder="Collection name"
+            :placeholder="t('collections.bookmark.namePlaceholder')"
             @keydown.esc.stop.prevent="cancelCreating"
           />
           <button class="collection-bookmark__submit" type="submit" :disabled="creatingCollection">
@@ -79,7 +79,7 @@
         <p v-else-if="collectionsStore.error" class="collection-bookmark__error">{{ collectionsStore.error }}</p>
 
         <div class="collection-bookmark__rows">
-          <p v-if="customMemberships.length === 0" class="collection-bookmark__empty">No collections yet</p>
+          <p v-if="customMemberships.length === 0" class="collection-bookmark__empty">{{ t('collections.bookmark.empty') }}</p>
           <button
             v-for="collection in customMemberships"
             :key="collection.slug"
@@ -111,6 +111,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import { useAuthStore } from '../stores/auth';
 import { useCollectionsStore } from '../stores/collections';
@@ -122,6 +123,7 @@ const props = defineProps<{
   placement: 'feed' | 'viewer';
 }>();
 
+const { t } = useI18n();
 const authStore = useAuthStore();
 const collectionsStore = useCollectionsStore();
 const rootElement = ref<HTMLElement | null>(null);
@@ -148,7 +150,9 @@ const popoverArrowEdgePaddingPx = 20;
 
 const canUseCollections = computed(() => authStore.canUseSharedCollections || authStore.canUseLocalCollections);
 const isSaved = computed(() => collectionsStore.isSaved(props.item.id));
-const buttonLabel = computed(() => (isSaved.value ? 'Remove saved post' : 'Save post'));
+const buttonLabel = computed(() =>
+  isSaved.value ? t('collections.bookmark.removeSavedPost') : t('collections.bookmark.savePost')
+);
 const memberships = computed(() => collectionsStore.membershipByImageId[props.item.id]?.items ?? collectionsStore.items.map((collection) => ({
   ...collection,
   containsImage: collection.isDefault && isSaved.value
@@ -208,7 +212,7 @@ async function openPopover() {
   await nextTick();
   updatePopoverPosition();
   await collectionsStore.fetchMembership(props.item.id).catch((error) => {
-    localError.value = error instanceof Error ? error.message : 'Unable to load collections';
+    localError.value = error instanceof Error ? error.message : t('collections.bookmark.errors.loadCollections');
   });
   await nextTick();
   updatePopoverPosition();
@@ -374,7 +378,7 @@ function cancelCreating() {
 async function submitCreate() {
   const name = collectionName.value.trim();
   if (!name) {
-    localError.value = 'Collection name is required.';
+    localError.value = t('collections.detail.edit.required');
     return;
   }
 
@@ -386,7 +390,7 @@ async function submitCreate() {
     collectionName.value = '';
     closePopover();
   } catch (error) {
-    localError.value = error instanceof Error ? error.message : 'Unable to create collection';
+    localError.value = error instanceof Error ? error.message : t('collections.detail.edit.createError');
     await nextTick();
     updatePopoverPosition();
   } finally {
@@ -403,12 +407,12 @@ async function toggleCollection(slug: string) {
       closePopover();
     }
   } catch (error) {
-    localError.value = error instanceof Error ? error.message : 'Unable to update collection';
+    localError.value = error instanceof Error ? error.message : t('collections.detail.edit.updateError');
   }
 }
 
 function displayCollectionName(collection: CollectionSummary) {
-  return collection.isDefault ? 'All Posts' : collection.name;
+  return collection.isDefault ? t('collections.shared.defaultName') : collection.name;
 }
 
 watch(popoverOpen, (isOpen) => {

--- a/client/src/components/FeedCard.vue
+++ b/client/src/components/FeedCard.vue
@@ -43,8 +43,8 @@
       <button
         class="inline-flex items-center justify-center w-8 h-8 p-0 border-0 text-muted bg-transparent cursor-pointer"
         type="button"
-        aria-label="More options"
-        title="More options"
+        :aria-label="t('post.feedCard.moreOptions')"
+        :title="t('post.feedCard.moreOptions')"
         @click="menuOpen = true"
       >
         <svg class="w-[1.15rem] h-[1.15rem]" viewBox="0 0 24 24" role="presentation">
@@ -237,8 +237,8 @@
           <RouterLink
             class="inline-flex items-center justify-center w-8 h-8 border-0 bg-transparent cursor-pointer color-inherit transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px"
             :to="{ name: 'folder', params: { slug: item.folderSlug } }"
-            aria-label="Open folder"
-            title="Open folder"
+            :aria-label="t('post.viewer.openFolder')"
+            :title="t('post.viewer.openFolder')"
           >
             <span class="i-fluent-folder-16-regular w-[1.30rem] h-[1.30rem]" aria-hidden="true" />
           </RouterLink>
@@ -249,8 +249,8 @@
             class="inline-flex items-center justify-center w-8 h-8 border-0 bg-transparent cursor-pointer color-inherit transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px"
             :href="downloadOriginalMediaUrl"
             download
-            aria-label="Download original file"
-            title="Download original file"
+            :aria-label="t('post.viewer.downloadOriginalFile')"
+            :title="t('post.viewer.downloadOriginalFile')"
           >
             <svg class="w-[1.45rem] h-[1.45rem]" viewBox="0 0 24 24" role="presentation">
               <path
@@ -268,8 +268,8 @@
             :href="originalMediaUrl"
             target="_blank"
             rel="noreferrer"
-            aria-label="Open original file"
-            title="Open original file"
+            :aria-label="t('post.viewer.openOriginalFile')"
+            :title="t('post.viewer.openOriginalFile')"
           >
             <svg class="w-[1.45rem] h-[1.45rem]" viewBox="0 0 24 24" role="presentation">
               <path
@@ -307,7 +307,7 @@
           @click="openCaptionEditor"
         >
           <span class="i-fluent-edit-16-regular w-[1.15rem] h-[1.15rem] shrink-0" aria-hidden="true" />
-          <span>Edit caption</span>
+          <span>{{ t('post.viewer.editCaption') }}</span>
         </button>
         <button
           class="flex items-center gap-[0.8rem] w-full px-4 py-[0.95rem] border-0 border-b border-border text-text bg-transparent cursor-pointer text-left"
@@ -324,7 +324,7 @@
               stroke-width="1.8"
             />
           </svg>
-          <span>Open original</span>
+          <span>{{ t('post.viewer.openOriginalFile') }}</span>
         </button>
         <button
           v-if="authStore.canDeleteMedia"
@@ -342,7 +342,7 @@
             />
             <path d="M12 2h8v2h-8z" fill="currentColor" />
           </svg>
-          <span>{{ deleting ? 'Deleting...' : 'Delete post' }}</span>
+          <span>{{ t('post.viewer.deletePost') }}</span>
         </button>
         <button
           class="flex items-center gap-[0.8rem] w-full px-4 py-[0.95rem] border-0 text-text bg-transparent cursor-pointer text-left"
@@ -359,7 +359,7 @@
               stroke-width="1.8"
             />
           </svg>
-          <span>Cancel</span>
+          <span>{{ t('common.cancel') }}</span>
         </button>
       </div>
     </div>
@@ -378,7 +378,7 @@
 
     <ConfirmDialog
       v-if="confirmDeleteOpen"
-      title="Delete this post?"
+      :title="t('post.feedCard.delete.title')"
       :message="deleteDialogMessage"
       :confirm-label="deleteDialogConfirmLabel"
       :loading="deleting"
@@ -394,15 +394,15 @@
             :disabled="deleting"
           />
           <span class="grid gap-[0.18rem]">
-            <span class="text-[0.92rem] font-semibold text-text">Also permanently delete original file from disk</span>
-            <span class="text-[0.84rem] text-muted">Keep this unchecked to move the post to Trash while keeping the source file on disk.</span>
+            <span class="text-[0.92rem] font-semibold text-text">{{ t('post.feedCard.delete.deleteOriginalLabel') }}</span>
+            <span class="text-[0.84rem] text-muted">{{ t('post.feedCard.delete.deleteOriginalDescription') }}</span>
           </span>
         </label>
         <p
           v-if="deleteOriginalFromDisk"
           class="m-0 mt-3 px-3 py-[0.8rem] rounded-[0.9rem] border border-[rgba(217,48,37,0.24)] text-[0.84rem] text-[#b42318] bg-[rgba(217,48,37,0.08)]"
         >
-          This will permanently delete the original file, thumbnail, and preview from disk. This action cannot be undone.
+          {{ t('post.feedCard.delete.deleteOriginalWarning') }}
         </p>
         <p
           v-if="deleteError"
@@ -419,6 +419,7 @@
 import 'vidstack/bundle';
 
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { RouterLink, useRoute } from 'vue-router';
 import type { PlayerSrc } from 'vidstack';
 import type { MediaPlayerElement } from 'vidstack/elements';
@@ -479,6 +480,7 @@ const likesStore = useLikesStore();
 const foldersStore = useFoldersStore();
 const momentsStore = useMomentsStore();
 const route = useRoute();
+const { t, locale } = useI18n();
 const menuOpen = ref(false);
 const deleting = ref(false);
 const confirmDeleteOpen = ref(false);
@@ -515,13 +517,15 @@ const imageRoute = computed(() => ({
 const isHomeContext = computed(() => props.context === 'home');
 const showHomeStoryAvatar = computed(() => isHomeContext.value && props.hasAvatarStory);
 const shouldOpenPostInModal = computed(() => props.context !== 'home');
-const folderStoriesLabel = computed(() => `Open ${props.item.folderName} stories`);
-const folderAvatarLabel = computed(() => `Open ${props.item.folderName}`);
+const folderStoriesLabel = computed(() => t('post.feedCard.openStories', { name: props.item.folderName }));
+const folderAvatarLabel = computed(() => t('post.feedCard.openFolderAvatar', { name: props.item.folderName }));
 const likeActionLabel = computed(() => likesStore.toggleAriaLabel(likesStore.isLiked(props.item.id)));
-const openMediaLabel = computed(() => (props.item.mediaType === 'video' ? 'Open reel' : 'Open post'));
+const openMediaLabel = computed(() =>
+  props.item.mediaType === 'video' ? t('post.feedCard.openReel') : t('post.feedCard.openPost')
+);
 const caption = computed(() => resolveDisplayCaption(props.item));
 const formattedDate = computed(() =>
-  new Date(props.item.takenAt ?? props.item.sortTimestamp).toLocaleDateString(undefined, {
+  new Date(props.item.takenAt ?? props.item.sortTimestamp).toLocaleDateString(locale.value, {
     month: 'short',
     day: 'numeric',
     year: 'numeric'
@@ -548,10 +552,12 @@ const showHomeVideoSurfaceControls = computed(() => props.isActiveVideo || isHom
 const showHomeVideoPausedIndicator = computed(() => showHomeVideoSurfaceControls.value && isHomeVideoPaused.value);
 const deleteDialogMessage = computed(() =>
   deleteOriginalFromDisk.value
-    ? 'This will permanently delete the post from the app and remove original media from disk.'
-    : 'This will delete the post from the app and move it to Trash. The original file will stay on disk unless you choose permanent deletion.'
+    ? t('post.feedCard.delete.messagePermanent')
+    : t('post.feedCard.delete.messageTrash')
 );
-const deleteDialogConfirmLabel = computed(() => (deleteOriginalFromDisk.value ? 'Permanently Delete' : 'Delete'));
+const deleteDialogConfirmLabel = computed(() =>
+  deleteOriginalFromDisk.value ? t('post.feedCard.delete.confirmPermanent') : t('post.feedCard.delete.confirm')
+);
 
 function isPrimaryPlainClick(event: MouseEvent) {
   return !event.defaultPrevented && event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;

--- a/client/src/components/FolderHeader.vue
+++ b/client/src/components/FolderHeader.vue
@@ -5,7 +5,7 @@
         v-if="hasAvatarStory"
         type="button"
         class="block border-0 bg-transparent p-0 rounded-full cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text/55 focus-visible:ring-offset-4 focus-visible:ring-offset-bg"
-        aria-label="Open folder stories"
+        :aria-label="t('folder.header.openStories')"
         @click="emit('openAvatarStory')"
       >
         <div class="rounded-full p-[0.22rem] shadow-[0_16px_34px_rgba(246,106,61,0.12)] transition-transform duration-[180ms] hover:scale-[1.02]" style="background: var(--story-ring);">
@@ -18,7 +18,7 @@
         <a
           :href="href"
           class="block rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text/55 focus-visible:ring-offset-4 focus-visible:ring-offset-bg"
-          aria-label="Open folder avatar"
+          :aria-label="t('folder.header.openAvatar')"
           @click="handleAvatarNavigation($event, navigate)"
         >
           <div class="rounded-full p-[0.22rem] shadow-[0_12px_24px_rgba(99,115,129,0.12)] transition-transform duration-[180ms] hover:scale-[1.02]" style="background: rgba(43, 48, 54, 0.8);">
@@ -43,17 +43,17 @@
           class="inline-flex items-center justify-center px-4 pt-2 pb-1.5 text-[0.75rem] font-semibold leading-none rounded-lg bg-surface-hover text-text hover:bg-border transition-colors border border-border cursor-pointer"
           @click="openProfileEditor"
         >
-          Edit App Folder
+          {{ t('folder.header.editButton') }}
         </button>
       </div>
       <p v-if="folder.breadcrumb" class="m-0 text-[0.84rem] font-medium tracking-[0.02em] text-muted">{{ folder.breadcrumb }}</p>
       <div class="flex items-center gap-[1.6rem] flex-wrap text-[0.95rem] leading-none max-sm:justify-center">
-        <span><strong class="mr-[0.35rem] font-semibold">{{ folder.imageCount }}</strong>posts</span>
-        <span><strong class="mr-[0.35rem] font-semibold">{{ folder.videoCount }}</strong>reels</span>
-        <span v-if="folder.latestImageMtimeMs"><strong class="mr-[0.35rem] font-semibold">{{ formattedUpdatedDate }}</strong>updated</span>
+        <span>{{ t('folder.header.posts', { count: folder.imageCount }) }}</span>
+        <span>{{ t('folder.header.reels', { count: folder.videoCount }) }}</span>
+        <span v-if="folder.latestImageMtimeMs">{{ t('folder.header.updated', { date: formattedUpdatedDate }) }}</span>
       </div>
       <div class="grid max-w-[29rem] gap-[0.28rem] max-sm:max-w-none">
-        <span class="text-[0.74rem] font-bold tracking-[0.1em] text-muted uppercase">Library path</span>
+        <span class="text-[0.74rem] font-bold tracking-[0.1em] text-muted uppercase">{{ t('folder.header.libraryPath') }}</span>
         <p class="m-0 font-mono text-[0.8rem] leading-[1.5] text-muted break-all">{{ folder.folderPath }}</p>
       </div>
       <div v-if="folder.description" class="max-w-[34rem] pt-[0.25rem]">
@@ -74,7 +74,7 @@
             type="button"
             :aria-expanded="isDescriptionExpanded"
             :aria-controls="descriptionId"
-            :aria-label="isDescriptionExpanded ? 'Collapse description' : 'Expand description'"
+            :aria-label="isDescriptionExpanded ? t('folder.header.collapseDescription') : t('folder.header.expandDescription')"
             @click="isDescriptionExpanded = !isDescriptionExpanded"
           >
             <span
@@ -103,6 +103,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { RouterLink, useRoute } from 'vue-router';
 import type { FolderSummary } from '../types/api';
 import Avatar from './Avatar.vue';
@@ -124,6 +125,7 @@ const appStore = useAppStore();
 const authStore = useAuthStore();
 const foldersStore = useFoldersStore();
 const route = useRoute();
+const { locale, t } = useI18n();
 
 const isEditingProfile = ref(false);
 const savingProfile = ref(false);
@@ -138,7 +140,7 @@ let syncingDescriptionOverflow = false;
 
 const formattedUpdatedDate = computed(() =>
   props.folder.latestImageMtimeMs
-    ? new Date(props.folder.latestImageMtimeMs).toLocaleDateString(undefined, {
+    ? new Date(props.folder.latestImageMtimeMs).toLocaleDateString(locale.value, {
         month: 'short',
         day: 'numeric',
         year: 'numeric'
@@ -153,7 +155,7 @@ async function handleSaveProfile(data: { name: string; description: string | nul
     await foldersStore.updateFolderProfile(props.folder.slug, data.name, data.description);
     closeProfileEditor();
   } catch (error) {
-    profileError.value = error instanceof Error ? error.message : 'Failed to update profile';
+    profileError.value = error instanceof Error ? error.message : t('folder.header.errors.updateProfile');
   } finally {
     savingProfile.value = false;
   }

--- a/client/src/components/FolderProfileModal.vue
+++ b/client/src/components/FolderProfileModal.vue
@@ -2,11 +2,11 @@
   <div class="fixed inset-0 z-60 flex items-center justify-center p-6 bg-black/55" @click.self="$emit('cancel')">
     <section class="w-[min(100%,32rem)] p-[1.4rem] bg-surface border border-border rounded-[1.2rem] shadow-[var(--shadow)]" role="dialog" aria-modal="true" :aria-labelledby="titleId">
       <div class="grid gap-[1.2rem]">
-        <h2 :id="titleId" class="m-0 text-[1.25rem] font-semibold">Edit App Folder</h2>
+        <h2 :id="titleId" class="m-0 text-[1.25rem] font-semibold">{{ t('folder.profileModal.title') }}</h2>
 
         <form @submit.prevent="submit" class="grid gap-[1.1rem]">
           <div class="grid gap-[0.4rem]">
-            <label for="profile-name" class="text-[0.85rem] font-semibold text-text">Name</label>
+            <label for="profile-name" class="text-[0.85rem] font-semibold text-text">{{ t('common.name') }}</label>
             <input
               id="profile-name"
               v-model="formData.name"
@@ -14,20 +14,20 @@
               class="w-full px-3 py-2 text-[0.95rem] bg-bg border border-border rounded-lg text-text focus:outline-none focus:border-[#4B5563] transition-colors"
               required
               maxlength="255"
-              placeholder="Folder display name"
+              :placeholder="t('folder.profileModal.namePlaceholder')"
             />
           </div>
 
           <div class="grid gap-[0.35rem]">
             <div class="flex items-center justify-between">
-              <label for="profile-description" class="text-[0.85rem] font-semibold text-text">Description</label>
+              <label for="profile-description" class="text-[0.85rem] font-semibold text-text">{{ t('common.description') }}</label>
               <span class="text-[0.75rem] text-muted">{{ formData.description?.length || 0 }} / 300</span>
             </div>
             <textarea
               id="profile-description"
               v-model="formData.description"
               class="w-full min-h-[6rem] rounded-lg border border-border bg-surface px-[0.75rem] py-[0.6rem] text-[0.95rem] text-text placeholder-muted resize-y focus:border-text focus:outline-none focus:ring-1 focus:ring-text"
-              placeholder="Add a description to this folder..."
+              :placeholder="t('folder.profileModal.descriptionPlaceholder')"
               maxlength="300"
             ></textarea>
           </div>
@@ -41,10 +41,10 @@
 
           <div class="flex justify-end gap-3 mt-2">
             <button class="min-h-[2.5rem] px-4 py-[0.6rem] border border-transparent rounded-[0.75rem] font-semibold cursor-pointer bg-surface-hover text-text disabled:opacity-70 disabled:cursor-wait" type="button" @click="$emit('cancel')">
-              Cancel
+              {{ t('common.cancel') }}
             </button>
             <button class="min-h-[2.5rem] px-4 py-[0.6rem] border border-transparent rounded-[0.75rem] font-semibold cursor-pointer bg-text text-bg disabled:opacity-70 disabled:cursor-wait" type="submit" :disabled="loading">
-              {{ loading ? 'Saving...' : 'Save' }}
+              {{ loading ? t('common.saving') : t('common.save') }}
             </button>
           </div>
         </form>
@@ -55,6 +55,7 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 const props = defineProps<{
   initialName: string;
@@ -68,6 +69,7 @@ const emit = defineEmits<{
   save: [data: { name: string; description: string | null }];
 }>();
 
+const { t } = useI18n();
 const titleId = `profile-dialog-title-${Math.random().toString(36).slice(2, 10)}`;
 const validationError = ref<string | null>(null);
 
@@ -80,7 +82,7 @@ const errorMessage = computed(() => validationError.value ?? props.error ?? null
 
 function submit() {
   if (!formData.name.trim()) {
-    validationError.value = 'Name is required.';
+    validationError.value = t('folder.profileModal.errors.nameRequired');
     return;
   }
 

--- a/client/src/components/InfiniteLoader.vue
+++ b/client/src/components/InfiniteLoader.vue
@@ -6,16 +6,17 @@
       type="button"
       @click="$emit('load-more')"
     >
-      Load more
+      {{ t('common.loadMore') }}
     </button>
-    <span v-else-if="loading" class="text-muted">Loading more...</span>
+    <span v-else-if="loading" class="text-muted">{{ t('common.loadingMore') }}</span>
     <span v-else-if="hasMore" class="sr-only">Loading continues automatically when you reach the end.</span>
-    <span v-else class="text-muted">You are caught up</span>
+    <span v-else class="text-muted">{{ t('common.youAreCaughtUp') }}</span>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 const props = withDefaults(defineProps<{
   loading: boolean;
@@ -29,6 +30,7 @@ const emit = defineEmits<{
   'load-more': [];
 }>();
 
+const { t } = useI18n();
 const sentinel = ref<HTMLElement | null>(null);
 const isIntersecting = ref(false);
 let observer: IntersectionObserver | null = null;

--- a/client/src/components/PostCaptionModal.test.ts
+++ b/client/src/components/PostCaptionModal.test.ts
@@ -1,9 +1,14 @@
 import { mount } from '@vue/test-utils';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
+import { DEFAULT_LOCALE, i18n } from '../locales';
 import PostCaptionModal from './PostCaptionModal.vue';
 
 describe('PostCaptionModal', () => {
+  beforeEach(() => {
+    i18n.global.locale.value = DEFAULT_LOCALE;
+  });
+
   it('emits a trimmed caption when saving', async () => {
     const wrapper = mount(PostCaptionModal, {
       props: {
@@ -58,5 +63,20 @@ describe('PostCaptionModal', () => {
     });
 
     expect((wrapper.get('textarea').element as HTMLTextAreaElement).value).toBe('city walk 002');
+  });
+
+  it('renders translated Chinese labels', () => {
+    i18n.global.locale.value = 'zh';
+
+    const wrapper = mount(PostCaptionModal, {
+      props: {
+        filename: 'road-trip_001.jpg',
+        caption: 'Golden hour'
+      }
+    });
+
+    expect(wrapper.text()).toContain('编辑说明');
+    expect(wrapper.text()).toContain('重置为文件名');
+    expect((wrapper.get('textarea').element as HTMLTextAreaElement).placeholder).toBe('写点说明...');
   });
 });

--- a/client/src/components/PostCaptionModal.vue
+++ b/client/src/components/PostCaptionModal.vue
@@ -7,12 +7,12 @@
       :aria-labelledby="titleId"
     >
       <div class="grid gap-[1.2rem]">
-        <h2 :id="titleId" class="m-0 text-[1.25rem] font-semibold">Edit caption</h2>
+        <h2 :id="titleId" class="m-0 text-[1.25rem] font-semibold">{{ t('post.captionModal.title') }}</h2>
 
         <form class="grid gap-[1.1rem]" @submit.prevent="submit">
           <div class="grid gap-[0.35rem]">
             <div class="flex items-center justify-between gap-4">
-              <label for="post-caption" class="text-[0.85rem] font-semibold text-text">Caption</label>
+              <label for="post-caption" class="text-[0.85rem] font-semibold text-text">{{ t('post.captionModal.captionLabel') }}</label>
               <span class="text-[0.75rem] text-muted">{{ formData.caption.length }} / 300</span>
             </div>
             <textarea
@@ -20,7 +20,7 @@
               v-model="formData.caption"
               class="w-full min-h-[7rem] rounded-lg border border-border bg-surface px-[0.75rem] py-[0.6rem] text-[0.95rem] text-text placeholder-muted resize-y focus:border-text focus:outline-none focus:ring-1 focus:ring-text"
               maxlength="300"
-              placeholder="Write a caption..."
+              :placeholder="t('post.captionModal.placeholder')"
             />
           </div>
 
@@ -39,7 +39,7 @@
               :disabled="loading"
               @click="resetToFilename"
             >
-              Reset to filename
+              {{ t('post.captionModal.resetToFilename') }}
             </button>
             <div class="flex items-center gap-3 ml-auto">
               <button
@@ -48,14 +48,14 @@
                 :disabled="loading"
                 @click="$emit('cancel')"
               >
-                Cancel
+                {{ t('common.cancel') }}
               </button>
               <button
                 class="min-h-[2.5rem] px-4 py-[0.6rem] border border-transparent rounded-[0.75rem] font-semibold cursor-pointer bg-text text-bg disabled:opacity-70 disabled:cursor-wait"
                 type="submit"
                 :disabled="loading"
               >
-                {{ loading ? 'Saving...' : 'Save' }}
+                {{ loading ? t('common.saving') : t('common.save') }}
               </button>
             </div>
           </div>
@@ -67,6 +67,7 @@
 
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import { normalizeCaptionInput, resolveDisplayCaption } from '../utils/caption';
 
@@ -82,6 +83,7 @@ const emit = defineEmits<{
   save: [caption: string | null];
 }>();
 
+const { t } = useI18n();
 const titleId = `caption-dialog-title-${Math.random().toString(36).slice(2, 10)}`;
 const hasCustomCaption = computed(() => props.caption !== null && props.caption !== undefined);
 const formData = reactive({

--- a/client/src/components/PostViewer.vue
+++ b/client/src/components/PostViewer.vue
@@ -9,7 +9,7 @@
       v-if="isModal"
       class="viewer__modal-close"
       type="button"
-      aria-label="Close post"
+      :aria-label="t('post.viewer.close')"
       @click="$emit('close')"
     >
       <svg
@@ -42,7 +42,7 @@
         params: { id: String(previousNavigationImageId) },
         query: route.query,
       }"
-      aria-label="Previous post"
+      :aria-label="t('post.viewer.previous')"
     >
       <svg class="w-4 h-4" viewBox="0 0 24 24" role="presentation">
         <path
@@ -70,7 +70,7 @@
         params: { id: String(nextNavigationImageId) },
         query: route.query,
       }"
-      aria-label="Next post"
+      :aria-label="t('post.viewer.next')"
     >
       <svg class="w-4 h-4" viewBox="0 0 24 24" role="presentation">
         <path
@@ -91,7 +91,7 @@
       type="button"
       :aria-expanded="isSidebarExpanded"
       :aria-label="
-        isSidebarExpanded ? 'Hide post details' : 'Show post details'
+        isSidebarExpanded ? t('post.viewer.hideDetails') : t('post.viewer.showDetails')
       "
       @click="toggleSidebar"
     >
@@ -136,7 +136,7 @@
           <div
             class="viewer__media-shell viewer__media-shell--video viewer__media-shell--video-interactive"
             :style="mediaShellStyle"
-            aria-label="Toggle playback"
+            :aria-label="t('post.viewer.togglePlayback')"
             role="button"
             tabindex="0"
             @click="handleVideoSurfaceClick"
@@ -169,7 +169,7 @@
                   <div class="viewer__player-controls-group">
                     <media-play-button
                       class="viewer__player-control"
-                      aria-label="Toggle playback"
+                      :aria-label="t('post.viewer.togglePlayback')"
                     >
                       <span
                         class="viewer__player-control-icon viewer__player-play-icon viewer__player-play-icon--play i-fluent-play-16-filled"
@@ -186,7 +186,7 @@
                   <div class="viewer__player-controls-group">
                     <media-mute-button
                       class="viewer__player-control"
-                      aria-label="Toggle sound"
+                      :aria-label="t('post.viewer.toggleSound')"
                     >
                       <span
                         class="viewer__player-control-icon viewer__player-mute-icon viewer__player-mute-icon--on i-fluent-speaker-2-16-regular"
@@ -204,11 +204,11 @@
                       type="button"
                       :aria-label="
                         isPlayingHd
-                          ? 'Switch to preview quality'
-                          : 'Switch to HD original'
+                          ? t('post.viewer.switchToPreviewQuality')
+                          : t('post.viewer.switchToHdOriginal')
                       "
                       :aria-pressed="isPlayingHd"
-                      :title="isPlayingHd ? 'Preview quality' : 'HD original'"
+                      :title="isPlayingHd ? t('post.viewer.previewQuality') : t('post.viewer.hdOriginal')"
                       @click.stop="toggleHdSource"
                     >
                       <span
@@ -223,7 +223,7 @@
                     </button>
                     <media-fullscreen-button
                       class="viewer__player-control"
-                      aria-label="Toggle fullscreen"
+                      :aria-label="t('post.viewer.toggleFullscreen')"
                       target="media"
                     >
                       <span
@@ -270,7 +270,7 @@
         v-if="isModalSidebarOverlayVisible"
         class="viewer__drawer-backdrop"
         type="button"
-        aria-label="Hide post details"
+        :aria-label="t('post.viewer.hideDetails')"
         @click="handleSidebarBackdropClick"
       />
 
@@ -308,7 +308,7 @@
           <RouterLink
             class="viewer__sidebar-folder-link flex items-center gap-[0.85rem] min-w-0"
             :to="{ name: 'folder', params: { slug: image.folderSlug } }"
-            aria-label="Open folder"
+            :aria-label="t('post.viewer.openFolder')"
           >
             <Avatar
               class="h-[2.65rem] w-[2.65rem]"
@@ -320,11 +320,7 @@
                 {{ image.folderName }}
               </h2>
               <p class="viewer__sidebar-breadcrumb m-0 text-muted truncate">
-                {{
-                  folder?.breadcrumb ??
-                  image.folderBreadcrumb ??
-                  "Top-level source folder"
-                }}
+                {{ folderBreadcrumbLabel }}
               </p>
             </div>
           </RouterLink>
@@ -344,15 +340,15 @@
               v-if="authStore.canManageLibrary"
               class="inline-flex items-center justify-center mt-[0.05rem] w-6 h-6 p-0 border-0 rounded-full bg-transparent text-muted cursor-pointer transition-colors hover:text-text"
               type="button"
-              aria-label="Edit caption"
-              title="Edit caption"
+              :aria-label="t('post.viewer.editCaption')"
+              :title="t('post.viewer.editCaption')"
               @click="openCaptionEditor"
             >
               <span class="i-fluent-edit-16-regular w-4 h-4" aria-hidden="true" />
             </button>
           </div>
           <p class="viewer__sidebar-path mt-3 text-muted">
-            <span class="viewer__sidebar-path-label">Folder Path</span>
+            <span class="viewer__sidebar-path-label">{{ t('post.viewer.folderPath') }}</span>
             <span class="viewer__sidebar-path-value">{{ image.relativePath }}</span>
           </p>
         </div>
@@ -361,7 +357,7 @@
         <dl class="viewer__sidebar-stats m-0 px-5 pt-[0.9rem]">
           <div class="viewer__sidebar-stat">
             <dt class="viewer__sidebar-stat-label">
-              Dimensions
+              {{ t('post.viewer.stats.dimensions') }}
             </dt>
             <dd class="viewer__sidebar-stat-value m-0 text-[0.96rem] font-semibold">
               {{ image.width }} × {{ image.height }}
@@ -369,14 +365,10 @@
           </div>
           <div class="viewer__sidebar-stat">
             <dt class="viewer__sidebar-stat-label">
-              Type
+              {{ t('post.viewer.stats.type') }}
             </dt>
             <dd class="viewer__sidebar-stat-value m-0 text-[0.96rem] font-semibold">
-              {{
-                image.mediaType === "video"
-                  ? `Video (${image.mimeType})`
-                  : image.mimeType
-              }}
+              {{ mediaTypeLabel }}
             </dd>
           </div>
           <div
@@ -384,7 +376,7 @@
             class="viewer__sidebar-stat"
           >
             <dt class="viewer__sidebar-stat-label">
-              Duration
+              {{ t('post.viewer.stats.duration') }}
             </dt>
             <dd class="viewer__sidebar-stat-value m-0 text-[0.96rem] font-semibold">
               {{ formattedDuration }}
@@ -392,7 +384,7 @@
           </div>
           <div class="viewer__sidebar-stat">
             <dt class="viewer__sidebar-stat-label">
-              Size
+              {{ t('post.viewer.stats.size') }}
             </dt>
             <dd class="viewer__sidebar-stat-value m-0 text-[0.96rem] font-semibold">{{ fileSize }}</dd>
           </div>
@@ -401,7 +393,7 @@
             class="viewer__sidebar-stat"
           >
             <dt class="viewer__sidebar-stat-label">
-              Place
+              {{ t('post.viewer.stats.place') }}
             </dt>
             <dd class="viewer__sidebar-stat-value m-0 text-[0.96rem] font-semibold">
               <RouterLink
@@ -472,8 +464,8 @@
               v-if="authStore.canManageLibrary"
               class="viewer__sidebar-action inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer text-text transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px disabled:opacity-45 disabled:cursor-wait disabled:transform-none"
               type="button"
-              aria-label="Set as folder cover"
-              title="Set as folder cover"
+              :aria-label="t('post.viewer.setAsCover')"
+              :title="t('post.viewer.setAsCover')"
               :disabled="settingCover || isCurrentCover"
               @click="handleSetCover"
             >
@@ -484,8 +476,8 @@
               class="viewer__sidebar-action inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer text-text transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px"
               :href="downloadOriginalMediaUrl"
               download
-              aria-label="Download original file"
-              title="Download original file"
+              :aria-label="t('post.viewer.downloadOriginalFile')"
+              :title="t('post.viewer.downloadOriginalFile')"
             >
               <svg
                 class="w-[1.55rem] h-[1.55rem]"
@@ -508,8 +500,8 @@
               :href="originalMediaUrl"
               target="_blank"
               rel="noreferrer"
-              aria-label="Open original file"
-              title="Open original file"
+              :aria-label="t('post.viewer.openOriginalFile')"
+              :title="t('post.viewer.openOriginalFile')"
             >
               <svg
                 class="w-[1.55rem] h-[1.55rem]"
@@ -547,7 +539,7 @@
               v-if="authStore.canDeleteMedia"
               class="viewer__sidebar-action inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer text-[#d93025] transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px disabled:opacity-45 disabled:cursor-wait disabled:transform-none"
               type="button"
-              aria-label="Delete post"
+              :aria-label="t('post.viewer.deletePost')"
               :disabled="deleting"
               @click="$emit('delete')"
             >
@@ -588,6 +580,7 @@
   import "vidstack/bundle"
 
   import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue"
+  import { useI18n } from "vue-i18n"
   import { RouterLink, useRoute, useRouter } from "vue-router"
   import type { PlayerSrc } from "vidstack"
   import type { MediaPlayerElement } from "vidstack/elements"
@@ -626,6 +619,7 @@
   const foldersStore = useFoldersStore()
   const route = useRoute()
   const router = useRouter()
+  const { locale, t } = useI18n()
   const playerElement = ref<MediaPlayerElement | null>(null)
   const cardWrapperElement = ref<HTMLElement | null>(null)
   const sidebarElement = ref<HTMLElement | null>(null)
@@ -754,11 +748,23 @@
 
   const folderAvatar = computed(() => props.folder?.avatarUrl ?? null)
   const caption = computed(() => (props.image ? resolveDisplayCaption(props.image) : ""))
+  const folderBreadcrumbLabel = computed(() =>
+    props.folder?.breadcrumb ?? props.image?.folderBreadcrumb ?? t('folder.shared.topLevelSourceFolder'),
+  )
+  const mediaTypeLabel = computed(() => {
+    if (!props.image) {
+      return ""
+    }
+
+    return props.image.mediaType === "video"
+      ? t('post.viewer.videoType', { mimeType: props.image.mimeType })
+      : props.image.mimeType
+  })
   const formattedDate = computed(() =>
     props.image
       ? new Date(
           props.image.takenAt ?? props.image.sortTimestamp,
-        ).toLocaleDateString(undefined, {
+        ).toLocaleDateString(locale.value, {
           month: "short",
           day: "numeric",
           year: "numeric",
@@ -797,49 +803,49 @@
 
     if (location) {
       details.push({
-        label: "Location",
+        label: t('post.viewer.metadata.location'),
         value: location,
       })
     }
 
     if (camera) {
       details.push({
-        label: "Camera",
+        label: t('post.viewer.metadata.camera'),
         value: camera,
       })
     }
 
     if (exif.lensModel) {
       details.push({
-        label: "Lens",
+        label: t('post.viewer.metadata.lens'),
         value: exif.lensModel,
       })
     }
 
     if (aperture) {
       details.push({
-        label: "Aperture",
+        label: t('post.viewer.metadata.aperture'),
         value: aperture,
       })
     }
 
     if (shutter) {
       details.push({
-        label: "Shutter",
+        label: t('post.viewer.metadata.shutter'),
         value: shutter,
       })
     }
 
     if (iso) {
       details.push({
-        label: "ISO",
+        label: t('post.viewer.metadata.iso'),
         value: iso,
       })
     }
 
     if (focalLength) {
       details.push({
-        label: "Focal length",
+        label: t('post.viewer.metadata.focalLength'),
         value: focalLength,
       })
     }

--- a/client/src/components/ReelActionRail.vue
+++ b/client/src/components/ReelActionRail.vue
@@ -20,7 +20,8 @@
       <button
         class="reel-action-rail__button"
         type="button"
-        :aria-label="infoOpen ? 'Hide reel details' : 'Show reel details'"
+        :aria-label="infoOpen ? t('reels.rail.hideDetails') : t('reels.rail.showDetails')"
+        :title="infoOpen ? t('reels.rail.hideDetails') : t('reels.rail.showDetails')"
         :aria-pressed="infoOpen"
         @click="$emit('toggle-info')"
       >
@@ -40,8 +41,8 @@
       class="reel-action-rail__button"
       :href="downloadOriginalMediaUrl"
       download
-      aria-label="Download original file"
-      title="Download original file"
+      :aria-label="t('reels.rail.downloadOriginal')"
+      :title="t('reels.rail.downloadOriginal')"
     >
       <span class="reel-action-rail__icon i-fluent-arrow-download-20-regular" aria-hidden="true" />
     </a>
@@ -49,7 +50,8 @@
     <RouterLink
       class="reel-action-rail__button"
       :to="{ name: 'folder', params: { slug: item.folderSlug } }"
-      aria-label="Open folder"
+      :aria-label="t('reels.rail.openFolder')"
+      :title="t('reels.rail.openFolder')"
     >
       <span class="reel-action-rail__icon i-fluent-folder-16-regular" aria-hidden="true" />
     </RouterLink>
@@ -58,6 +60,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { RouterLink } from 'vue-router';
 
 import { useAuthStore } from '../stores/auth';
@@ -76,6 +79,7 @@ defineEmits<{
 
 const authStore = useAuthStore();
 const likesStore = useLikesStore();
+const { t } = useI18n();
 const isLiked = computed(() => likesStore.isLiked(props.item.id));
 const downloadOriginalMediaUrl = computed(() => getOriginalMediaDownloadUrl(props.item.id));
 

--- a/client/src/components/ReelInfoSidebar.vue
+++ b/client/src/components/ReelInfoSidebar.vue
@@ -2,15 +2,15 @@
   <aside
     class="reels-info-sidebar sidebar"
     :class="{ 'reels-info-sidebar--anchor-right': anchor === 'right' }"
-    aria-label="Reel details"
+    :aria-label="t('reels.info.ariaLabel')"
   >
     <div class="reels-info-sidebar__header">
-      <p class="reels-info-sidebar__eyebrow">Reel Details</p>
+      <p class="reels-info-sidebar__eyebrow">{{ t('reels.info.eyebrow') }}</p>
 
       <button
         class="reels-info-sidebar__close"
         type="button"
-        aria-label="Hide reel details"
+        :aria-label="t('reels.info.hideDetails')"
         @click="$emit('close')"
       >
         <svg class="reels-info-sidebar__close-icon" viewBox="0 0 24 24" role="presentation">
@@ -30,7 +30,8 @@
       <RouterLink
         class="reels-info-sidebar__folder-link"
         :to="{ name: 'folder', params: { slug: item.folderSlug } }"
-        aria-label="Open folder"
+        :aria-label="t('reels.info.openFolder')"
+        :title="t('reels.info.openFolder')"
       >
         <Avatar
           class="reels-info-sidebar__avatar"
@@ -54,19 +55,19 @@
 
     <dl class="reels-info-sidebar__stats">
       <div class="reels-info-sidebar__stat">
-        <dt class="reels-info-sidebar__stat-label">Resolution</dt>
+        <dt class="reels-info-sidebar__stat-label">{{ t('reels.info.resolution') }}</dt>
         <dd class="reels-info-sidebar__stat-value">{{ dimensionsLabel }}</dd>
       </div>
       <div class="reels-info-sidebar__stat">
-        <dt class="reels-info-sidebar__stat-label">Length</dt>
+        <dt class="reels-info-sidebar__stat-label">{{ t('reels.info.length') }}</dt>
         <dd class="reels-info-sidebar__stat-value">{{ durationLabel }}</dd>
       </div>
       <div class="reels-info-sidebar__stat">
-        <dt class="reels-info-sidebar__stat-label">Size</dt>
+        <dt class="reels-info-sidebar__stat-label">{{ t('reels.info.size') }}</dt>
         <dd class="reels-info-sidebar__stat-value">{{ fileSizeLabel }}</dd>
       </div>
       <div class="reels-info-sidebar__stat">
-        <dt class="reels-info-sidebar__stat-label">Format</dt>
+        <dt class="reels-info-sidebar__stat-label">{{ t('reels.info.format') }}</dt>
         <dd class="reels-info-sidebar__stat-value">{{ formatLabel }}</dd>
       </div>
     </dl>
@@ -77,7 +78,7 @@
       role="status"
       aria-live="polite"
     >
-      Loading reel details...
+      {{ t('reels.info.loading') }}
     </p>
     <p v-else-if="error" class="reels-info-sidebar__notice reels-info-sidebar__notice--error" role="status">
       {{ error }}
@@ -85,12 +86,12 @@
 
     <dl class="reels-info-sidebar__meta">
       <div class="reels-info-sidebar__meta-item">
-        <dt class="reels-info-sidebar__meta-label">Folder Path</dt>
+        <dt class="reels-info-sidebar__meta-label">{{ t('reels.info.folderPath') }}</dt>
         <dd class="reels-info-sidebar__meta-value">{{ item.folderPath }}</dd>
       </div>
 
       <div v-if="mimeLabel" class="reels-info-sidebar__meta-item">
-        <dt class="reels-info-sidebar__meta-label">MIME Type</dt>
+        <dt class="reels-info-sidebar__meta-label">{{ t('reels.info.mimeType') }}</dt>
         <dd class="reels-info-sidebar__meta-value">{{ mimeLabel }}</dd>
       </div>
     </dl>
@@ -100,6 +101,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { RouterLink } from 'vue-router';
 
 import { fetchImage } from '../api/gallery';
@@ -121,6 +123,7 @@ defineEmits<{
   close: [];
 }>();
 
+const { t, locale } = useI18n();
 const detail = ref<ImageDetail | null>(null);
 const loading = ref(false);
 const error = ref<string | null>(null);
@@ -137,7 +140,7 @@ const caption = computed(() =>
 );
 const formattedDate = computed(() =>
   new Date(detail.value?.takenAt ?? detail.value?.sortTimestamp ?? props.item.takenAt ?? props.item.sortTimestamp).toLocaleDateString(
-    undefined,
+    locale.value,
     {
       month: 'short',
       day: 'numeric',
@@ -146,20 +149,20 @@ const formattedDate = computed(() =>
   )
 );
 const folderBreadcrumb = computed(
-  () => props.folder?.breadcrumb ?? detail.value?.folderBreadcrumb ?? props.item.folderBreadcrumb ?? 'Top-level source folder'
+  () => props.folder?.breadcrumb ?? detail.value?.folderBreadcrumb ?? props.item.folderBreadcrumb ?? t('reels.info.topLevelSourceFolder')
 );
 const dimensionsLabel = computed(() => `${detail.value?.width ?? props.item.width} x ${detail.value?.height ?? props.item.height}`);
-const durationLabel = computed(() => formatMediaDuration(detail.value?.durationMs ?? props.item.durationMs) || 'Unavailable');
+const durationLabel = computed(() => formatMediaDuration(detail.value?.durationMs ?? props.item.durationMs) || t('reels.info.unavailable'));
 const formatLabel = computed(() => {
   if (!detail.value?.mimeType) {
-    return 'Video';
+    return t('reels.info.video');
   }
 
   return detail.value.mimeType.replace(/^video\//, '').toUpperCase();
 });
 const fileSizeLabel = computed(() => {
   if (!detail.value) {
-    return loading.value ? 'Loading...' : 'Unavailable';
+    return loading.value ? t('common.loading') : t('reels.info.unavailable');
   }
 
   return `${(detail.value.fileSize / (1024 * 1024)).toFixed(2)} MB`;
@@ -206,7 +209,7 @@ watch(
         }
 
         detail.value = null;
-        error.value = loadError instanceof Error ? loadError.message : 'Unable to load reel details.';
+        error.value = loadError instanceof Error ? loadError.message : t('reels.info.loadError');
       } finally {
         if (currentToken === requestToken) {
           loading.value = false;

--- a/client/src/components/SidebarNav.vue
+++ b/client/src/components/SidebarNav.vue
@@ -5,7 +5,7 @@
     <RouterLink
       class="sidebar__brand relative inline-flex items-center justify-center w-12 h-12 p-[0.3rem] rounded-[1rem] color-inherit transition-[background-color,transform,opacity] duration-180 hover:bg-surface-hover hover:-translate-y-px"
       to="/"
-      aria-label="Foldergram home"
+      :aria-label="t('nav.foldergramHome')"
     >
       <span
         class="pointer-events-none absolute top-[0.16rem] left-1/2 -translate-x-1/2 text-[0.42rem] leading-none tracking-[0.08em] text-muted"
@@ -40,7 +40,7 @@
                 opacity 0.18s ease,
                 max-width 0.22s ease;
             "
-            >Home</span
+            >{{ t('nav.home') }}</span
           >
         </a>
       </RouterLink>
@@ -72,7 +72,7 @@
                 opacity 0.18s ease,
                 max-width 0.22s ease;
             "
-            >Reels</span
+            >{{ t('nav.reels') }}</span
           >
         </a>
       </RouterLink>
@@ -104,7 +104,7 @@
                 opacity 0.18s ease,
                 max-width 0.22s ease;
             "
-            >Search</span
+            >{{ t('nav.search') }}</span
           >
         </a>
       </RouterLink>
@@ -136,7 +136,7 @@
                 opacity 0.18s ease,
                 max-width 0.22s ease;
             "
-            >Library</span
+            >{{ t('nav.library') }}</span
           >
         </a>
       </RouterLink>
@@ -169,7 +169,7 @@
                 opacity 0.18s ease,
                 max-width 0.22s ease;
             "
-            >Places</span
+            >{{ t('nav.places') }}</span
           >
         </a>
       </RouterLink>
@@ -244,7 +244,7 @@
                 opacity 0.18s ease,
                 max-width 0.22s ease;
             "
-            >Collections</span
+            >{{ t('nav.collections') }}</span
           >
         </a>
       </RouterLink>
@@ -256,7 +256,7 @@
             opacity 0.18s ease,
             max-width 0.22s ease;
         "
-        >Folders Spotlight</span
+        >{{ t('nav.foldersSpotlight') }}</span
       >
       <div
         class="flex min-h-0 flex-col gap-[0.2rem] max-h-[22.5rem] overflow-y-auto [scrollbar-width:none]"
@@ -294,7 +294,7 @@
             >
               <strong class="truncate text-[0.82rem]">{{ folder.name }}</strong>
               <small class="truncate text-[0.68rem] text-muted">{{
-                folder.breadcrumb ?? `${folder.imageCount} posts`
+                folder.breadcrumb ?? t('nav.folderPosts', { count: folder.imageCount })
               }}</small>
             </span>
           </a>
@@ -321,7 +321,7 @@
             @click="closeMoreMenu"
           >
             <span class="i-fluent-delete-16-regular w-[1.18rem] h-[1.18rem] shrink-0" aria-hidden="true" />
-            <span>Trash</span>
+            <span>{{ t('nav.trash') }}</span>
           </RouterLink>
 
           <RouterLink v-if="authStore.canAccessSettings" custom :to="{ name: 'settings' }" v-slot="{ href, navigate, isActive }">
@@ -329,13 +329,13 @@
               :href="href"
               class="flex items-center gap-[0.95rem] px-[1.2rem] py-[1rem] text-[0.98rem] text-text transition-colors duration-150 hover:bg-surface-hover"
               @click="handleSettingsNavigate($event, navigate)"
-            >
-              <span
-                class="w-[1.18rem] h-[1.18rem] shrink-0"
-                :class="isActive ? 'i-fluent-settings-20-filled' : 'i-fluent-settings-20-regular'"
-                aria-hidden="true"
-              />
-              <span>Settings</span>
+              >
+                <span
+                  class="w-[1.18rem] h-[1.18rem] shrink-0"
+                  :class="isActive ? 'i-fluent-settings-20-filled' : 'i-fluent-settings-20-regular'"
+                  aria-hidden="true"
+                />
+              <span>{{ t('nav.settings') }}</span>
             </a>
           </RouterLink>
 
@@ -350,7 +350,7 @@
               class="i-fluent-key-16-regular w-[1.18rem] h-[1.18rem] shrink-0"
               aria-hidden="true"
             />
-            <span>Unlock admin</span>
+            <span>{{ t('nav.unlockAdmin') }}</span>
           </button>
 
           <button
@@ -369,7 +369,7 @@
               class="i-fluent-weather-sunny-20-regular w-[1.18rem] h-[1.18rem] shrink-0"
               aria-hidden="true"
             />
-            <span>Switch appearance</span>
+            <span>{{ t('nav.switchAppearance') }}</span>
           </button>
 
           <button
@@ -407,7 +407,7 @@
                 opacity 0.18s ease,
                 max-width 0.22s ease;
             "
-            >More</span
+            >{{ t('nav.more') }}</span
           >
         </button>
       </div>
@@ -417,6 +417,7 @@
 
 <script setup lang="ts">
   import { computed, onMounted, onUnmounted, ref, watch } from "vue"
+  import { useI18n } from "vue-i18n"
   import { RouterLink, useRoute } from "vue-router"
 
   import { useAppStore } from "../stores/app"
@@ -429,6 +430,7 @@
   import Avatar from "./Avatar.vue"
   import BrandMark from "./BrandMark.vue"
 
+  const { t } = useI18n()
   const appVersion = __APP_VERSION__
   const appStore = useAppStore()
   const authStore = useAuthStore()
@@ -449,7 +451,7 @@
     ),
   )
   const appearanceLabel = computed(() =>
-    appStore.theme === "light" ? "Switch to dark mode" : "Switch to light mode",
+    appStore.theme === "light" ? t("nav.switchToDarkMode") : t("nav.switchToLightMode"),
   )
   const showPlacesNav = computed(() =>
     placesStore.items.length > 0 && placesStore.listError === null,
@@ -461,7 +463,7 @@
     route.name === "collections" || route.name === "collection",
   )
   const signOutLabel = computed(() =>
-    authStore.accessMode === "public" ? "Return to public view" : "Sign out",
+    authStore.accessMode === "public" ? t("nav.returnToPublicView") : t("nav.signOut"),
   )
   const sidebarActiveClass =
     "router-link-active bg-[color-mix(in_srgb,var(--surface)_92%,transparent_8%)] font-bold"

--- a/client/src/components/StoriesModal.test.ts
+++ b/client/src/components/StoriesModal.test.ts
@@ -3,6 +3,7 @@ import { createPinia, setActivePinia } from 'pinia';
 import { reactive } from 'vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { DEFAULT_LOCALE, i18n } from '../locales';
 import type { FeedItem, RailCapsule, RailViewerStoreContract } from '../types/api';
 import { useAppStore } from '../stores/app';
 import StoriesModal from './StoriesModal.vue';
@@ -47,14 +48,15 @@ function createVideoItem(id: number): FeedItem {
   };
 }
 
-function createCapsule(id: string, title: string, item: FeedItem): RailCapsule {
+function createCapsule(id: string, title: string, item: FeedItem, latestActivityTimestamp?: number | null): RailCapsule {
   return {
     id,
     title,
     subtitle: 'Recent story set',
     dateContext: 'Latest Mar 28, 2026',
     imageCount: 1,
-    coverImage: item
+    coverImage: item,
+    ...(latestActivityTimestamp !== undefined ? { latestActivityTimestamp } : {})
   };
 }
 
@@ -136,6 +138,7 @@ describe('StoriesModal', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     setActivePinia(createPinia());
+    i18n.global.locale.value = DEFAULT_LOCALE;
     const appStore = useAppStore();
     appStore.$patch({
       videoMuted: true,
@@ -471,5 +474,52 @@ describe('StoriesModal', () => {
     expect(loadCapsule).toHaveBeenCalledTimes(2);
     expect(loadCapsule).toHaveBeenLastCalledWith(capsule.id);
     expect(wrapper.text()).not.toContain('Unable to load this story capsule');
+  });
+
+  it('localizes story meta and footer dates with the active app locale', async () => {
+    i18n.global.locale.value = 'zh';
+
+    const imageItem = createImageItem(801);
+    const latestActivityTimestamp = new Date('2026-03-28T12:00:00.000Z').getTime();
+    const capsule = createCapsule('capsule-localized-meta', 'Tigers', imageItem, latestActivityTimestamp);
+    const store = createStore([capsule], {
+      [capsule.id]: [imageItem]
+    });
+
+    const wrapper = mount(StoriesModal, {
+      props: {
+        items: [capsule],
+        initialId: capsule.id,
+        railSingularLabel: 'Story',
+        store
+      },
+      global: {
+        stubs: {
+          Avatar: {
+            template: '<div data-test="avatar" />'
+          },
+          ResilientImage: {
+            template: '<img data-test="resilient-image" />'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    const expectedStoryDate = new Intl.DateTimeFormat('zh', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    }).format(new Date(latestActivityTimestamp));
+    const expectedFooterDate = new Intl.DateTimeFormat('zh', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    }).format(new Date(imageItem.takenAt ?? imageItem.sortTimestamp));
+
+    expect(wrapper.text()).toContain(`1 项 · 最新 ${expectedStoryDate}`);
+    expect(wrapper.text()).toContain(expectedFooterDate);
+    expect(wrapper.text()).not.toContain('1 items · Latest');
   });
 });

--- a/client/src/components/StoriesModal.vue
+++ b/client/src/components/StoriesModal.vue
@@ -39,7 +39,7 @@
             <div class="story-side-card__shade" />
             <div class="story-side-card__meta">
               <strong class="block truncate text-[0.92rem]">{{ previousCapsule.title }}</strong>
-              <span class="block truncate text-[0.78rem] text-white/68">{{ previousCapsule.imageCount }} items</span>
+              <span class="block truncate text-[0.78rem] text-white/68">{{ formatRailItemCount(previousCapsule.imageCount) }}</span>
             </div>
           </article>
         </button>
@@ -245,7 +245,7 @@
             <div class="story-side-card__shade" />
             <div class="story-side-card__meta">
               <strong class="block truncate text-[0.9rem]">{{ capsule.title }}</strong>
-              <span class="block truncate text-[0.76rem] text-white/68">{{ capsule.imageCount }} items</span>
+              <span class="block truncate text-[0.76rem] text-white/68">{{ formatRailItemCount(capsule.imageCount) }}</span>
             </div>
           </article>
         </button>
@@ -258,6 +258,7 @@
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 
 import { useHorizontalSwipe } from '../composables/useHorizontalSwipe';
+import { i18n } from '../locales';
 import type { FeedItem, RailCapsule, RailViewerStoreContract } from '../types/api';
 import { useAppStore } from '../stores/app';
 import { getOriginalMediaDownloadUrl } from '../utils/original-media';
@@ -278,6 +279,34 @@ const props = defineProps<{
 const emit = defineEmits<{
   close: [];
 }>();
+
+function getCurrentLocale() {
+  return i18n.global.locale.value;
+}
+
+function formatRailItemCount(count: number) {
+  return count === 1
+    ? i18n.global.t('common.railViewer.itemCountOne', { count })
+    : i18n.global.t('common.railViewer.itemCountOther', { count });
+}
+
+function formatCapsuleDateContext(capsule: RailCapsule) {
+  if (capsule.latestActivityTimestamp === null) {
+    return i18n.global.t('common.railViewer.noRecentActivity');
+  }
+
+  if (typeof capsule.latestActivityTimestamp === 'number' && Number.isFinite(capsule.latestActivityTimestamp) && capsule.latestActivityTimestamp > 0) {
+    const date = new Intl.DateTimeFormat(getCurrentLocale(), {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    }).format(new Date(capsule.latestActivityTimestamp));
+
+    return i18n.global.t('common.railViewer.latestDate', { date });
+  }
+
+  return capsule.dateContext;
+}
 
 const appStore = useAppStore();
 const activeCapsuleId = ref(props.initialId);
@@ -334,7 +363,7 @@ const activeCapsuleMeta = computed(() => {
     return '';
   }
 
-  return `${activeCapsule.value.imageCount} items · ${activeCapsule.value.dateContext}`;
+  return `${formatRailItemCount(activeCapsule.value.imageCount)} · ${formatCapsuleDateContext(activeCapsule.value)}`;
 });
 const currentError = computed(() => props.store.currentError ?? null);
 const footerMeta = computed(() => {
@@ -342,11 +371,11 @@ const footerMeta = computed(() => {
     return '';
   }
 
-  return new Date(displayImage.value.takenAt ?? displayImage.value.sortTimestamp).toLocaleDateString(undefined, {
+  return new Intl.DateTimeFormat(getCurrentLocale(), {
     month: 'short',
     day: 'numeric',
     year: 'numeric'
-  });
+  }).format(new Date(displayImage.value.takenAt ?? displayImage.value.sortTimestamp));
 });
 const canGoPreviousImage = computed(() => !transitionPending.value && activeImages.value.length > 0 && activeImageIndex.value > 0);
 const canGoNextImage = computed(

--- a/client/src/components/TopNav.vue
+++ b/client/src/components/TopNav.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- Mobile bottom nav — hidden on desktop (md+) -->
-  <nav class="mobile-nav" aria-label="Primary navigation">
+  <nav class="mobile-nav" :aria-label="t('nav.primary')">
     <div v-if="moreMenuOpen" class="mobile-nav__backdrop" @click="closeMoreMenu" />
 
     <div class="mobile-nav__bar">
@@ -9,7 +9,7 @@
           :href="href"
           class="mobile-nav__item mobile-nav__brand"
           :class="isActive ? mobileNavActiveClass : ''"
-          aria-label="Foldergram home"
+          :aria-label="t('nav.foldergramHome')"
           @click="handleNavNavigate($event, navigate)"
         >
           <BrandMark />
@@ -22,7 +22,7 @@
             :href="href"
             class="mobile-nav__item"
             :class="isActive ? mobileNavActiveClass : ''"
-            aria-label="Reels"
+            :aria-label="t('nav.reels')"
             @click="handleNavNavigate($event, navigate)"
           >
             <span class="mobile-nav__icon" :class="isActive ? 'i-fluent-play-circle-24-filled' : 'i-fluent-play-circle-24-regular'" aria-hidden="true" />
@@ -34,7 +34,7 @@
             :href="href"
             class="mobile-nav__item"
             :class="isActive ? mobileNavActiveClass : ''"
-            aria-label="Search"
+            :aria-label="t('nav.search')"
             @click="handleNavNavigate($event, navigate)"
           >
             <span class="mobile-nav__icon" :class="isActive ? 'i-fluent-search-16-filled' : 'i-fluent-search-16-regular'" aria-hidden="true" />
@@ -46,7 +46,7 @@
             :href="href"
             class="mobile-nav__item"
             :class="isActive ? mobileNavActiveClass : ''"
-            aria-label="Library"
+            :aria-label="t('nav.library')"
             @click="handleNavNavigate($event, navigate)"
           >
             <span class="mobile-nav__icon" :class="isActive ? 'i-fluent-folder-16-filled' : 'i-fluent-folder-16-regular'" aria-hidden="true" />
@@ -58,7 +58,7 @@
             :href="href"
             class="mobile-nav__item mobile-nav__item--places"
             :class="isActive || isPlacesRoute ? mobileNavActiveClass : ''"
-            aria-label="Places"
+            :aria-label="t('nav.places')"
             @click="handleNavNavigate($event, navigate)"
           >
             <span class="mobile-nav__icon" :class="isActive || isPlacesRoute ? 'i-fluent-location-20-filled' : 'i-fluent-location-20-regular'" aria-hidden="true" />
@@ -70,7 +70,7 @@
             :href="href"
             class="mobile-nav__item mobile-nav__item--likes"
             :class="isActive ? mobileNavActiveClass : ''"
-            :aria-label="`${likesStore.collectionLabel} (${likesStore.items.length})`"
+            :aria-label="t('nav.likesAriaLabel', { label: likesStore.collectionLabel, count: likesStore.items.length })"
             @click="handleNavNavigate($event, navigate)"
           >
             <span class="mobile-nav__icon" :class="isActive ? 'i-fluent-heart-20-filled' : 'i-fluent-heart-20-regular'" aria-hidden="true" />
@@ -87,7 +87,7 @@
             :href="href"
             class="mobile-nav__item mobile-nav__item--collections"
             :class="isActive || isCollectionsRoute ? mobileNavActiveClass : ''"
-            aria-label="Collections"
+            :aria-label="t('nav.collections')"
             @click="handleNavNavigate($event, navigate)"
           >
             <span class="mobile-nav__icon" :class="isActive || isCollectionsRoute ? 'i-fluent-bookmark-20-filled' : 'i-fluent-bookmark-20-regular'" aria-hidden="true" />
@@ -99,7 +99,7 @@
             class="mobile-nav__item mobile-nav__more-button"
             :class="moreButtonClasses"
             type="button"
-            aria-label="More"
+            :aria-label="t('nav.more')"
             aria-haspopup="menu"
             :aria-expanded="moreMenuOpen"
             :data-open="moreMenuOpen ? 'true' : 'false'"
@@ -135,7 +135,7 @@
                 @click="handleNavNavigate($event, navigate)"
               >
                 <span class="mobile-nav__menu-icon" :class="isActive || isCollectionsRoute ? 'i-fluent-bookmark-20-filled' : 'i-fluent-bookmark-20-regular'" aria-hidden="true" />
-                <span>Collections</span>
+                <span>{{ t('nav.collections') }}</span>
                 <small class="mobile-nav__menu-badge">{{ collectionsStore.defaultCollection?.itemCount ?? 0 }}</small>
               </a>
             </RouterLink>
@@ -147,7 +147,7 @@
               @click="closeMoreMenu"
             >
               <span class="mobile-nav__menu-icon i-fluent-delete-16-regular" aria-hidden="true" />
-              <span>Trash</span>
+              <span>{{ t('nav.trash') }}</span>
             </RouterLink>
 
             <RouterLink v-if="authStore.canAccessSettings" custom :to="{ name: 'settings' }" v-slot="{ href, navigate, isActive }">
@@ -162,7 +162,7 @@
                   :class="isActive ? 'i-fluent-settings-20-filled' : 'i-fluent-settings-20-regular'"
                   aria-hidden="true"
                 />
-                <span>Settings</span>
+                <span>{{ t('nav.settings') }}</span>
               </a>
             </RouterLink>
 
@@ -174,7 +174,7 @@
               @click="handleUnlockAdmin"
             >
               <span class="mobile-nav__menu-icon i-fluent-key-16-regular" aria-hidden="true" />
-              <span>Unlock admin</span>
+              <span>{{ t('nav.unlockAdmin') }}</span>
             </button>
 
             <button
@@ -193,7 +193,7 @@
                 class="mobile-nav__menu-icon i-fluent-weather-sunny-20-regular"
                 aria-hidden="true"
               />
-              <span>Switch appearance</span>
+              <span>{{ t('nav.switchAppearance') }}</span>
             </button>
 
             <button
@@ -215,6 +215,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { RouterLink, useRoute } from 'vue-router';
 
 import { useAppStore } from '../stores/app';
@@ -224,6 +225,7 @@ import { useLikesStore } from '../stores/likes';
 import { usePlacesStore } from '../stores/places';
 import BrandMark from './BrandMark.vue';
 
+const { t } = useI18n();
 const appStore = useAppStore();
 const authStore = useAuthStore();
 const collectionsStore = useCollectionsStore();
@@ -231,8 +233,8 @@ const likesStore = useLikesStore();
 const placesStore = usePlacesStore();
 const route = useRoute();
 const moreMenuOpen = ref(false);
-const themeLabel = computed(() => (appStore.theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode'));
-const signOutLabel = computed(() => (authStore.accessMode === 'public' ? 'Return to public view' : 'Sign out'));
+const themeLabel = computed(() => (appStore.theme === 'light' ? t('nav.switchToDarkMode') : t('nav.switchToLightMode')));
+const signOutLabel = computed(() => (authStore.accessMode === 'public' ? t('nav.returnToPublicView') : t('nav.signOut')));
 const showPlacesNav = computed(() => placesStore.items.length > 0 && placesStore.listError === null);
 const isPlacesRoute = computed(() => route.name === 'places' || route.name === 'place');
 const isLikesRoute = computed(() => route.name === 'likes');

--- a/client/src/composables/useImageCaptionEditor.ts
+++ b/client/src/composables/useImageCaptionEditor.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue';
 
 import { updateImageCaption as updateImageCaptionRequest } from '../api/gallery';
+import { i18n } from '../locales';
 import { useCollectionsStore } from '../stores/collections';
 import { useExploreStore } from '../stores/explore';
 import { useFeedStore } from '../stores/feed';
@@ -58,7 +59,7 @@ export function useImageCaptionEditor() {
       applyCaption(updatedImage.id, updatedImage.caption ?? null);
       return updatedImage;
     } catch (saveError) {
-      error.value = saveError instanceof Error ? saveError.message : 'Unable to update caption';
+      error.value = saveError instanceof Error ? saveError.message : i18n.global.t('post.captionModal.errors.update');
       throw saveError;
     } finally {
       saving.value = false;

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1,0 +1,977 @@
+{
+  "common": {
+    "cancel": "Cancel",
+    "close": "Close",
+    "description": "Description",
+    "loadMore": "Load more",
+    "loadingMore": "Loading more...",
+    "name": "Name",
+    "newFeature": "New Feature",
+    "open": "Open",
+    "retry": "Retry",
+    "save": "Save",
+    "saveChanges": "Save changes",
+    "saved": "Saved",
+    "saving": "Saving...",
+    "youAreCaughtUp": "You are caught up",
+    "loading": "Loading..."
+  },
+  "app": {
+    "authLoading": {
+      "eyebrow": "Access Protection",
+      "title": "Checking access",
+      "description": "Loading the current password protection status."
+    }
+  },
+  "auth": {
+    "gate": {
+      "eyebrow": "Shared Password",
+      "title": "Unlock Foldergram",
+      "passwordLabel": "Password",
+      "descriptionPassword": "This library accepts either the admin password or the viewer password for local access.",
+      "descriptionAdmin": "This library is protected with the admin password for local and homelab access.",
+      "placeholderPassword": "Enter the admin or viewer password",
+      "placeholderAdmin": "Enter the admin password",
+      "unlocking": "Unlocking...",
+      "unlock": "Unlock Library",
+      "unableToSignIn": "Unable to sign in."
+    },
+    "adminUnlock": {
+      "eyebrow": "Admin Unlock",
+      "title": "Unlock admin access",
+      "closeAria": "Close admin unlock dialog",
+      "description": "Enter the admin password to open Settings, Trash, scans, rebuild tools, and other admin-only actions.",
+      "passwordLabel": "Admin password",
+      "placeholder": "Enter the admin password",
+      "unlocking": "Unlocking...",
+      "unlock": "Unlock Admin",
+      "unableToUnlock": "Unable to unlock admin access."
+    }
+  },
+  "nav": {
+    "primary": "Primary navigation",
+    "foldergramHome": "Foldergram home",
+    "home": "Home",
+    "reels": "Reels",
+    "search": "Search",
+    "library": "Library",
+    "places": "Places",
+    "collections": "Collections",
+    "more": "More",
+    "trash": "Trash",
+    "settings": "Settings",
+    "unlockAdmin": "Unlock admin",
+    "switchAppearance": "Switch appearance",
+    "switchToDarkMode": "Switch to dark mode",
+    "switchToLightMode": "Switch to light mode",
+    "signOut": "Sign out",
+    "returnToPublicView": "Return to public view",
+    "foldersSpotlight": "Folders Spotlight",
+    "likesAriaLabel": "{label} ({count})",
+    "folderPosts": "{count} posts"
+  },
+  "settings": {
+    "eyebrow": "Settings",
+    "title": "Library Controls",
+    "description": "Manage scans, app defaults, access, and the library index.",
+    "sections": {
+      "navigation": "Settings sections",
+      "library": {
+        "label": "Scan & Library",
+        "shortLabel": "Scan and Library",
+        "description": "Index media, rebuild thumbnails, and maintain the library index"
+      },
+      "general": {
+        "label": "General Settings",
+        "description": "Stories mode, excluded folders, and feed defaults"
+      },
+      "places": {
+        "label": "Places",
+        "description": "Offline city lookup and place assignment"
+      },
+      "access": {
+        "label": "Security & Access",
+        "shortLabel": "Security and Access",
+        "description": "Password locks & viewer roles"
+      },
+      "status": {
+        "label": "System Status",
+        "description": "Storage overview & scan history"
+      }
+    },
+    "places": {
+      "banner": {
+        "title": "Places from photo GPS data",
+        "description": "Group GPS-tagged photos by offline city and location labels.",
+        "helper": "Prepare the local GeoNames dataset, then rebuild place assignments for the photos already in your library.",
+        "setup": "Set up Places",
+        "dismissAria": "Dismiss places announcement",
+        "availableLater": "The download is opt-in, and the Places tab stays available in Settings later."
+      },
+      "section": {
+        "title": "Offline places",
+        "description": "Prepare GeoNames city data, then rebuild place links from existing photo coordinates.",
+        "prepared": "Prepared",
+        "notPrepared": "Not Prepared",
+        "datasetLabel": "Dataset",
+        "rowsLabel": "Rows",
+        "notImported": "Not imported",
+        "importedAt": "Imported {value}.",
+        "fallbackDataset": "GeoNames cities500",
+        "prepareButton": "Prepare Geodata",
+        "preparingButton": "Preparing...",
+        "rebuildButton": "Rebuild Place Assignments",
+        "rebuildingButton": "Rebuilding...",
+        "loadStatusError": "Unable to load places status",
+        "actions": {
+          "ready": "Offline place data is ready.",
+          "prepareError": "Unable to prepare offline place data.",
+          "rebuilt": "Rebuilt places for {assigned} of {processed} posts.",
+          "rebuildError": "Unable to rebuild place assignments."
+        }
+      }
+    },
+    "general": {
+      "migration": {
+        "eyebrow": "Stories Migration",
+        "title": "This library may already use folders named stories",
+        "description": "Foldergram can now treat stories/ as profile stories and highlights by default. Choose whether to keep legacy folder behavior or switch to the new reserved stories mode, then rescan the library.",
+        "dismissAria": "Dismiss stories migration notice",
+        "useFeature": "Use Stories Feature",
+        "keepLegacy": "Keep Legacy Behavior",
+        "helper": "Choose a mode here, then save it below. Run a library scan afterward so the indexed folder structure matches.",
+        "helperSaving": "Wait for the current settings update to finish first."
+      },
+      "announcement": {
+        "title": "Stories",
+        "headline": "Reserved stories/ folders can power App Folder stories",
+        "description": "Drop direct media into AppFolder/stories for the avatar story set, and use direct child folders for highlight circles. Nested folders stay inside the same highlight capsule.",
+        "dismissAria": "Dismiss stories announcement",
+        "showStructure": "See directory structure",
+        "hideStructure": "Hide directory structure"
+      },
+      "card": {
+        "title": "General Settings",
+        "description": "App-wide defaults for stories folders, excluded folders, Home, Reels, and app folders."
+      },
+      "language": {
+        "label": "App language",
+        "description": "Choose the language used for navigation, dialogs, and other translated app UI on this device.",
+        "helper": "Applies immediately in this browser. Missing translations fall back to English.",
+        "selectLabel": "App language",
+        "options": {
+          "en": "English",
+          "es": "Spanish",
+          "zh": "Chinese"
+        }
+      },
+      "homeFeed": {
+        "label": "Home feed sort order",
+        "description": "Choose the first feed mode shown on Home.",
+        "closeMenuAria": "Close home feed sort menu",
+        "options": {
+          "random": {
+            "label": "Random",
+            "description": "Steady shuffle."
+          },
+          "recent": {
+            "label": "Recent",
+            "description": "Newest first."
+          },
+          "rediscover": {
+            "label": "Rediscover",
+            "description": "Bring older picks back."
+          }
+        }
+      },
+      "reelsFeed": {
+        "label": "Reels feed sort order",
+        "description": "Choose the default queue style when Reels opens.",
+        "closeMenuAria": "Close reels feed sort menu",
+        "options": {
+          "random": {
+            "label": "Random",
+            "description": "Stable session shuffle."
+          },
+          "recent": {
+            "label": "Recent",
+            "description": "Newest videos first."
+          },
+          "recommended": {
+            "label": "Recommended",
+            "description": "Affinity-ranked mix."
+          }
+        }
+      },
+      "folderOrder": {
+        "label": "App folder photo order",
+        "description": "Choose the default order for photos inside app folders.",
+        "closeMenuAria": "Close app folder photo order menu",
+        "options": {
+          "newest": {
+            "label": "Newest First",
+            "description": "Recent photos appear first."
+          },
+          "oldest": {
+            "label": "Oldest First",
+            "description": "Earlier photos appear first."
+          }
+        }
+      },
+      "storiesMode": {
+        "label": "Treat stories folders as normal app folders",
+        "scanRequired": "Scan required",
+        "explainAria": "Explain stories folders setting",
+        "explainDescription": "When this stays off, AppFolder/stories becomes the source for avatar stories and highlight circles. Turn it on only if folders literally named stories should continue behaving like normal folders everywhere in the app.",
+        "toggleLabel": "Toggle stories folders behavior",
+        "enabledDescription": "Legacy mode is enabled. stories folders remain ordinary app folders everywhere.",
+        "disabledDescription": "Reserved stories mode is enabled. AppFolder/stories powers avatar stories and highlight circles."
+      },
+      "excludedFolders": {
+        "label": "Excluded source folders",
+        "description": "Skip matching folders anywhere by name or by exact relative path under the gallery root. Hidden paths and app-managed storage stay excluded automatically.",
+        "customRules": "Custom rules",
+        "envRulesLabel": "Read-only env rules",
+        "envRulesDescription": "Change GALLERY_EXCLUDED_FOLDERS in .env or Docker and restart the app to update these.",
+        "envRulesEmpty": "No env-backed folder exclusions are configured.",
+        "activeRulesLabel": "Currently active saved rules",
+        "activeRulesDescription": "This combines the saved textarea rules with any env-backed entries. New textarea edits appear here after you save them.",
+        "activeRulesEmpty": "No saved custom or env-backed folder exclusions are active."
+      },
+      "actionNote": {
+        "loading": "Loading the current app preferences...",
+        "excludedAndOther": "Save the folder exclusion rules with the other app-wide changes. Run a library scan afterward so stories and excluded folders reindex correctly.",
+        "excludedOnly": "This saves the custom excluded folders only. Run a library scan afterward so those folders disappear from the index.",
+        "storiesAndDefaults": "Save the new stories rule and the updated browsing defaults together.",
+        "storiesOnly": "This saves the stories folders rule only. Run a library scan afterward to reindex with the new behavior.",
+        "multipleDefaults": "Save these browsing defaults together. Home visitors can still switch modes on the homepage; Reels and app folders use app defaults.",
+        "homeOnly": "This updates the first feed mode shown on Home for this app. Visitors can still switch modes from the homepage.",
+        "reelsOnly": "This updates the queue style used when Reels opens for this app. Visitors cannot switch modes from the reels page.",
+        "folderOnly": "This updates the default photo order used by app folder grids.",
+        "idle": "These are the current app-wide defaults for Home, Reels, app folders, stories folders, and excluded folders."
+      },
+      "rescanNotice": {
+        "excludedAndStories": "Save these changes, then run a library scan before expecting stories folders and excluded folders to update.",
+        "excludedOnly": "Save this change, then run a library scan before excluded folders disappear from the index.",
+        "storiesOnly": "Save this change, then run a library scan before expecting stories folders, avatar stories, or highlights to update."
+      },
+      "feedback": {
+        "settingsAndFolderRulesSaved": "Settings were saved. Run a library scan to apply the folder rule changes.",
+        "folderRulesAndStoriesSaved": "Folder exclusion rules and stories folder behavior were saved. Run a library scan to apply them.",
+        "excludedFoldersSaved": "Excluded folders were saved. Run a library scan to apply them.",
+        "settingsAndStoriesSaved": "Settings were saved. Run a library scan to apply the stories folder change.",
+        "storiesSaved": "Stories folder behavior was saved. Run a library scan to apply it.",
+        "defaultsSaved": "App-wide browsing defaults were updated.",
+        "homeSaved": "The homepage now opens with {label}.",
+        "reelsSaved": "Reels now opens with {label}.",
+        "folderOrderSaved": "App folders now open with {label}.",
+        "parts": {
+          "excludedFolders": "excluded folders",
+          "storiesFolderHandling": "stories folder handling",
+          "homeFeedDefault": "Home feed default",
+          "reelsFeedDefault": "Reels feed default",
+          "appFolderOrder": "app folder order"
+        }
+      },
+      "errors": {
+        "validateExcludedFolders": "Unable to validate the excluded folder rules.",
+        "update": "Unable to update the general settings.",
+        "partialUpdate": "Some settings were saved ({parts}), but the update did not finish: {message}"
+      }
+    },
+    "library": {
+      "legacyMigration": {
+        "title": "Legacy derivative migration pending",
+        "messageOne": "{count} indexed media record still uses the old mirrored thumbnail and preview paths. Run Scan Library to move it into asset-key storage.",
+        "messageOther": "{count} indexed media records still use the old mirrored thumbnail and preview paths. Run Scan Library to move them into asset-key storage."
+      },
+      "scanCard": {
+        "title": "Scan Library",
+        "description": "Run a scan after adding folders or when you want to refresh indexed media."
+      },
+      "statusLabel": {
+        "storageUnavailable": "Storage unavailable",
+        "scanInProgress": "Scan in progress",
+        "rebuildActive": "Rebuild active",
+        "ready": "Ready"
+      },
+      "scanButton": {
+        "active": "Scanning library...",
+        "idle": "Run Scan Library"
+      },
+      "scanActionNote": {
+        "loading": "Loading current library status...",
+        "rebuildRequired": "Rebuild the library index first because the gallery location changed.",
+        "otherTaskActive": "Another library task is running. Live progress appears in the sticky status bar.",
+        "progress": "Live progress appears in the sticky status bar.",
+        "legacyMigration": "Run Scan Library to move legacy mirrored thumbnails and previews into the asset-key storage layout.",
+        "idle": "Scans check for added, updated, or missing media."
+      },
+      "thumbnailCard": {
+        "title": "Regenerate Thumbnails",
+        "description": "Rebuild feed and profile thumbnails plus video posters from indexed media only. Original files are not affected."
+      },
+      "thumbnailButton": {
+        "active": "Regenerating now...",
+        "idle": "Regenerate Thumbnails"
+      },
+      "thumbnailActionNote": {
+        "loading": "Loading current library status...",
+        "rebuildRequired": "Unavailable until the library index is rebuilt for the new gallery location.",
+        "progress": "Live progress appears in the sticky status bar.",
+        "rebuildActive": "Wait for the full rebuild to finish first.",
+        "scanActive": "Wait for the current scan to finish first.",
+        "legacyMigration": "This keeps the current thumbnail paths and does not migrate legacy mirrored derivatives. Run Scan Library instead to move them into asset-key storage.",
+        "idle": "Use this for a faster thumbnail-only refresh."
+      },
+      "dangerZone": {
+        "title": "Danger Zone",
+        "recommended": "Recommended",
+        "rebuildTitle": "Rebuild Library Index",
+        "rebuildDescription": "Reset the library index, reuse matching cached media, and generate only missing derivatives from the current gallery root.",
+        "currentGalleryRoot": "Current gallery root",
+        "previousGalleryRoot": "Previous gallery root"
+      },
+      "rebuildButton": {
+        "active": "Rebuilding now...",
+        "idle": "Rebuild Library Index"
+      },
+      "rebuildActionNote": {
+        "loading": "Loading current library status...",
+        "progress": "Live progress appears in the sticky status bar.",
+        "thumbnailActive": "Wait for thumbnail regeneration to finish first.",
+        "scanActive": "Wait for the current scan to finish first.",
+        "rebuildRequired": "Recommended because the gallery location changed.",
+        "idle": "Use this to reset the index and reuse matching derivatives from the previous library index."
+      },
+      "dialogs": {
+        "rebuildTitle": "Rebuild the current library index?",
+        "rebuildMessage": "This will clear the indexed database tables for folders, posts, likes, and scan history, then rescan the active gallery root. Existing thumbnails and previews from the previous index will be reused when they still match the current files, and only missing or changed derivatives will be generated. Original files in the gallery will not be deleted.",
+        "rebuildConfirm": "Rebuild Library Index",
+        "rebuildLoading": "Rebuilding...",
+        "thumbnailsTitle": "Regenerate thumbnails only?",
+        "thumbnailsMessage": "This will remove generated feed and profile thumbnails plus video poster images, then rebuild them from the current indexed library using each item's current thumbnail path. Previews, likes, scan history, and indexed library records will not be changed. Original files in the gallery will not be deleted.",
+        "thumbnailsConfirm": "Regenerate Thumbnails",
+        "thumbnailsLoading": "Regenerating..."
+      },
+      "errors": {
+        "startScan": "Unable to start a library scan.",
+        "rebuild": "Unable to rebuild the current library index.",
+        "regenerate": "Unable to regenerate thumbnails."
+      }
+    },
+    "notices": {
+      "scanError": {
+        "eyebrow": "Scan Needs Attention",
+        "title": "The last scan completed with errors",
+        "fullReportPrefix": "Full report:",
+        "dismissAria": "Dismiss scan warning",
+        "actionNote": "Run a new library scan to retry failed media and fill in any missing thumbnails or previews.",
+        "messages": {
+          "genericNoDetails": "Some media failed during the last run. Scan the library again to retry any missed files and derivative generation.",
+          "ffmpegMissing": "Video processing tools are missing from the server environment. Install FFmpeg so scans can read video metadata and generate video derivatives.",
+          "withReport": "Some media failed during the last run. Review the sample error and full report path below, then scan the library again to retry failed media and derivative generation.",
+          "withSample": "Some media failed during the last run. Review the sample error below, then scan the library again to retry any missed files and derivative generation."
+        },
+        "detailMore": "{line} (+{count} more)"
+      },
+      "ignoredRootMedia": {
+        "dismissAria": "Dismiss gallery root warning",
+        "messageOne": "{count} supported file is being ignored in the gallery root. Move it into a folder inside your gallery root to create App Folders. Files placed directly in the gallery root are ignored.",
+        "messageOther": "{count} supported files are being ignored in the gallery root. Move them into a folder inside your gallery root to create App Folders. Files placed directly in the gallery root are ignored."
+      }
+    },
+    "access": {
+      "section": {
+        "title": "Admin and viewer access",
+        "description": "Protect admin actions with an admin password, then optionally issue a separate viewer password for browsing-only sessions.",
+        "locked": "Admin Locked",
+        "open": "Open Access"
+      },
+      "fields": {
+        "adminPassword": "Admin password",
+        "confirmPassword": "Confirm password",
+        "currentPassword": "Current password",
+        "newPassword": "New password",
+        "confirmNewPassword": "Confirm new password",
+        "viewerPassword": "Viewer password",
+        "confirmViewerPassword": "Confirm viewer password"
+      },
+      "placeholders": {
+        "minimumLength": "Minimum {count} characters",
+        "repeatPassword": "Repeat the password",
+        "enterNewViewerPassword": "Enter a new viewer password",
+        "repeatNewViewerPassword": "Repeat the new viewer password",
+        "repeatViewerPassword": "Repeat the viewer password"
+      },
+      "enable": {
+        "description": "The admin password is stored as a one-way hash and unlocks this browser with a signed session cookie.",
+        "buttonLoading": "Enabling...",
+        "buttonIdle": "Enable Admin Password",
+        "success": "The admin password is now enabled for this Foldergram instance.",
+        "error": "Unable to enable the admin password."
+      },
+      "change": {
+        "title": "Change admin password",
+        "description": "Update the admin password and invalidate older sessions.",
+        "showForm": "Change Password",
+        "hideForm": "Hide Form",
+        "helper": "Use at least 8 characters. Changing the password signs out any older sessions.",
+        "buttonLoading": "Updating...",
+        "buttonIdle": "Change Admin Password",
+        "missingCurrent": "Enter the current password to change it.",
+        "success": "The admin password was updated and existing sessions were invalidated.",
+        "error": "Unable to change the admin password."
+      },
+      "viewer": {
+        "title": "Viewer access",
+        "description": "Issue a browsing-only password for viewer sessions or open the library for anonymous public viewing.",
+        "modes": {
+          "adminOnlyTitle": "Admin only",
+          "adminOnlyDescription": "Only the admin password can unlock the app.",
+          "viewerPasswordTitle": "Viewer password",
+          "viewerPasswordDescription": "Allow a separate viewer login that can browse and use shared likes without seeing admin controls.",
+          "publicTitle": "Public",
+          "publicDescription": "Allow anonymous browsing with browser-local favorites while keeping admin unlock available from More."
+        },
+        "status": {
+          "adminPasswordOff": "Admin Password Off",
+          "viewerPasswordOn": "Viewer Password On",
+          "publicViewerOn": "Public Viewer On",
+          "adminOnly": "Admin Only"
+        },
+        "summary": {
+          "enableAdminFirst": "Enable the admin password first",
+          "viewerPasswordEnabled": "Viewer password access is enabled",
+          "publicEnabled": "Public viewer access is enabled",
+          "off": "Viewer access is currently off"
+        },
+        "summaryCopy": {
+          "enableAdminFirst": "Viewer access settings become available after the admin password is enabled.",
+          "viewerPasswordEnabled": "Viewers can sign in with the separate viewer password, use shared likes, and browse without admin controls. To replace that password, enter a new one below. The current viewer password is not required.",
+          "publicEnabled": "Anyone who can reach this Foldergram can browse without logging in. Favorites stay in the current browser only, and admins can elevate from More with the admin password.",
+          "off": "Only the admin password can unlock the app right now. Turn on viewer password mode below if you want a browsing-only login."
+        },
+        "helper": {
+          "viewerPasswordRotate": "Enter a new viewer password below to rotate it. You do not need the current viewer password.",
+          "viewerPasswordNew": "Viewer logins get shared likes but cannot reach Settings, Trash, or any destructive action.",
+          "public": "Anonymous visitors can browse immediately, use browser-local favorites, and unlock admin access from More when needed.",
+          "disableFromPassword": "Saving this will turn off viewer logins and return the app to admin-only access.",
+          "disableFromPublic": "Saving this will disable public browsing and return the app to admin-only access.",
+          "off": "Viewer access is currently off, so only the admin password can unlock the app."
+        },
+        "buttons": {
+          "updateViewerPassword": "Update Viewer Password",
+          "enableViewerAccess": "Enable Viewer Access",
+          "savePublicAccess": "Save Public Access",
+          "enablePublicAccess": "Enable Public Access",
+          "disableViewerAccess": "Disable Viewer Access",
+          "saveViewerAccess": "Save Viewer Access"
+        },
+        "success": {
+          "password": "Viewer password access is enabled. The viewer password was saved.",
+          "public": "Public viewer access is enabled. Anonymous visitors can now browse with browser-local favorites.",
+          "off": "Viewer access has been turned off. Only admin logins are allowed now."
+        },
+        "error": "Unable to update viewer access."
+      },
+      "danger": {
+        "title": "Danger Zone",
+        "disableTitle": "Disable admin password",
+        "disableDescription": "Turn the admin password back off for this Foldergram instance.",
+        "showForm": "Disable Access",
+        "hideForm": "Hide Form",
+        "buttonLoading": "Disabling...",
+        "buttonIdle": "Disable Admin Password",
+        "signOut": "Sign Out",
+        "signOutError": "Unable to sign out.",
+        "missingCurrent": "Enter the current password to disable protection.",
+        "success": "The admin password has been disabled.",
+        "error": "Unable to disable the admin password."
+      },
+      "authProtection": {
+        "enabled": "Admin protection is active for this browser session. Use the controls below to rotate the admin password, configure viewer access, sign out, or turn protection off again.",
+        "disabled": "Protection is currently off. Anyone who can reach this app on your network can browse the library with full local access until you enable an admin password."
+      },
+      "validation": {
+        "minLength": "Password must be at least {count} characters.",
+        "empty": "Password cannot be empty.",
+        "mismatch": "The password confirmation does not match."
+      }
+    },
+    "status": {
+      "never": "Never",
+      "storage": {
+        "available": "Available",
+        "unavailable": "Unavailable"
+      },
+      "libraryStatus": {
+        "title": "Library Status",
+        "description": "Current storage and index state.",
+        "storage": "Storage",
+        "folders": "Folders",
+        "indexedPosts": "Indexed posts",
+        "indexedVideos": "Indexed videos"
+      },
+      "lastScan": {
+        "title": "Last Scan",
+        "description": "Most recent completed run tracked by the app.",
+        "status": "Status",
+        "finished": "Finished",
+        "filesScanned": "Files scanned",
+        "changes": "Changes",
+        "statusValues": {
+          "none": "No completed scans yet",
+          "completed": "completed",
+          "completedWithErrors": "completed with errors",
+          "failed": "failed",
+          "running": "running"
+        },
+        "changeValues": {
+          "new": "new",
+          "updated": "updated",
+          "removed": "removed"
+        }
+      }
+    }
+  },
+  "home": {
+    "sidebar": {
+      "ariaLabel": "Folder recommendations",
+      "suggestedFolders": "Suggested folders",
+      "viewLikes": "View likes",
+      "viewFavorites": "View favorites",
+      "openFolder": "Open",
+      "openSourceText": "Foldergram is open source.",
+      "viewOnGitHub": "View on GitHub"
+    }
+  },
+  "likes": {
+    "labels": {
+      "sharedCollection": "Likes",
+      "localCollection": "Favorites",
+      "sharedSection": "Liked posts",
+      "localSection": "Favorite posts"
+    },
+    "view": {
+      "rebuilding": "Rebuilding the library index. {label} will return after the refreshed library finishes loading.",
+      "sectionsAria": "{label} sections"
+    },
+    "states": {
+      "sharedEmptyTitle": "No liked posts yet",
+      "localEmptyTitle": "No favorites yet",
+      "sharedEmptyDescription": "Tap the heart under any post and it will appear here.",
+      "localEmptyDescription": "Tap the heart under any post and it will appear here in this browser.",
+      "sharedLoadingLabel": "Loading likes...",
+      "localLoadingLabel": "Loading favorites...",
+      "sharedErrorTitle": "Could not load likes",
+      "localErrorTitle": "Could not load favorites"
+    },
+    "actions": {
+      "likePost": "Like post",
+      "unlikePost": "Unlike post",
+      "favoritePost": "Favorite post",
+      "removeFavoriteFromPost": "Remove favorite from post"
+    },
+    "errors": {
+      "loadShared": "Unable to load likes",
+      "loadLocal": "Unable to load favorites",
+      "updateShared": "Unable to update likes",
+      "updateLocal": "Unable to update favorites"
+    }
+  },
+  "moments": {
+    "rails": {
+      "moments": {
+        "title": "Moments",
+        "description": "Memory capsules shaped by real capture dates from your library.",
+        "singularLabel": "Moment"
+      },
+      "highlights": {
+        "title": "Stories",
+        "description": "Curated story-style sets from your library when capture dates are sparse or synthetic.",
+        "singularLabel": "Story"
+      }
+    },
+    "capsules": {
+      "onThisDay": {
+        "title": "On This Day",
+        "subtitle": "{date} across previous years"
+      },
+      "thisWeekPreviousYears": {
+        "title": "This Week",
+        "subtitle": "{range} from previous years"
+      },
+      "fromLastYear": {
+        "title": "Last Year Around Now",
+        "subtitle": "A revisit to {monthYear}"
+      },
+      "highlightRecentBatches": {
+        "title": "Recent Batches",
+        "subtitle": "Latest runs gathered into one set",
+        "dateContextOne": "{count} batch",
+        "dateContextOther": "{count} batches"
+      },
+      "highlightForgottenFavorites": {
+        "title": "Forgotten Favorites",
+        "subtitle": "Older liked posts worth another look",
+        "dateContext": "Liked and older than 6 months"
+      },
+      "highlightDeepCuts": {
+        "title": "Deep Cuts",
+        "subtitle": "Older posts resurfaced from the archive",
+        "dateContext": "Older than 6 months"
+      },
+      "highlightLuckyDip": {
+        "title": "Lucky Dip",
+        "subtitle": "A playful mix from across the library",
+        "dateContext": "Stable for today"
+      }
+    },
+    "view": {
+      "rebuilding": "Rebuilding the library index. This view will repopulate when the refreshed home rail is ready.",
+      "loading": "Loading {label}...",
+      "loadError": "Could not load {label}",
+      "emptyTitle": "This {label} is empty",
+      "emptyDescription": "Try another {label} from the homepage.",
+      "postCount": "{count} posts"
+    }
+  },
+  "folder": {
+    "shared": {
+      "topLevelSourceFolder": "Top-level source folder"
+    },
+    "header": {
+      "openStories": "Open folder stories",
+      "openAvatar": "Open folder avatar",
+      "editButton": "Edit App Folder",
+      "posts": "{count} posts",
+      "reels": "{count} reels",
+      "updated": "{date} updated",
+      "libraryPath": "Library path",
+      "expandDescription": "Expand description",
+      "collapseDescription": "Collapse description",
+      "errors": {
+        "updateProfile": "Failed to update profile"
+      }
+    },
+    "profileModal": {
+      "title": "Edit App Folder",
+      "namePlaceholder": "Folder display name",
+      "descriptionPlaceholder": "Add a description to this folder...",
+      "errors": {
+        "nameRequired": "Name is required."
+      }
+    },
+    "tabs": {
+      "posts": "Posts",
+      "reels": "Reels",
+      "sections": "Folder sections"
+    }
+  },
+  "reels": {
+    "view": {
+      "libraryUnavailableTitle": "Library storage unavailable",
+      "loadErrorTitle": "Could not load reels",
+      "loadingTitle": "Loading reels",
+      "loadingDescription": "Pulling together a video-only queue from your indexed library.",
+      "emptyTitle": "No reels available",
+      "emptyDescription": "Add indexed videos to your library and they will show up here after the next scan.",
+      "navigationAria": "Reel navigation",
+      "previous": "Previous reel",
+      "next": "Next reel"
+    },
+    "rail": {
+      "hideDetails": "Hide reel details",
+      "showDetails": "Show reel details",
+      "downloadOriginal": "Download original file",
+      "openFolder": "Open folder"
+    },
+    "info": {
+      "ariaLabel": "Reel details",
+      "eyebrow": "Reel Details",
+      "hideDetails": "Hide reel details",
+      "openFolder": "Open folder",
+      "topLevelSourceFolder": "Top-level source folder",
+      "unavailable": "Unavailable",
+      "video": "Video",
+      "loadError": "Unable to load reel details.",
+      "resolution": "Resolution",
+      "length": "Length",
+      "size": "Size",
+      "format": "Format",
+      "loading": "Loading reel details...",
+      "folderPath": "Folder Path",
+      "mimeType": "MIME Type"
+    }
+  },
+  "post": {
+    "captionModal": {
+      "title": "Edit caption",
+      "captionLabel": "Caption",
+      "placeholder": "Write a caption...",
+      "resetToFilename": "Reset to filename",
+      "errors": {
+        "update": "Unable to update caption"
+      }
+    },
+    "viewer": {
+      "close": "Close post",
+      "previous": "Previous post",
+      "next": "Next post",
+      "showDetails": "Show post details",
+      "hideDetails": "Hide post details",
+      "togglePlayback": "Toggle playback",
+      "toggleSound": "Toggle sound",
+      "toggleFullscreen": "Toggle fullscreen",
+      "switchToPreviewQuality": "Switch to preview quality",
+      "switchToHdOriginal": "Switch to HD original",
+      "previewQuality": "Preview quality",
+      "hdOriginal": "HD original",
+      "openFolder": "Open folder",
+      "editCaption": "Edit caption",
+      "folderPath": "Folder Path",
+      "stats": {
+        "dimensions": "Dimensions",
+        "type": "Type",
+        "duration": "Duration",
+        "size": "Size",
+        "place": "Place"
+      },
+      "metadata": {
+        "location": "Location",
+        "camera": "Camera",
+        "lens": "Lens",
+        "aperture": "Aperture",
+        "shutter": "Shutter",
+        "iso": "ISO",
+        "focalLength": "Focal length"
+      },
+      "videoType": "Video ({mimeType})",
+      "setAsCover": "Set as folder cover",
+      "downloadOriginalFile": "Download original file",
+      "openOriginalFile": "Open original file",
+      "deletePost": "Delete post"
+    },
+    "feedCard": {
+      "openStories": "Open {name} stories",
+      "openFolderAvatar": "Open {name}",
+      "openReel": "Open reel",
+      "openPost": "Open post",
+      "moreOptions": "More options",
+      "delete": {
+        "title": "Delete this post?",
+        "messagePermanent": "This will permanently delete the post from the app and remove original media from disk.",
+        "messageTrash": "This will delete the post from the app and move it to Trash. The original file will stay on disk unless you choose permanent deletion.",
+        "confirmPermanent": "Permanently Delete",
+        "confirm": "Delete",
+        "deleteOriginalLabel": "Also permanently delete original file from disk",
+        "deleteOriginalDescription": "Keep this unchecked to move the post to Trash while keeping the source file on disk.",
+        "deleteOriginalWarning": "This will permanently delete the original file, thumbnail, and preview from disk. This action cannot be undone."
+      }
+    }
+  },
+  "collections": {
+    "shared": {
+      "defaultName": "All Posts",
+      "postCountOne": "{count} post",
+      "postCountOther": "{count} posts"
+    },
+    "bookmark": {
+      "dialogLabel": "Collections",
+      "title": "Collections",
+      "createCollection": "Create collection",
+      "namePlaceholder": "Collection name",
+      "empty": "No collections yet",
+      "savePost": "Save post",
+      "removeSavedPost": "Remove saved post",
+      "errors": {
+        "loadCollections": "Unable to load collections"
+      }
+    },
+    "list": {
+      "libraryUnavailableTitle": "Library storage unavailable",
+      "loadErrorTitle": "Could not load collections",
+      "loading": "Loading collections...",
+      "emptyTitle": "No collections yet",
+      "emptyDescription": "Saved posts will appear in All Posts."
+    },
+    "detail": {
+      "fallbackTitle": "Collection",
+      "libraryUnavailableTitle": "Library storage unavailable",
+      "loadErrorTitle": "Could not load collection",
+      "back": "Collections",
+      "options": "Collection options",
+      "actionsLabel": "Collection actions",
+      "emptyTitle": "{name} is empty",
+      "emptyDescriptionDefault": "Use the bookmark action under any post to save it here.",
+      "emptyDescriptionCustom": "Bookmarked posts assigned to this collection will appear here.",
+      "loading": "Loading collection...",
+      "menu": {
+        "delete": "Delete collection",
+        "edit": "Edit Collection",
+        "cancel": "Cancel"
+      },
+      "edit": {
+        "title": "Edit collection",
+        "saving": "Saving...",
+        "done": "Done",
+        "required": "Collection name is required.",
+        "createError": "Unable to create collection",
+        "updateError": "Unable to update collection"
+      },
+      "delete": {
+        "title": "Delete collection?",
+        "message": "When you delete this collection, the photos and videos will still be saved.",
+        "deleting": "Deleting...",
+        "confirm": "Delete",
+        "cancel": "Cancel",
+        "error": "Unable to delete collection"
+      }
+    }
+  },
+  "placesPage": {
+    "eyebrow": "Places",
+    "title": "All places",
+    "description": "Browse posts grouped from offline location data.",
+    "stats": {
+      "places": "Places",
+      "posts": "Posts"
+    },
+    "errors": {
+      "load": "Could not load places"
+    },
+    "searchPlaceholder": "Search names, regions, or coordinates...",
+    "sort": {
+      "postsDesc": "Most posts",
+      "nameAsc": "Name A-Z",
+      "nameDesc": "Name Z-A",
+      "countryAsc": "Country A-Z"
+    },
+    "resultsOne": "{count} result",
+    "resultsOther": "{count} results",
+    "loading": "Loading places...",
+    "emptyTitle": "No places indexed yet",
+    "emptyDescription": "Prepare offline place data and rebuild assignments from Settings to group posts by location.",
+    "noMatch": "No places match. Try a different search or sort.",
+    "metadataFallback": "Offline city-level place",
+    "postCountOne": "{count} post",
+    "postCountOther": "{count} posts",
+    "kinds": {
+      "manual": "Manual place",
+      "nearestCity": "Nearest city",
+      "cityMatch": "City match"
+    },
+    "readiness": {
+      "ready": "Ready",
+      "empty": "Empty"
+    }
+  },
+  "placePage": {
+    "errors": {
+      "load": "Could not load place"
+    },
+    "badge": "Offline place",
+    "coordinatesLabel": "coordinates",
+    "sourceLabel": "Source",
+    "approximateBadge": "Approximate city match",
+    "emptyTitle": "No posts for this place",
+    "emptyDescription": "Place assignments can be rebuilt from Settings after offline place data is prepared.",
+    "metadataFallback": "Offline city-level place",
+    "heroApproximate": "Grouped from stored photo GPS coordinates and matched to the nearest city for offline browsing.",
+    "heroExact": "Resolved from stored photo GPS coordinates and kept available offline.",
+    "postCountOne": "post",
+    "postCountOther": "posts",
+    "kind": {
+      "offline": "Offline",
+      "manual": "Manual",
+      "nearestCity": "Nearest city",
+      "city": "City",
+      "place": "place",
+      "match": "match"
+    }
+  },
+  "libraryPage": {
+    "eyebrow": "Library",
+    "title": "All folders",
+    "description": "Browse and search every indexed app folder.",
+    "stats": {
+      "folders": "Folders",
+      "posts": "Posts"
+    },
+    "errors": {
+      "load": "Could not load folders"
+    },
+    "searchPlaceholder": "Search names or path segments...",
+    "sort": {
+      "recentDesc": "Recently updated",
+      "imagesDesc": "Most posts",
+      "nameAsc": "Name A-Z",
+      "nameDesc": "Name Z-A",
+      "pathAsc": "Path A-Z"
+    },
+    "resultsOne": "{count} result",
+    "resultsOther": "{count} results",
+    "loading": "Loading folders...",
+    "emptyTitle": "No folders indexed yet",
+    "emptyDescription": "Add media-containing source folders under the gallery root and run a scan.",
+    "noMatch": "No folders match. Try a different search or filter.",
+    "topLevelSourceFolder": "Top-level source folder",
+    "postsCountOne": "{count} post",
+    "postsCountOther": "{count} posts",
+    "reelsCountOne": "{count} reel",
+    "reelsCountOther": "{count} reels",
+    "readiness": {
+      "ready": "Ready",
+      "empty": "Empty"
+    },
+    "moreOptions": "More options",
+    "openFolder": "Open folder",
+    "deleteFolder": "Delete folder",
+    "noRecentMedia": "No recent media",
+    "delete": {
+      "title": "Delete this app folder?",
+      "sourceTooTitle": "Delete the source folder too",
+      "sourceTooNoChildren": "Also remove the source folder itself instead of only deleting its direct posts.",
+      "sourceTooWithChildrenOne": "Also remove {count} child app folder and every file inside the subtree.",
+      "sourceTooWithChildrenOther": "Also remove {count} child app folders and every file inside the subtree.",
+      "warning": "Doing this will permanently delete the selected source folder and every child folder and file inside it, including unsupported files. This action cannot be undone.",
+      "directPostsOne": "{count} direct post",
+      "directPostsOther": "{count} direct posts",
+      "childFoldersOne": "{count} child app folder",
+      "childFoldersOther": "{count} child app folders",
+      "messageDeleteSource": "This will permanently delete {directPosts} and remove this source folder from the hard drive.",
+      "messageKeepChildren": "This will permanently delete {directPosts}. {childFolders} will be kept.",
+      "messageEmptyFolder": "This will permanently delete {directPosts}. The source folder itself will only be removed if it becomes empty.",
+      "confirmSubtree": "Delete folder subtree",
+      "confirmFolder": "Delete app folder",
+      "loadingSubtree": "Deleting subtree...",
+      "loadingFolder": "Deleting...",
+      "error": "Unable to delete this app folder."
+    }
+  },
+  "explore": {
+    "back": "Back to explore posts",
+    "searchPlaceholder": "Search",
+    "clearSearch": "Clear search",
+    "recentTitle": "Recent",
+    "clearAll": "Clear all",
+    "tabsAria": "Search result tabs",
+    "tabs": {
+      "media": "Photos & Videos",
+      "folders": "App Folders"
+    },
+    "errors": {
+      "search": "Could not search posts",
+      "load": "Could not load explore"
+    },
+    "emptySearchTitle": "No matching photos or videos",
+    "emptySearchDescription": "Try a different filename or folder keyword.",
+    "loadingFolders": "Loading folders...",
+    "noFoldersFound": "No app folders found.",
+    "emptyTitle": "Nothing to explore yet",
+    "emptyDescription": "Index a few folders and this page will start surfacing posts here.",
+    "folderPostsOne": "{count} post",
+    "folderPostsOther": "{count} posts"
+  }
+}

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -14,7 +14,13 @@
     "saved": "Saved",
     "saving": "Saving...",
     "youAreCaughtUp": "You are caught up",
-    "loading": "Loading..."
+    "loading": "Loading...",
+    "railViewer": {
+      "itemCountOne": "{count} item",
+      "itemCountOther": "{count} items",
+      "latestDate": "Latest {date}",
+      "noRecentActivity": "No recent activity"
+    }
   },
   "app": {
     "authLoading": {

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -158,12 +158,13 @@
       },
       "card": {
         "title": "General Settings",
-        "description": "App-wide defaults for stories folders, excluded folders, Home, Reels, and app folders."
+        "description": "App-wide defaults for language, stories folders, excluded folders, Home, Reels, and app folders."
       },
       "language": {
         "label": "App language",
         "description": "Choose the language used for navigation, dialogs, and other translated app UI on this device.",
-        "helper": "Applies immediately in this browser. Missing translations fall back to English.",
+        "helper": "Applies immediately in this browser. Save changes below to make the selected language the app-wide default. Missing translations fall back to English.",
+        "overrideNotice": "App default is {savedLabel}. This browser is temporarily using {currentLabel} from a browser-only setting. Save changes to make {currentLabel} the default.",
         "selectLabel": "App language",
         "options": {
           "en": "English",
@@ -248,13 +249,14 @@
         "loading": "Loading the current app preferences...",
         "excludedAndOther": "Save the folder exclusion rules with the other app-wide changes. Run a library scan afterward so stories and excluded folders reindex correctly.",
         "excludedOnly": "This saves the custom excluded folders only. Run a library scan afterward so those folders disappear from the index.",
-        "storiesAndDefaults": "Save the new stories rule and the updated browsing defaults together.",
+        "storiesAndDefaults": "Save the new stories rule and the updated app defaults together.",
         "storiesOnly": "This saves the stories folders rule only. Run a library scan afterward to reindex with the new behavior.",
-        "multipleDefaults": "Save these browsing defaults together. Home visitors can still switch modes on the homepage; Reels and app folders use app defaults.",
+        "multipleDefaults": "Save these app defaults together. Language applies immediately in this browser; Home visitors can still switch modes on the homepage; Reels and app folders use app defaults.",
+        "languageOnly": "This changes the language immediately in this browser. Save it too if you want the selected language to become the app-wide default.",
         "homeOnly": "This updates the first feed mode shown on Home for this app. Visitors can still switch modes from the homepage.",
         "reelsOnly": "This updates the queue style used when Reels opens for this app. Visitors cannot switch modes from the reels page.",
         "folderOnly": "This updates the default photo order used by app folder grids.",
-        "idle": "These are the current app-wide defaults for Home, Reels, app folders, stories folders, and excluded folders."
+        "idle": "These are the current app-wide defaults for language, Home, Reels, app folders, stories folders, and excluded folders."
       },
       "rescanNotice": {
         "excludedAndStories": "Save these changes, then run a library scan before expecting stories folders and excluded folders to update.",
@@ -267,11 +269,13 @@
         "excludedFoldersSaved": "Excluded folders were saved. Run a library scan to apply them.",
         "settingsAndStoriesSaved": "Settings were saved. Run a library scan to apply the stories folder change.",
         "storiesSaved": "Stories folder behavior was saved. Run a library scan to apply it.",
-        "defaultsSaved": "App-wide browsing defaults were updated.",
+        "defaultsSaved": "App-wide defaults were updated.",
+        "languageSaved": "App language default saved as {label}.",
         "homeSaved": "The homepage now opens with {label}.",
         "reelsSaved": "Reels now opens with {label}.",
         "folderOrderSaved": "App folders now open with {label}.",
         "parts": {
+          "appLanguage": "app language",
           "excludedFolders": "excluded folders",
           "storiesFolderHandling": "stories folder handling",
           "homeFeedDefault": "Home feed default",
@@ -954,6 +958,46 @@
       "loadingSubtree": "Deleting subtree...",
       "loadingFolder": "Deleting...",
       "error": "Unable to delete this app folder."
+    }
+  },
+  "trashPage": {
+    "eyebrow": "Trash",
+    "title": "Deleted posts",
+    "description": "Posts moved here stay on disk until you permanently delete them.",
+    "selectedOne": "{count} selected post",
+    "selectedOther": "{count} selected posts",
+    "restoreButton": "Restore",
+    "deleteButton": "Permanently Delete",
+    "libraryUnavailableTitle": "Library storage unavailable",
+    "libraryUnavailableDescription": "Configured library storage is unavailable.",
+    "loadErrorTitle": "Could not load trash",
+    "loading": "Loading trash...",
+    "emptyTitle": "Trash is empty",
+    "emptyDescription": "Deleted posts will appear here so you can restore them or remove them permanently.",
+    "selectItem": "Select {label}",
+    "deselectItem": "Deselect {label}",
+    "trashedAt": "Trashed {date}",
+    "recently": "recently",
+    "openFolder": "Open folder",
+    "restoreDialog": {
+      "title": "Restore selected posts?",
+      "messageOne": "Restore {count} selected post to the app?",
+      "messageOther": "Restore {count} selected posts to the app?",
+      "confirm": "Restore",
+      "loading": "Restoring..."
+    },
+    "deleteDialog": {
+      "title": "Permanently delete selected posts?",
+      "messageOne": "This will permanently delete {count} selected post and remove the original file from disk.",
+      "messageOther": "This will permanently delete {count} selected posts and remove original files from disk.",
+      "confirm": "Permanently Delete",
+      "loading": "Deleting...",
+      "warning": "Original files, thumbnails, and previews will be removed permanently. This action cannot be undone."
+    },
+    "errors": {
+      "refresh": "Unable to refresh the updated library state.",
+      "processOne": "{count} post could not be processed.",
+      "processOther": "{count} posts could not be processed."
     }
   },
   "explore": {

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -1,0 +1,977 @@
+{
+  "common": {
+    "cancel": "Cancelar",
+    "close": "Cerrar",
+    "description": "Descripción",
+    "loadMore": "Cargar más",
+    "loadingMore": "Cargando más...",
+    "name": "Nombre",
+    "newFeature": "Nueva función",
+    "open": "Abrir",
+    "retry": "Reintentar",
+    "save": "Guardar",
+    "saveChanges": "Guardar cambios",
+    "saved": "Guardado",
+    "saving": "Guardando...",
+    "youAreCaughtUp": "Ya viste todo",
+    "loading": "Cargando..."
+  },
+  "app": {
+    "authLoading": {
+      "eyebrow": "Protección de acceso",
+      "title": "Verificando acceso",
+      "description": "Cargando el estado actual de la protección con contraseña."
+    }
+  },
+  "auth": {
+    "gate": {
+      "eyebrow": "Contraseña compartida",
+      "title": "Desbloquear Foldergram",
+      "passwordLabel": "Contraseña",
+      "descriptionPassword": "Esta biblioteca acepta la contraseña de administrador o la de visualización para el acceso local.",
+      "descriptionAdmin": "Esta biblioteca está protegida con la contraseña de administrador para acceso local y de homelab.",
+      "placeholderPassword": "Introduce la contraseña de administrador o de visualización",
+      "placeholderAdmin": "Introduce la contraseña de administrador",
+      "unlocking": "Desbloqueando...",
+      "unlock": "Desbloquear biblioteca",
+      "unableToSignIn": "No se pudo iniciar sesión."
+    },
+    "adminUnlock": {
+      "eyebrow": "Desbloqueo de administrador",
+      "title": "Desbloquear acceso de administrador",
+      "closeAria": "Cerrar el diálogo de desbloqueo de administrador",
+      "description": "Introduce la contraseña de administrador para abrir Ajustes, Papelera, escaneos, herramientas de reconstrucción y otras acciones solo para administradores.",
+      "passwordLabel": "Contraseña de administrador",
+      "placeholder": "Introduce la contraseña de administrador",
+      "unlocking": "Desbloqueando...",
+      "unlock": "Desbloquear administrador",
+      "unableToUnlock": "No se pudo desbloquear el acceso de administrador."
+    }
+  },
+  "nav": {
+    "primary": "Navegación principal",
+    "foldergramHome": "Inicio de Foldergram",
+    "home": "Inicio",
+    "reels": "Reels",
+    "search": "Buscar",
+    "library": "Biblioteca",
+    "places": "Lugares",
+    "collections": "Colecciones",
+    "more": "Más",
+    "trash": "Papelera",
+    "settings": "Ajustes",
+    "unlockAdmin": "Desbloquear admin",
+    "switchAppearance": "Cambiar apariencia",
+    "switchToDarkMode": "Cambiar al modo oscuro",
+    "switchToLightMode": "Cambiar al modo claro",
+    "signOut": "Cerrar sesión",
+    "returnToPublicView": "Volver a la vista pública",
+    "foldersSpotlight": "Carpetas destacadas",
+    "likesAriaLabel": "{label} ({count})",
+    "folderPosts": "{count} publicaciones"
+  },
+  "settings": {
+    "eyebrow": "Ajustes",
+    "title": "Controles de la biblioteca",
+    "description": "Administra escaneos, valores predeterminados de la app, acceso y el índice de la biblioteca.",
+    "sections": {
+      "navigation": "Secciones de ajustes",
+      "library": {
+        "label": "Escaneo y biblioteca",
+        "shortLabel": "Escaneo y biblioteca",
+        "description": "Indexa medios, reconstruye miniaturas y mantiene el índice de la biblioteca"
+      },
+      "general": {
+        "label": "Ajustes generales",
+        "description": "Modo de stories, carpetas excluidas y valores del feed"
+      },
+      "places": {
+        "label": "Lugares",
+        "description": "Búsqueda de ciudades sin conexión y asignación de lugares"
+      },
+      "access": {
+        "label": "Seguridad y acceso",
+        "shortLabel": "Seguridad y acceso",
+        "description": "Bloqueos con contraseña y roles de visualización"
+      },
+      "status": {
+        "label": "Estado del sistema",
+        "description": "Resumen de almacenamiento e historial de escaneos"
+      }
+    },
+    "places": {
+      "banner": {
+        "title": "Lugares a partir de los datos GPS de las fotos",
+        "description": "Agrupa las fotos con GPS por ciudad y etiquetas de ubicación sin conexión.",
+        "helper": "Prepara el conjunto de datos local de GeoNames y luego reconstruye las asignaciones de lugares para las fotos que ya están en tu biblioteca.",
+        "setup": "Configurar Lugares",
+        "dismissAria": "Descartar anuncio de Lugares",
+        "availableLater": "La descarga es opcional y la pestaña Lugares seguirá disponible más tarde en Configuración."
+      },
+      "section": {
+        "title": "Lugares sin conexión",
+        "description": "Prepara los datos de ciudades de GeoNames y luego reconstruye los enlaces de lugares a partir de las coordenadas existentes de las fotos.",
+        "prepared": "Preparado",
+        "notPrepared": "No preparado",
+        "datasetLabel": "Conjunto de datos",
+        "rowsLabel": "Filas",
+        "notImported": "No importado",
+        "importedAt": "Importado {value}.",
+        "fallbackDataset": "GeoNames cities500",
+        "prepareButton": "Preparar geodatos",
+        "preparingButton": "Preparando...",
+        "rebuildButton": "Reconstruir asignaciones de lugares",
+        "rebuildingButton": "Reconstruyendo...",
+        "loadStatusError": "No se pudo cargar el estado de lugares",
+        "actions": {
+          "ready": "Los datos de lugares sin conexión están listos.",
+          "prepareError": "No se pudieron preparar los datos de lugares sin conexión.",
+          "rebuilt": "Se reconstruyeron lugares para {assigned} de {processed} publicaciones.",
+          "rebuildError": "No se pudieron reconstruir las asignaciones de lugares."
+        }
+      }
+    },
+    "general": {
+      "migration": {
+        "eyebrow": "Migración de stories",
+        "title": "Esta biblioteca puede que ya use carpetas llamadas stories",
+        "description": "Foldergram ahora puede tratar stories/ como stories de perfil y destacados de forma predeterminada. Elige si quieres mantener el comportamiento heredado de las carpetas o cambiar al nuevo modo reservado de stories y luego vuelve a escanear la biblioteca.",
+        "dismissAria": "Descartar aviso de migración de stories",
+        "useFeature": "Usar función de Stories",
+        "keepLegacy": "Mantener comportamiento heredado",
+        "helper": "Elige aquí un modo y luego guárdalo abajo. Después ejecuta un escaneo de la biblioteca para que la estructura indexada coincida.",
+        "helperSaving": "Espera a que termine la actualización actual de ajustes."
+      },
+      "announcement": {
+        "title": "Stories",
+        "headline": "Las carpetas reservadas stories/ pueden alimentar las stories de las carpetas de la app",
+        "description": "Coloca medios directos en AppFolder/stories para el conjunto de stories del avatar y usa carpetas hijas directas para los círculos destacados. Las carpetas anidadas permanecen dentro del mismo destacado.",
+        "dismissAria": "Descartar anuncio de stories",
+        "showStructure": "Ver estructura de directorios",
+        "hideStructure": "Ocultar estructura de directorios"
+      },
+      "card": {
+        "title": "Ajustes generales",
+        "description": "Valores predeterminados de toda la app para carpetas stories, carpetas excluidas, Inicio, Reels y carpetas de la app."
+      },
+      "language": {
+        "label": "Idioma de la aplicación",
+        "description": "Elige el idioma usado para la navegación, los diálogos y otras partes traducidas de la interfaz en este dispositivo.",
+        "helper": "Se aplica de inmediato en este navegador. Las traducciones que falten usan el texto en inglés.",
+        "selectLabel": "Idioma de la aplicación",
+        "options": {
+          "en": "Inglés",
+          "es": "Español",
+          "zh": "Chino"
+        }
+      },
+      "homeFeed": {
+        "label": "Orden del feed de Inicio",
+        "description": "Elige el primer modo de feed que se muestra en Inicio.",
+        "closeMenuAria": "Cerrar menú de orden del feed de Inicio",
+        "options": {
+          "random": {
+            "label": "Aleatorio",
+            "description": "Mezcla estable."
+          },
+          "recent": {
+            "label": "Reciente",
+            "description": "Lo más nuevo primero."
+          },
+          "rediscover": {
+            "label": "Redescubrir",
+            "description": "Recupera selecciones más antiguas."
+          }
+        }
+      },
+      "reelsFeed": {
+        "label": "Orden del feed de Reels",
+        "description": "Elige el estilo de cola predeterminado cuando se abre Reels.",
+        "closeMenuAria": "Cerrar menú de orden del feed de Reels",
+        "options": {
+          "random": {
+            "label": "Aleatorio",
+            "description": "Mezcla estable para la sesión."
+          },
+          "recent": {
+            "label": "Reciente",
+            "description": "Los videos más nuevos primero."
+          },
+          "recommended": {
+            "label": "Recomendado",
+            "description": "Mezcla clasificada por afinidad."
+          }
+        }
+      },
+      "folderOrder": {
+        "label": "Orden de fotos de las carpetas de la app",
+        "description": "Elige el orden predeterminado de las fotos dentro de las carpetas de la app.",
+        "closeMenuAria": "Cerrar menú del orden de fotos de las carpetas de la app",
+        "options": {
+          "newest": {
+            "label": "Más nuevas primero",
+            "description": "Las fotos recientes aparecen primero."
+          },
+          "oldest": {
+            "label": "Más antiguas primero",
+            "description": "Las fotos anteriores aparecen primero."
+          }
+        }
+      },
+      "storiesMode": {
+        "label": "Tratar las carpetas stories como carpetas normales de la app",
+        "scanRequired": "Requiere escaneo",
+        "explainAria": "Explicar la opción de carpetas stories",
+        "explainDescription": "Cuando esto permanece desactivado, AppFolder/stories se convierte en la fuente de las stories del avatar y de los círculos destacados. Actívalo solo si las carpetas llamadas literalmente stories deben seguir comportándose como carpetas normales en toda la app.",
+        "toggleLabel": "Cambiar el comportamiento de las carpetas stories",
+        "enabledDescription": "El modo heredado está activado. Las carpetas stories siguen siendo carpetas normales de la app en todas partes.",
+        "disabledDescription": "El modo reservado de stories está activado. AppFolder/stories alimenta las stories del avatar y los círculos destacados."
+      },
+      "excludedFolders": {
+        "label": "Carpetas de origen excluidas",
+        "description": "Omite carpetas coincidentes en cualquier lugar por nombre o por ruta relativa exacta bajo la raíz de la galería. Las rutas ocultas y el almacenamiento administrado por la app siguen excluyéndose automáticamente.",
+        "customRules": "Reglas personalizadas",
+        "envRulesLabel": "Reglas de entorno de solo lectura",
+        "envRulesDescription": "Cambia GALLERY_EXCLUDED_FOLDERS en .env o Docker y reinicia la app para actualizarlas.",
+        "envRulesEmpty": "No hay exclusiones de carpetas respaldadas por variables de entorno configuradas.",
+        "activeRulesLabel": "Reglas guardadas activas actualmente",
+        "activeRulesDescription": "Esto combina las reglas guardadas en el área de texto con cualquier entrada respaldada por variables de entorno. Las ediciones nuevas del área de texto aparecen aquí después de guardarlas.",
+        "activeRulesEmpty": "No hay reglas activas de carpetas excluidas guardadas o respaldadas por variables de entorno."
+      },
+      "actionNote": {
+        "loading": "Cargando las preferencias actuales de la app...",
+        "excludedAndOther": "Guarda las reglas de exclusión de carpetas junto con los otros cambios de toda la app. Después ejecuta un escaneo de la biblioteca para que stories y carpetas excluidas se reindexen correctamente.",
+        "excludedOnly": "Esto solo guarda las carpetas excluidas personalizadas. Después ejecuta un escaneo de la biblioteca para que esas carpetas desaparezcan del índice.",
+        "storiesAndDefaults": "Guarda juntos la nueva regla de stories y los valores de navegación actualizados.",
+        "storiesOnly": "Esto solo guarda la regla de carpetas stories. Después ejecuta un escaneo de la biblioteca para reindexar con el nuevo comportamiento.",
+        "multipleDefaults": "Guarda juntos estos valores de navegación. Los visitantes de Inicio aún pueden cambiar de modo en la página principal; Reels y las carpetas de la app usan los valores predeterminados de la app.",
+        "homeOnly": "Esto actualiza el primer modo de feed que se muestra en Inicio para esta app. Los visitantes aún pueden cambiar de modo desde la página principal.",
+        "reelsOnly": "Esto actualiza el estilo de cola usado cuando se abre Reels para esta app. Los visitantes no pueden cambiar de modo desde la página de Reels.",
+        "folderOnly": "Esto actualiza el orden de fotos predeterminado usado por las cuadrículas de carpetas de la app.",
+        "idle": "Estos son los valores actuales de toda la app para Inicio, Reels, carpetas de la app, carpetas stories y carpetas excluidas."
+      },
+      "rescanNotice": {
+        "excludedAndStories": "Guarda estos cambios y luego ejecuta un escaneo de la biblioteca antes de esperar que se actualicen las carpetas stories y las carpetas excluidas.",
+        "excludedOnly": "Guarda este cambio y luego ejecuta un escaneo de la biblioteca antes de que las carpetas excluidas desaparezcan del índice.",
+        "storiesOnly": "Guarda este cambio y luego ejecuta un escaneo de la biblioteca antes de esperar que se actualicen las carpetas stories, las stories del avatar o los destacados."
+      },
+      "feedback": {
+        "settingsAndFolderRulesSaved": "Los ajustes se guardaron. Ejecuta un escaneo de la biblioteca para aplicar los cambios de reglas de carpetas.",
+        "folderRulesAndStoriesSaved": "Se guardaron las reglas de exclusión de carpetas y el comportamiento de las carpetas stories. Ejecuta un escaneo de la biblioteca para aplicarlos.",
+        "excludedFoldersSaved": "Se guardaron las carpetas excluidas. Ejecuta un escaneo de la biblioteca para aplicarlas.",
+        "settingsAndStoriesSaved": "Los ajustes se guardaron. Ejecuta un escaneo de la biblioteca para aplicar el cambio de carpetas stories.",
+        "storiesSaved": "Se guardó el comportamiento de las carpetas stories. Ejecuta un escaneo de la biblioteca para aplicarlo.",
+        "defaultsSaved": "Se actualizaron los valores de navegación de toda la app.",
+        "homeSaved": "La página de Inicio ahora se abre con {label}.",
+        "reelsSaved": "Reels ahora se abre con {label}.",
+        "folderOrderSaved": "Las carpetas de la app ahora se abren con {label}.",
+        "parts": {
+          "excludedFolders": "carpetas excluidas",
+          "storiesFolderHandling": "comportamiento de las carpetas stories",
+          "homeFeedDefault": "predeterminado del feed de Inicio",
+          "reelsFeedDefault": "predeterminado de Reels",
+          "appFolderOrder": "orden de las carpetas de la app"
+        }
+      },
+      "errors": {
+        "validateExcludedFolders": "No se pudieron validar las reglas de carpetas excluidas.",
+        "update": "No se pudieron actualizar los ajustes generales.",
+        "partialUpdate": "Se guardaron algunos ajustes ({parts}), pero la actualización no terminó: {message}"
+      }
+    },
+    "library": {
+      "legacyMigration": {
+        "title": "Migración heredada de derivados pendiente",
+        "messageOne": "{count} registro de medio indexado aún usa las antiguas rutas reflejadas de miniaturas y vistas previas. Ejecuta Escanear biblioteca para moverlo al almacenamiento por clave de recurso.",
+        "messageOther": "{count} registros de medios indexados aún usan las antiguas rutas reflejadas de miniaturas y vistas previas. Ejecuta Escanear biblioteca para moverlos al almacenamiento por clave de recurso."
+      },
+      "scanCard": {
+        "title": "Escanear biblioteca",
+        "description": "Ejecuta un escaneo después de añadir carpetas o cuando quieras refrescar los medios indexados."
+      },
+      "statusLabel": {
+        "storageUnavailable": "Almacenamiento no disponible",
+        "scanInProgress": "Escaneo en progreso",
+        "rebuildActive": "Reconstrucción activa",
+        "ready": "Listo"
+      },
+      "scanButton": {
+        "active": "Escaneando biblioteca...",
+        "idle": "Ejecutar escaneo de la biblioteca"
+      },
+      "scanActionNote": {
+        "loading": "Cargando el estado actual de la biblioteca...",
+        "rebuildRequired": "Reconstruye primero el índice de la biblioteca porque cambió la ubicación de la galería.",
+        "otherTaskActive": "Hay otra tarea de biblioteca en ejecución. El progreso en vivo aparece en la barra de estado fija.",
+        "progress": "El progreso en vivo aparece en la barra de estado fija.",
+        "legacyMigration": "Ejecuta Escanear biblioteca para mover miniaturas y vistas previas reflejadas heredadas al diseño de almacenamiento con claves de recursos.",
+        "idle": "Los escaneos comprueban medios añadidos, actualizados o faltantes."
+      },
+      "thumbnailCard": {
+        "title": "Regenerar miniaturas",
+        "description": "Reconstruye miniaturas del feed y del perfil más pósteres de video solo a partir de medios indexados. Los archivos originales no se ven afectados."
+      },
+      "thumbnailButton": {
+        "active": "Regenerando...",
+        "idle": "Regenerar miniaturas"
+      },
+      "thumbnailActionNote": {
+        "loading": "Cargando el estado actual de la biblioteca...",
+        "rebuildRequired": "No disponible hasta que se reconstruya el índice de la biblioteca para la nueva ubicación de la galería.",
+        "progress": "El progreso en vivo aparece en la barra de estado fija.",
+        "rebuildActive": "Espera a que termine la reconstrucción completa primero.",
+        "scanActive": "Espera a que termine el escaneo actual primero.",
+        "legacyMigration": "Esto conserva las rutas actuales de las miniaturas y no migra los derivados reflejados heredados. Ejecuta Escanear biblioteca para moverlos al almacenamiento con claves de recursos.",
+        "idle": "Usa esto para una actualización más rápida solo de miniaturas."
+      },
+      "dangerZone": {
+        "title": "Zona de peligro",
+        "recommended": "Recomendado",
+        "rebuildTitle": "Reconstruir índice de la biblioteca",
+        "rebuildDescription": "Restablece el índice de la biblioteca, reutiliza medios en caché coincidentes y genera solo los derivados faltantes desde la raíz actual de la galería.",
+        "currentGalleryRoot": "Raíz actual de la galería",
+        "previousGalleryRoot": "Raíz anterior de la galería"
+      },
+      "rebuildButton": {
+        "active": "Reconstruyendo...",
+        "idle": "Reconstruir índice de la biblioteca"
+      },
+      "rebuildActionNote": {
+        "loading": "Cargando el estado actual de la biblioteca...",
+        "progress": "El progreso en vivo aparece en la barra de estado fija.",
+        "thumbnailActive": "Espera a que termine primero la regeneración de miniaturas.",
+        "scanActive": "Espera a que termine el escaneo actual primero.",
+        "rebuildRequired": "Recomendado porque cambió la ubicación de la galería.",
+        "idle": "Usa esto para restablecer el índice y reutilizar derivados coincidentes del índice anterior de la biblioteca."
+      },
+      "dialogs": {
+        "rebuildTitle": "¿Reconstruir el índice actual de la biblioteca?",
+        "rebuildMessage": "Esto borrará las tablas indexadas de carpetas, publicaciones, me gusta e historial de escaneos, y luego volverá a escanear la raíz activa de la galería. Las miniaturas y vistas previas existentes del índice anterior se reutilizarán cuando sigan coincidiendo con los archivos actuales, y solo se generarán derivados faltantes o modificados. Los archivos originales de la galería no se eliminarán.",
+        "rebuildConfirm": "Reconstruir índice de la biblioteca",
+        "rebuildLoading": "Reconstruyendo...",
+        "thumbnailsTitle": "¿Regenerar solo miniaturas?",
+        "thumbnailsMessage": "Esto eliminará las miniaturas generadas del feed y del perfil más las imágenes póster de video, y luego las reconstruirá desde la biblioteca indexada actual usando la ruta de miniatura actual de cada elemento. Las vistas previas, los me gusta, el historial de escaneos y los registros indexados de la biblioteca no se cambiarán. Los archivos originales de la galería no se eliminarán.",
+        "thumbnailsConfirm": "Regenerar miniaturas",
+        "thumbnailsLoading": "Regenerando..."
+      },
+      "errors": {
+        "startScan": "No se pudo iniciar un escaneo de la biblioteca.",
+        "rebuild": "No se pudo reconstruir el índice actual de la biblioteca.",
+        "regenerate": "No se pudieron regenerar las miniaturas."
+      }
+    },
+    "notices": {
+      "scanError": {
+        "eyebrow": "El escaneo necesita atención",
+        "title": "El último escaneo terminó con errores",
+        "fullReportPrefix": "Informe completo:",
+        "dismissAria": "Descartar advertencia del escaneo",
+        "actionNote": "Ejecuta un nuevo escaneo de la biblioteca para reintentar medios fallidos y completar miniaturas o vistas previas faltantes.",
+        "messages": {
+          "genericNoDetails": "Algunos medios fallaron durante la última ejecución. Vuelve a escanear la biblioteca para reintentar cualquier archivo omitido y la generación de derivados.",
+          "ffmpegMissing": "Faltan herramientas de procesamiento de video en el entorno del servidor. Instala FFmpeg para que los escaneos puedan leer metadatos de video y generar derivados de video.",
+          "withReport": "Algunos medios fallaron durante la última ejecución. Revisa el error de ejemplo y la ruta del informe completo a continuación, luego vuelve a escanear la biblioteca para reintentar medios fallidos y la generación de derivados.",
+          "withSample": "Algunos medios fallaron durante la última ejecución. Revisa el error de ejemplo a continuación, luego vuelve a escanear la biblioteca para reintentar cualquier archivo omitido y la generación de derivados."
+        },
+        "detailMore": "{line} (+{count} más)"
+      },
+      "ignoredRootMedia": {
+        "dismissAria": "Descartar advertencia de la raíz de la galería",
+        "messageOne": "Se está ignorando {count} archivo compatible en la raíz de la galería. Muévelo a una carpeta dentro de la raíz de la galería para crear carpetas de la app. Los archivos colocados directamente en la raíz de la galería se ignoran.",
+        "messageOther": "Se están ignorando {count} archivos compatibles en la raíz de la galería. Muévelos a una carpeta dentro de la raíz de la galería para crear carpetas de la app. Los archivos colocados directamente en la raíz de la galería se ignoran."
+      }
+    },
+    "access": {
+      "section": {
+        "title": "Acceso de administrador y visor",
+        "description": "Protege las acciones de administrador con una contraseña de administrador y, opcionalmente, emite una contraseña de visor separada para sesiones solo de navegación.",
+        "locked": "Admin bloqueado",
+        "open": "Acceso abierto"
+      },
+      "fields": {
+        "adminPassword": "Contraseña de administrador",
+        "confirmPassword": "Confirmar contraseña",
+        "currentPassword": "Contraseña actual",
+        "newPassword": "Nueva contraseña",
+        "confirmNewPassword": "Confirmar nueva contraseña",
+        "viewerPassword": "Contraseña del visor",
+        "confirmViewerPassword": "Confirmar contraseña del visor"
+      },
+      "placeholders": {
+        "minimumLength": "Mínimo {count} caracteres",
+        "repeatPassword": "Repite la contraseña",
+        "enterNewViewerPassword": "Introduce una nueva contraseña de visor",
+        "repeatNewViewerPassword": "Repite la nueva contraseña del visor",
+        "repeatViewerPassword": "Repite la contraseña del visor"
+      },
+      "enable": {
+        "description": "La contraseña de administrador se almacena como un hash de una sola vía y desbloquea este navegador con una cookie de sesión firmada.",
+        "buttonLoading": "Activando...",
+        "buttonIdle": "Activar contraseña de administrador",
+        "success": "La contraseña de administrador ya está activada para esta instancia de Foldergram.",
+        "error": "No se pudo activar la contraseña de administrador."
+      },
+      "change": {
+        "title": "Cambiar contraseña de administrador",
+        "description": "Actualiza la contraseña de administrador e invalida las sesiones anteriores.",
+        "showForm": "Cambiar contraseña",
+        "hideForm": "Ocultar formulario",
+        "helper": "Usa al menos 8 caracteres. Cambiar la contraseña cerrará las sesiones anteriores.",
+        "buttonLoading": "Actualizando...",
+        "buttonIdle": "Cambiar contraseña de administrador",
+        "missingCurrent": "Introduce la contraseña actual para cambiarla.",
+        "success": "La contraseña de administrador se actualizó y las sesiones existentes fueron invalidadas.",
+        "error": "No se pudo cambiar la contraseña de administrador."
+      },
+      "viewer": {
+        "title": "Acceso de visor",
+        "description": "Emite una contraseña solo para navegación para sesiones de visor o abre la biblioteca para la visualización pública anónima.",
+        "modes": {
+          "adminOnlyTitle": "Solo administrador",
+          "adminOnlyDescription": "Solo la contraseña de administrador puede desbloquear la app.",
+          "viewerPasswordTitle": "Contraseña de visor",
+          "viewerPasswordDescription": "Permite un inicio de sesión de visor separado que puede navegar y usar me gusta compartidos sin ver controles de administrador.",
+          "publicTitle": "Público",
+          "publicDescription": "Permite la navegación anónima con favoritos locales del navegador mientras mantiene el desbloqueo de administrador disponible desde Más."
+        },
+        "status": {
+          "adminPasswordOff": "Contraseña de admin desactivada",
+          "viewerPasswordOn": "Contraseña de visor activada",
+          "publicViewerOn": "Visor público activado",
+          "adminOnly": "Solo administrador"
+        },
+        "summary": {
+          "enableAdminFirst": "Activa primero la contraseña de administrador",
+          "viewerPasswordEnabled": "El acceso con contraseña de visor está activado",
+          "publicEnabled": "El acceso de visor público está activado",
+          "off": "El acceso de visor está desactivado"
+        },
+        "summaryCopy": {
+          "enableAdminFirst": "La configuración de acceso de visor estará disponible después de activar la contraseña de administrador.",
+          "viewerPasswordEnabled": "Los visores pueden iniciar sesión con la contraseña de visor separada, usar me gusta compartidos y navegar sin controles de administrador. Para reemplazar esa contraseña, introduce una nueva abajo. No se requiere la contraseña actual del visor.",
+          "publicEnabled": "Cualquiera que pueda acceder a este Foldergram puede navegar sin iniciar sesión. Los favoritos permanecen solo en el navegador actual, y los administradores pueden elevar desde Más con la contraseña de administrador.",
+          "off": "Solo la contraseña de administrador puede desbloquear la app en este momento. Activa el modo de contraseña de visor abajo si quieres un inicio de sesión solo de navegación."
+        },
+        "helper": {
+          "viewerPasswordRotate": "Introduce una nueva contraseña de visor abajo para rotarla. No necesitas la contraseña actual del visor.",
+          "viewerPasswordNew": "Los inicios de sesión de visor obtienen me gusta compartidos pero no pueden acceder a Configuración, Papelera ni a ninguna acción destructiva.",
+          "public": "Los visitantes anónimos pueden navegar de inmediato, usar favoritos locales del navegador y desbloquear acceso de administrador desde Más cuando sea necesario.",
+          "disableFromPassword": "Guardar esto desactivará los inicios de sesión de visor y devolverá la app al acceso solo de administrador.",
+          "disableFromPublic": "Guardar esto desactivará la navegación pública y devolverá la app al acceso solo de administrador.",
+          "off": "El acceso de visor está desactivado, así que solo la contraseña de administrador puede desbloquear la app."
+        },
+        "buttons": {
+          "updateViewerPassword": "Actualizar contraseña de visor",
+          "enableViewerAccess": "Activar acceso de visor",
+          "savePublicAccess": "Guardar acceso público",
+          "enablePublicAccess": "Activar acceso público",
+          "disableViewerAccess": "Desactivar acceso de visor",
+          "saveViewerAccess": "Guardar acceso de visor"
+        },
+        "success": {
+          "password": "El acceso con contraseña de visor está activado. La contraseña del visor se guardó.",
+          "public": "El acceso público de visor está activado. Los visitantes anónimos ya pueden navegar con favoritos locales del navegador.",
+          "off": "El acceso de visor se ha desactivado. Ahora solo se permiten inicios de sesión de administrador."
+        },
+        "error": "No se pudo actualizar el acceso de visor."
+      },
+      "danger": {
+        "title": "Zona de peligro",
+        "disableTitle": "Desactivar contraseña de administrador",
+        "disableDescription": "Vuelve a desactivar la contraseña de administrador para esta instancia de Foldergram.",
+        "showForm": "Desactivar acceso",
+        "hideForm": "Ocultar formulario",
+        "buttonLoading": "Desactivando...",
+        "buttonIdle": "Desactivar contraseña de administrador",
+        "signOut": "Cerrar sesión",
+        "signOutError": "No se pudo cerrar la sesión.",
+        "missingCurrent": "Introduce la contraseña actual para desactivar la protección.",
+        "success": "La contraseña de administrador se ha desactivado.",
+        "error": "No se pudo desactivar la contraseña de administrador."
+      },
+      "authProtection": {
+        "enabled": "La protección de administrador está activa para esta sesión del navegador. Usa los controles de abajo para rotar la contraseña de administrador, configurar el acceso de visor, cerrar sesión o volver a desactivar la protección.",
+        "disabled": "La protección está desactivada actualmente. Cualquiera que pueda acceder a esta app en tu red puede navegar por la biblioteca con acceso local completo hasta que actives una contraseña de administrador."
+      },
+      "validation": {
+        "minLength": "La contraseña debe tener al menos {count} caracteres.",
+        "empty": "La contraseña no puede estar vacía.",
+        "mismatch": "La confirmación de la contraseña no coincide."
+      }
+    },
+    "status": {
+      "never": "Nunca",
+      "storage": {
+        "available": "Disponible",
+        "unavailable": "No disponible"
+      },
+      "libraryStatus": {
+        "title": "Estado de la biblioteca",
+        "description": "Estado actual del almacenamiento y del índice.",
+        "storage": "Almacenamiento",
+        "folders": "Carpetas",
+        "indexedPosts": "Publicaciones indexadas",
+        "indexedVideos": "Videos indexados"
+      },
+      "lastScan": {
+        "title": "Último escaneo",
+        "description": "La ejecución completada más reciente registrada por la app.",
+        "status": "Estado",
+        "finished": "Finalizado",
+        "filesScanned": "Archivos escaneados",
+        "changes": "Cambios",
+        "statusValues": {
+          "none": "Aún no hay escaneos completados",
+          "completed": "completado",
+          "completedWithErrors": "completado con errores",
+          "failed": "fallido",
+          "running": "en ejecución"
+        },
+        "changeValues": {
+          "new": "nuevos",
+          "updated": "actualizados",
+          "removed": "eliminados"
+        }
+      }
+    }
+  },
+  "home": {
+    "sidebar": {
+      "ariaLabel": "Recomendaciones de carpetas",
+      "suggestedFolders": "Carpetas sugeridas",
+      "viewLikes": "Ver me gusta",
+      "viewFavorites": "Ver favoritos",
+      "openFolder": "Abrir",
+      "openSourceText": "Foldergram es de código abierto.",
+      "viewOnGitHub": "Ver en GitHub"
+    }
+  },
+  "likes": {
+    "labels": {
+      "sharedCollection": "Me gusta",
+      "localCollection": "Favoritos",
+      "sharedSection": "Publicaciones con me gusta",
+      "localSection": "Publicaciones favoritas"
+    },
+    "view": {
+      "rebuilding": "Se está reconstruyendo el índice de la biblioteca. {label} volverá cuando termine de cargarse la biblioteca actualizada.",
+      "sectionsAria": "Secciones de {label}"
+    },
+    "states": {
+      "sharedEmptyTitle": "Aún no hay publicaciones con me gusta",
+      "localEmptyTitle": "Aún no hay favoritos",
+      "sharedEmptyDescription": "Toca el corazón debajo de cualquier publicación y aparecerá aquí.",
+      "localEmptyDescription": "Toca el corazón debajo de cualquier publicación y aparecerá aquí en este navegador.",
+      "sharedLoadingLabel": "Cargando me gusta...",
+      "localLoadingLabel": "Cargando favoritos...",
+      "sharedErrorTitle": "No se pudieron cargar los me gusta",
+      "localErrorTitle": "No se pudieron cargar los favoritos"
+    },
+    "actions": {
+      "likePost": "Marcar me gusta en la publicación",
+      "unlikePost": "Quitar me gusta de la publicación",
+      "favoritePost": "Agregar publicación a favoritos",
+      "removeFavoriteFromPost": "Quitar publicación de favoritos"
+    },
+    "errors": {
+      "loadShared": "No se pudieron cargar los me gusta",
+      "loadLocal": "No se pudieron cargar los favoritos",
+      "updateShared": "No se pudieron actualizar los me gusta",
+      "updateLocal": "No se pudieron actualizar los favoritos"
+    }
+  },
+  "moments": {
+    "rails": {
+      "moments": {
+        "title": "Momentos",
+        "description": "Cápsulas de recuerdos formadas por las fechas reales de captura de tu biblioteca.",
+        "singularLabel": "Momento"
+      },
+      "highlights": {
+        "title": "Historias",
+        "description": "Conjuntos de estilo story seleccionados de tu biblioteca cuando las fechas de captura son escasas o sintéticas.",
+        "singularLabel": "Historia"
+      }
+    },
+    "capsules": {
+      "onThisDay": {
+        "title": "Un día como hoy",
+        "subtitle": "{date} en años anteriores"
+      },
+      "thisWeekPreviousYears": {
+        "title": "Esta semana",
+        "subtitle": "{range} en años anteriores"
+      },
+      "fromLastYear": {
+        "title": "Por estas fechas el año pasado",
+        "subtitle": "Un repaso a {monthYear}"
+      },
+      "highlightRecentBatches": {
+        "title": "Lotes recientes",
+        "subtitle": "Las últimas tandas reunidas en un solo set",
+        "dateContextOne": "{count} lote",
+        "dateContextOther": "{count} lotes"
+      },
+      "highlightForgottenFavorites": {
+        "title": "Favoritos olvidados",
+        "subtitle": "Publicaciones antiguas con me gusta que merece la pena volver a ver",
+        "dateContext": "Con me gusta y con más de 6 meses"
+      },
+      "highlightDeepCuts": {
+        "title": "Joyas ocultas",
+        "subtitle": "Publicaciones antiguas rescatadas del archivo",
+        "dateContext": "Con más de 6 meses"
+      },
+      "highlightLuckyDip": {
+        "title": "Sorpresa aleatoria",
+        "subtitle": "Una mezcla juguetona de toda la biblioteca",
+        "dateContext": "Estable por hoy"
+      }
+    },
+    "view": {
+      "rebuilding": "Se está reconstruyendo el índice de la biblioteca. Esta vista volverá a poblarse cuando el carril de inicio renovado esté listo.",
+      "loading": "Cargando {label}...",
+      "loadError": "No se pudo cargar {label}",
+      "emptyTitle": "Este {label} está vacío",
+      "emptyDescription": "Prueba otro {label} desde la página de inicio.",
+      "postCount": "{count} publicaciones"
+    }
+  },
+  "folder": {
+    "shared": {
+      "topLevelSourceFolder": "Carpeta fuente de nivel superior"
+    },
+    "header": {
+      "openStories": "Abrir stories de la carpeta",
+      "openAvatar": "Abrir avatar de la carpeta",
+      "editButton": "Editar carpeta de la app",
+      "posts": "{count} publicaciones",
+      "reels": "{count} reels",
+      "updated": "{date} actualizado",
+      "libraryPath": "Ruta de la biblioteca",
+      "expandDescription": "Expandir descripción",
+      "collapseDescription": "Contraer descripción",
+      "errors": {
+        "updateProfile": "No se pudo actualizar el perfil"
+      }
+    },
+    "profileModal": {
+      "title": "Editar carpeta de la app",
+      "namePlaceholder": "Nombre visible de la carpeta",
+      "descriptionPlaceholder": "Añade una descripción a esta carpeta...",
+      "errors": {
+        "nameRequired": "El nombre es obligatorio."
+      }
+    },
+    "tabs": {
+      "posts": "Publicaciones",
+      "reels": "Reels",
+      "sections": "Secciones de carpeta"
+    }
+  },
+  "reels": {
+    "view": {
+      "libraryUnavailableTitle": "Almacenamiento de la biblioteca no disponible",
+      "loadErrorTitle": "No se pudieron cargar los reels",
+      "loadingTitle": "Cargando reels",
+      "loadingDescription": "Preparando una cola solo de video a partir de tu biblioteca indexada.",
+      "emptyTitle": "No hay reels disponibles",
+      "emptyDescription": "Agrega videos indexados a tu biblioteca y aparecerán aquí después del próximo escaneo.",
+      "navigationAria": "Navegación de reels",
+      "previous": "Reel anterior",
+      "next": "Siguiente reel"
+    },
+    "rail": {
+      "hideDetails": "Ocultar detalles del reel",
+      "showDetails": "Mostrar detalles del reel",
+      "downloadOriginal": "Descargar archivo original",
+      "openFolder": "Abrir carpeta"
+    },
+    "info": {
+      "ariaLabel": "Detalles del reel",
+      "eyebrow": "Detalles del reel",
+      "hideDetails": "Ocultar detalles del reel",
+      "openFolder": "Abrir carpeta",
+      "topLevelSourceFolder": "Carpeta fuente de nivel superior",
+      "unavailable": "No disponible",
+      "video": "Video",
+      "loadError": "No se pudieron cargar los detalles del reel.",
+      "resolution": "Resolución",
+      "length": "Duración",
+      "size": "Tamaño",
+      "format": "Formato",
+      "loading": "Cargando detalles del reel...",
+      "folderPath": "Ruta de la carpeta",
+      "mimeType": "Tipo MIME"
+    }
+  },
+  "post": {
+    "captionModal": {
+      "title": "Editar descripción",
+      "captionLabel": "Descripción",
+      "placeholder": "Escribe una descripción...",
+      "resetToFilename": "Restablecer al nombre del archivo",
+      "errors": {
+        "update": "No se pudo actualizar la descripción"
+      }
+    },
+    "viewer": {
+      "close": "Cerrar publicación",
+      "previous": "Publicación anterior",
+      "next": "Siguiente publicación",
+      "showDetails": "Mostrar detalles de la publicación",
+      "hideDetails": "Ocultar detalles de la publicación",
+      "togglePlayback": "Alternar reproducción",
+      "toggleSound": "Alternar sonido",
+      "toggleFullscreen": "Alternar pantalla completa",
+      "switchToPreviewQuality": "Cambiar a calidad de vista previa",
+      "switchToHdOriginal": "Cambiar al original en HD",
+      "previewQuality": "Calidad de vista previa",
+      "hdOriginal": "Original en HD",
+      "openFolder": "Abrir carpeta",
+      "editCaption": "Editar descripción",
+      "folderPath": "Ruta de la carpeta",
+      "stats": {
+        "dimensions": "Dimensiones",
+        "type": "Tipo",
+        "duration": "Duración",
+        "size": "Tamaño",
+        "place": "Lugar"
+      },
+      "metadata": {
+        "location": "Ubicación",
+        "camera": "Cámara",
+        "lens": "Lente",
+        "aperture": "Apertura",
+        "shutter": "Obturación",
+        "iso": "ISO",
+        "focalLength": "Distancia focal"
+      },
+      "videoType": "Video ({mimeType})",
+      "setAsCover": "Establecer como portada de la carpeta",
+      "downloadOriginalFile": "Descargar archivo original",
+      "openOriginalFile": "Abrir archivo original",
+      "deletePost": "Eliminar publicación"
+    },
+    "feedCard": {
+      "openStories": "Abrir historias de {name}",
+      "openFolderAvatar": "Abrir {name}",
+      "openReel": "Abrir reel",
+      "openPost": "Abrir publicación",
+      "moreOptions": "Más opciones",
+      "delete": {
+        "title": "¿Eliminar esta publicación?",
+        "messagePermanent": "Esto eliminará permanentemente la publicación de la app y quitará el archivo original del disco.",
+        "messageTrash": "Esto eliminará la publicación de la app y la moverá a la Papelera. El archivo original seguirá en el disco a menos que elijas la eliminación permanente.",
+        "confirmPermanent": "Eliminar permanentemente",
+        "confirm": "Eliminar",
+        "deleteOriginalLabel": "Eliminar también de forma permanente el archivo original del disco",
+        "deleteOriginalDescription": "Déjalo desmarcado para mover la publicación a la Papelera mientras conservas el archivo fuente en el disco.",
+        "deleteOriginalWarning": "Esto eliminará permanentemente del disco el archivo original, la miniatura y la vista previa. Esta acción no se puede deshacer."
+      }
+    }
+  },
+  "collections": {
+    "shared": {
+      "defaultName": "Todas las publicaciones",
+      "postCountOne": "{count} publicación",
+      "postCountOther": "{count} publicaciones"
+    },
+    "bookmark": {
+      "dialogLabel": "Colecciones",
+      "title": "Colecciones",
+      "createCollection": "Crear colección",
+      "namePlaceholder": "Nombre de la colección",
+      "empty": "Aún no hay colecciones",
+      "savePost": "Guardar publicación",
+      "removeSavedPost": "Quitar publicación guardada",
+      "errors": {
+        "loadCollections": "No se pudieron cargar las colecciones"
+      }
+    },
+    "list": {
+      "libraryUnavailableTitle": "Almacenamiento de la biblioteca no disponible",
+      "loadErrorTitle": "No se pudieron cargar las colecciones",
+      "loading": "Cargando colecciones...",
+      "emptyTitle": "Aún no hay colecciones",
+      "emptyDescription": "Las publicaciones guardadas aparecerán en Todas las publicaciones."
+    },
+    "detail": {
+      "fallbackTitle": "Colección",
+      "libraryUnavailableTitle": "Almacenamiento de la biblioteca no disponible",
+      "loadErrorTitle": "No se pudo cargar la colección",
+      "back": "Colecciones",
+      "options": "Opciones de la colección",
+      "actionsLabel": "Acciones de la colección",
+      "emptyTitle": "{name} está vacía",
+      "emptyDescriptionDefault": "Usa la acción de marcador debajo de cualquier publicación para guardarla aquí.",
+      "emptyDescriptionCustom": "Las publicaciones guardadas asignadas a esta colección aparecerán aquí.",
+      "loading": "Cargando colección...",
+      "menu": {
+        "delete": "Eliminar colección",
+        "edit": "Editar colección",
+        "cancel": "Cancelar"
+      },
+      "edit": {
+        "title": "Editar colección",
+        "saving": "Guardando...",
+        "done": "Listo",
+        "required": "El nombre de la colección es obligatorio.",
+        "createError": "No se pudo crear la colección",
+        "updateError": "No se pudo actualizar la colección"
+      },
+      "delete": {
+        "title": "¿Eliminar colección?",
+        "message": "Cuando elimines esta colección, las fotos y los videos seguirán guardados.",
+        "deleting": "Eliminando...",
+        "confirm": "Eliminar",
+        "cancel": "Cancelar",
+        "error": "No se pudo eliminar la colección"
+      }
+    }
+  },
+  "placesPage": {
+    "eyebrow": "Lugares",
+    "title": "Todos los lugares",
+    "description": "Explora publicaciones agrupadas a partir de datos de ubicación sin conexión.",
+    "stats": {
+      "places": "Lugares",
+      "posts": "Publicaciones"
+    },
+    "errors": {
+      "load": "No se pudieron cargar los lugares"
+    },
+    "searchPlaceholder": "Buscar nombres, regiones o coordenadas...",
+    "sort": {
+      "postsDesc": "Más publicaciones",
+      "nameAsc": "Nombre A-Z",
+      "nameDesc": "Nombre Z-A",
+      "countryAsc": "País A-Z"
+    },
+    "resultsOne": "{count} resultado",
+    "resultsOther": "{count} resultados",
+    "loading": "Cargando lugares...",
+    "emptyTitle": "Aún no hay lugares indexados",
+    "emptyDescription": "Prepara los datos de lugares sin conexión y reconstruye las asignaciones desde Configuración para agrupar publicaciones por ubicación.",
+    "noMatch": "No hay lugares que coincidan. Prueba otra búsqueda u orden.",
+    "metadataFallback": "Lugar sin conexión a nivel de ciudad",
+    "postCountOne": "{count} publicación",
+    "postCountOther": "{count} publicaciones",
+    "kinds": {
+      "manual": "Lugar manual",
+      "nearestCity": "Ciudad más cercana",
+      "cityMatch": "Coincidencia de ciudad"
+    },
+    "readiness": {
+      "ready": "Listo",
+      "empty": "Vacío"
+    }
+  },
+  "placePage": {
+    "errors": {
+      "load": "No se pudo cargar el lugar"
+    },
+    "badge": "Lugar sin conexión",
+    "coordinatesLabel": "coordenadas",
+    "sourceLabel": "Origen",
+    "approximateBadge": "Coincidencia aproximada de ciudad",
+    "emptyTitle": "No hay publicaciones para este lugar",
+    "emptyDescription": "Las asignaciones de lugares se pueden reconstruir desde Configuración después de preparar los datos de lugares sin conexión.",
+    "metadataFallback": "Lugar sin conexión a nivel de ciudad",
+    "heroApproximate": "Agrupado a partir de coordenadas GPS almacenadas en las fotos y asociado con la ciudad más cercana para la navegación sin conexión.",
+    "heroExact": "Resuelto a partir de coordenadas GPS almacenadas en las fotos y mantenido disponible sin conexión.",
+    "postCountOne": "publicación",
+    "postCountOther": "publicaciones",
+    "kind": {
+      "offline": "Sin conexión",
+      "manual": "Manual",
+      "nearestCity": "Ciudad más cercana",
+      "city": "Ciudad",
+      "place": "lugar",
+      "match": "coincidencia"
+    }
+  },
+  "libraryPage": {
+    "eyebrow": "Biblioteca",
+    "title": "Todas las carpetas",
+    "description": "Explora y busca cada carpeta de la app indexada.",
+    "stats": {
+      "folders": "Carpetas",
+      "posts": "Publicaciones"
+    },
+    "errors": {
+      "load": "No se pudieron cargar las carpetas"
+    },
+    "searchPlaceholder": "Buscar nombres o segmentos de ruta...",
+    "sort": {
+      "recentDesc": "Actualizadas recientemente",
+      "imagesDesc": "Más publicaciones",
+      "nameAsc": "Nombre A-Z",
+      "nameDesc": "Nombre Z-A",
+      "pathAsc": "Ruta A-Z"
+    },
+    "resultsOne": "{count} resultado",
+    "resultsOther": "{count} resultados",
+    "loading": "Cargando carpetas...",
+    "emptyTitle": "Aún no hay carpetas indexadas",
+    "emptyDescription": "Añade carpetas fuente con medios dentro de la raíz de la galería y ejecuta un escaneo.",
+    "noMatch": "No hay carpetas que coincidan. Prueba otra búsqueda o filtro.",
+    "topLevelSourceFolder": "Carpeta fuente de nivel superior",
+    "postsCountOne": "{count} publicación",
+    "postsCountOther": "{count} publicaciones",
+    "reelsCountOne": "{count} reel",
+    "reelsCountOther": "{count} reels",
+    "readiness": {
+      "ready": "Listo",
+      "empty": "Vacío"
+    },
+    "moreOptions": "Más opciones",
+    "openFolder": "Abrir carpeta",
+    "deleteFolder": "Eliminar carpeta",
+    "noRecentMedia": "No hay medios recientes",
+    "delete": {
+      "title": "¿Eliminar esta carpeta de la app?",
+      "sourceTooTitle": "Eliminar también la carpeta fuente",
+      "sourceTooNoChildren": "También elimina la propia carpeta fuente en lugar de borrar solo sus publicaciones directas.",
+      "sourceTooWithChildrenOne": "También elimina {count} carpeta hija de la app y todos los archivos dentro del subárbol.",
+      "sourceTooWithChildrenOther": "También elimina {count} carpetas hijas de la app y todos los archivos dentro del subárbol.",
+      "warning": "Esto eliminará permanentemente la carpeta fuente seleccionada y cada carpeta hija y archivo dentro de ella, incluidos los archivos no compatibles. Esta acción no se puede deshacer.",
+      "directPostsOne": "{count} publicación directa",
+      "directPostsOther": "{count} publicaciones directas",
+      "childFoldersOne": "{count} carpeta hija de la app",
+      "childFoldersOther": "{count} carpetas hijas de la app",
+      "messageDeleteSource": "Esto eliminará permanentemente {directPosts} y quitará esta carpeta fuente del disco duro.",
+      "messageKeepChildren": "Esto eliminará permanentemente {directPosts}. Se conservarán {childFolders}.",
+      "messageEmptyFolder": "Esto eliminará permanentemente {directPosts}. La propia carpeta fuente solo se eliminará si queda vacía.",
+      "confirmSubtree": "Eliminar subárbol de carpetas",
+      "confirmFolder": "Eliminar carpeta de la app",
+      "loadingSubtree": "Eliminando subárbol...",
+      "loadingFolder": "Eliminando...",
+      "error": "No se pudo eliminar esta carpeta de la app."
+    }
+  },
+  "explore": {
+    "back": "Volver a publicaciones de explorar",
+    "searchPlaceholder": "Buscar",
+    "clearSearch": "Borrar búsqueda",
+    "recentTitle": "Reciente",
+    "clearAll": "Borrar todo",
+    "tabsAria": "Pestañas de resultados de búsqueda",
+    "tabs": {
+      "media": "Fotos y videos",
+      "folders": "Carpetas de la app"
+    },
+    "errors": {
+      "search": "No se pudieron buscar publicaciones",
+      "load": "No se pudo cargar Explorar"
+    },
+    "emptySearchTitle": "No hay fotos ni videos que coincidan",
+    "emptySearchDescription": "Prueba con otro nombre de archivo o palabra clave de carpeta.",
+    "loadingFolders": "Cargando carpetas...",
+    "noFoldersFound": "No se encontraron carpetas de la app.",
+    "emptyTitle": "Todavía no hay nada para explorar",
+    "emptyDescription": "Indexa algunas carpetas y esta página empezará a mostrar publicaciones aquí.",
+    "folderPostsOne": "{count} publicación",
+    "folderPostsOther": "{count} publicaciones"
+  }
+}

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -14,7 +14,13 @@
     "saved": "Guardado",
     "saving": "Guardando...",
     "youAreCaughtUp": "Ya viste todo",
-    "loading": "Cargando..."
+    "loading": "Cargando...",
+    "railViewer": {
+      "itemCountOne": "{count} elemento",
+      "itemCountOther": "{count} elementos",
+      "latestDate": "Último {date}",
+      "noRecentActivity": "Sin actividad reciente"
+    }
   },
   "app": {
     "authLoading": {

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -158,12 +158,13 @@
       },
       "card": {
         "title": "Ajustes generales",
-        "description": "Valores predeterminados de toda la app para carpetas stories, carpetas excluidas, Inicio, Reels y carpetas de la app."
+        "description": "Valores predeterminados de toda la app para idioma, carpetas stories, carpetas excluidas, Inicio, Reels y carpetas de la app."
       },
       "language": {
         "label": "Idioma de la aplicación",
         "description": "Elige el idioma usado para la navegación, los diálogos y otras partes traducidas de la interfaz en este dispositivo.",
-        "helper": "Se aplica de inmediato en este navegador. Las traducciones que falten usan el texto en inglés.",
+        "helper": "Se aplica de inmediato en este navegador. Guarda los cambios abajo para convertir el idioma seleccionado en el predeterminado de toda la app. Las traducciones que falten usan el texto en inglés.",
+        "overrideNotice": "El valor predeterminado de la app es {savedLabel}. Este navegador está usando temporalmente {currentLabel} desde una configuración solo de este navegador. Guarda los cambios para convertir {currentLabel} en el predeterminado.",
         "selectLabel": "Idioma de la aplicación",
         "options": {
           "en": "Inglés",
@@ -248,13 +249,14 @@
         "loading": "Cargando las preferencias actuales de la app...",
         "excludedAndOther": "Guarda las reglas de exclusión de carpetas junto con los otros cambios de toda la app. Después ejecuta un escaneo de la biblioteca para que stories y carpetas excluidas se reindexen correctamente.",
         "excludedOnly": "Esto solo guarda las carpetas excluidas personalizadas. Después ejecuta un escaneo de la biblioteca para que esas carpetas desaparezcan del índice.",
-        "storiesAndDefaults": "Guarda juntos la nueva regla de stories y los valores de navegación actualizados.",
+        "storiesAndDefaults": "Guarda juntos la nueva regla de stories y los valores globales actualizados.",
         "storiesOnly": "Esto solo guarda la regla de carpetas stories. Después ejecuta un escaneo de la biblioteca para reindexar con el nuevo comportamiento.",
-        "multipleDefaults": "Guarda juntos estos valores de navegación. Los visitantes de Inicio aún pueden cambiar de modo en la página principal; Reels y las carpetas de la app usan los valores predeterminados de la app.",
+        "multipleDefaults": "Guarda juntos estos valores globales. El idioma se aplica de inmediato en este navegador; los visitantes de Inicio aún pueden cambiar de modo en la página principal; Reels y las carpetas de la app usan los valores predeterminados de la app.",
+        "languageOnly": "Esto cambia el idioma de inmediato en este navegador. Guárdalo también si quieres que el idioma seleccionado se convierta en el predeterminado de toda la app.",
         "homeOnly": "Esto actualiza el primer modo de feed que se muestra en Inicio para esta app. Los visitantes aún pueden cambiar de modo desde la página principal.",
         "reelsOnly": "Esto actualiza el estilo de cola usado cuando se abre Reels para esta app. Los visitantes no pueden cambiar de modo desde la página de Reels.",
         "folderOnly": "Esto actualiza el orden de fotos predeterminado usado por las cuadrículas de carpetas de la app.",
-        "idle": "Estos son los valores actuales de toda la app para Inicio, Reels, carpetas de la app, carpetas stories y carpetas excluidas."
+        "idle": "Estos son los valores actuales de toda la app para idioma, Inicio, Reels, carpetas de la app, carpetas stories y carpetas excluidas."
       },
       "rescanNotice": {
         "excludedAndStories": "Guarda estos cambios y luego ejecuta un escaneo de la biblioteca antes de esperar que se actualicen las carpetas stories y las carpetas excluidas.",
@@ -267,11 +269,13 @@
         "excludedFoldersSaved": "Se guardaron las carpetas excluidas. Ejecuta un escaneo de la biblioteca para aplicarlas.",
         "settingsAndStoriesSaved": "Los ajustes se guardaron. Ejecuta un escaneo de la biblioteca para aplicar el cambio de carpetas stories.",
         "storiesSaved": "Se guardó el comportamiento de las carpetas stories. Ejecuta un escaneo de la biblioteca para aplicarlo.",
-        "defaultsSaved": "Se actualizaron los valores de navegación de toda la app.",
+        "defaultsSaved": "Se actualizaron los valores predeterminados de toda la app.",
+        "languageSaved": "El idioma predeterminado de la app se guardó como {label}.",
         "homeSaved": "La página de Inicio ahora se abre con {label}.",
         "reelsSaved": "Reels ahora se abre con {label}.",
         "folderOrderSaved": "Las carpetas de la app ahora se abren con {label}.",
         "parts": {
+          "appLanguage": "idioma de la app",
           "excludedFolders": "carpetas excluidas",
           "storiesFolderHandling": "comportamiento de las carpetas stories",
           "homeFeedDefault": "predeterminado del feed de Inicio",
@@ -954,6 +958,46 @@
       "loadingSubtree": "Eliminando subárbol...",
       "loadingFolder": "Eliminando...",
       "error": "No se pudo eliminar esta carpeta de la app."
+    }
+  },
+  "trashPage": {
+    "eyebrow": "Papelera",
+    "title": "Publicaciones eliminadas",
+    "description": "Las publicaciones movidas aquí permanecen en el disco hasta que las elimines de forma permanente.",
+    "selectedOne": "{count} publicación seleccionada",
+    "selectedOther": "{count} publicaciones seleccionadas",
+    "restoreButton": "Restaurar",
+    "deleteButton": "Eliminar permanentemente",
+    "libraryUnavailableTitle": "Almacenamiento de la biblioteca no disponible",
+    "libraryUnavailableDescription": "El almacenamiento configurado de la biblioteca no está disponible.",
+    "loadErrorTitle": "No se pudo cargar la papelera",
+    "loading": "Cargando papelera...",
+    "emptyTitle": "La papelera está vacía",
+    "emptyDescription": "Las publicaciones eliminadas aparecerán aquí para que puedas restaurarlas o quitarlas permanentemente.",
+    "selectItem": "Seleccionar {label}",
+    "deselectItem": "Deseleccionar {label}",
+    "trashedAt": "En papelera {date}",
+    "recently": "recientemente",
+    "openFolder": "Abrir carpeta",
+    "restoreDialog": {
+      "title": "¿Restaurar las publicaciones seleccionadas?",
+      "messageOne": "¿Restaurar {count} publicación seleccionada en la app?",
+      "messageOther": "¿Restaurar {count} publicaciones seleccionadas en la app?",
+      "confirm": "Restaurar",
+      "loading": "Restaurando..."
+    },
+    "deleteDialog": {
+      "title": "¿Eliminar permanentemente las publicaciones seleccionadas?",
+      "messageOne": "Esto eliminará permanentemente {count} publicación seleccionada y quitará el archivo original del disco.",
+      "messageOther": "Esto eliminará permanentemente {count} publicaciones seleccionadas y quitará los archivos originales del disco.",
+      "confirm": "Eliminar permanentemente",
+      "loading": "Eliminando...",
+      "warning": "Los archivos originales, las miniaturas y las vistas previas se eliminarán permanentemente. Esta acción no se puede deshacer."
+    },
+    "errors": {
+      "refresh": "No se pudo refrescar el estado actualizado de la biblioteca.",
+      "processOne": "No se pudo procesar {count} publicación.",
+      "processOther": "No se pudieron procesar {count} publicaciones."
     }
   },
   "explore": {

--- a/client/src/locales/index.ts
+++ b/client/src/locales/index.ts
@@ -1,0 +1,65 @@
+import { createI18n } from 'vue-i18n';
+
+import en from './en.json';
+import es from './es.json';
+import zh from './zh.json';
+
+export const SUPPORTED_LOCALES = ['en', 'es', 'zh'] as const;
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+export const DEFAULT_LOCALE: SupportedLocale = 'en';
+
+const messages: Record<SupportedLocale, typeof en> = {
+  en,
+  es,
+  zh
+};
+
+export function resolveSupportedLocale(locale: string | null | undefined): SupportedLocale | null {
+  if (!locale) {
+    return null;
+  }
+
+  const normalizedLocale = locale.trim().replace(/_/g, '-').toLowerCase();
+  if (!normalizedLocale) {
+    return null;
+  }
+
+  if ((SUPPORTED_LOCALES as readonly string[]).includes(normalizedLocale)) {
+    return normalizedLocale as SupportedLocale;
+  }
+
+  const [baseLocale] = normalizedLocale.split('-');
+  if (baseLocale && (SUPPORTED_LOCALES as readonly string[]).includes(baseLocale)) {
+    return baseLocale as SupportedLocale;
+  }
+
+  return null;
+}
+
+export function resolvePreferredLocale(...candidates: Array<string | null | undefined>): SupportedLocale {
+  for (const candidate of candidates) {
+    const locale = resolveSupportedLocale(candidate);
+    if (locale) {
+      return locale;
+    }
+  }
+
+  return DEFAULT_LOCALE;
+}
+
+export function syncDocumentLanguage(locale: SupportedLocale) {
+  if (typeof document !== 'undefined') {
+    document.documentElement.lang = locale;
+  }
+}
+
+export function createFoldergramI18n(locale: SupportedLocale = DEFAULT_LOCALE) {
+  return createI18n({
+    legacy: false,
+    locale,
+    fallbackLocale: DEFAULT_LOCALE,
+    messages
+  });
+}
+
+export const i18n = createFoldergramI18n();

--- a/client/src/locales/validation.test.ts
+++ b/client/src/locales/validation.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import en from './en.json';
+import { DEFAULT_LOCALE, resolvePreferredLocale, resolveSupportedLocale } from './index';
+
+type LocaleTree = Record<string, LocaleTree | string>;
+
+const localeModules = import.meta.glob('./*.json', {
+  eager: true,
+  import: 'default'
+}) as Record<string, LocaleTree>;
+
+function collectLeafPaths(tree: LocaleTree, prefix = ''): string[] {
+  const paths: string[] = [];
+
+  for (const [key, value] of Object.entries(tree)) {
+    const nextPrefix = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === 'string') {
+      paths.push(nextPrefix);
+      continue;
+    }
+
+    paths.push(...collectLeafPaths(value, nextPrefix));
+  }
+
+  return paths;
+}
+
+describe('locale validation', () => {
+  it('treats English as the canonical locale tree', () => {
+    const englishPaths = collectLeafPaths(en as LocaleTree);
+
+    expect(englishPaths.length).toBeGreaterThan(0);
+
+    for (const [modulePath, localeMessages] of Object.entries(localeModules)) {
+      if (modulePath.endsWith('/en.json')) {
+        continue;
+      }
+
+      expect(collectLeafPaths(localeMessages)).toEqual(englishPaths);
+    }
+  });
+
+  it('normalizes supported locales and falls back to English', () => {
+    expect(resolveSupportedLocale('en')).toBe('en');
+    expect(resolveSupportedLocale('en-US')).toBe('en');
+    expect(resolveSupportedLocale('es')).toBe('es');
+    expect(resolveSupportedLocale('es-MX')).toBe('es');
+    expect(resolveSupportedLocale('zh')).toBe('zh');
+    expect(resolveSupportedLocale('zh-CN')).toBe('zh');
+    expect(resolveSupportedLocale('EN_gb')).toBe('en');
+    expect(resolveSupportedLocale('fr')).toBeNull();
+    expect(resolvePreferredLocale('fr-FR', 'es-MX')).toBe('es');
+    expect(resolvePreferredLocale('fr-FR', 'zh-CN')).toBe('zh');
+    expect(resolvePreferredLocale('fr-FR')).toBe(DEFAULT_LOCALE);
+  });
+});

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -158,12 +158,13 @@
       },
       "card": {
         "title": "常规设置",
-        "description": "适用于 stories 文件夹、排除文件夹、首页、短片和应用文件夹的全局默认项。"
+        "description": "适用于语言、stories 文件夹、排除文件夹、首页、短片和应用文件夹的全局默认项。"
       },
       "language": {
         "label": "应用语言",
         "description": "选择此设备上用于导航、对话框和其他已翻译应用界面的语言。",
-        "helper": "会立即在当前浏览器中生效。缺失翻译时会回退到英文。",
+        "helper": "会立即在当前浏览器中生效。在下方保存更改后，所选语言也会成为整个应用的默认语言。缺失翻译时会回退到英文。",
+        "overrideNotice": "应用默认语言是{savedLabel}。当前浏览器正通过仅限此浏览器的设置临时使用{currentLabel}。保存更改即可将{currentLabel}设为默认语言。",
         "selectLabel": "应用语言",
         "options": {
           "en": "英语",
@@ -248,13 +249,14 @@
         "loading": "正在加载当前应用偏好...",
         "excludedAndOther": "将文件夹排除规则与其他全局更改一起保存。随后运行一次图库扫描，以便 stories 和排除文件夹正确重新索引。",
         "excludedOnly": "这只会保存自定义排除文件夹。随后运行一次图库扫描，以便这些文件夹从索引中消失。",
-        "storiesAndDefaults": "将新的 stories 规则与更新后的浏览默认项一起保存。",
+        "storiesAndDefaults": "将新的 stories 规则与更新后的全局默认项一起保存。",
         "storiesOnly": "这只会保存 stories 文件夹规则。随后运行一次图库扫描，以新行为重新建立索引。",
-        "multipleDefaults": "一起保存这些浏览默认项。首页访问者仍可在主页上切换模式；短片和应用文件夹使用应用默认项。",
+        "multipleDefaults": "一起保存这些全局默认项。语言会立即在当前浏览器中生效；首页访问者仍可在主页上切换模式；短片和应用文件夹使用应用默认项。",
+        "languageOnly": "这会立即更改当前浏览器中的语言。如需让所选语言也成为整个应用的默认语言，请再保存一次。",
         "homeOnly": "这会更新此应用首页打开时显示的首个动态流模式。访问者仍可从主页切换模式。",
         "reelsOnly": "这会更新此应用打开短片时使用的队列样式。访问者无法从短片页面切换模式。",
         "folderOnly": "这会更新应用文件夹网格使用的默认照片顺序。",
-        "idle": "这些是当前适用于首页、短片、应用文件夹、stories 文件夹和排除文件夹的全局默认项。"
+        "idle": "这些是当前适用于语言、首页、短片、应用文件夹、stories 文件夹和排除文件夹的全局默认项。"
       },
       "rescanNotice": {
         "excludedAndStories": "保存这些更改后，请先运行一次图库扫描，再期待 stories 文件夹和排除文件夹更新。",
@@ -267,11 +269,13 @@
         "excludedFoldersSaved": "排除文件夹已保存。请运行一次图库扫描以应用它们。",
         "settingsAndStoriesSaved": "设置已保存。请运行一次图库扫描以应用 stories 文件夹更改。",
         "storiesSaved": "stories 文件夹行为已保存。请运行一次图库扫描以应用它。",
-        "defaultsSaved": "全局浏览默认项已更新。",
+        "defaultsSaved": "全局默认项已更新。",
+        "languageSaved": "应用语言默认值已保存为{label}。",
         "homeSaved": "首页现在会以 {label} 打开。",
         "reelsSaved": "短片现在会以 {label} 打开。",
         "folderOrderSaved": "应用文件夹现在会以 {label} 打开。",
         "parts": {
+          "appLanguage": "应用语言",
           "excludedFolders": "排除文件夹",
           "storiesFolderHandling": "stories 文件夹行为",
           "homeFeedDefault": "首页动态默认项",
@@ -954,6 +958,46 @@
       "loadingSubtree": "正在删除子树...",
       "loadingFolder": "正在删除...",
       "error": "无法删除此应用文件夹。"
+    }
+  },
+  "trashPage": {
+    "eyebrow": "回收站",
+    "title": "已删除的帖子",
+    "description": "移到这里的帖子会保留在磁盘上，直到你将其永久删除。",
+    "selectedOne": "已选 {count} 条帖子",
+    "selectedOther": "已选 {count} 条帖子",
+    "restoreButton": "恢复",
+    "deleteButton": "永久删除",
+    "libraryUnavailableTitle": "图库存储不可用",
+    "libraryUnavailableDescription": "当前配置的图库存储不可用。",
+    "loadErrorTitle": "无法加载回收站",
+    "loading": "正在加载回收站...",
+    "emptyTitle": "回收站为空",
+    "emptyDescription": "已删除的帖子会显示在这里，方便你恢复或永久移除。",
+    "selectItem": "选择 {label}",
+    "deselectItem": "取消选择 {label}",
+    "trashedAt": "{date} 已移入回收站",
+    "recently": "刚刚",
+    "openFolder": "打开文件夹",
+    "restoreDialog": {
+      "title": "恢复所选帖子？",
+      "messageOne": "要将所选的 {count} 条帖子恢复到应用中吗？",
+      "messageOther": "要将所选的 {count} 条帖子恢复到应用中吗？",
+      "confirm": "恢复",
+      "loading": "正在恢复..."
+    },
+    "deleteDialog": {
+      "title": "永久删除所选帖子？",
+      "messageOne": "这将永久删除所选的 {count} 条帖子，并从磁盘移除原始文件。",
+      "messageOther": "这将永久删除所选的 {count} 条帖子，并从磁盘移除原始文件。",
+      "confirm": "永久删除",
+      "loading": "正在删除...",
+      "warning": "原始文件、缩略图和预览图都会被永久删除。此操作无法撤销。"
+    },
+    "errors": {
+      "refresh": "无法刷新更新后的图库状态。",
+      "processOne": "有 {count} 条帖子无法处理。",
+      "processOther": "有 {count} 条帖子无法处理。"
     }
   },
   "explore": {

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -14,7 +14,13 @@
     "saved": "已保存",
     "saving": "保存中...",
     "youAreCaughtUp": "你已经看到最新内容了",
-    "loading": "加载中..."
+    "loading": "加载中...",
+    "railViewer": {
+      "itemCountOne": "{count} 项",
+      "itemCountOther": "{count} 项",
+      "latestDate": "最新 {date}",
+      "noRecentActivity": "最近没有活动"
+    }
   },
   "app": {
     "authLoading": {

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -1,0 +1,977 @@
+{
+  "common": {
+    "cancel": "取消",
+    "close": "关闭",
+    "description": "描述",
+    "loadMore": "加载更多",
+    "loadingMore": "正在加载更多...",
+    "name": "名称",
+    "newFeature": "新功能",
+    "open": "打开",
+    "retry": "重试",
+    "save": "保存",
+    "saveChanges": "保存更改",
+    "saved": "已保存",
+    "saving": "保存中...",
+    "youAreCaughtUp": "你已经看到最新内容了",
+    "loading": "加载中..."
+  },
+  "app": {
+    "authLoading": {
+      "eyebrow": "访问保护",
+      "title": "正在检查访问权限",
+      "description": "正在加载当前密码保护状态。"
+    }
+  },
+  "auth": {
+    "gate": {
+      "eyebrow": "共享密码",
+      "title": "解锁 Foldergram",
+      "passwordLabel": "密码",
+      "descriptionPassword": "此图库接受管理员密码或查看者密码进行本地访问。",
+      "descriptionAdmin": "此图库使用管理员密码进行本地和 homelab 访问保护。",
+      "placeholderPassword": "输入管理员或查看者密码",
+      "placeholderAdmin": "输入管理员密码",
+      "unlocking": "正在解锁...",
+      "unlock": "解锁图库",
+      "unableToSignIn": "无法登录。"
+    },
+    "adminUnlock": {
+      "eyebrow": "管理员解锁",
+      "title": "解锁管理员访问",
+      "closeAria": "关闭管理员解锁对话框",
+      "description": "输入管理员密码以打开设置、回收站、扫描、重建工具和其他仅限管理员的操作。",
+      "passwordLabel": "管理员密码",
+      "placeholder": "输入管理员密码",
+      "unlocking": "正在解锁...",
+      "unlock": "解锁管理员",
+      "unableToUnlock": "无法解锁管理员访问。"
+    }
+  },
+  "nav": {
+    "primary": "主导航",
+    "foldergramHome": "Foldergram 首页",
+    "home": "首页",
+    "reels": "短片",
+    "search": "搜索",
+    "library": "图库",
+    "places": "地点",
+    "collections": "收藏集",
+    "more": "更多",
+    "trash": "回收站",
+    "settings": "设置",
+    "unlockAdmin": "解锁管理员",
+    "switchAppearance": "切换外观",
+    "switchToDarkMode": "切换到深色模式",
+    "switchToLightMode": "切换到浅色模式",
+    "signOut": "退出登录",
+    "returnToPublicView": "返回公开视图",
+    "foldersSpotlight": "精选文件夹",
+    "likesAriaLabel": "{label} ({count})",
+    "folderPosts": "{count} 个帖子"
+  },
+  "settings": {
+    "eyebrow": "设置",
+    "title": "图库控制",
+    "description": "管理扫描、应用默认项、访问权限和图库索引。",
+    "sections": {
+      "navigation": "设置分区",
+      "library": {
+        "label": "扫描与图库",
+        "shortLabel": "扫描与图库",
+        "description": "索引媒体、重建缩略图并维护图库索引"
+      },
+      "general": {
+        "label": "常规设置",
+        "description": "Stories 模式、排除文件夹和动态流默认项"
+      },
+      "places": {
+        "label": "地点",
+        "description": "离线城市查找和地点分配"
+      },
+      "access": {
+        "label": "安全与访问",
+        "shortLabel": "安全与访问",
+        "description": "密码锁和查看角色"
+      },
+      "status": {
+        "label": "系统状态",
+        "description": "存储概览和扫描历史"
+      }
+    },
+    "places": {
+      "banner": {
+        "title": "基于照片 GPS 数据的地点",
+        "description": "按离线城市和位置标签对带 GPS 的照片进行分组。",
+        "helper": "准备本地 GeoNames 数据集，然后为图库中已有的照片重建地点分配。",
+        "setup": "设置地点",
+        "dismissAria": "关闭地点公告",
+        "availableLater": "下载是可选的，之后也可以继续在设置中的“地点”标签页里使用。"
+      },
+      "section": {
+        "title": "离线地点",
+        "description": "准备 GeoNames 城市数据，然后根据现有照片坐标重建地点链接。",
+        "prepared": "已准备",
+        "notPrepared": "未准备",
+        "datasetLabel": "数据集",
+        "rowsLabel": "行数",
+        "notImported": "未导入",
+        "importedAt": "已导入于 {value}。",
+        "fallbackDataset": "GeoNames cities500",
+        "prepareButton": "准备地理数据",
+        "preparingButton": "准备中...",
+        "rebuildButton": "重建地点分配",
+        "rebuildingButton": "重建中...",
+        "loadStatusError": "无法加载地点状态",
+        "actions": {
+          "ready": "离线地点数据已就绪。",
+          "prepareError": "无法准备离线地点数据。",
+          "rebuilt": "已为 {processed} 篇帖子中的 {assigned} 篇重建地点。",
+          "rebuildError": "无法重建地点分配。"
+        }
+      }
+    },
+    "general": {
+      "migration": {
+        "eyebrow": "Stories 迁移",
+        "title": "此图库可能已经在使用名为 stories 的文件夹",
+        "description": "Foldergram 现在默认可以将 stories/ 视为资料 stories 和精选内容。请选择保留旧版文件夹行为，或切换到新的保留 stories 模式，然后重新扫描图库。",
+        "dismissAria": "关闭 stories 迁移提示",
+        "useFeature": "使用 Stories 功能",
+        "keepLegacy": "保留旧版行为",
+        "helper": "先在这里选择模式，再在下方保存。随后运行一次图库扫描，让索引后的文件夹结构与之匹配。",
+        "helperSaving": "请先等待当前设置更新完成。"
+      },
+      "announcement": {
+        "title": "Stories",
+        "headline": "保留的 stories/ 文件夹可以驱动应用文件夹的 Stories",
+        "description": "将直接媒体放入 AppFolder/stories 作为头像 story 集合，并使用直接子文件夹作为精选圆圈。嵌套文件夹会保留在同一个精选胶囊中。",
+        "dismissAria": "关闭 stories 公告",
+        "showStructure": "查看目录结构",
+        "hideStructure": "隐藏目录结构"
+      },
+      "card": {
+        "title": "常规设置",
+        "description": "适用于 stories 文件夹、排除文件夹、首页、短片和应用文件夹的全局默认项。"
+      },
+      "language": {
+        "label": "应用语言",
+        "description": "选择此设备上用于导航、对话框和其他已翻译应用界面的语言。",
+        "helper": "会立即在当前浏览器中生效。缺失翻译时会回退到英文。",
+        "selectLabel": "应用语言",
+        "options": {
+          "en": "英语",
+          "es": "西班牙语",
+          "zh": "中文"
+        }
+      },
+      "homeFeed": {
+        "label": "首页动态流排序",
+        "description": "选择首页打开时显示的首个动态流模式。",
+        "closeMenuAria": "关闭首页动态流排序菜单",
+        "options": {
+          "random": {
+            "label": "随机",
+            "description": "稳定洗牌。"
+          },
+          "recent": {
+            "label": "最新",
+            "description": "最新内容优先。"
+          },
+          "rediscover": {
+            "label": "重新发现",
+            "description": "让较早的精选内容再次出现。"
+          }
+        }
+      },
+      "reelsFeed": {
+        "label": "短片动态流排序",
+        "description": "选择打开短片时使用的默认队列样式。",
+        "closeMenuAria": "关闭短片动态流排序菜单",
+        "options": {
+          "random": {
+            "label": "随机",
+            "description": "稳定的会话洗牌。"
+          },
+          "recent": {
+            "label": "最新",
+            "description": "最新视频优先。"
+          },
+          "recommended": {
+            "label": "推荐",
+            "description": "按偏好排序的混合队列。"
+          }
+        }
+      },
+      "folderOrder": {
+        "label": "应用文件夹照片顺序",
+        "description": "选择应用文件夹内照片的默认排序方式。",
+        "closeMenuAria": "关闭应用文件夹照片顺序菜单",
+        "options": {
+          "newest": {
+            "label": "最新优先",
+            "description": "较新的照片显示在前。"
+          },
+          "oldest": {
+            "label": "最旧优先",
+            "description": "较早的照片显示在前。"
+          }
+        }
+      },
+      "storiesMode": {
+        "label": "将 stories 文件夹视为普通应用文件夹",
+        "scanRequired": "需要扫描",
+        "explainAria": "解释 stories 文件夹设置",
+        "explainDescription": "关闭此选项时，AppFolder/stories 会成为头像 stories 和精选圆圈的来源。仅当名称恰好为 stories 的文件夹应继续在整个应用中表现为普通文件夹时，才应开启此选项。",
+        "toggleLabel": "切换 stories 文件夹行为",
+        "enabledDescription": "旧版模式已启用。stories 文件夹会继续在所有位置作为普通应用文件夹。",
+        "disabledDescription": "保留 stories 模式已启用。AppFolder/stories 会驱动头像 stories 和精选圆圈。"
+      },
+      "excludedFolders": {
+        "label": "排除的源文件夹",
+        "description": "按名称或图库根目录下的精确相对路径跳过匹配文件夹。隐藏路径和应用管理的存储仍会自动排除。",
+        "customRules": "自定义规则",
+        "envRulesLabel": "只读环境规则",
+        "envRulesDescription": "在 .env 或 Docker 中更改 GALLERY_EXCLUDED_FOLDERS 并重启应用，即可更新这些规则。",
+        "envRulesEmpty": "当前未配置任何环境变量支持的文件夹排除规则。",
+        "activeRulesLabel": "当前生效的已保存规则",
+        "activeRulesDescription": "这里会合并文本区域中保存的规则与所有环境变量支持的条目。新的文本区域编辑会在保存后显示在这里。",
+        "activeRulesEmpty": "当前没有生效的已保存或环境变量支持的文件夹排除规则。"
+      },
+      "actionNote": {
+        "loading": "正在加载当前应用偏好...",
+        "excludedAndOther": "将文件夹排除规则与其他全局更改一起保存。随后运行一次图库扫描，以便 stories 和排除文件夹正确重新索引。",
+        "excludedOnly": "这只会保存自定义排除文件夹。随后运行一次图库扫描，以便这些文件夹从索引中消失。",
+        "storiesAndDefaults": "将新的 stories 规则与更新后的浏览默认项一起保存。",
+        "storiesOnly": "这只会保存 stories 文件夹规则。随后运行一次图库扫描，以新行为重新建立索引。",
+        "multipleDefaults": "一起保存这些浏览默认项。首页访问者仍可在主页上切换模式；短片和应用文件夹使用应用默认项。",
+        "homeOnly": "这会更新此应用首页打开时显示的首个动态流模式。访问者仍可从主页切换模式。",
+        "reelsOnly": "这会更新此应用打开短片时使用的队列样式。访问者无法从短片页面切换模式。",
+        "folderOnly": "这会更新应用文件夹网格使用的默认照片顺序。",
+        "idle": "这些是当前适用于首页、短片、应用文件夹、stories 文件夹和排除文件夹的全局默认项。"
+      },
+      "rescanNotice": {
+        "excludedAndStories": "保存这些更改后，请先运行一次图库扫描，再期待 stories 文件夹和排除文件夹更新。",
+        "excludedOnly": "保存此更改后，请先运行一次图库扫描，再期待排除文件夹从索引中消失。",
+        "storiesOnly": "保存此更改后，请先运行一次图库扫描，再期待 stories 文件夹、头像 stories 或精选内容更新。"
+      },
+      "feedback": {
+        "settingsAndFolderRulesSaved": "设置已保存。请运行一次图库扫描以应用文件夹规则更改。",
+        "folderRulesAndStoriesSaved": "文件夹排除规则和 stories 文件夹行为已保存。请运行一次图库扫描以应用它们。",
+        "excludedFoldersSaved": "排除文件夹已保存。请运行一次图库扫描以应用它们。",
+        "settingsAndStoriesSaved": "设置已保存。请运行一次图库扫描以应用 stories 文件夹更改。",
+        "storiesSaved": "stories 文件夹行为已保存。请运行一次图库扫描以应用它。",
+        "defaultsSaved": "全局浏览默认项已更新。",
+        "homeSaved": "首页现在会以 {label} 打开。",
+        "reelsSaved": "短片现在会以 {label} 打开。",
+        "folderOrderSaved": "应用文件夹现在会以 {label} 打开。",
+        "parts": {
+          "excludedFolders": "排除文件夹",
+          "storiesFolderHandling": "stories 文件夹行为",
+          "homeFeedDefault": "首页动态默认项",
+          "reelsFeedDefault": "短片默认项",
+          "appFolderOrder": "应用文件夹顺序"
+        }
+      },
+      "errors": {
+        "validateExcludedFolders": "无法验证已排除文件夹规则。",
+        "update": "无法更新常规设置。",
+        "partialUpdate": "部分设置已保存（{parts}），但更新未能完成：{message}"
+      }
+    },
+    "library": {
+      "legacyMigration": {
+        "title": "旧版派生资源迁移待处理",
+        "messageOne": "{count} 条已索引媒体记录仍在使用旧的镜像缩略图和预览路径。运行“扫描图库”即可将其迁移到资源键存储。",
+        "messageOther": "{count} 条已索引媒体记录仍在使用旧的镜像缩略图和预览路径。运行“扫描图库”即可将它们迁移到资源键存储。"
+      },
+      "scanCard": {
+        "title": "扫描图库",
+        "description": "在添加文件夹后，或你想刷新已索引媒体时运行一次扫描。"
+      },
+      "statusLabel": {
+        "storageUnavailable": "存储不可用",
+        "scanInProgress": "扫描进行中",
+        "rebuildActive": "重建进行中",
+        "ready": "就绪"
+      },
+      "scanButton": {
+        "active": "正在扫描图库...",
+        "idle": "运行图库扫描"
+      },
+      "scanActionNote": {
+        "loading": "正在加载当前图库状态...",
+        "rebuildRequired": "由于图库位置已更改，请先重建图库索引。",
+        "otherTaskActive": "当前还有其他图库任务正在运行。实时进度会显示在置顶状态栏中。",
+        "progress": "实时进度会显示在置顶状态栏中。",
+        "legacyMigration": "运行“扫描图库”可将旧的镜像缩略图和预览图迁移到资源键存储布局。",
+        "idle": "扫描会检查新增、更新或缺失的媒体。"
+      },
+      "thumbnailCard": {
+        "title": "重新生成缩略图",
+        "description": "仅从已索引媒体重建动态流和资料缩略图以及视频封面。原始文件不会受到影响。"
+      },
+      "thumbnailButton": {
+        "active": "正在重新生成...",
+        "idle": "重新生成缩略图"
+      },
+      "thumbnailActionNote": {
+        "loading": "正在加载当前图库状态...",
+        "rebuildRequired": "在为新的图库位置重建索引之前，此操作不可用。",
+        "progress": "实时进度会显示在置顶状态栏中。",
+        "rebuildActive": "请先等待完整重建完成。",
+        "scanActive": "请先等待当前扫描完成。",
+        "legacyMigration": "此操作会保留当前缩略图路径，不会迁移旧的镜像衍生资源。请改为运行“扫描图库”以将其迁移到资源键存储。",
+        "idle": "需要更快的纯缩略图刷新时可使用此操作。"
+      },
+      "dangerZone": {
+        "title": "危险区域",
+        "recommended": "推荐",
+        "rebuildTitle": "重建图库索引",
+        "rebuildDescription": "重置图库索引，复用可匹配的缓存媒体，并仅从当前图库根目录生成缺失的衍生资源。",
+        "currentGalleryRoot": "当前图库根目录",
+        "previousGalleryRoot": "上一个图库根目录"
+      },
+      "rebuildButton": {
+        "active": "正在重建...",
+        "idle": "重建图库索引"
+      },
+      "rebuildActionNote": {
+        "loading": "正在加载当前图库状态...",
+        "progress": "实时进度会显示在置顶状态栏中。",
+        "thumbnailActive": "请先等待缩略图重新生成完成。",
+        "scanActive": "请先等待当前扫描完成。",
+        "rebuildRequired": "由于图库位置已更改，建议执行此操作。",
+        "idle": "使用此操作可以重置索引，并复用上一个图库索引中仍可匹配的衍生资源。"
+      },
+      "dialogs": {
+        "rebuildTitle": "要重建当前图库索引吗？",
+        "rebuildMessage": "此操作会清空文件夹、帖子、喜欢和扫描历史等已索引数据库表，然后重新扫描当前启用的图库根目录。若之前索引中的缩略图和预览仍与当前文件匹配，则会继续复用，并只生成缺失或已更改的衍生资源。图库中的原始文件不会被删除。",
+        "rebuildConfirm": "重建图库索引",
+        "rebuildLoading": "重建中...",
+        "thumbnailsTitle": "只重新生成缩略图？",
+        "thumbnailsMessage": "此操作会删除已生成的动态流和资料缩略图以及视频封面图，然后根据当前索引图库中每个项目的现有缩略图路径重新生成。预览图、喜欢、扫描历史和已索引图库记录都不会改变。图库中的原始文件不会被删除。",
+        "thumbnailsConfirm": "重新生成缩略图",
+        "thumbnailsLoading": "重新生成中..."
+      },
+      "errors": {
+        "startScan": "无法启动图库扫描。",
+        "rebuild": "无法重建当前图库索引。",
+        "regenerate": "无法重新生成缩略图。"
+      }
+    },
+    "notices": {
+      "scanError": {
+        "eyebrow": "扫描需要注意",
+        "title": "上一次扫描已完成，但包含错误",
+        "fullReportPrefix": "完整报告：",
+        "dismissAria": "关闭扫描警告",
+        "actionNote": "重新运行一次图库扫描，以重试失败的媒体并补齐缺失的缩略图或预览图。",
+        "messages": {
+          "genericNoDetails": "上一次运行期间有部分媒体处理失败。请再次扫描图库，以重试遗漏的文件和衍生资源生成。",
+          "ffmpegMissing": "服务器环境缺少视频处理工具。请安装 FFmpeg，这样扫描才能读取视频元数据并生成视频衍生资源。",
+          "withReport": "上一次运行期间有部分媒体处理失败。请查看下面的示例错误和完整报告路径，然后再次扫描图库，以重试失败的媒体和衍生资源生成。",
+          "withSample": "上一次运行期间有部分媒体处理失败。请查看下面的示例错误，然后再次扫描图库，以重试遗漏的文件和衍生资源生成。"
+        },
+        "detailMore": "{line}（另有 {count} 条）"
+      },
+      "ignoredRootMedia": {
+        "dismissAria": "关闭图库根目录警告",
+        "messageOne": "图库根目录中有 {count} 个受支持文件被忽略。请把它移到图库根目录下的某个文件夹中，以创建应用文件夹。直接放在图库根目录中的文件会被忽略。",
+        "messageOther": "图库根目录中有 {count} 个受支持文件被忽略。请把它们移到图库根目录下的某个文件夹中，以创建应用文件夹。直接放在图库根目录中的文件会被忽略。"
+      }
+    },
+    "access": {
+      "section": {
+        "title": "管理员与访客访问",
+        "description": "使用管理员密码保护管理操作，并可选择为仅浏览会话单独提供访客密码。",
+        "locked": "管理员已锁定",
+        "open": "开放访问"
+      },
+      "fields": {
+        "adminPassword": "管理员密码",
+        "confirmPassword": "确认密码",
+        "currentPassword": "当前密码",
+        "newPassword": "新密码",
+        "confirmNewPassword": "确认新密码",
+        "viewerPassword": "访客密码",
+        "confirmViewerPassword": "确认访客密码"
+      },
+      "placeholders": {
+        "minimumLength": "至少 {count} 个字符",
+        "repeatPassword": "再次输入密码",
+        "enterNewViewerPassword": "输入新的访客密码",
+        "repeatNewViewerPassword": "再次输入新的访客密码",
+        "repeatViewerPassword": "再次输入访客密码"
+      },
+      "enable": {
+        "description": "管理员密码会以单向哈希方式保存，并通过签名会话 Cookie 解锁当前浏览器。",
+        "buttonLoading": "启用中...",
+        "buttonIdle": "启用管理员密码",
+        "success": "此 Foldergram 实例现已启用管理员密码。",
+        "error": "无法启用管理员密码。"
+      },
+      "change": {
+        "title": "更改管理员密码",
+        "description": "更新管理员密码并使旧会话失效。",
+        "showForm": "更改密码",
+        "hideForm": "隐藏表单",
+        "helper": "请至少使用 8 个字符。更改密码会使旧会话退出登录。",
+        "buttonLoading": "更新中...",
+        "buttonIdle": "更改管理员密码",
+        "missingCurrent": "请输入当前密码以继续更改。",
+        "success": "管理员密码已更新，现有会话已失效。",
+        "error": "无法更改管理员密码。"
+      },
+      "viewer": {
+        "title": "访客访问",
+        "description": "为访客会话提供仅浏览密码，或将图库开放为匿名公共浏览。",
+        "modes": {
+          "adminOnlyTitle": "仅管理员",
+          "adminOnlyDescription": "只有管理员密码可以解锁应用。",
+          "viewerPasswordTitle": "访客密码",
+          "viewerPasswordDescription": "允许使用单独的访客登录浏览，并使用共享喜欢功能，但不会显示管理员控制项。",
+          "publicTitle": "公开",
+          "publicDescription": "允许匿名浏览，并使用浏览器本地收藏，同时仍可从“更多”中使用管理员解锁。"
+        },
+        "status": {
+          "adminPasswordOff": "管理员密码已关闭",
+          "viewerPasswordOn": "访客密码已开启",
+          "publicViewerOn": "公开访客已开启",
+          "adminOnly": "仅管理员"
+        },
+        "summary": {
+          "enableAdminFirst": "请先启用管理员密码",
+          "viewerPasswordEnabled": "访客密码访问已开启",
+          "publicEnabled": "公开访客访问已开启",
+          "off": "访客访问当前已关闭"
+        },
+        "summaryCopy": {
+          "enableAdminFirst": "启用管理员密码后，访客访问设置才会可用。",
+          "viewerPasswordEnabled": "访客可以使用单独的访客密码登录、使用共享喜欢功能，并且在没有管理员控制项的情况下浏览。若要替换该密码，请在下方输入新密码。不需要当前访客密码。",
+          "publicEnabled": "任何能访问这个 Foldergram 的人都可以无需登录直接浏览。收藏仅保存在当前浏览器中，管理员仍可通过“更多”中的管理员密码提权。",
+          "off": "当前只有管理员密码可以解锁应用。如果你希望提供仅浏览登录，请在下方开启访客密码模式。"
+        },
+        "helper": {
+          "viewerPasswordRotate": "在下方输入新的访客密码即可轮换，不需要当前访客密码。",
+          "viewerPasswordNew": "访客登录可以使用共享喜欢，但无法访问设置、回收站或任何破坏性操作。",
+          "public": "匿名访客可以立即浏览、使用浏览器本地收藏，并在需要时从“更多”中解锁管理员访问。",
+          "disableFromPassword": "保存后将关闭访客登录，并恢复为仅管理员访问。",
+          "disableFromPublic": "保存后将关闭公开浏览，并恢复为仅管理员访问。",
+          "off": "访客访问当前已关闭，因此只有管理员密码可以解锁应用。"
+        },
+        "buttons": {
+          "updateViewerPassword": "更新访客密码",
+          "enableViewerAccess": "启用访客访问",
+          "savePublicAccess": "保存公开访问",
+          "enablePublicAccess": "启用公开访问",
+          "disableViewerAccess": "关闭访客访问",
+          "saveViewerAccess": "保存访客访问"
+        },
+        "success": {
+          "password": "访客密码访问已启用，访客密码已保存。",
+          "public": "公开访客访问已启用。匿名访客现在可以使用浏览器本地收藏进行浏览。",
+          "off": "访客访问已关闭。现在只允许管理员登录。"
+        },
+        "error": "无法更新访客访问。"
+      },
+      "danger": {
+        "title": "危险区域",
+        "disableTitle": "关闭管理员密码",
+        "disableDescription": "为这个 Foldergram 实例重新关闭管理员密码。",
+        "showForm": "关闭访问",
+        "hideForm": "隐藏表单",
+        "buttonLoading": "关闭中...",
+        "buttonIdle": "关闭管理员密码",
+        "signOut": "退出登录",
+        "signOutError": "无法退出登录。",
+        "missingCurrent": "请输入当前密码以关闭保护。",
+        "success": "管理员密码已关闭。",
+        "error": "无法关闭管理员密码。"
+      },
+      "authProtection": {
+        "enabled": "当前浏览器会话已启用管理员保护。你可以使用下方控件轮换管理员密码、配置访客访问、退出登录，或再次关闭保护。",
+        "disabled": "当前保护已关闭。任何能在你的网络中访问此应用的人，在你启用管理员密码之前都可以完整浏览图库。"
+      },
+      "validation": {
+        "minLength": "密码至少需要 {count} 个字符。",
+        "empty": "密码不能为空。",
+        "mismatch": "两次输入的密码不一致。"
+      }
+    },
+    "status": {
+      "never": "从未",
+      "storage": {
+        "available": "可用",
+        "unavailable": "不可用"
+      },
+      "libraryStatus": {
+        "title": "图库状态",
+        "description": "当前存储与索引状态。",
+        "storage": "存储",
+        "folders": "文件夹",
+        "indexedPosts": "已索引帖子",
+        "indexedVideos": "已索引视频"
+      },
+      "lastScan": {
+        "title": "上次扫描",
+        "description": "应用记录的最近一次已完成运行。",
+        "status": "状态",
+        "finished": "完成时间",
+        "filesScanned": "已扫描文件",
+        "changes": "变更",
+        "statusValues": {
+          "none": "还没有已完成的扫描",
+          "completed": "已完成",
+          "completedWithErrors": "已完成但有错误",
+          "failed": "失败",
+          "running": "进行中"
+        },
+        "changeValues": {
+          "new": "新增",
+          "updated": "已更新",
+          "removed": "已移除"
+        }
+      }
+    }
+  },
+  "home": {
+    "sidebar": {
+      "ariaLabel": "文件夹推荐",
+      "suggestedFolders": "推荐文件夹",
+      "viewLikes": "查看赞过",
+      "viewFavorites": "查看收藏",
+      "openFolder": "打开",
+      "openSourceText": "Foldergram 是开源的。",
+      "viewOnGitHub": "在 GitHub 上查看"
+    }
+  },
+  "likes": {
+    "labels": {
+      "sharedCollection": "赞过",
+      "localCollection": "收藏",
+      "sharedSection": "已赞帖子",
+      "localSection": "收藏帖子"
+    },
+    "view": {
+      "rebuilding": "正在重建图库索引。刷新后的图库加载完成后，{label} 会重新出现。",
+      "sectionsAria": "{label} 分区"
+    },
+    "states": {
+      "sharedEmptyTitle": "还没有赞过的帖子",
+      "localEmptyTitle": "还没有收藏内容",
+      "sharedEmptyDescription": "点按任意帖子下方的心形，它就会出现在这里。",
+      "localEmptyDescription": "点按任意帖子下方的心形，它就会出现在此浏览器中的这里。",
+      "sharedLoadingLabel": "正在加载赞过内容...",
+      "localLoadingLabel": "正在加载收藏...",
+      "sharedErrorTitle": "无法加载赞过内容",
+      "localErrorTitle": "无法加载收藏"
+    },
+    "actions": {
+      "likePost": "点赞帖子",
+      "unlikePost": "取消点赞",
+      "favoritePost": "收藏帖子",
+      "removeFavoriteFromPost": "取消收藏帖子"
+    },
+    "errors": {
+      "loadShared": "无法加载赞过内容",
+      "loadLocal": "无法加载收藏",
+      "updateShared": "无法更新赞过内容",
+      "updateLocal": "无法更新收藏"
+    }
+  },
+  "moments": {
+    "rails": {
+      "moments": {
+        "title": "时刻",
+        "description": "根据图库中真实拍摄日期整理出的回忆胶囊。",
+        "singularLabel": "时刻"
+      },
+      "highlights": {
+        "title": "故事",
+        "description": "当拍摄日期稀少或是合成日期时，从图库中整理出的故事风格合集。",
+        "singularLabel": "故事"
+      }
+    },
+    "capsules": {
+      "onThisDay": {
+        "title": "历史上的今天",
+        "subtitle": "{date} 在往年此日"
+      },
+      "thisWeekPreviousYears": {
+        "title": "本周回顾",
+        "subtitle": "{range} 的往年回顾"
+      },
+      "fromLastYear": {
+        "title": "去年此时",
+        "subtitle": "重温 {monthYear}"
+      },
+      "highlightRecentBatches": {
+        "title": "近期批次",
+        "subtitle": "将最近几次拍摄合并为一个合集",
+        "dateContextOne": "{count} 个批次",
+        "dateContextOther": "{count} 个批次"
+      },
+      "highlightForgottenFavorites": {
+        "title": "被遗忘的最爱",
+        "subtitle": "值得再看一眼的旧赞帖子",
+        "dateContext": "已点赞且早于 6 个月"
+      },
+      "highlightDeepCuts": {
+        "title": "旧藏精选",
+        "subtitle": "从档案中重新浮现的旧帖子",
+        "dateContext": "早于 6 个月"
+      },
+      "highlightLuckyDip": {
+        "title": "随机惊喜",
+        "subtitle": "来自整个图库的轻松混合",
+        "dateContext": "今天内保持稳定"
+      }
+    },
+    "view": {
+      "rebuilding": "正在重建图库索引。刷新后的首页故事栏准备好后，此视图会重新填充。",
+      "loading": "正在加载{label}...",
+      "loadError": "无法加载{label}",
+      "emptyTitle": "这个{label}是空的",
+      "emptyDescription": "请从首页尝试另一个{label}。",
+      "postCount": "{count} 个帖子"
+    }
+  },
+  "folder": {
+    "shared": {
+      "topLevelSourceFolder": "顶层源文件夹"
+    },
+    "header": {
+      "openStories": "打开文件夹 stories",
+      "openAvatar": "打开文件夹头像",
+      "editButton": "编辑应用文件夹",
+      "posts": "{count} 个帖子",
+      "reels": "{count} 条短片",
+      "updated": "{date} 已更新",
+      "libraryPath": "图库路径",
+      "expandDescription": "展开描述",
+      "collapseDescription": "收起描述",
+      "errors": {
+        "updateProfile": "更新资料失败"
+      }
+    },
+    "profileModal": {
+      "title": "编辑应用文件夹",
+      "namePlaceholder": "文件夹显示名称",
+      "descriptionPlaceholder": "为此文件夹添加描述...",
+      "errors": {
+        "nameRequired": "名称为必填项。"
+      }
+    },
+    "tabs": {
+      "posts": "帖子",
+      "reels": "短片",
+      "sections": "文件夹分区"
+    }
+  },
+  "reels": {
+    "view": {
+      "libraryUnavailableTitle": "图库存储不可用",
+      "loadErrorTitle": "无法加载短片",
+      "loadingTitle": "正在加载短片",
+      "loadingDescription": "正在从已索引的图库中整理仅包含视频的队列。",
+      "emptyTitle": "暂无可用短片",
+      "emptyDescription": "将已索引的视频添加到图库后，它们会在下一次扫描后出现在这里。",
+      "navigationAria": "短片导航",
+      "previous": "上一条短片",
+      "next": "下一条短片"
+    },
+    "rail": {
+      "hideDetails": "隐藏短片详情",
+      "showDetails": "显示短片详情",
+      "downloadOriginal": "下载原始文件",
+      "openFolder": "打开文件夹"
+    },
+    "info": {
+      "ariaLabel": "短片详情",
+      "eyebrow": "短片详情",
+      "hideDetails": "隐藏短片详情",
+      "openFolder": "打开文件夹",
+      "topLevelSourceFolder": "顶级源文件夹",
+      "unavailable": "不可用",
+      "video": "视频",
+      "loadError": "无法加载短片详情。",
+      "resolution": "分辨率",
+      "length": "时长",
+      "size": "大小",
+      "format": "格式",
+      "loading": "正在加载短片详情...",
+      "folderPath": "文件夹路径",
+      "mimeType": "MIME 类型"
+    }
+  },
+  "post": {
+    "captionModal": {
+      "title": "编辑说明",
+      "captionLabel": "说明",
+      "placeholder": "写点说明...",
+      "resetToFilename": "重置为文件名",
+      "errors": {
+        "update": "无法更新说明"
+      }
+    },
+    "viewer": {
+      "close": "关闭帖子",
+      "previous": "上一条帖子",
+      "next": "下一条帖子",
+      "showDetails": "显示帖子详情",
+      "hideDetails": "隐藏帖子详情",
+      "togglePlayback": "切换播放",
+      "toggleSound": "切换声音",
+      "toggleFullscreen": "切换全屏",
+      "switchToPreviewQuality": "切换到预览画质",
+      "switchToHdOriginal": "切换到高清原片",
+      "previewQuality": "预览画质",
+      "hdOriginal": "高清原片",
+      "openFolder": "打开文件夹",
+      "editCaption": "编辑说明",
+      "folderPath": "文件夹路径",
+      "stats": {
+        "dimensions": "尺寸",
+        "type": "类型",
+        "duration": "时长",
+        "size": "大小",
+        "place": "地点"
+      },
+      "metadata": {
+        "location": "位置",
+        "camera": "相机",
+        "lens": "镜头",
+        "aperture": "光圈",
+        "shutter": "快门",
+        "iso": "ISO",
+        "focalLength": "焦距"
+      },
+      "videoType": "视频（{mimeType}）",
+      "setAsCover": "设为文件夹封面",
+      "downloadOriginalFile": "下载原始文件",
+      "openOriginalFile": "打开原始文件",
+      "deletePost": "删除帖子"
+    },
+    "feedCard": {
+      "openStories": "打开 {name} 的动态",
+      "openFolderAvatar": "打开 {name}",
+      "openReel": "打开短片",
+      "openPost": "打开帖子",
+      "moreOptions": "更多选项",
+      "delete": {
+        "title": "删除这条帖子？",
+        "messagePermanent": "这会从应用中永久删除这条帖子，并从磁盘移除原始媒体文件。",
+        "messageTrash": "这会从应用中删除这条帖子并将其移入回收站。除非你选择永久删除，否则原始文件仍会保留在磁盘上。",
+        "confirmPermanent": "永久删除",
+        "confirm": "删除",
+        "deleteOriginalLabel": "同时从磁盘永久删除原始文件",
+        "deleteOriginalDescription": "保持未勾选可将帖子移入回收站，同时保留磁盘上的源文件。",
+        "deleteOriginalWarning": "这会从磁盘永久删除原始文件、缩略图和预览图。此操作无法撤销。"
+      }
+    }
+  },
+  "collections": {
+    "shared": {
+      "defaultName": "全部帖子",
+      "postCountOne": "{count} 篇帖子",
+      "postCountOther": "{count} 篇帖子"
+    },
+    "bookmark": {
+      "dialogLabel": "合集",
+      "title": "合集",
+      "createCollection": "创建合集",
+      "namePlaceholder": "合集名称",
+      "empty": "还没有合集",
+      "savePost": "收藏帖子",
+      "removeSavedPost": "取消收藏帖子",
+      "errors": {
+        "loadCollections": "无法加载合集"
+      }
+    },
+    "list": {
+      "libraryUnavailableTitle": "图库存储不可用",
+      "loadErrorTitle": "无法加载合集",
+      "loading": "正在加载合集...",
+      "emptyTitle": "还没有合集",
+      "emptyDescription": "已保存的帖子会显示在“全部帖子”中。"
+    },
+    "detail": {
+      "fallbackTitle": "合集",
+      "libraryUnavailableTitle": "图库存储不可用",
+      "loadErrorTitle": "无法加载合集",
+      "back": "合集",
+      "options": "合集选项",
+      "actionsLabel": "合集操作",
+      "emptyTitle": "{name}为空",
+      "emptyDescriptionDefault": "在任意帖子下方使用收藏操作即可把它保存到这里。",
+      "emptyDescriptionCustom": "分配到此合集的已收藏帖子会显示在这里。",
+      "loading": "正在加载合集...",
+      "menu": {
+        "delete": "删除合集",
+        "edit": "编辑合集",
+        "cancel": "取消"
+      },
+      "edit": {
+        "title": "编辑合集",
+        "saving": "保存中...",
+        "done": "完成",
+        "required": "合集名称为必填项。",
+        "createError": "无法创建合集",
+        "updateError": "无法更新合集"
+      },
+      "delete": {
+        "title": "删除此合集？",
+        "message": "删除此合集后，照片和视频仍会保留为已保存状态。",
+        "deleting": "删除中...",
+        "confirm": "删除",
+        "cancel": "取消",
+        "error": "无法删除合集"
+      }
+    }
+  },
+  "placesPage": {
+    "eyebrow": "地点",
+    "title": "全部地点",
+    "description": "浏览根据离线位置数据分组的帖子。",
+    "stats": {
+      "places": "地点",
+      "posts": "帖子"
+    },
+    "errors": {
+      "load": "无法加载地点"
+    },
+    "searchPlaceholder": "搜索名称、地区或坐标...",
+    "sort": {
+      "postsDesc": "帖子最多",
+      "nameAsc": "名称 A-Z",
+      "nameDesc": "名称 Z-A",
+      "countryAsc": "国家 A-Z"
+    },
+    "resultsOne": "{count} 个结果",
+    "resultsOther": "{count} 个结果",
+    "loading": "正在加载地点...",
+    "emptyTitle": "还没有已索引的地点",
+    "emptyDescription": "先在设置中准备离线地点数据并重建分配，然后即可按位置对帖子分组。",
+    "noMatch": "没有匹配的地点。请尝试其他搜索词或排序。",
+    "metadataFallback": "离线城市级地点",
+    "postCountOne": "{count} 篇帖子",
+    "postCountOther": "{count} 篇帖子",
+    "kinds": {
+      "manual": "手动地点",
+      "nearestCity": "最近城市",
+      "cityMatch": "城市匹配"
+    },
+    "readiness": {
+      "ready": "就绪",
+      "empty": "空"
+    }
+  },
+  "placePage": {
+    "errors": {
+      "load": "无法加载地点"
+    },
+    "badge": "离线地点",
+    "coordinatesLabel": "坐标",
+    "sourceLabel": "来源",
+    "approximateBadge": "近似城市匹配",
+    "emptyTitle": "此地点没有帖子",
+    "emptyDescription": "准备好离线地点数据后，可以在设置中重建地点分配。",
+    "metadataFallback": "离线城市级地点",
+    "heroApproximate": "根据已存储的照片 GPS 坐标分组，并匹配到最近城市，以便离线浏览。",
+    "heroExact": "根据已存储的照片 GPS 坐标解析，并保持离线可用。",
+    "postCountOne": "帖子",
+    "postCountOther": "帖子",
+    "kind": {
+      "offline": "离线",
+      "manual": "手动",
+      "nearestCity": "最近城市",
+      "city": "城市",
+      "place": "地点",
+      "match": "匹配"
+    }
+  },
+  "libraryPage": {
+    "eyebrow": "图库",
+    "title": "全部文件夹",
+    "description": "浏览并搜索所有已索引的应用文件夹。",
+    "stats": {
+      "folders": "文件夹",
+      "posts": "帖子"
+    },
+    "errors": {
+      "load": "无法加载文件夹"
+    },
+    "searchPlaceholder": "搜索名称或路径片段...",
+    "sort": {
+      "recentDesc": "最近更新",
+      "imagesDesc": "帖子最多",
+      "nameAsc": "名称 A-Z",
+      "nameDesc": "名称 Z-A",
+      "pathAsc": "路径 A-Z"
+    },
+    "resultsOne": "{count} 个结果",
+    "resultsOther": "{count} 个结果",
+    "loading": "正在加载文件夹...",
+    "emptyTitle": "还没有已索引的文件夹",
+    "emptyDescription": "在图库根目录下添加包含媒体的源文件夹，然后运行一次扫描。",
+    "noMatch": "没有匹配的文件夹。请尝试其他搜索或筛选。",
+    "topLevelSourceFolder": "顶级源文件夹",
+    "postsCountOne": "{count} 篇帖子",
+    "postsCountOther": "{count} 篇帖子",
+    "reelsCountOne": "{count} 条短片",
+    "reelsCountOther": "{count} 条短片",
+    "readiness": {
+      "ready": "就绪",
+      "empty": "空"
+    },
+    "moreOptions": "更多选项",
+    "openFolder": "打开文件夹",
+    "deleteFolder": "删除文件夹",
+    "noRecentMedia": "没有最近媒体",
+    "delete": {
+      "title": "删除此应用文件夹？",
+      "sourceTooTitle": "同时删除源文件夹",
+      "sourceTooNoChildren": "除了删除该文件夹的直接帖子外，也一并删除源文件夹本身。",
+      "sourceTooWithChildrenOne": "同时删除 {count} 个子应用文件夹及其子树中的所有文件。",
+      "sourceTooWithChildrenOther": "同时删除 {count} 个子应用文件夹及其子树中的所有文件。",
+      "warning": "这样做会永久删除所选源文件夹及其内部的所有子文件夹和文件，包括不受支持的文件。此操作无法撤销。",
+      "directPostsOne": "{count} 个直接帖子",
+      "directPostsOther": "{count} 个直接帖子",
+      "childFoldersOne": "{count} 个子应用文件夹",
+      "childFoldersOther": "{count} 个子应用文件夹",
+      "messageDeleteSource": "这会永久删除 {directPosts}，并从硬盘中移除此源文件夹。",
+      "messageKeepChildren": "这会永久删除 {directPosts}。{childFolders} 会被保留。",
+      "messageEmptyFolder": "这会永久删除 {directPosts}。仅当源文件夹变为空时，它本身才会被移除。",
+      "confirmSubtree": "删除文件夹子树",
+      "confirmFolder": "删除应用文件夹",
+      "loadingSubtree": "正在删除子树...",
+      "loadingFolder": "正在删除...",
+      "error": "无法删除此应用文件夹。"
+    }
+  },
+  "explore": {
+    "back": "返回探索帖子",
+    "searchPlaceholder": "搜索",
+    "clearSearch": "清除搜索",
+    "recentTitle": "最近",
+    "clearAll": "清除全部",
+    "tabsAria": "搜索结果标签页",
+    "tabs": {
+      "media": "照片和视频",
+      "folders": "应用文件夹"
+    },
+    "errors": {
+      "search": "无法搜索帖子",
+      "load": "无法加载探索页"
+    },
+    "emptySearchTitle": "没有匹配的照片或视频",
+    "emptySearchDescription": "请尝试其他文件名或文件夹关键词。",
+    "loadingFolders": "正在加载文件夹...",
+    "noFoldersFound": "未找到应用文件夹。",
+    "emptyTitle": "暂时没有可探索内容",
+    "emptyDescription": "先为几个文件夹建立索引，这个页面就会开始在这里展示帖子。",
+    "folderPostsOne": "{count} 篇帖子",
+    "folderPostsOther": "{count} 篇帖子"
+  }
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -2,6 +2,7 @@ import { createApp } from 'vue';
 
 import App from './App.vue';
 import { AUTH_REQUIRED_EVENT } from './api/http';
+import { i18n } from './locales';
 import { canAccessRoute, router } from './router';
 import { useAppStore } from './stores/app';
 import { useAuthStore } from './stores/auth';
@@ -47,11 +48,13 @@ async function bootstrap() {
   const app = createApp(App);
 
   app.use(pinia);
+  app.use(i18n);
   app.use(router);
 
   const appStore = useAppStore(pinia);
   const authStore = useAuthStore(pinia);
 
+  appStore.initializeLocale();
   appStore.initializeTheme();
 
   if (typeof appStore.initializeVideoMuted === 'function') {

--- a/client/src/stores/app.test.ts
+++ b/client/src/stores/app.test.ts
@@ -1,0 +1,85 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { DEFAULT_LOCALE, i18n } from '../locales';
+import { useAppStore } from './app';
+
+function setNavigatorLocales(locales: string[], language = locales[0] ?? 'en-US') {
+  Object.defineProperty(window.navigator, 'languages', {
+    configurable: true,
+    value: locales
+  });
+
+  Object.defineProperty(window.navigator, 'language', {
+    configurable: true,
+    value: language
+  });
+}
+
+describe('useAppStore locale preferences', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    window.localStorage.clear();
+    setNavigatorLocales(['en-US']);
+    document.documentElement.lang = '';
+    i18n.global.locale.value = DEFAULT_LOCALE;
+  });
+
+  it('initializes locale from localStorage before browser preferences', () => {
+    window.localStorage.setItem('foldergram-locale', 'en');
+    setNavigatorLocales(['fr-FR'], 'fr-FR');
+
+    const store = useAppStore();
+    store.initializeLocale();
+
+    expect(store.locale).toBe('en');
+    expect(i18n.global.locale.value).toBe('en');
+    expect(document.documentElement.lang).toBe('en');
+  });
+
+  it('falls back to English when stored and browser locales are unsupported', () => {
+    window.localStorage.setItem('foldergram-locale', 'fr');
+    setNavigatorLocales(['de-DE'], 'de-DE');
+
+    const store = useAppStore();
+    store.initializeLocale();
+
+    expect(store.locale).toBe(DEFAULT_LOCALE);
+    expect(i18n.global.locale.value).toBe(DEFAULT_LOCALE);
+    expect(document.documentElement.lang).toBe(DEFAULT_LOCALE);
+  });
+
+  it('uses a supported browser locale when no saved locale exists', () => {
+    setNavigatorLocales(['es-ES'], 'es-ES');
+
+    const store = useAppStore();
+    store.initializeLocale();
+
+    expect(store.locale).toBe('es');
+    expect(i18n.global.locale.value).toBe('es');
+    expect(document.documentElement.lang).toBe('es');
+    expect(window.localStorage.getItem('foldergram-locale')).toBe('es');
+  });
+
+  it('normalizes Chinese browser locales to zh', () => {
+    setNavigatorLocales(['zh-CN'], 'zh-CN');
+
+    const store = useAppStore();
+    store.initializeLocale();
+
+    expect(store.locale).toBe('zh');
+    expect(i18n.global.locale.value).toBe('zh');
+    expect(document.documentElement.lang).toBe('zh');
+    expect(window.localStorage.getItem('foldergram-locale')).toBe('zh');
+  });
+
+  it('normalizes region locales before persisting them', () => {
+    const store = useAppStore();
+    store.setLocale('zh-TW');
+
+    expect(store.locale).toBe('zh');
+    expect(i18n.global.locale.value).toBe('zh');
+    expect(document.documentElement.lang).toBe('zh');
+    expect(window.localStorage.getItem('foldergram-locale')).toBe('zh');
+  });
+});

--- a/client/src/stores/app.test.ts
+++ b/client/src/stores/app.test.ts
@@ -1,8 +1,28 @@
 import { createPinia, setActivePinia } from 'pinia';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DEFAULT_LOCALE, i18n } from '../locales';
+import type { AppStatus } from '../types/api';
 import { useAppStore } from './app';
+
+const {
+  fetchAdminScanProgressMock,
+  fetchAdminStatsMock,
+  fetchScanProgressMock,
+  fetchStatusMock
+} = vi.hoisted(() => ({
+  fetchAdminScanProgressMock: vi.fn(),
+  fetchAdminStatsMock: vi.fn(),
+  fetchScanProgressMock: vi.fn(),
+  fetchStatusMock: vi.fn()
+}));
+
+vi.mock('../api/gallery', () => ({
+  fetchAdminScanProgress: fetchAdminScanProgressMock,
+  fetchAdminStats: fetchAdminStatsMock,
+  fetchScanProgress: fetchScanProgressMock,
+  fetchStats: fetchStatusMock
+}));
 
 function setNavigatorLocales(locales: string[], language = locales[0] ?? 'en-US') {
   Object.defineProperty(window.navigator, 'languages', {
@@ -16,6 +36,60 @@ function setNavigatorLocales(locales: string[], language = locales[0] ?? 'en-US'
   });
 }
 
+function createAppStatus(defaultLocale: AppStatus['preferences']['defaultLocale'] = null): AppStatus {
+  return {
+    folders: 3,
+    indexedImages: 18,
+    indexedVideos: 6,
+    scan: {
+      isScanning: false,
+      scanReason: null,
+      phase: 'idle',
+      startedAt: null,
+      runId: null,
+      migrationTotalRows: 0,
+      processedMigrationRows: 0,
+      migratedDerivativeFiles: 0,
+      missingDerivativeFiles: 0,
+      repairedDerivativeFiles: 0,
+      backfilledAssetKeys: 0,
+      discoveredFolders: 0,
+      processedFolders: 0,
+      discoveredImages: 0,
+      processedImages: 0,
+      queuedDerivativeJobs: 0,
+      processedDerivativeJobs: 0,
+      generatedThumbnails: 0,
+      generatedPreviews: 0,
+      currentOperation: null,
+      currentFile: null,
+      currentPhaseMessage: null,
+      currentFolder: null,
+      lastCompletedScan: null
+    },
+    storage: {
+      available: true,
+      reason: null
+    },
+    libraryIndex: {
+      rebuildRequired: false,
+      reason: null,
+      ignoredRootMediaCount: 0
+    },
+    preferences: {
+      defaultLocale,
+      defaultHomeFeedMode: 'random',
+      defaultReelsFeedMode: 'random',
+      defaultFolderImageOrder: 'newest',
+      treatStoriesAsFolders: false
+    },
+    storiesMigration: {
+      hasLegacyStoriesCandidates: false,
+      decisionPending: false
+    }
+  };
+}
+
 describe('useAppStore locale preferences', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
@@ -23,6 +97,10 @@ describe('useAppStore locale preferences', () => {
     setNavigatorLocales(['en-US']);
     document.documentElement.lang = '';
     i18n.global.locale.value = DEFAULT_LOCALE;
+    fetchAdminScanProgressMock.mockReset();
+    fetchAdminStatsMock.mockReset();
+    fetchScanProgressMock.mockReset();
+    fetchStatusMock.mockReset();
   });
 
   it('initializes locale from localStorage before browser preferences', () => {
@@ -37,6 +115,18 @@ describe('useAppStore locale preferences', () => {
     expect(document.documentElement.lang).toBe('en');
   });
 
+  it('normalizes stored region locales on startup', () => {
+    window.localStorage.setItem('foldergram-locale', 'zh-TW');
+
+    const store = useAppStore();
+    store.initializeLocale();
+
+    expect(store.locale).toBe('zh');
+    expect(i18n.global.locale.value).toBe('zh');
+    expect(document.documentElement.lang).toBe('zh');
+    expect(window.localStorage.getItem('foldergram-locale')).toBe('zh');
+  });
+
   it('falls back to English when stored and browser locales are unsupported', () => {
     window.localStorage.setItem('foldergram-locale', 'fr');
     setNavigatorLocales(['de-DE'], 'de-DE');
@@ -47,6 +137,7 @@ describe('useAppStore locale preferences', () => {
     expect(store.locale).toBe(DEFAULT_LOCALE);
     expect(i18n.global.locale.value).toBe(DEFAULT_LOCALE);
     expect(document.documentElement.lang).toBe(DEFAULT_LOCALE);
+    expect(window.localStorage.getItem('foldergram-locale')).toBeNull();
   });
 
   it('uses a supported browser locale when no saved locale exists', () => {
@@ -58,7 +149,7 @@ describe('useAppStore locale preferences', () => {
     expect(store.locale).toBe('es');
     expect(i18n.global.locale.value).toBe('es');
     expect(document.documentElement.lang).toBe('es');
-    expect(window.localStorage.getItem('foldergram-locale')).toBe('es');
+    expect(window.localStorage.getItem('foldergram-locale')).toBeNull();
   });
 
   it('normalizes Chinese browser locales to zh', () => {
@@ -70,7 +161,7 @@ describe('useAppStore locale preferences', () => {
     expect(store.locale).toBe('zh');
     expect(i18n.global.locale.value).toBe('zh');
     expect(document.documentElement.lang).toBe('zh');
-    expect(window.localStorage.getItem('foldergram-locale')).toBe('zh');
+    expect(window.localStorage.getItem('foldergram-locale')).toBeNull();
   });
 
   it('normalizes region locales before persisting them', () => {
@@ -81,5 +172,59 @@ describe('useAppStore locale preferences', () => {
     expect(i18n.global.locale.value).toBe('zh');
     expect(document.documentElement.lang).toBe('zh');
     expect(window.localStorage.getItem('foldergram-locale')).toBe('zh');
+  });
+
+  it('applies the saved app default locale after stats load when no local override exists', async () => {
+    setNavigatorLocales(['en-US'], 'en-US');
+    fetchAdminStatsMock.mockResolvedValue(createAppStatus('zh'));
+
+    const store = useAppStore();
+    store.initializeLocale();
+    await store.fetchStats();
+
+    expect(store.locale).toBe('zh');
+    expect(i18n.global.locale.value).toBe('zh');
+    expect(document.documentElement.lang).toBe('zh');
+    expect(window.localStorage.getItem('foldergram-locale')).toBeNull();
+  });
+
+  it('applies the auth-status app default locale when no local override exists', () => {
+    setNavigatorLocales(['en-US'], 'en-US');
+
+    const store = useAppStore();
+    store.initializeLocale();
+    store.syncLocaleFromAuthStatus('zh');
+
+    expect(store.locale).toBe('zh');
+    expect(i18n.global.locale.value).toBe('zh');
+    expect(document.documentElement.lang).toBe('zh');
+    expect(window.localStorage.getItem('foldergram-locale')).toBeNull();
+  });
+
+  it('keeps the browser local override ahead of the saved app default locale', async () => {
+    window.localStorage.setItem('foldergram-locale', 'es');
+    fetchAdminStatsMock.mockResolvedValue(createAppStatus('zh'));
+
+    const store = useAppStore();
+    store.initializeLocale();
+    await store.fetchStats();
+
+    expect(store.locale).toBe('es');
+    expect(i18n.global.locale.value).toBe('es');
+    expect(document.documentElement.lang).toBe('es');
+    expect(window.localStorage.getItem('foldergram-locale')).toBe('es');
+  });
+
+  it('keeps the browser local override ahead of the auth-status app default locale', () => {
+    window.localStorage.setItem('foldergram-locale', 'es');
+
+    const store = useAppStore();
+    store.initializeLocale();
+    store.syncLocaleFromAuthStatus('zh');
+
+    expect(store.locale).toBe('es');
+    expect(i18n.global.locale.value).toBe('es');
+    expect(document.documentElement.lang).toBe('es');
+    expect(window.localStorage.getItem('foldergram-locale')).toBe('es');
   });
 });

--- a/client/src/stores/app.ts
+++ b/client/src/stores/app.ts
@@ -6,6 +6,7 @@ import {
   fetchScanProgress,
   fetchStats as fetchStatus
 } from '../api/gallery';
+import { DEFAULT_LOCALE, i18n, resolvePreferredLocale, syncDocumentLanguage, type SupportedLocale } from '../locales';
 import type { AppStatus, FeedMode, FolderImageOrder, ReelsFeedMode, ScanProgress } from '../types/api';
 import { useAuthStore } from './auth';
 
@@ -14,6 +15,7 @@ interface AppState {
   loadingStats: boolean;
   error: string | null;
   theme: 'light' | 'dark';
+  locale: SupportedLocale;
   videoMuted: boolean;
   lastOpenedFolderSlug: string | null;
   recentOpenedFolderSlugs: string[];
@@ -24,6 +26,7 @@ interface AppState {
 }
 
 const THEME_STORAGE_KEY = 'foldergram-theme';
+const LOCALE_STORAGE_KEY = 'foldergram-locale';
 const VIDEO_MUTED_STORAGE_KEY = 'foldergram-video-muted';
 const LAST_OPENED_FOLDER_STORAGE_KEY = 'foldergram-last-opened-folder';
 const RECENT_OPENED_FOLDERS_STORAGE_KEY = 'foldergram-recent-opened-folders';
@@ -57,6 +60,7 @@ export const useAppStore = defineStore('app', {
     loadingStats: false,
     error: null,
     theme: 'light',
+    locale: DEFAULT_LOCALE,
     videoMuted: true,
     lastOpenedFolderSlug: null,
     recentOpenedFolderSlugs: [],
@@ -104,6 +108,19 @@ export const useAppStore = defineStore('app', {
       this.setTheme(preferredTheme);
     },
 
+    initializeLocale() {
+      const browserLocales =
+        typeof navigator === 'undefined'
+          ? []
+          : [...(Array.isArray(navigator.languages) ? navigator.languages : []), navigator.language];
+      const preferredLocale = resolvePreferredLocale(
+        typeof window === 'undefined' ? null : window.localStorage.getItem(LOCALE_STORAGE_KEY),
+        ...browserLocales
+      );
+
+      this.setLocale(preferredLocale);
+    },
+
     initializeLastOpenedFolder() {
       const savedSlug = window.localStorage.getItem(LAST_OPENED_FOLDER_STORAGE_KEY);
       this.lastOpenedFolderSlug = savedSlug && savedSlug.length > 0 ? savedSlug : null;
@@ -120,6 +137,18 @@ export const useAppStore = defineStore('app', {
       this.theme = theme;
       document.documentElement.dataset.theme = theme;
       window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    },
+
+    setLocale(locale: string | SupportedLocale) {
+      const resolvedLocale = resolvePreferredLocale(locale);
+
+      this.locale = resolvedLocale;
+      i18n.global.locale.value = resolvedLocale;
+      syncDocumentLanguage(resolvedLocale);
+
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(LOCALE_STORAGE_KEY, resolvedLocale);
+      }
     },
 
     toggleTheme() {

--- a/client/src/stores/app.ts
+++ b/client/src/stores/app.ts
@@ -6,7 +6,14 @@ import {
   fetchScanProgress,
   fetchStats as fetchStatus
 } from '../api/gallery';
-import { DEFAULT_LOCALE, i18n, resolvePreferredLocale, syncDocumentLanguage, type SupportedLocale } from '../locales';
+import {
+  DEFAULT_LOCALE,
+  i18n,
+  resolvePreferredLocale,
+  resolveSupportedLocale,
+  syncDocumentLanguage,
+  type SupportedLocale
+} from '../locales';
 import type { AppStatus, FeedMode, FolderImageOrder, ReelsFeedMode, ScanProgress } from '../types/api';
 import { useAuthStore } from './auth';
 
@@ -54,6 +61,26 @@ function parseStoredRecentFolderSlugs(value: string | null): string[] {
   }
 }
 
+function getStoredLocalePreference(): SupportedLocale | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return resolveSupportedLocale(window.localStorage.getItem(LOCALE_STORAGE_KEY));
+}
+
+function getBrowserLocaleCandidates(): string[] {
+  if (typeof navigator === 'undefined') {
+    return [];
+  }
+
+  return [...(Array.isArray(navigator.languages) ? navigator.languages : []), navigator.language];
+}
+
+function resolveSavedDefaultLocale(locale: string | null | undefined): SupportedLocale | null {
+  return resolveSupportedLocale(locale);
+}
+
 export const useAppStore = defineStore('app', {
   state: (): AppState => ({
     stats: null,
@@ -78,6 +105,7 @@ export const useAppStore = defineStore('app', {
     hasCompletedScan: (state) => state.stats?.scan.lastCompletedScan !== null,
     isInitialScan: (state) => state.stats?.scan.isScanning === true && state.stats?.scan.lastCompletedScan === null,
     defaultHomeFeedMode: (state): FeedMode => state.stats?.preferences.defaultHomeFeedMode ?? 'random',
+    savedDefaultLocale: (state): SupportedLocale | null => resolveSupportedLocale(state.stats?.preferences.defaultLocale ?? null),
     defaultReelsFeedMode: (state): ReelsFeedMode => state.stats?.preferences.defaultReelsFeedMode ?? 'random',
     defaultFolderImageOrder: (state): FolderImageOrder => state.stats?.preferences.defaultFolderImageOrder ?? 'newest',
     treatStoriesAsFolders: (state) => state.stats?.preferences.treatStoriesAsFolders === true
@@ -109,16 +137,25 @@ export const useAppStore = defineStore('app', {
     },
 
     initializeLocale() {
-      const browserLocales =
-        typeof navigator === 'undefined'
-          ? []
-          : [...(Array.isArray(navigator.languages) ? navigator.languages : []), navigator.language];
-      const preferredLocale = resolvePreferredLocale(
-        typeof window === 'undefined' ? null : window.localStorage.getItem(LOCALE_STORAGE_KEY),
-        ...browserLocales
-      );
+      const rawStoredLocale = typeof window === 'undefined' ? null : window.localStorage.getItem(LOCALE_STORAGE_KEY);
+      const storedLocale = resolveSupportedLocale(rawStoredLocale);
 
-      this.setLocale(preferredLocale);
+      if (typeof window !== 'undefined') {
+        if (rawStoredLocale && storedLocale && rawStoredLocale !== storedLocale) {
+          window.localStorage.setItem(LOCALE_STORAGE_KEY, storedLocale);
+        }
+
+        if (rawStoredLocale && !storedLocale) {
+          window.localStorage.removeItem(LOCALE_STORAGE_KEY);
+        }
+      }
+
+      if (storedLocale) {
+        this.setLocale(storedLocale, { persist: false });
+        return;
+      }
+
+      this.setLocale(resolvePreferredLocale(...getBrowserLocaleCandidates()), { persist: false });
     },
 
     initializeLastOpenedFolder() {
@@ -139,16 +176,37 @@ export const useAppStore = defineStore('app', {
       window.localStorage.setItem(THEME_STORAGE_KEY, theme);
     },
 
-    setLocale(locale: string | SupportedLocale) {
+    setLocale(locale: string | SupportedLocale, options: { persist?: boolean } = {}) {
       const resolvedLocale = resolvePreferredLocale(locale);
 
       this.locale = resolvedLocale;
       i18n.global.locale.value = resolvedLocale;
       syncDocumentLanguage(resolvedLocale);
 
-      if (typeof window !== 'undefined') {
+      if ((options.persist ?? true) && typeof window !== 'undefined') {
         window.localStorage.setItem(LOCALE_STORAGE_KEY, resolvedLocale);
       }
+    },
+
+    syncLocaleFromSavedDefault(defaultLocale: string | null | undefined) {
+      if (getStoredLocalePreference()) {
+        return;
+      }
+
+      const resolvedLocale = resolveSavedDefaultLocale(defaultLocale);
+      if (!resolvedLocale) {
+        return;
+      }
+
+      this.setLocale(resolvedLocale, { persist: false });
+    },
+
+    syncLocaleFromStats(stats?: AppStatus | null) {
+      this.syncLocaleFromSavedDefault((stats ?? this.stats)?.preferences.defaultLocale ?? null);
+    },
+
+    syncLocaleFromAuthStatus(defaultLocale: string | null | undefined) {
+      this.syncLocaleFromSavedDefault(defaultLocale);
     },
 
     toggleTheme() {
@@ -349,6 +407,7 @@ export const useAppStore = defineStore('app', {
         this.stats = this.shouldUseAdminScanProgress()
           ? await fetchAdminStats()
           : await fetchStatus();
+        this.syncLocaleFromStats(this.stats);
         this.statsPollFailures = 0;
 
         if (options.background && this.error) {

--- a/client/src/stores/auth.test.ts
+++ b/client/src/stores/auth.test.ts
@@ -1,0 +1,102 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAuthStore } from './auth';
+
+const {
+  changePasswordProtectionMock,
+  disablePasswordProtectionMock,
+  enablePasswordProtectionMock,
+  fetchAuthStatusMock,
+  loginWithPasswordMock,
+  logoutMock,
+  unlockAdminSessionMock,
+  updateViewerAccessMock
+} = vi.hoisted(() => ({
+  changePasswordProtectionMock: vi.fn(),
+  disablePasswordProtectionMock: vi.fn(),
+  enablePasswordProtectionMock: vi.fn(),
+  fetchAuthStatusMock: vi.fn(),
+  loginWithPasswordMock: vi.fn(),
+  logoutMock: vi.fn(),
+  unlockAdminSessionMock: vi.fn(),
+  updateViewerAccessMock: vi.fn()
+}));
+
+vi.mock('../api/gallery', () => ({
+  changePasswordProtection: changePasswordProtectionMock,
+  disablePasswordProtection: disablePasswordProtectionMock,
+  enablePasswordProtection: enablePasswordProtectionMock,
+  fetchAuthStatus: fetchAuthStatusMock,
+  loginWithPassword: loginWithPasswordMock,
+  logout: logoutMock,
+  unlockAdmin: unlockAdminSessionMock,
+  updateViewerAccess: updateViewerAccessMock
+}));
+
+describe('auth store locale status', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    changePasswordProtectionMock.mockReset();
+    disablePasswordProtectionMock.mockReset();
+    enablePasswordProtectionMock.mockReset();
+    fetchAuthStatusMock.mockReset();
+    loginWithPasswordMock.mockReset();
+    logoutMock.mockReset();
+    unlockAdminSessionMock.mockReset();
+    updateViewerAccessMock.mockReset();
+  });
+
+  it('stores the saved app default locale from public auth status', async () => {
+    fetchAuthStatusMock.mockResolvedValue({
+      enabled: true,
+      authenticated: false,
+      role: 'anonymous',
+      accessMode: 'password',
+      likesMode: 'local',
+      defaultLocale: 'zh',
+      capabilities: {
+        canManageLibrary: false,
+        canDeleteMedia: false,
+        canAccessSettings: false,
+        canUseSharedLikes: false,
+        canUseLocalFavorites: true,
+        canUseSharedCollections: false,
+        canUseLocalCollections: true
+      }
+    });
+
+    const authStore = useAuthStore();
+    await authStore.initialize();
+
+    expect(authStore.defaultLocale).toBe('zh');
+    expect(authStore.requiresLogin).toBe(true);
+  });
+
+  it('preserves the saved app default locale when a session becomes unauthorized', () => {
+    const authStore = useAuthStore();
+    authStore.$patch({
+      enabled: true,
+      authenticated: true,
+      role: 'viewer',
+      accessMode: 'password',
+      likesMode: 'shared',
+      defaultLocale: 'zh',
+      capabilities: {
+        canManageLibrary: false,
+        canDeleteMedia: false,
+        canAccessSettings: false,
+        canUseSharedLikes: true,
+        canUseLocalFavorites: false,
+        canUseSharedCollections: true,
+        canUseLocalCollections: false
+      }
+    });
+
+    authStore.handleUnauthorized();
+
+    expect(authStore.authenticated).toBe(false);
+    expect(authStore.defaultLocale).toBe('zh');
+    expect(authStore.requiresLogin).toBe(true);
+  });
+});

--- a/client/src/stores/auth.ts
+++ b/client/src/stores/auth.ts
@@ -21,6 +21,7 @@ interface AuthState {
   role: AuthRole;
   accessMode: ViewerAccessMode;
   likesMode: LikesMode;
+  defaultLocale: AuthStatus['defaultLocale'];
   capabilities: AuthCapabilities;
   error: string | null;
 }
@@ -61,13 +62,18 @@ function createCapabilities(role: AuthRole): AuthCapabilities {
   };
 }
 
-function createAnonymousStatus(enabled: boolean, accessMode: ViewerAccessMode): AuthStatus {
+function createAnonymousStatus(
+  enabled: boolean,
+  accessMode: ViewerAccessMode,
+  defaultLocale: AuthStatus['defaultLocale']
+): AuthStatus {
   return {
     enabled,
     authenticated: false,
     role: 'anonymous',
     accessMode,
     likesMode: 'local',
+    defaultLocale,
     capabilities: createCapabilities('anonymous')
   };
 }
@@ -91,6 +97,7 @@ export const useAuthStore = defineStore('auth', {
     role: 'admin',
     accessMode: 'off',
     likesMode: 'shared',
+    defaultLocale: null,
     capabilities: createCapabilities('admin'),
     error: null
   }),
@@ -119,6 +126,7 @@ export const useAuthStore = defineStore('auth', {
       this.role = status.role;
       this.accessMode = status.accessMode;
       this.likesMode = status.likesMode;
+      this.defaultLocale = status.defaultLocale;
       this.capabilities = status.capabilities;
       this.ready = true;
     },
@@ -147,7 +155,7 @@ export const useAuthStore = defineStore('auth', {
 
       this.ready = true;
       this.loading = false;
-      this.applyStatus(createAnonymousStatus(this.enabled, this.accessMode));
+      this.applyStatus(createAnonymousStatus(this.enabled, this.accessMode, this.defaultLocale));
       this.unlockDialogOpen = false;
       this.error = this.accessMode === 'public' ? null : message;
     },

--- a/client/src/stores/folder-stories.test.ts
+++ b/client/src/stores/folder-stories.test.ts
@@ -41,6 +41,7 @@ function createStoriesPayload(): FolderStoriesPayload {
         title: 'Beach Club',
         subtitle: 'Beach Club story set',
         dateContext: 'Latest Mar 28, 2026',
+        latestActivityTimestamp: new Date('2026-03-28T12:00:00.000Z').getTime(),
         imageCount: 1,
         presentation: 'avatar',
         coverImage

--- a/client/src/stores/likes.test.ts
+++ b/client/src/stores/likes.test.ts
@@ -1,0 +1,55 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { DEFAULT_LOCALE, i18n } from '../locales';
+import type { FeedItem } from '../types/api';
+import { useLikesStore } from './likes';
+
+function createFeedItem(id: number): FeedItem {
+  return {
+    id,
+    folderId: 1,
+    folderSlug: 'animal-planet',
+    folderName: 'Animal Planet',
+    folderPath: 'animal-planet',
+    folderBreadcrumb: null,
+    filename: `post-${id}.jpg`,
+    width: 1080,
+    height: 1350,
+    mediaType: 'image',
+    durationMs: null,
+    isAnimated: false,
+    thumbnailUrl: `/thumbs/${id}.webp`,
+    previewUrl: `/previews/${id}.webp`,
+    sortTimestamp: 1_777_000_000_000 + id,
+    takenAt: 1_777_000_000_000 + id
+  };
+}
+
+describe('useLikesStore localization', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    i18n.global.locale.value = DEFAULT_LOCALE;
+  });
+
+  it('reacts to locale changes for shared and local saved-item labels', () => {
+    const store = useLikesStore();
+
+    store.syncFromItems([createFeedItem(1)], 'shared');
+
+    expect(store.collectionLabel).toBe('Likes');
+    expect(store.collectionSectionLabel).toBe('Liked posts');
+
+    i18n.global.locale.value = 'zh';
+
+    expect(store.collectionLabel).toBe('赞过');
+    expect(store.collectionSectionLabel).toBe('已赞帖子');
+    expect(store.toggleAriaLabel(false)).toBe('点赞帖子');
+
+    store.syncFromItems([createFeedItem(2)], 'local');
+
+    expect(store.collectionLabel).toBe('收藏');
+    expect(store.collectionSectionLabel).toBe('收藏帖子');
+    expect(store.toggleAriaLabel(true)).toBe('取消收藏帖子');
+  });
+});

--- a/client/src/stores/likes.ts
+++ b/client/src/stores/likes.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 
 import { fetchLikes, likeImage, unlikeImage } from '../api/gallery';
+import { i18n } from '../locales';
 import type { FeedItem, LikesMode } from '../types/api';
 import { updateCaptionInItems } from '../utils/caption';
 import { useAuthStore } from './auth';
@@ -98,17 +99,50 @@ export const useLikesStore = defineStore('likes', {
   getters: {
     isLiked: (state) => (id: number) => state.likedIds.includes(id),
     isPending: (state) => (id: number) => state.pendingIds.includes(id),
-    collectionLabel: (state) => (state.mode === 'local' ? 'Favorites' : 'Likes'),
-    collectionSectionLabel: (state) => (state.mode === 'local' ? 'Favorite posts' : 'Liked posts'),
-    emptyTitle: (state) => (state.mode === 'local' ? 'No favorites yet' : 'No liked posts yet'),
-    emptyDescription: (state) =>
-      state.mode === 'local'
-        ? 'Tap the heart under any post and it will appear here in this browser.'
-        : 'Tap the heart under any post and it will appear here.',
-    loadingLabel: (state) => (state.mode === 'local' ? 'Loading favorites...' : 'Loading likes...'),
-    errorTitle: (state) => (state.mode === 'local' ? 'Could not load favorites' : 'Could not load likes'),
+    collectionLabel: (state) => {
+      void i18n.global.locale.value;
+      return state.mode === 'local'
+        ? i18n.global.t('likes.labels.localCollection')
+        : i18n.global.t('likes.labels.sharedCollection');
+    },
+    collectionSectionLabel: (state) => {
+      void i18n.global.locale.value;
+      return state.mode === 'local'
+        ? i18n.global.t('likes.labels.localSection')
+        : i18n.global.t('likes.labels.sharedSection');
+    },
+    emptyTitle: (state) => {
+      void i18n.global.locale.value;
+      return state.mode === 'local'
+        ? i18n.global.t('likes.states.localEmptyTitle')
+        : i18n.global.t('likes.states.sharedEmptyTitle');
+    },
+    emptyDescription: (state) => {
+      void i18n.global.locale.value;
+      return state.mode === 'local'
+        ? i18n.global.t('likes.states.localEmptyDescription')
+        : i18n.global.t('likes.states.sharedEmptyDescription');
+    },
+    loadingLabel: (state) => {
+      void i18n.global.locale.value;
+      return state.mode === 'local'
+        ? i18n.global.t('likes.states.localLoadingLabel')
+        : i18n.global.t('likes.states.sharedLoadingLabel');
+    },
+    errorTitle: (state) => {
+      void i18n.global.locale.value;
+      return state.mode === 'local'
+        ? i18n.global.t('likes.states.localErrorTitle')
+        : i18n.global.t('likes.states.sharedErrorTitle');
+    },
     toggleAriaLabel: (state) => (liked: boolean) =>
-      state.mode === 'local' ? (liked ? 'Remove favorite from post' : 'Favorite post') : liked ? 'Unlike post' : 'Like post'
+      state.mode === 'local'
+        ? liked
+          ? i18n.global.t('likes.actions.removeFavoriteFromPost')
+          : i18n.global.t('likes.actions.favoritePost')
+        : liked
+          ? i18n.global.t('likes.actions.unlikePost')
+          : i18n.global.t('likes.actions.likePost')
   },
   actions: {
     syncFromItems(items: FeedItem[], mode: LikesMode) {
@@ -153,7 +187,11 @@ export const useLikesStore = defineStore('likes', {
 
         this.initialized = true;
       } catch (error) {
-        this.error = error instanceof Error ? error.message : `Unable to load ${this.mode === 'local' ? 'favorites' : 'likes'}`;
+        this.error = error instanceof Error
+          ? error.message
+          : this.mode === 'local'
+            ? i18n.global.t('likes.errors.loadLocal')
+            : i18n.global.t('likes.errors.loadShared');
       } finally {
         this.loading = false;
       }
@@ -197,7 +235,11 @@ export const useLikesStore = defineStore('likes', {
           this.items = this.items.filter((entry) => entry.id !== item.id);
         }
 
-        this.error = error instanceof Error ? error.message : `Unable to update ${mode === 'local' ? 'favorites' : 'likes'}`;
+        this.error = error instanceof Error
+          ? error.message
+          : mode === 'local'
+            ? i18n.global.t('likes.errors.updateLocal')
+            : i18n.global.t('likes.errors.updateShared');
       } finally {
         if (mode === 'local') {
           writeLocalFavorites(this.items);

--- a/client/src/stores/moments.test.ts
+++ b/client/src/stores/moments.test.ts
@@ -26,14 +26,21 @@ function createFeedItem(id: number): FeedItem {
   };
 }
 
-function createCapsule(id: string, title: string, subtitle: string, dateContext: string): MomentCapsule {
+function createCapsule(
+  id: string,
+  title: string,
+  subtitle: string,
+  dateContext: string,
+  momentDate?: MomentCapsule['momentDate']
+): MomentCapsule {
   return {
     id,
     title,
     subtitle,
     dateContext,
     imageCount: 2,
-    coverImage: createFeedItem(1)
+    coverImage: createFeedItem(1),
+    ...(momentDate ? { momentDate } : {})
   };
 }
 
@@ -91,42 +98,91 @@ describe('useMomentsStore localization', () => {
   });
 
   it('localizes date-based moment capsules without leaving English subtitle or date copy behind', () => {
+    vi.setSystemTime(new Date('2026-05-31T12:00:00.000Z'));
+
     const store = useMomentsStore();
 
     store.$patch({
       railKind: 'moments',
       items: [
-        createCapsule('on-this-day', 'On This Day', 'May 29 across previous years', 'May 29'),
-        createCapsule('this-week-previous-years', 'This Week', 'May 22-36, 2026 from previous years', 'May 22-36, 2026'),
-        createCapsule('from-last-year', 'Last Year Around Now', 'A revisit to May 2025', 'Apr 14, 2025 to Jul 13, 2025')
+        createCapsule('on-this-day', 'On This Day', 'May 29 across previous years', 'May 29', {
+          type: 'on-this-day',
+          date: {
+            year: 2026,
+            month: 5,
+            day: 29
+          }
+        }),
+        createCapsule('this-week-previous-years', 'This Week', 'May 22-Jun 5, 2026 from previous years', 'May 22-Jun 5, 2026', {
+          type: 'this-week-previous-years',
+          startDate: {
+            year: 2026,
+            month: 5,
+            day: 22
+          },
+          endDate: {
+            year: 2026,
+            month: 6,
+            day: 5
+          }
+        }),
+        createCapsule('from-last-year', 'Last Year Around Now', 'A revisit to May 2025', 'Apr 14, 2025 to Jul 13, 2025', {
+          type: 'from-last-year',
+          referenceDate: {
+            year: 2025,
+            month: 5,
+            day: 29
+          },
+          startDate: {
+            year: 2025,
+            month: 4,
+            day: 14
+          },
+          endDate: {
+            year: 2025,
+            month: 7,
+            day: 13
+          }
+        })
       ],
-      currentMoment: createCapsule('from-last-year', 'Last Year Around Now', 'A revisit to May 2025', 'Apr 14, 2025 to Jul 13, 2025')
+      currentMoment: createCapsule(
+        'from-last-year',
+        'Last Year Around Now',
+        'A revisit to May 2025',
+        'Apr 14, 2025 to Jul 13, 2025',
+        {
+          type: 'from-last-year',
+          referenceDate: {
+            year: 2025,
+            month: 5,
+            day: 29
+          },
+          startDate: {
+            year: 2025,
+            month: 4,
+            day: 14
+          },
+          endDate: {
+            year: 2025,
+            month: 7,
+            day: 13
+          }
+        }
+      )
     });
 
     i18n.global.locale.value = 'zh';
 
-    const now = new Date('2026-05-29T12:00:00.000Z');
-    const referenceDate = new Date(now);
-    referenceDate.setFullYear(referenceDate.getFullYear() - 1);
-    const thisWeekStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
-    const thisWeekEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 7);
-    const lastYearStart = new Date(referenceDate);
-    lastYearStart.setDate(lastYearStart.getDate() - 45);
-    lastYearStart.setHours(0, 0, 0, 0);
-    const lastYearEnd = new Date(referenceDate);
-    lastYearEnd.setDate(lastYearEnd.getDate() + 45);
-    lastYearEnd.setHours(23, 59, 59, 999);
-
     const expectedMonthDay = new Intl.DateTimeFormat('zh', {
       month: 'long',
       day: 'numeric'
-    }).format(now);
-    const expectedThisWeekRange = formatRange('zh', thisWeekStart, thisWeekEnd);
+    }).format(new Date(2026, 4, 29));
+    const expectedThisWeekRange = formatRange('zh', new Date(2026, 4, 22), new Date(2026, 5, 5));
     const expectedLastYearMonth = new Intl.DateTimeFormat('zh', {
       month: 'long',
       year: 'numeric'
-    }).format(referenceDate);
-    const expectedLastYearRange = formatRange('zh', lastYearStart, lastYearEnd);
+    }).format(new Date(2025, 4, 29));
+    const expectedLastYearRange = formatRange('zh', new Date(2025, 3, 14), new Date(2025, 6, 13));
 
     expect(store.localizedItems[0]).toMatchObject({
       title: '历史上的今天',
@@ -142,6 +198,82 @@ describe('useMomentsStore localization', () => {
       title: '去年此时',
       subtitle: `重温 ${expectedLastYearMonth}`,
       dateContext: expectedLastYearRange
+    });
+  });
+
+  it('preserves the server-selected capsule copy when momentDate is missing instead of recomputing from the client clock', () => {
+    vi.setSystemTime(new Date('2026-05-31T12:00:00.000Z'));
+
+    const store = useMomentsStore();
+
+    store.$patch({
+      railKind: 'moments',
+      items: [createCapsule('on-this-day', 'On This Day', 'May 29 across previous years', 'May 29')],
+      currentMoment: createCapsule('from-last-year', 'Last Year Around Now', 'A revisit to May 2025', 'Apr 14, 2025 to Jul 13, 2025')
+    });
+
+    i18n.global.locale.value = 'zh';
+
+    expect(store.localizedItems[0]).toMatchObject({
+      title: 'On This Day',
+      subtitle: 'May 29 across previous years',
+      dateContext: 'May 29'
+    });
+    expect(store.currentCapsule).toMatchObject({
+      title: 'Last Year Around Now',
+      subtitle: 'A revisit to May 2025',
+      dateContext: 'Apr 14, 2025 to Jul 13, 2025'
+    });
+  });
+
+  it('ignores malformed momentDate payloads without throwing during localization', () => {
+    const store = useMomentsStore();
+
+    store.$patch({
+      railKind: 'moments',
+      items: [
+        createCapsule('from-last-year', 'Last Year Around Now', 'A revisit to May 2025', 'Apr 14, 2025 to Jul 13, 2025', {
+          type: 'from-last-year',
+          referenceDate: {
+            year: 2025,
+            month: 13,
+            day: 29
+          },
+          startDate: {
+            year: 2025,
+            month: 4,
+            day: 14
+          },
+          endDate: {
+            year: 2025,
+            month: 7,
+            day: 13
+          }
+        })
+      ],
+      currentMoment: createCapsule('on-this-day', 'On This Day', 'May 29 across previous years', 'May 29', {
+        type: 'on-this-day',
+        date: {
+          year: 2026,
+          month: 2,
+          day: 31
+        }
+      })
+    });
+
+    i18n.global.locale.value = 'zh';
+
+    expect(() => store.localizedItems[0]).not.toThrow();
+    expect(() => store.currentCapsule).not.toThrow();
+    expect(store.localizedItems[0]).toMatchObject({
+      title: 'Last Year Around Now',
+      subtitle: 'A revisit to May 2025',
+      dateContext: 'Apr 14, 2025 to Jul 13, 2025'
+    });
+    expect(store.currentCapsule).toMatchObject({
+      title: 'On This Day',
+      subtitle: 'May 29 across previous years',
+      dateContext: 'May 29'
     });
   });
 });

--- a/client/src/stores/moments.test.ts
+++ b/client/src/stores/moments.test.ts
@@ -1,0 +1,147 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_LOCALE, i18n } from '../locales';
+import type { FeedItem, MomentCapsule } from '../types/api';
+import { useMomentsStore } from './moments';
+
+function createFeedItem(id: number): FeedItem {
+  return {
+    id,
+    folderId: 2,
+    folderSlug: 'weekend-trip',
+    folderName: 'Weekend Trip',
+    folderPath: 'weekend-trip',
+    folderBreadcrumb: null,
+    filename: `capsule-${id}.jpg`,
+    width: 1080,
+    height: 1080,
+    mediaType: 'image',
+    durationMs: null,
+    isAnimated: false,
+    thumbnailUrl: `/thumbs/${id}.webp`,
+    previewUrl: `/previews/${id}.webp`,
+    sortTimestamp: 1_777_100_000_000 + id,
+    takenAt: 1_777_100_000_000 + id
+  };
+}
+
+function createCapsule(id: string, title: string, subtitle: string, dateContext: string): MomentCapsule {
+  return {
+    id,
+    title,
+    subtitle,
+    dateContext,
+    imageCount: 2,
+    coverImage: createFeedItem(1)
+  };
+}
+
+function formatRange(locale: string, startDate: Date, endDate: Date) {
+  const formatter = new Intl.DateTimeFormat(locale, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  });
+
+  if (typeof formatter.formatRange === 'function') {
+    return formatter.formatRange(startDate, endDate);
+  }
+
+  return `${formatter.format(startDate)} - ${formatter.format(endDate)}`;
+}
+
+describe('useMomentsStore localization', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    i18n.global.locale.value = DEFAULT_LOCALE;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-29T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('localizes highlight rails and static capsule titles from their ids', () => {
+    const store = useMomentsStore();
+
+    store.$patch({
+      railKind: 'highlights',
+      items: [
+        createCapsule('highlight-recent-batches', 'Recent Batches', 'Latest runs gathered into one set', '2 batches'),
+        createCapsule('highlight-lucky-dip', 'Lucky Dip', 'A playful mix from across the library', 'Stable for today')
+      ],
+      currentMoment: createCapsule(
+        'highlight-recent-batches',
+        'Recent Batches',
+        'Latest runs gathered into one set',
+        '2 batches'
+      )
+    });
+
+    i18n.global.locale.value = 'zh';
+
+    expect(store.displayRailTitle).toBe('故事');
+    expect(store.displayRailSingularLabel).toBe('故事');
+    expect(store.localizedItems[0]?.title).toBe('近期批次');
+    expect(store.localizedItems[0]?.subtitle).toBe('将最近几次拍摄合并为一个合集');
+    expect(store.localizedItems[0]?.dateContext).toBe('2 个批次');
+    expect(store.currentCapsule?.title).toBe('近期批次');
+  });
+
+  it('localizes date-based moment capsules without leaving English subtitle or date copy behind', () => {
+    const store = useMomentsStore();
+
+    store.$patch({
+      railKind: 'moments',
+      items: [
+        createCapsule('on-this-day', 'On This Day', 'May 29 across previous years', 'May 29'),
+        createCapsule('this-week-previous-years', 'This Week', 'May 22-36, 2026 from previous years', 'May 22-36, 2026'),
+        createCapsule('from-last-year', 'Last Year Around Now', 'A revisit to May 2025', 'Apr 14, 2025 to Jul 13, 2025')
+      ],
+      currentMoment: createCapsule('from-last-year', 'Last Year Around Now', 'A revisit to May 2025', 'Apr 14, 2025 to Jul 13, 2025')
+    });
+
+    i18n.global.locale.value = 'zh';
+
+    const now = new Date('2026-05-29T12:00:00.000Z');
+    const referenceDate = new Date(now);
+    referenceDate.setFullYear(referenceDate.getFullYear() - 1);
+    const thisWeekStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
+    const thisWeekEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 7);
+    const lastYearStart = new Date(referenceDate);
+    lastYearStart.setDate(lastYearStart.getDate() - 45);
+    lastYearStart.setHours(0, 0, 0, 0);
+    const lastYearEnd = new Date(referenceDate);
+    lastYearEnd.setDate(lastYearEnd.getDate() + 45);
+    lastYearEnd.setHours(23, 59, 59, 999);
+
+    const expectedMonthDay = new Intl.DateTimeFormat('zh', {
+      month: 'long',
+      day: 'numeric'
+    }).format(now);
+    const expectedThisWeekRange = formatRange('zh', thisWeekStart, thisWeekEnd);
+    const expectedLastYearMonth = new Intl.DateTimeFormat('zh', {
+      month: 'long',
+      year: 'numeric'
+    }).format(referenceDate);
+    const expectedLastYearRange = formatRange('zh', lastYearStart, lastYearEnd);
+
+    expect(store.localizedItems[0]).toMatchObject({
+      title: '历史上的今天',
+      subtitle: `${expectedMonthDay} 在往年此日`,
+      dateContext: expectedMonthDay
+    });
+    expect(store.localizedItems[1]).toMatchObject({
+      title: '本周回顾',
+      subtitle: `${expectedThisWeekRange} 的往年回顾`,
+      dateContext: expectedThisWeekRange
+    });
+    expect(store.currentCapsule).toMatchObject({
+      title: '去年此时',
+      subtitle: `重温 ${expectedLastYearMonth}`,
+      dateContext: expectedLastYearRange
+    });
+  });
+});

--- a/client/src/stores/moments.ts
+++ b/client/src/stores/moments.ts
@@ -2,11 +2,8 @@ import { defineStore } from 'pinia';
 
 import { fetchMomentFeed, fetchMoments } from '../api/gallery';
 import { i18n } from '../locales';
-import type { FeedItem, FeedRailKind, MomentCapsule } from '../types/api';
+import type { CalendarDateParts, FeedItem, FeedRailKind, MomentCapsule } from '../types/api';
 import { updateCaptionInItems } from '../utils/caption';
-
-const THIS_WEEK_RADIUS_DAYS = 7;
-const LAST_YEAR_RADIUS_DAYS = 45;
 
 interface MomentsState {
   railKind: FeedRailKind;
@@ -56,21 +53,63 @@ function getCurrentLocale() {
   return i18n.global.locale.value;
 }
 
-function formatLocalizedMonthDay(date: Date) {
+function createDateFromParts(date: CalendarDateParts): Date | null {
+  if (
+    !Number.isInteger(date.year)
+    || !Number.isInteger(date.month)
+    || !Number.isInteger(date.day)
+    || date.month < 1
+    || date.month > 12
+    || date.day < 1
+    || date.day > 31
+  ) {
+    return null;
+  }
+
+  const parsedDate = new Date(date.year, date.month - 1, date.day);
+  if (
+    Number.isNaN(parsedDate.getTime())
+    || parsedDate.getFullYear() !== date.year
+    || parsedDate.getMonth() !== date.month - 1
+    || parsedDate.getDate() !== date.day
+  ) {
+    return null;
+  }
+
+  return parsedDate;
+}
+
+function formatLocalizedMonthDay(date: CalendarDateParts): string | null {
+  const localizedDate = createDateFromParts(date);
+  if (!localizedDate) {
+    return null;
+  }
+
   return new Intl.DateTimeFormat(getCurrentLocale(), {
     month: 'long',
     day: 'numeric'
-  }).format(date);
+  }).format(localizedDate);
 }
 
-function formatLocalizedMonthYear(date: Date) {
+function formatLocalizedMonthYear(date: CalendarDateParts): string | null {
+  const localizedDate = createDateFromParts(date);
+  if (!localizedDate) {
+    return null;
+  }
+
   return new Intl.DateTimeFormat(getCurrentLocale(), {
     month: 'long',
     year: 'numeric'
-  }).format(date);
+  }).format(localizedDate);
 }
 
-function formatLocalizedDateRange(startDate: Date, endDate: Date) {
+function formatLocalizedDateRange(startDate: CalendarDateParts, endDate: CalendarDateParts): string | null {
+  const localizedStartDate = createDateFromParts(startDate);
+  const localizedEndDate = createDateFromParts(endDate);
+  if (!localizedStartDate || !localizedEndDate) {
+    return null;
+  }
+
   const formatter = new Intl.DateTimeFormat(getCurrentLocale(), {
     month: 'short',
     day: 'numeric',
@@ -78,10 +117,10 @@ function formatLocalizedDateRange(startDate: Date, endDate: Date) {
   });
 
   if (typeof formatter.formatRange === 'function') {
-    return formatter.formatRange(startDate, endDate);
+    return formatter.formatRange(localizedStartDate, localizedEndDate);
   }
 
-  return `${formatter.format(startDate)} - ${formatter.format(endDate)}`;
+  return `${formatter.format(localizedStartDate)} - ${formatter.format(localizedEndDate)}`;
 }
 
 function localizeCapsule(capsule: MomentCapsule, railKind: FeedRailKind): MomentCapsule {
@@ -89,7 +128,14 @@ function localizeCapsule(capsule: MomentCapsule, railKind: FeedRailKind): Moment
 
   switch (capsule.id) {
     case 'on-this-day': {
-      const date = formatLocalizedMonthDay(new Date());
+      if (capsule.momentDate?.type !== 'on-this-day') {
+        return capsule;
+      }
+
+      const date = formatLocalizedMonthDay(capsule.momentDate.date);
+      if (!date) {
+        return capsule;
+      }
 
       return {
         ...capsule,
@@ -99,10 +145,15 @@ function localizeCapsule(capsule: MomentCapsule, railKind: FeedRailKind): Moment
       };
     }
     case 'this-week-previous-years': {
-      const now = new Date();
-      const startDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() - THIS_WEEK_RADIUS_DAYS);
-      const endDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() + THIS_WEEK_RADIUS_DAYS);
+      if (capsule.momentDate?.type !== 'this-week-previous-years') {
+        return capsule;
+      }
+
+      const { startDate, endDate } = capsule.momentDate;
       const range = formatLocalizedDateRange(startDate, endDate);
+      if (!range) {
+        return capsule;
+      }
 
       return {
         ...capsule,
@@ -112,24 +163,24 @@ function localizeCapsule(capsule: MomentCapsule, railKind: FeedRailKind): Moment
       };
     }
     case 'from-last-year': {
-      const referenceDate = new Date();
-      referenceDate.setFullYear(referenceDate.getFullYear() - 1);
+      if (capsule.momentDate?.type !== 'from-last-year') {
+        return capsule;
+      }
 
-      const startDate = new Date(referenceDate);
-      startDate.setDate(startDate.getDate() - LAST_YEAR_RADIUS_DAYS);
-      startDate.setHours(0, 0, 0, 0);
-
-      const endDate = new Date(referenceDate);
-      endDate.setDate(endDate.getDate() + LAST_YEAR_RADIUS_DAYS);
-      endDate.setHours(23, 59, 59, 999);
+      const { referenceDate, startDate, endDate } = capsule.momentDate;
+      const monthYear = formatLocalizedMonthYear(referenceDate);
+      const range = formatLocalizedDateRange(startDate, endDate);
+      if (!monthYear || !range) {
+        return capsule;
+      }
 
       return {
         ...capsule,
         title: i18n.global.t('moments.capsules.fromLastYear.title'),
         subtitle: i18n.global.t('moments.capsules.fromLastYear.subtitle', {
-          monthYear: formatLocalizedMonthYear(referenceDate)
+          monthYear
         }),
-        dateContext: formatLocalizedDateRange(startDate, endDate)
+        dateContext: range
       };
     }
     case 'highlight-recent-batches': {

--- a/client/src/stores/moments.ts
+++ b/client/src/stores/moments.ts
@@ -1,8 +1,12 @@
 import { defineStore } from 'pinia';
 
 import { fetchMomentFeed, fetchMoments } from '../api/gallery';
+import { i18n } from '../locales';
 import type { FeedItem, FeedRailKind, MomentCapsule } from '../types/api';
 import { updateCaptionInItems } from '../utils/caption';
+
+const THIS_WEEK_RADIUS_DAYS = 7;
+const LAST_YEAR_RADIUS_DAYS = 45;
 
 interface MomentsState {
   railKind: FeedRailKind;
@@ -19,6 +23,152 @@ interface MomentsState {
   currentHasMore: boolean;
   loadingMoment: boolean;
   momentError: string | null;
+}
+
+function parseLeadingCount(value: string): number | null {
+  const match = value.match(/^(\d+)/);
+  if (!match) {
+    return null;
+  }
+
+  return Number.parseInt(match[1], 10);
+}
+
+function localizeRailLabels(kind: FeedRailKind) {
+  void i18n.global.locale.value;
+
+  if (kind === 'highlights') {
+    return {
+      title: i18n.global.t('moments.rails.highlights.title'),
+      description: i18n.global.t('moments.rails.highlights.description'),
+      singularLabel: i18n.global.t('moments.rails.highlights.singularLabel')
+    };
+  }
+
+  return {
+    title: i18n.global.t('moments.rails.moments.title'),
+    description: i18n.global.t('moments.rails.moments.description'),
+    singularLabel: i18n.global.t('moments.rails.moments.singularLabel')
+  };
+}
+
+function getCurrentLocale() {
+  return i18n.global.locale.value;
+}
+
+function formatLocalizedMonthDay(date: Date) {
+  return new Intl.DateTimeFormat(getCurrentLocale(), {
+    month: 'long',
+    day: 'numeric'
+  }).format(date);
+}
+
+function formatLocalizedMonthYear(date: Date) {
+  return new Intl.DateTimeFormat(getCurrentLocale(), {
+    month: 'long',
+    year: 'numeric'
+  }).format(date);
+}
+
+function formatLocalizedDateRange(startDate: Date, endDate: Date) {
+  const formatter = new Intl.DateTimeFormat(getCurrentLocale(), {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  });
+
+  if (typeof formatter.formatRange === 'function') {
+    return formatter.formatRange(startDate, endDate);
+  }
+
+  return `${formatter.format(startDate)} - ${formatter.format(endDate)}`;
+}
+
+function localizeCapsule(capsule: MomentCapsule, railKind: FeedRailKind): MomentCapsule {
+  void i18n.global.locale.value;
+
+  switch (capsule.id) {
+    case 'on-this-day': {
+      const date = formatLocalizedMonthDay(new Date());
+
+      return {
+        ...capsule,
+        title: i18n.global.t('moments.capsules.onThisDay.title'),
+        subtitle: i18n.global.t('moments.capsules.onThisDay.subtitle', { date }),
+        dateContext: date
+      };
+    }
+    case 'this-week-previous-years': {
+      const now = new Date();
+      const startDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() - THIS_WEEK_RADIUS_DAYS);
+      const endDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() + THIS_WEEK_RADIUS_DAYS);
+      const range = formatLocalizedDateRange(startDate, endDate);
+
+      return {
+        ...capsule,
+        title: i18n.global.t('moments.capsules.thisWeekPreviousYears.title'),
+        subtitle: i18n.global.t('moments.capsules.thisWeekPreviousYears.subtitle', { range }),
+        dateContext: range
+      };
+    }
+    case 'from-last-year': {
+      const referenceDate = new Date();
+      referenceDate.setFullYear(referenceDate.getFullYear() - 1);
+
+      const startDate = new Date(referenceDate);
+      startDate.setDate(startDate.getDate() - LAST_YEAR_RADIUS_DAYS);
+      startDate.setHours(0, 0, 0, 0);
+
+      const endDate = new Date(referenceDate);
+      endDate.setDate(endDate.getDate() + LAST_YEAR_RADIUS_DAYS);
+      endDate.setHours(23, 59, 59, 999);
+
+      return {
+        ...capsule,
+        title: i18n.global.t('moments.capsules.fromLastYear.title'),
+        subtitle: i18n.global.t('moments.capsules.fromLastYear.subtitle', {
+          monthYear: formatLocalizedMonthYear(referenceDate)
+        }),
+        dateContext: formatLocalizedDateRange(startDate, endDate)
+      };
+    }
+    case 'highlight-recent-batches': {
+      const count = parseLeadingCount(capsule.dateContext) ?? 0;
+
+      return {
+        ...capsule,
+        title: i18n.global.t('moments.capsules.highlightRecentBatches.title'),
+        subtitle: i18n.global.t('moments.capsules.highlightRecentBatches.subtitle'),
+        dateContext:
+          count === 1
+            ? i18n.global.t('moments.capsules.highlightRecentBatches.dateContextOne', { count })
+            : i18n.global.t('moments.capsules.highlightRecentBatches.dateContextOther', { count })
+      };
+    }
+    case 'highlight-forgotten-favorites':
+      return {
+        ...capsule,
+        title: i18n.global.t('moments.capsules.highlightForgottenFavorites.title'),
+        subtitle: i18n.global.t('moments.capsules.highlightForgottenFavorites.subtitle'),
+        dateContext: i18n.global.t('moments.capsules.highlightForgottenFavorites.dateContext')
+      };
+    case 'highlight-deep-cuts':
+      return {
+        ...capsule,
+        title: i18n.global.t('moments.capsules.highlightDeepCuts.title'),
+        subtitle: i18n.global.t('moments.capsules.highlightDeepCuts.subtitle'),
+        dateContext: i18n.global.t('moments.capsules.highlightDeepCuts.dateContext')
+      };
+    case 'highlight-lucky-dip':
+      return {
+        ...capsule,
+        title: i18n.global.t('moments.capsules.highlightLuckyDip.title'),
+        subtitle: i18n.global.t('moments.capsules.highlightLuckyDip.subtitle'),
+        dateContext: i18n.global.t('moments.capsules.highlightLuckyDip.dateContext')
+      };
+    default:
+      return railKind === 'highlights' ? capsule : capsule;
+  }
 }
 
 export const useMomentsStore = defineStore('moments', {
@@ -39,7 +189,11 @@ export const useMomentsStore = defineStore('moments', {
     momentError: null
   }),
   getters: {
-    currentCapsule: (state) => state.currentMoment,
+    displayRailTitle: (state) => localizeRailLabels(state.railKind).title,
+    displayRailDescription: (state) => localizeRailLabels(state.railKind).description,
+    displayRailSingularLabel: (state) => localizeRailLabels(state.railKind).singularLabel,
+    localizedItems: (state) => state.items.map((item) => localizeCapsule(item, state.railKind)),
+    currentCapsule: (state) => (state.currentMoment ? localizeCapsule(state.currentMoment, state.railKind) : null),
     currentError: (state) => state.momentError
   },
   actions: {

--- a/client/src/stores/places.ts
+++ b/client/src/stores/places.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 
 import { fetchPlaceImages, fetchPlaces, fetchPlacesStatus, preparePlacesGeodata, rebuildPlaces } from '../api/gallery';
+import { i18n } from '../locales';
 import type { FeedItem, PlaceDetail, PlacesStatus } from '../types/api';
 import { updateCaptionInItems } from '../utils/caption';
 
@@ -62,7 +63,7 @@ export const usePlacesStore = defineStore('places', {
       } catch (error) {
         this.items = [];
         this.hasLoadedList = false;
-        this.listError = error instanceof Error ? error.message : 'Unable to load places';
+        this.listError = error instanceof Error ? error.message : i18n.global.t('placesPage.errors.load');
       } finally {
         this.loadingList = false;
       }
@@ -105,7 +106,7 @@ export const usePlacesStore = defineStore('places', {
         }
 
         this.currentPlace = null;
-        this.placeError = error instanceof Error ? error.message : 'Unable to load place';
+        this.placeError = error instanceof Error ? error.message : i18n.global.t('placePage.errors.load');
       } finally {
         if (this.placeRequestId === requestId && this.currentSlug === slug) {
           this.loadingPlace = false;
@@ -118,7 +119,7 @@ export const usePlacesStore = defineStore('places', {
       try {
         this.status = await fetchPlacesStatus();
       } catch (error) {
-        this.statusError = error instanceof Error ? error.message : 'Unable to load places status';
+        this.statusError = error instanceof Error ? error.message : i18n.global.t('settings.places.section.loadStatusError');
       }
     },
 
@@ -128,9 +129,9 @@ export const usePlacesStore = defineStore('places', {
       try {
         const payload = await preparePlacesGeodata();
         this.status = payload.status;
-        this.actionMessage = 'Offline place data is ready.';
+        this.actionMessage = i18n.global.t('settings.places.section.actions.ready');
       } catch (error) {
-        this.actionMessage = error instanceof Error ? error.message : 'Unable to prepare offline place data.';
+        this.actionMessage = error instanceof Error ? error.message : i18n.global.t('settings.places.section.actions.prepareError');
       } finally {
         this.preparing = false;
       }
@@ -141,10 +142,13 @@ export const usePlacesStore = defineStore('places', {
       this.actionMessage = null;
       try {
         const result = await rebuildPlaces();
-        this.actionMessage = `Rebuilt places for ${result.assigned} of ${result.processed} posts.`;
+        this.actionMessage = i18n.global.t('settings.places.section.actions.rebuilt', {
+          assigned: new Intl.NumberFormat(i18n.global.locale.value).format(result.assigned),
+          processed: new Intl.NumberFormat(i18n.global.locale.value).format(result.processed)
+        });
         await this.fetchPlaces(true);
       } catch (error) {
-        this.actionMessage = error instanceof Error ? error.message : 'Unable to rebuild place assignments.';
+        this.actionMessage = error instanceof Error ? error.message : i18n.global.t('settings.places.section.actions.rebuildError');
       } finally {
         this.rebuilding = false;
       }

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -140,9 +140,35 @@ export interface RailCapsule {
   imageCount: number;
   coverImage: FeedItem;
   presentation?: StoryCapsulePresentation;
+  latestActivityTimestamp?: number | null;
 }
 
-export type MomentCapsule = RailCapsule;
+export interface CalendarDateParts {
+  year: number;
+  month: number;
+  day: number;
+}
+
+export type MomentDateMetadata =
+  | {
+      type: 'on-this-day';
+      date: CalendarDateParts;
+    }
+  | {
+      type: 'this-week-previous-years';
+      startDate: CalendarDateParts;
+      endDate: CalendarDateParts;
+    }
+  | {
+      type: 'from-last-year';
+      referenceDate: CalendarDateParts;
+      startDate: CalendarDateParts;
+      endDate: CalendarDateParts;
+    };
+
+export interface MomentCapsule extends RailCapsule {
+  momentDate?: MomentDateMetadata;
+}
 
 export interface MomentsPayload {
   railKind: FeedRailKind;
@@ -157,7 +183,7 @@ export interface MomentFeedPayload extends PaginatedFeed {
   railTitle: string;
   railDescription: string;
   railSingularLabel: string;
-  moment: RailCapsule;
+  moment: MomentCapsule;
 }
 
 export interface FolderStoriesPayload {

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -1,3 +1,5 @@
+import type { SupportedLocale } from '../locales';
+
 export type FeedMode = 'recent' | 'rediscover' | 'random';
 export type ReelsFeedMode = 'recommended' | 'recent' | 'random';
 export type FolderImageOrder = 'newest' | 'oldest';
@@ -18,6 +20,10 @@ export type ScanOperation =
 
 export interface HomeFeedDefaultSetting {
   defaultMode: FeedMode;
+}
+
+export interface AppLocaleSetting {
+  defaultLocale: SupportedLocale;
 }
 
 export interface ReelsFeedDefaultSetting {
@@ -412,6 +418,7 @@ export interface AppStatus {
     ignoredRootMediaCount: number;
   };
   preferences: {
+    defaultLocale?: SupportedLocale | null;
     defaultHomeFeedMode: FeedMode;
     defaultReelsFeedMode: ReelsFeedMode;
     defaultFolderImageOrder?: FolderImageOrder;
@@ -461,6 +468,7 @@ export interface AuthStatus {
   role: AuthRole;
   accessMode: ViewerAccessMode;
   likesMode: LikesMode;
+  defaultLocale: SupportedLocale | null;
   capabilities: AuthCapabilities;
 }
 

--- a/client/src/views/CollectionView.vue
+++ b/client/src/views/CollectionView.vue
@@ -2,15 +2,19 @@
   <section class="w-[min(100%,58rem)] mx-auto">
     <EmptyState
       v-if="appStore.isLibraryUnavailable"
-      title="Library storage unavailable"
+      :title="t('collections.detail.libraryUnavailableTitle')"
       :description="appStore.libraryUnavailableReason"
     />
-    <ErrorState v-else-if="collectionsStore.collectionError" title="Could not load collection" :message="collectionsStore.collectionError" />
+    <ErrorState
+      v-else-if="collectionsStore.collectionError"
+      :title="t('collections.detail.loadErrorTitle')"
+      :message="collectionsStore.collectionError"
+    />
     <template v-else>
       <header class="collection-page__header" :aria-label="collectionTitle">
         <RouterLink class="collection-page__back-link" :to="{ name: 'collections' }">
           <span class="i-fluent-chevron-left-20-regular collection-page__back-icon" aria-hidden="true" />
-          <span>Collections</span>
+          <span>{{ t('collections.detail.back') }}</span>
         </RouterLink>
         <div class="collection-page__title-row">
           <h1 class="collection-page__title">{{ collectionTitle }}</h1>
@@ -18,8 +22,8 @@
             v-if="canManageCurrentCollection"
             class="collection-page__menu-button"
             type="button"
-            aria-label="Collection options"
-            title="Collection options"
+            :aria-label="t('collections.detail.options')"
+            :title="t('collections.detail.options')"
             @click="menuOpen = true"
           >
             <span class="i-fluent-more-horizontal-24-filled" aria-hidden="true" />
@@ -29,11 +33,11 @@
 
       <EmptyState
         v-if="!collectionsStore.loadingCollection && collectionsStore.currentImages.length === 0"
-        :title="`${collectionTitle} is empty`"
+        :title="t('collections.detail.emptyTitle', { name: collectionTitle })"
         :description="emptyDescription"
       />
       <div v-else-if="collectionsStore.loadingCollection && collectionsStore.currentImages.length === 0" class="card p-8 text-center">
-        <p class="text-muted">Loading collection...</p>
+        <p class="text-muted">{{ t('collections.detail.loading') }}</p>
       </div>
       <FolderGrid v-else :items="collectionsStore.currentImages" variant="posts" columns="three" />
       <InfiniteLoader
@@ -45,15 +49,20 @@
     </template>
 
     <div v-if="menuOpen" class="collection-action-backdrop" @click.self="menuOpen = false">
-      <div class="collection-action-sheet" role="dialog" aria-modal="true" aria-label="Collection actions">
+      <div
+        class="collection-action-sheet"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="t('collections.detail.actionsLabel')"
+      >
         <button class="collection-action-sheet__item collection-action-sheet__item--danger" type="button" @click="openDeleteDialog">
-          Delete collection
+          {{ t('collections.detail.menu.delete') }}
         </button>
         <button class="collection-action-sheet__item" type="button" @click="openEditDialog">
-          Edit Collection
+          {{ t('collections.detail.menu.edit') }}
         </button>
         <button class="collection-action-sheet__item" type="button" @click="menuOpen = false">
-          Cancel
+          {{ t('collections.detail.menu.cancel') }}
         </button>
       </div>
     </div>
@@ -61,12 +70,12 @@
     <div v-if="editDialogOpen" class="collection-action-backdrop" @click.self="closeEditDialog">
       <section class="collection-edit-dialog" role="dialog" aria-modal="true" aria-labelledby="edit-collection-title">
         <header class="collection-edit-dialog__header">
-          <h2 id="edit-collection-title">Edit collection</h2>
+          <h2 id="edit-collection-title">{{ t('collections.detail.edit.title') }}</h2>
           <button
             class="collection-edit-dialog__close"
             type="button"
-            aria-label="Close"
-            title="Close"
+            :aria-label="t('common.close')"
+            :title="t('common.close')"
             :disabled="editingCollection"
             @click="closeEditDialog"
           >
@@ -84,7 +93,7 @@
           />
           <p v-if="actionError" class="collection-management-error">{{ actionError }}</p>
           <button class="collection-edit-dialog__done" type="submit" :disabled="editingCollection">
-            {{ editingCollection ? 'Saving...' : 'Done' }}
+            {{ editingCollection ? t('collections.detail.edit.saving') : t('collections.detail.edit.done') }}
           </button>
         </form>
       </section>
@@ -93,8 +102,8 @@
     <div v-if="deleteDialogOpen" class="collection-action-backdrop" @click.self="closeDeleteDialog">
       <section class="collection-delete-dialog" role="dialog" aria-modal="true" aria-labelledby="delete-collection-title">
         <div class="collection-delete-dialog__copy">
-          <h2 id="delete-collection-title">Delete collection?</h2>
-          <p>When you delete this collection, the photos and videos will still be saved.</p>
+          <h2 id="delete-collection-title">{{ t('collections.detail.delete.title') }}</h2>
+          <p>{{ t('collections.detail.delete.message') }}</p>
         </div>
         <p v-if="actionError" class="collection-management-error collection-management-error--dialog">{{ actionError }}</p>
         <button
@@ -103,7 +112,7 @@
           :disabled="deletingCollection"
           @click="confirmDelete"
         >
-          {{ deletingCollection ? 'Deleting...' : 'Delete' }}
+          {{ deletingCollection ? t('collections.detail.delete.deleting') : t('collections.detail.delete.confirm') }}
         </button>
         <button
           class="collection-delete-dialog__action"
@@ -111,7 +120,7 @@
           :disabled="deletingCollection"
           @click="closeDeleteDialog"
         >
-          Cancel
+          {{ t('collections.detail.delete.cancel') }}
         </button>
       </section>
     </div>
@@ -120,6 +129,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { RouterLink, useRouter } from 'vue-router';
 
 import EmptyState from '../components/EmptyState.vue';
@@ -136,6 +146,7 @@ const props = defineProps<{
 const appStore = useAppStore();
 const collectionsStore = useCollectionsStore();
 const router = useRouter();
+const { t } = useI18n();
 const menuOpen = ref(false);
 const editDialogOpen = ref(false);
 const deleteDialogOpen = ref(false);
@@ -146,15 +157,17 @@ const editingCollection = ref(false);
 const deletingCollection = ref(false);
 const collectionTitle = computed(() => {
   if (!collectionsStore.currentCollection) {
-    return 'Collection';
+    return t('collections.detail.fallbackTitle');
   }
 
-  return collectionsStore.currentCollection.isDefault ? 'All Posts' : collectionsStore.currentCollection.name;
+  return collectionsStore.currentCollection.isDefault
+    ? t('collections.shared.defaultName')
+    : collectionsStore.currentCollection.name;
 });
 const emptyDescription = computed(() =>
   collectionsStore.currentCollection?.isDefault
-    ? 'Use the bookmark action under any post to save it here.'
-    : 'Bookmarked posts assigned to this collection will appear here.'
+    ? t('collections.detail.emptyDescriptionDefault')
+    : t('collections.detail.emptyDescriptionCustom')
 );
 const canManageCurrentCollection = computed(() => collectionsStore.currentCollection?.isDefault === false);
 
@@ -203,7 +216,7 @@ function closeDeleteDialog() {
 async function submitRename() {
   const name = editName.value.trim();
   if (!name) {
-    actionError.value = 'Collection name is required.';
+    actionError.value = t('collections.detail.edit.required');
     return;
   }
 
@@ -214,7 +227,7 @@ async function submitRename() {
     await collectionsStore.updateCollectionName(props.slug, name);
     editDialogOpen.value = false;
   } catch (error) {
-    actionError.value = error instanceof Error ? error.message : 'Unable to update collection';
+    actionError.value = error instanceof Error ? error.message : t('collections.detail.edit.updateError');
   } finally {
     editingCollection.value = false;
   }
@@ -229,7 +242,7 @@ async function confirmDelete() {
     deleteDialogOpen.value = false;
     await router.push({ name: 'collections' });
   } catch (error) {
-    actionError.value = error instanceof Error ? error.message : 'Unable to delete collection';
+    actionError.value = error instanceof Error ? error.message : t('collections.detail.delete.error');
   } finally {
     deletingCollection.value = false;
   }

--- a/client/src/views/CollectionsView.vue
+++ b/client/src/views/CollectionsView.vue
@@ -2,13 +2,17 @@
   <section class="w-[min(100%,58rem)] mx-auto">
     <EmptyState
       v-if="appStore.isLibraryUnavailable"
-      title="Library storage unavailable"
+      :title="t('collections.list.libraryUnavailableTitle')"
       :description="appStore.libraryUnavailableReason"
     />
-    <ErrorState v-else-if="collectionsStore.error" title="Could not load collections" :message="collectionsStore.error" />
+    <ErrorState
+      v-else-if="collectionsStore.error"
+      :title="t('collections.list.loadErrorTitle')"
+      :message="collectionsStore.error"
+    />
     <template v-else>
       <div v-if="collectionsStore.loading" class="card p-8 text-center">
-        <p class="text-muted">Loading collections...</p>
+        <p class="text-muted">{{ t('collections.list.loading') }}</p>
       </div>
 
       <section v-else-if="collectionsStore.items.length > 0" class="grid gap-[1px] grid-cols-2 md:grid-cols-3">
@@ -46,15 +50,15 @@
           <div v-else class="h-full w-full bg-[linear-gradient(135deg,#262b31_0%,#111827_100%)]"></div>
           <div class="absolute inset-x-0 bottom-0 grid gap-[0.15rem] px-3 py-3 bg-[linear-gradient(180deg,rgba(10,14,24,0)_0%,rgba(10,14,24,0.82)_100%)]">
             <strong class="truncate text-[0.95rem]">{{ displayCollectionName(collection) }}</strong>
-            <span class="text-[0.74rem] font-semibold text-white/78">{{ formatCount(collection.itemCount) }} posts</span>
+            <span class="text-[0.74rem] font-semibold text-white/78">{{ formatPostCount(collection.itemCount) }}</span>
           </div>
         </RouterLink>
       </section>
 
       <EmptyState
         v-else
-        title="No collections yet"
-        description="Saved posts will appear in All Posts."
+        :title="t('collections.list.emptyTitle')"
+        :description="t('collections.list.emptyDescription')"
       />
     </template>
   </section>
@@ -62,6 +66,7 @@
 
 <script setup lang="ts">
 import { onMounted } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { RouterLink } from 'vue-router';
 
 import EmptyState from '../components/EmptyState.vue';
@@ -73,13 +78,20 @@ import type { CollectionSummary } from '../types/api';
 
 const appStore = useAppStore();
 const collectionsStore = useCollectionsStore();
+const { t, locale } = useI18n();
 
 function formatCount(value: number) {
-  return new Intl.NumberFormat().format(value);
+  return new Intl.NumberFormat(locale.value).format(value);
 }
 
 function displayCollectionName(collection: CollectionSummary) {
-  return collection.isDefault ? 'All Posts' : collection.name;
+  return collection.isDefault ? t('collections.shared.defaultName') : collection.name;
+}
+
+function formatPostCount(value: number) {
+  return value === 1
+    ? t('collections.shared.postCountOne', { count: formatCount(value) })
+    : t('collections.shared.postCountOther', { count: formatCount(value) });
 }
 
 function showAllPostsMosaic(collection: CollectionSummary) {

--- a/client/src/views/ExploreView.vue
+++ b/client/src/views/ExploreView.vue
@@ -11,7 +11,7 @@
           v-if="showSearchChrome"
           class="inline-flex h-11 w-11 items-center justify-center rounded-full border-0 bg-transparent p-0 text-muted transition-colors duration-150 hover:bg-surface-hover hover:text-text"
           type="button"
-          aria-label="Back to explore posts"
+          :aria-label="t('explore.back')"
           @click="closeSearch"
         >
           <svg
@@ -62,7 +62,7 @@
             v-model="searchQuery"
             class="w-full border-0 bg-transparent p-0 text-[1rem] text-text outline-none placeholder:text-muted"
             type="search"
-            placeholder="Search"
+            :placeholder="t('explore.searchPlaceholder')"
             spellcheck="false"
             @focus="activateSearch"
             @keydown.enter.prevent="commitSearch()"
@@ -72,7 +72,7 @@
             v-if="searchQuery.length > 0"
             class="inline-flex h-6 w-6 items-center justify-center rounded-full border-0 bg-surface-hover p-0 text-muted transition-colors duration-150 hover:bg-border hover:text-text"
             type="button"
-            aria-label="Clear search"
+            :aria-label="t('explore.clearSearch')"
             @click="clearSearch"
           >
             <svg
@@ -98,7 +98,7 @@
         class="explore-view__message-card max-w-[35rem]"
       >
         <h1 class="m-0 text-[1.15rem] font-semibold text-text">
-          Library storage unavailable
+          {{ t('reels.view.libraryUnavailableTitle') }}
         </h1>
         <p class="m-0 text-muted">{{ appStore.libraryUnavailableReason }}</p>
       </section>
@@ -109,14 +109,14 @@
             <h1
               class="m-0 text-[1.45rem] font-semibold tracking-[-0.03em] text-text"
             >
-              Recent
+              {{ t('explore.recentTitle') }}
             </h1>
             <button
               class="explore-view__recent-clear"
               type="button"
               @click="clearRecentSearches"
             >
-              Clear all
+              {{ t('explore.clearAll') }}
             </button>
           </div>
 
@@ -162,7 +162,7 @@
         <div
           class="explore-view__tabs flex flex-wrap gap-2"
           role="tablist"
-          aria-label="Search result tabs"
+          :aria-label="t('explore.tabsAria')"
         >
           <button
             class="explore-view__tab"
@@ -172,7 +172,7 @@
             :aria-selected="activeSearchTab === 'media'"
             @click="selectSearchTab('media')"
           >
-            Photos &amp; Videos
+            {{ t('explore.tabs.media') }}
           </button>
           <button
             class="explore-view__tab"
@@ -182,7 +182,7 @@
             :aria-selected="activeSearchTab === 'folders'"
             @click="selectSearchTab('folders')"
           >
-            App Folders
+            {{ t('explore.tabs.folders') }}
           </button>
         </div>
 
@@ -205,7 +205,7 @@
             class="explore-view__message-card mx-auto"
           >
             <h1 class="m-0 text-[1.15rem] font-semibold text-text">
-              Could not search posts
+              {{ t('explore.errors.search') }}
             </h1>
             <p class="m-0 text-muted">{{ exploreStore.searchError }}</p>
           </section>
@@ -218,10 +218,10 @@
             class="explore-view__message-card mx-auto"
           >
             <h1 class="m-0 text-[1.15rem] font-semibold text-text">
-              No matching photos or videos
+              {{ t('explore.emptySearchTitle') }}
             </h1>
             <p class="m-0 text-muted">
-              Try a different filename or folder keyword.
+              {{ t('explore.emptySearchDescription') }}
             </p>
           </section>
 
@@ -244,7 +244,7 @@
             v-if="foldersStore.loadingList && foldersStore.items.length === 0"
             class="m-0 text-[0.96rem] text-muted"
           >
-            Loading folders...
+            {{ t('explore.loadingFolders') }}
           </p>
 
           <div v-else class="grid gap-1">
@@ -276,7 +276,7 @@
               v-if="folderSearchResults.length === 0"
               class="m-0 pt-2 text-[1rem] text-muted"
             >
-              No app folders found.
+              {{ t('explore.noFoldersFound') }}
             </p>
           </div>
         </section>
@@ -301,7 +301,7 @@
           class="explore-view__message-card mx-auto"
         >
           <h1 class="m-0 text-[1.15rem] font-semibold text-text">
-            Could not load explore
+            {{ t('explore.errors.load') }}
           </h1>
           <p class="m-0 text-muted">{{ exploreStore.error }}</p>
         </section>
@@ -311,10 +311,10 @@
           class="explore-view__message-card mx-auto"
         >
           <h1 class="m-0 text-[1.15rem] font-semibold text-text">
-            Nothing to explore yet
+            {{ t('explore.emptyTitle') }}
           </h1>
           <p class="m-0 text-muted">
-            Index a few folders and this page will start surfacing posts here.
+            {{ t('explore.emptyDescription') }}
           </p>
         </section>
 
@@ -334,6 +334,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 
 import Avatar from '../components/Avatar.vue';
@@ -357,6 +358,7 @@ const foldersStore = useFoldersStore();
 const likesStore = useLikesStore();
 const route = useRoute();
 const router = useRouter();
+const { t, locale } = useI18n();
 
 const searchInput = ref<HTMLInputElement | null>(null);
 const searchQuery = ref(readRouteQueryValue(route.query.q));
@@ -575,7 +577,9 @@ function handleSearchMediaOpen() {
 
 function describeFolder(folder: FolderSummary): string {
   const location = folder.breadcrumb ?? folder.folderPath;
-  const postLabel = `${folder.imageCount} post${folder.imageCount === 1 ? '' : 's'}`;
+  const postLabel = folder.imageCount === 1
+    ? t('explore.folderPostsOne', { count: new Intl.NumberFormat(locale.value).format(folder.imageCount) })
+    : t('explore.folderPostsOther', { count: new Intl.NumberFormat(locale.value).format(folder.imageCount) });
 
   return `${location} • ${postLabel}`;
 }

--- a/client/src/views/FolderView.vue
+++ b/client/src/views/FolderView.vue
@@ -68,7 +68,7 @@
             <div
               v-if="folderStoriesStore.highlights.length"
               class="story-rail-shell mb-5"
-              aria-label="Folder stories"
+              :aria-label="t('folder.header.openStories')"
             >
               <div class="story-rail pb-3 pt-[0.12rem]">
                 <div class="story-rail__track mx-auto justify-center">
@@ -93,14 +93,14 @@
                 </div>
               </div>
             </div>
-            <div class="flex justify-center border-b border-border" aria-label="Folder sections">
+            <div class="flex justify-center border-b border-border" :aria-label="t('folder.tabs.sections')">
               <div class="flex items-center gap-40 pt-[0.2rem] max-sm:gap-[2.9rem] max-sm:pt-[0.12rem]">
                 <button
                   class="relative inline-flex h-[2.2rem] w-[3.15rem] cursor-pointer items-center justify-center border-0 bg-transparent p-0 text-muted transition-colors duration-[180ms] hover:text-text"
                   :class="activeTab === 'posts' ? 'text-text' : ''"
                   type="button"
-                  aria-label="Posts"
-                  title="Posts"
+                  :aria-label="t('folder.tabs.posts')"
+                  :title="t('folder.tabs.posts')"
                   :aria-pressed="activeTab === 'posts'"
                   @click="setTab('posts')"
                 >
@@ -131,8 +131,8 @@
                   class="relative inline-flex h-[2.2rem] w-[3.15rem] cursor-pointer items-center justify-center border-0 bg-transparent p-0 text-muted transition-colors duration-[180ms] hover:text-text"
                   :class="activeTab === 'reels' ? 'text-text' : ''"
                   type="button"
-                  aria-label="Reels"
-                  title="Reels"
+                  :aria-label="t('folder.tabs.reels')"
+                  :title="t('folder.tabs.reels')"
                   :aria-pressed="activeTab === 'reels'"
                   @click="setTab('reels')"
                 >
@@ -183,6 +183,7 @@
 
 <script setup lang="ts">
   import { computed, onMounted, ref, watch } from "vue"
+  import { useI18n } from "vue-i18n"
   import { useRoute, useRouter } from "vue-router"
 
   import EmptyState from "../components/EmptyState.vue"
@@ -205,6 +206,7 @@
   const foldersStore = useFoldersStore()
   const route = useRoute()
   const router = useRouter()
+  const { t } = useI18n()
   const hasLoadedOnce = ref(false)
   const activeStoryViewerId = ref<string | null>(null)
   const activeTab = computed(() =>

--- a/client/src/views/HomeView.test.ts
+++ b/client/src/views/HomeView.test.ts
@@ -3,6 +3,7 @@ import { flushPromises, mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 
+import { DEFAULT_LOCALE, i18n } from '../locales';
 import type { AppStatus, ScanProgress } from '../types/api';
 import { useAppStore } from '../stores/app';
 import { useFeedStore } from '../stores/feed';
@@ -124,6 +125,7 @@ describe('HomeView', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.restoreAllMocks();
+    i18n.global.locale.value = DEFAULT_LOCALE;
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,
       writable: true,
@@ -198,5 +200,39 @@ describe('HomeView', () => {
     expect(wrapper.get('.stories-bar.story-rail').attributes('aria-label')).toBe('Moments');
     expect(wrapper.get('.story-rail__track').classes()).not.toContain('justify-center');
     expect(wrapper.findAll('.story-rail__item')).toHaveLength(4);
+  });
+
+  it('localizes static highlight capsule titles on the home rail', async () => {
+    const appStore = useAppStore();
+    const feedStore = useFeedStore();
+    const momentsStore = useMomentsStore();
+
+    i18n.global.locale.value = 'zh';
+
+    appStore.$patch({
+      stats: createAppStatus({
+        isScanning: false
+      })
+    });
+    feedStore.$patch({
+      initialized: true,
+      loading: false,
+      items: []
+    });
+    momentsStore.$patch({
+      railKind: 'highlights',
+      items: [
+        createMomentCapsule('highlight-recent-batches', 'Recent Batches')
+      ]
+    });
+
+    vi.spyOn(feedStore, 'loadInitial').mockResolvedValue();
+    vi.spyOn(momentsStore, 'fetchMoments').mockResolvedValue();
+
+    const wrapper = mountHomeView();
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('近期批次');
   });
 });

--- a/client/src/views/HomeView.vue
+++ b/client/src/views/HomeView.vue
@@ -39,12 +39,12 @@
       </section>
 
       <section v-if="!appStore.isLibraryUnavailable" class="grid min-w-0 gap-[1rem] mb-5 w-full max-w-[39.375rem]">
-        <section v-if="momentsStore.items.length" class="mb-2 min-w-0">
+        <section v-if="displayMomentItems.length" class="mb-2 min-w-0">
           <div class="story-rail-shell">
-            <div class="stories-bar story-rail pb-5 pt-[0.12rem]" :aria-label="momentsStore.railTitle">
+            <div class="stories-bar story-rail pb-5 pt-[0.12rem]" :aria-label="momentsStore.displayRailTitle">
               <div class="story-rail__track">
               <button
-                v-for="moment in momentsStore.items"
+                v-for="moment in displayMomentItems"
                 :key="moment.id"
                 class="story-rail__item story-rail__button"
                 :title="`${moment.title} · ${moment.subtitle}`"
@@ -199,10 +199,10 @@
       </template>
 
       <StoriesModal
-        v-if="activeRailViewerId && momentsStore.items.length"
-        :items="momentsStore.items"
+        v-if="activeRailViewerId && displayMomentItems.length"
+        :items="displayMomentItems"
         :initial-id="activeRailViewerId"
-        :rail-singular-label="momentsStore.railSingularLabel"
+        :rail-singular-label="momentsStore.displayRailSingularLabel"
         :store="momentsStore"
         @close="closeRailViewer"
       />
@@ -224,20 +224,20 @@
         !isCompactHomeLayout
       "
       class="sticky top-8 grid gap-[1.15rem] w-[19.9375rem] text-muted"
-      aria-label="Folder recommendations"
+      :aria-label="t('home.sidebar.ariaLabel')"
     >
       <div class="flex items-center gap-[0.8rem]">
         <Avatar class="w-11 h-11" :name="homeSummaryFolder.name" :src="homeSummaryFolder.avatarUrl" />
         <div class="flex-1 min-w-0">
           <strong class="block text-text text-[0.87rem] font-bold">{{ homeSummaryFolder.name }}</strong>
-          <p class="m-0 mt-[0.12rem] text-[0.79rem] truncate">{{ homeSummaryFolder.breadcrumb ?? 'Top-level source folder' }}</p>
+          <p class="m-0 mt-[0.12rem] text-[0.79rem] truncate">{{ homeSummaryFolder.breadcrumb ?? t('folder.shared.topLevelSourceFolder') }}</p>
         </div>
-        <RouterLink class="ml-auto text-accent-strong text-[0.76rem] font-bold" :to="{ name: 'folder', params: { slug: homeSummaryFolder.slug } }">Open</RouterLink>
+        <RouterLink class="ml-auto text-accent-strong text-[0.76rem] font-bold" :to="{ name: 'folder', params: { slug: homeSummaryFolder.slug } }">{{ t('home.sidebar.openFolder') }}</RouterLink>
       </div>
 
       <div class="flex items-center justify-between gap-4 text-text text-[0.96rem] font-bold">
-        <span>Suggested folders</span>
-        <RouterLink class="text-muted text-[0.76rem] font-bold" :to="{ name: 'likes' }">View {{ likesStore.collectionLabel.toLowerCase() }}</RouterLink>
+        <span>{{ t('home.sidebar.suggestedFolders') }}</span>
+        <RouterLink class="text-muted text-[0.76rem] font-bold" :to="{ name: 'likes' }">{{ homeSidebarLinkLabel }}</RouterLink>
       </div>
 
       <div class="grid gap-[0.95rem]">
@@ -250,21 +250,21 @@
           <Avatar class="w-11 h-11" :name="folder.name" :src="folder.avatarUrl" />
           <div class="flex-1 min-w-0">
             <strong class="block text-text text-[0.87rem] font-bold">{{ folder.name }}</strong>
-            <p class="m-0 mt-[0.12rem] text-[0.79rem] truncate">{{ folder.breadcrumb ?? 'Top-level source folder' }}</p>
+            <p class="m-0 mt-[0.12rem] text-[0.79rem] truncate">{{ folder.breadcrumb ?? t('folder.shared.topLevelSourceFolder') }}</p>
           </div>
-          <span class="ml-auto text-accent-strong text-[0.76rem] font-bold">Open</span>
+          <span class="ml-auto text-accent-strong text-[0.76rem] font-bold">{{ t('home.sidebar.openFolder') }}</span>
         </RouterLink>
       </div>
 
       <p class="m-0 mt-[1.4rem] text-center text-[0.64rem] font-semibold uppercase tracking-[0.08em] leading-[1.7] text-muted">
-        Foldergram is open source.
+        {{ t('home.sidebar.openSourceText') }}
         <a
           class="text-muted transition-colors duration-180 hover:text-text"
           href="https://github.com/foldergram/foldergram"
           target="_blank"
           rel="noreferrer"
         >
-          View on GitHub
+          {{ t('home.sidebar.viewOnGitHub') }}
         </a>
       </p>
     </aside>
@@ -273,6 +273,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { RouterLink } from 'vue-router';
 
 import { triggerManualScan } from '../api/gallery';
@@ -300,6 +301,7 @@ const folderStoriesStore = useFolderStoriesStore();
 const likesStore = useLikesStore();
 const foldersStore = useFoldersStore();
 const momentsStore = useMomentsStore();
+const { t } = useI18n();
 const likedCountByFolder = computed(() => buildLikedCountByFolder(likesStore.items));
 const homeRecommendations = computed(() =>
   selectHomeRecommendations(foldersStore.items, likedCountByFolder.value, appStore.lastOpenedFolderSlug)
@@ -322,6 +324,11 @@ function formatCount(value: number) {
   return new Intl.NumberFormat().format(value);
 }
 
+const displayMomentItems = computed(() => momentsStore.localizedItems);
+const homeSidebarLinkLabel = computed(() =>
+  authStore.likesMode === 'local' ? t('home.sidebar.viewFavorites') : t('home.sidebar.viewLikes')
+);
+
 const indexedSummaryLabel = computed(() => {
   if (!appStore.stats) {
     return '';
@@ -332,23 +339,23 @@ const indexedSummaryLabel = computed(() => {
 const formattedIndexedImageCount = computed(() => formatCount(appStore.stats?.indexedImages ?? 0));
 const formattedIndexedVideoCount = computed(() => formatCount(appStore.stats?.indexedVideos ?? 0));
 const formattedFolderCount = computed(() => formatCount(appStore.stats?.folders ?? 0));
-const feedModes: Array<{ id: FeedMode; label: string; description: string }> = [
+const feedModes = computed<Array<{ id: FeedMode; label: string; description: string }>>(() => [
   {
     id: 'recent',
-    label: 'Recent',
-    description: 'Newest posts first.'
+    label: t('settings.general.homeFeed.options.recent.label'),
+    description: t('settings.general.homeFeed.options.recent.description')
   },
   {
     id: 'rediscover',
-    label: 'Rediscover',
-    description: 'Older posts resurface when they are worth another look.'
+    label: t('settings.general.homeFeed.options.rediscover.label'),
+    description: t('settings.general.homeFeed.options.rediscover.description')
   },
   {
     id: 'random',
-    label: 'Random',
-    description: 'A fresh shuffle that stays steady while you browse.'
+    label: t('settings.general.homeFeed.options.random.label'),
+    description: t('settings.general.homeFeed.options.random.description')
   }
-];
+]);
 const showInitialScanState = computed(
   () => appStore.isScanning && feedStore.items.length === 0 && !feedStore.loading && !feedStore.error
 );

--- a/client/src/views/LibraryView.vue
+++ b/client/src/views/LibraryView.vue
@@ -5,14 +5,14 @@
       class="flex items-end justify-between gap-4 max-sm:flex-col max-sm:items-start"
     >
       <div>
-        <span class="eyebrow">Library</span>
+        <span class="eyebrow">{{ t('libraryPage.eyebrow') }}</span>
         <h1
           class="mt-[0.15rem] mb-0 text-[clamp(1.55rem,2.4vw,2rem)] font-medium tracking-[-0.04em]"
         >
-          All folders
+          {{ t('libraryPage.title') }}
         </h1>
         <p class="m-0 mt-1 text-muted">
-          Browse and search every indexed app folder.
+          {{ t('libraryPage.description') }}
         </p>
       </div>
       <div
@@ -23,7 +23,7 @@
             {{ formatCount(foldersStore.items.length) }}
           </p>
           <p class="m-0 text-muted text-[0.72rem] uppercase tracking-[0.08em]">
-            Folders
+            {{ t('libraryPage.stats.folders') }}
           </p>
         </div>
         <div class="w-px h-8 bg-border"></div>
@@ -32,7 +32,7 @@
             {{ formatCount(totalIndexedImages) }}
           </p>
           <p class="m-0 text-muted text-[0.72rem] uppercase tracking-[0.08em]">
-            Posts
+            {{ t('libraryPage.stats.posts') }}
           </p>
         </div>
       </div>
@@ -40,12 +40,12 @@
 
     <EmptyState
       v-if="appStore.isLibraryUnavailable"
-      title="Library storage unavailable"
+      :title="t('reels.view.libraryUnavailableTitle')"
       :description="appStore.libraryUnavailableReason"
     />
     <ErrorState
       v-else-if="foldersStore.listError && foldersStore.items.length === 0"
-      title="Could not load folders"
+      :title="t('libraryPage.errors.load')"
       :message="foldersStore.listError"
     />
     <template v-else>
@@ -70,7 +70,7 @@
             v-model.trim="searchQuery"
             class="w-full h-10 pl-9 pr-4 border border-border rounded-[0.75rem] text-text text-[0.88rem] bg-surface-alt transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent/40 focus:shadow-[0_0_0_3px_var(--accent-soft)]"
             type="search"
-            placeholder="Search names or path segments…"
+            :placeholder="t('libraryPage.searchPlaceholder')"
           />
         </div>
 
@@ -79,11 +79,11 @@
             v-model="sortMode"
             class="h-10 pl-3 pr-9 border border-border rounded-[0.75rem] text-text text-[0.82rem] bg-surface-alt cursor-pointer appearance-none focus:outline-none focus:border-accent/40"
           >
-            <option value="recent-desc">Recently updated</option>
-            <option value="images-desc">Most posts</option>
-            <option value="name-asc">Name A–Z</option>
-            <option value="name-desc">Name Z–A</option>
-            <option value="path-asc">Path A–Z</option>
+            <option value="recent-desc">{{ t('libraryPage.sort.recentDesc') }}</option>
+            <option value="images-desc">{{ t('libraryPage.sort.imagesDesc') }}</option>
+            <option value="name-asc">{{ t('libraryPage.sort.nameAsc') }}</option>
+            <option value="name-desc">{{ t('libraryPage.sort.nameDesc') }}</option>
+            <option value="path-asc">{{ t('libraryPage.sort.pathAsc') }}</option>
           </select>
           <svg
             class="pointer-events-none absolute right-[0.65rem] top-1/2 -translate-y-1/2 w-[0.85rem] h-[0.85rem] text-muted"
@@ -98,24 +98,20 @@
           </svg>
         </div>
 
-        <span class="ml-auto text-muted text-[0.8rem] shrink-0"
-          >{{ formatCount(filteredFolders.length) }} result{{
-            filteredFolders.length !== 1 ? "s" : ""
-          }}</span
-        >
+        <span class="ml-auto text-muted text-[0.8rem] shrink-0">{{ formatResultsCount(filteredFolders.length) }}</span>
       </div>
 
       <section
         v-if="foldersStore.loadingList && foldersStore.items.length === 0"
         class="card p-12 text-center"
       >
-        <p class="text-muted">Loading folders…</p>
+        <p class="text-muted">{{ t('libraryPage.loading') }}</p>
       </section>
 
       <EmptyState
         v-else-if="foldersStore.items.length === 0"
-        title="No folders indexed yet"
-        description="Add media-containing source folders under the gallery root and run a scan."
+        :title="t('libraryPage.emptyTitle')"
+        :description="t('libraryPage.emptyDescription')"
       />
 
       <section
@@ -123,14 +119,14 @@
         class="card p-12 text-center"
       >
         <p class="m-0 text-muted">
-          No folders match. Try a different search or filter.
+          {{ t('libraryPage.noMatch') }}
         </p>
       </section>
 
       <section
         v-else
         class="bg-surface border border-border rounded-[1.1rem] shadow-[var(--shadow)] overflow-hidden"
-        aria-label="All folders"
+        :aria-label="t('libraryPage.title')"
       >
         <div
           v-for="(folder, i) in filteredFolders"
@@ -153,7 +149,7 @@
                 {{ folder.name }}
               </p>
               <p class="m-0 text-muted text-[0.76rem] truncate">
-                {{ folder.breadcrumb ?? "Top-level source folder" }}
+                {{ folder.breadcrumb ?? t('libraryPage.topLevelSourceFolder') }}
               </p>
               <p
                 class="m-0 hidden text-muted text-[0.74rem] truncate font-mono opacity-70 sm:block"
@@ -162,8 +158,8 @@
               </p>
               <div class="mt-1 grid gap-[0.1rem] sm:hidden">
                 <span class="text-[0.74rem] font-semibold text-text">
-                  {{ formatCount(folder.imageCount) }} posts ·
-                  {{ formatCount(folder.videoCount) }} reels
+                  {{ formatPostsCount(folder.imageCount) }} ·
+                  {{ formatReelsCount(folder.videoCount) }}
                 </span>
                 <span class="text-[0.72rem] text-muted">
                   {{ formatLatestDate(folder.latestImageMtimeMs) }}
@@ -176,23 +172,24 @@
             <div class="grid gap-[0.15rem] justify-items-end">
               <span
                 class="text-[0.82rem] font-semibold text-text tabular-nums"
-                >{{ formatCount(folder.imageCount) }} posts</span
+                >{{ formatPostsCount(folder.imageCount) }}</span
               >
               <span class="text-[0.72rem] text-muted">
-                {{ formatCount(folder.videoCount) }} reels · {{ formatLatestDate(folder.latestImageMtimeMs) }}
+                {{ formatReelsCount(folder.videoCount) }} · {{ formatLatestDate(folder.latestImageMtimeMs) }}
               </span>
             </div>
             <span
               class="w-[7px] h-[7px] rounded-full shrink-0"
               :class="folder.imageCount > 0 ? 'bg-[#1ca44e]' : 'bg-border'"
-              :title="folder.imageCount > 0 ? 'Ready' : 'Empty'"
+              :title="folder.imageCount > 0 ? t('libraryPage.readiness.ready') : t('libraryPage.readiness.empty')"
             ></span>
           </div>
 
           <button
             class="inline-flex items-center justify-center w-8 h-8 p-0 border-0 text-muted bg-transparent cursor-pointer rounded-full hover:bg-surface-alt transition-colors duration-150 shrink-0 max-sm:mt-[0.1rem]"
             type="button"
-            aria-label="More options"
+            :aria-label="t('libraryPage.moreOptions')"
+            :title="t('libraryPage.moreOptions')"
             @click.prevent="openMenu(folder)"
           >
             <svg
@@ -237,7 +234,7 @@
               stroke-width="1.8"
             />
           </svg>
-          <span>Open folder</span>
+          <span>{{ t('libraryPage.openFolder') }}</span>
         </button>
         <button
           v-if="authStore.canDeleteMedia"
@@ -259,7 +256,7 @@
               stroke-width="1.8"
             />
           </svg>
-          <span>Delete folder</span>
+          <span>{{ t('libraryPage.deleteFolder') }}</span>
         </button>
         <button
           class="flex items-center gap-[0.8rem] w-full px-4 py-[0.95rem] border-0 text-text bg-transparent cursor-pointer text-left"
@@ -280,7 +277,7 @@
               stroke-width="1.8"
             />
           </svg>
-          <span>Cancel</span>
+          <span>{{ t('common.cancel') }}</span>
         </button>
       </div>
     </div>
@@ -288,7 +285,7 @@
     <!-- Delete confirmation dialog -->
     <ConfirmDialog
       v-if="confirmDeleteFolder"
-      title="Delete this app folder?"
+      :title="t('libraryPage.delete.title')"
       :message="deleteFolderMessage"
       :confirm-label="deleteFolderConfirmLabel"
       :loading-label="deleteFolderLoadingLabel"
@@ -305,9 +302,7 @@
             :disabled="deleting"
           />
           <span class="grid gap-[0.18rem]">
-            <span class="text-[0.92rem] font-semibold text-text"
-              >Delete the source folder too</span
-            >
+            <span class="text-[0.92rem] font-semibold text-text">{{ t('libraryPage.delete.sourceTooTitle') }}</span>
             <span class="text-[0.84rem] text-muted">
               {{ deleteSourceFolderLabel }}
             </span>
@@ -317,9 +312,7 @@
           v-if="deleteSourceFolder"
           class="m-0 mt-3 px-3 py-[0.8rem] rounded-[0.9rem] border border-[rgba(217,48,37,0.24)] text-[0.84rem] text-[#b42318] bg-[rgba(217,48,37,0.08)]"
         >
-          Doing this will permanently delete the selected source folder and
-          every child folder and file inside it, including unsupported files.
-          This action cannot be undone.
+          {{ t('libraryPage.delete.warning') }}
         </p>
         <p
           v-if="deleteError"
@@ -334,6 +327,7 @@
 
 <script setup lang="ts">
   import { computed, onMounted, ref } from "vue"
+  import { useI18n } from "vue-i18n"
   import { RouterLink, useRouter } from "vue-router"
 
   import Avatar from "../components/Avatar.vue"
@@ -363,6 +357,7 @@
   const foldersStore = useFoldersStore()
   const momentsStore = useMomentsStore()
   const router = useRouter()
+  const { t, locale } = useI18n()
   const searchQuery = ref("")
   const sortMode = ref<LibrarySort>("recent-desc")
   const menuFolder = ref<FolderSummary | null>(null)
@@ -372,19 +367,37 @@
   const deleteError = ref<string | null>(null)
 
   function formatCount(value: number) {
-    return new Intl.NumberFormat().format(value)
+    return new Intl.NumberFormat(locale.value).format(value)
   }
 
   function formatLatestDate(value: number | null) {
     if (!value) {
-      return "No recent media"
+      return t("libraryPage.noRecentMedia")
     }
 
-    return new Date(value).toLocaleDateString(undefined, {
+    return new Date(value).toLocaleDateString(locale.value, {
       month: "short",
       day: "numeric",
       year: "numeric",
     })
+  }
+
+  function formatResultsCount(value: number) {
+    return value === 1
+      ? t("libraryPage.resultsOne", { count: formatCount(value) })
+      : t("libraryPage.resultsOther", { count: formatCount(value) })
+  }
+
+  function formatPostsCount(value: number) {
+    return value === 1
+      ? t("libraryPage.postsCountOne", { count: formatCount(value) })
+      : t("libraryPage.postsCountOther", { count: formatCount(value) })
+  }
+
+  function formatReelsCount(value: number) {
+    return value === 1
+      ? t("libraryPage.reelsCountOne", { count: formatCount(value) })
+      : t("libraryPage.reelsCountOther", { count: formatCount(value) })
   }
 
   const normalizedQuery = computed(() => searchQuery.value.trim().toLowerCase())
@@ -406,29 +419,38 @@
       return ""
     }
 
-    const directImageLabel = `${formatCount(confirmDeleteFolder.value.imageCount)} direct post${confirmDeleteFolder.value.imageCount !== 1 ? "s" : ""}`
+    const directImageLabel = confirmDeleteFolder.value.imageCount === 1
+      ? t("libraryPage.delete.directPostsOne", { count: formatCount(confirmDeleteFolder.value.imageCount) })
+      : t("libraryPage.delete.directPostsOther", { count: formatCount(confirmDeleteFolder.value.imageCount) })
     if (deleteSourceFolder.value) {
-      return `This will permanently delete ${directImageLabel} and remove this source folder from the hard drive.`
+      return t("libraryPage.delete.messageDeleteSource", { directPosts: directImageLabel })
     }
 
     if (deleteChildFolderCount.value > 0) {
-      return `This will permanently delete ${directImageLabel}. ${formatCount(deleteChildFolderCount.value)} child app folder${deleteChildFolderCount.value !== 1 ? "s" : ""} will be kept.`
+      return t("libraryPage.delete.messageKeepChildren", {
+        directPosts: directImageLabel,
+        childFolders: deleteChildFolderCount.value === 1
+          ? t("libraryPage.delete.childFoldersOne", { count: formatCount(deleteChildFolderCount.value) })
+          : t("libraryPage.delete.childFoldersOther", { count: formatCount(deleteChildFolderCount.value) })
+      })
     }
 
-    return `This will permanently delete ${directImageLabel}. The source folder itself will only be removed if it becomes empty.`
+    return t("libraryPage.delete.messageEmptyFolder", { directPosts: directImageLabel })
   })
   const deleteSourceFolderLabel = computed(() => {
     if (deleteChildFolderCount.value > 0) {
-      return `Also remove ${formatCount(deleteChildFolderCount.value)} child app folder${deleteChildFolderCount.value !== 1 ? "s" : ""} and every file inside the subtree.`
+      return deleteChildFolderCount.value === 1
+        ? t("libraryPage.delete.sourceTooWithChildrenOne", { count: formatCount(deleteChildFolderCount.value) })
+        : t("libraryPage.delete.sourceTooWithChildrenOther", { count: formatCount(deleteChildFolderCount.value) })
     }
 
-    return "Also remove the source folder itself instead of only deleting its direct posts."
+    return t("libraryPage.delete.sourceTooNoChildren")
   })
   const deleteFolderConfirmLabel = computed(() =>
-    deleteSourceFolder.value ? "Delete folder subtree" : "Delete app folder",
+    deleteSourceFolder.value ? t("libraryPage.delete.confirmSubtree") : t("libraryPage.delete.confirmFolder"),
   )
   const deleteFolderLoadingLabel = computed(() =>
-    deleteSourceFolder.value ? "Deleting subtree…" : "Deleting…",
+    deleteSourceFolder.value ? t("libraryPage.delete.loadingSubtree") : t("libraryPage.delete.loadingFolder"),
   )
 
   function matchesSearch(folder: FolderSummary, query: string) {
@@ -532,7 +554,7 @@
       deleteError.value =
         error instanceof Error
           ? error.message
-          : "Unable to delete this app folder."
+          : t("libraryPage.delete.error")
     } finally {
       deleting.value = false
     }

--- a/client/src/views/LikesView.vue
+++ b/client/src/views/LikesView.vue
@@ -6,11 +6,11 @@
       :description="appStore.libraryUnavailableReason"
     />
     <section v-else-if="appStore.isRebuilding && likesStore.items.length === 0" class="card p-8 text-center">
-      <p class="m-0 text-muted">Rebuilding the library index. {{ likesStore.collectionLabel }} will return after the refreshed library finishes loading.</p>
+      <p class="m-0 text-muted">{{ t('likes.view.rebuilding', { label: likesStore.collectionLabel }) }}</p>
     </section>
     <ErrorState v-else-if="likesStore.error" :title="likesStore.errorTitle" :message="likesStore.error" />
     <template v-else>
-      <div class="flex justify-center py-[0.95rem] mb-[0.45rem] border-t border-border" :aria-label="`${likesStore.collectionLabel} sections`">
+      <div class="flex justify-center py-[0.95rem] mb-[0.45rem] border-t border-border" :aria-label="t('likes.view.sectionsAria', { label: likesStore.collectionLabel })">
         <span class="relative pt-[0.1rem] text-text text-[0.78rem] font-bold tracking-[0.11em] uppercase">
           <span class="absolute left-0 right-0 top-[-1.05rem] h-px bg-text" aria-hidden="true"></span>
           {{ likesStore.collectionSectionLabel }}
@@ -31,6 +31,7 @@
 
 <script setup lang="ts">
 import { onMounted } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import EmptyState from '../components/EmptyState.vue';
 import ErrorState from '../components/ErrorState.vue';
@@ -40,6 +41,7 @@ import { useLikesStore } from '../stores/likes';
 
 const appStore = useAppStore();
 const likesStore = useLikesStore();
+const { t } = useI18n();
 
 onMounted(async () => {
   if (appStore.isLibraryUnavailable) {

--- a/client/src/views/MomentView.vue
+++ b/client/src/views/MomentView.vue
@@ -5,36 +5,36 @@
       title="Library storage unavailable"
       :description="appStore.libraryUnavailableReason"
     />
-    <section v-else-if="appStore.isRebuilding && !momentsStore.currentMoment" class="card p-8 text-center">
-      <p class="m-0 text-muted">Rebuilding the library index. This view will repopulate when the refreshed home rail is ready.</p>
+    <section v-else-if="appStore.isRebuilding && !momentsStore.currentCapsule" class="card p-8 text-center">
+      <p class="m-0 text-muted">{{ t('moments.view.rebuilding') }}</p>
     </section>
     <ErrorState
       v-else-if="momentsStore.momentError"
-      :title="`Could not load ${momentsStore.railSingularLabel.toLowerCase()}`"
+      :title="t('moments.view.loadError', { label: momentsStore.displayRailSingularLabel.toLowerCase() })"
       :message="momentsStore.momentError"
     />
-    <section v-else-if="momentsStore.loadingMoment && !momentsStore.currentMoment" class="card p-8 text-center">
-      <p class="m-0 text-muted">Loading {{ momentsStore.railSingularLabel.toLowerCase() }}...</p>
+    <section v-else-if="momentsStore.loadingMoment && !momentsStore.currentCapsule" class="card p-8 text-center">
+      <p class="m-0 text-muted">{{ t('moments.view.loading', { label: momentsStore.displayRailSingularLabel.toLowerCase() }) }}</p>
     </section>
-    <template v-else-if="momentsStore.currentMoment">
+    <template v-else-if="momentsStore.currentCapsule">
       <header class="grid gap-5 p-5 mb-5 border border-border rounded-[1.25rem] bg-surface shadow-[var(--shadow)] md:grid-cols-[6.5rem_minmax(0,1fr)]">
         <div class="overflow-hidden rounded-[1.1rem] aspect-square bg-surface-alt">
           <img
             class="block object-cover w-full h-full"
-            :src="momentsStore.currentMoment.coverImage.thumbnailUrl"
-            :alt="momentsStore.currentMoment.title"
+            :src="momentsStore.currentCapsule.coverImage.thumbnailUrl"
+            :alt="momentsStore.currentCapsule.title"
             loading="lazy"
           />
         </div>
         <div class="grid gap-[0.55rem]">
-          <span class="text-[0.74rem] font-bold tracking-[0.11em] uppercase text-accent-strong">{{ momentsStore.railSingularLabel }}</span>
+          <span class="text-[0.74rem] font-bold tracking-[0.11em] uppercase text-accent-strong">{{ momentsStore.displayRailSingularLabel }}</span>
           <div class="grid gap-[0.2rem]">
-            <h1 class="m-0 text-[1.7rem] leading-tight">{{ momentsStore.currentMoment.title }}</h1>
-            <p class="m-0 text-[0.96rem] text-muted">{{ momentsStore.currentMoment.subtitle }}</p>
+            <h1 class="m-0 text-[1.7rem] leading-tight">{{ momentsStore.currentCapsule.title }}</h1>
+            <p class="m-0 text-[0.96rem] text-muted">{{ momentsStore.currentCapsule.subtitle }}</p>
           </div>
           <div class="flex flex-wrap gap-3 text-[0.82rem] text-muted">
-            <span>{{ momentsStore.currentMoment.imageCount }} posts</span>
-            <span>{{ momentsStore.currentMoment.dateContext }}</span>
+            <span>{{ t('moments.view.postCount', { count: momentsStore.currentCapsule.imageCount }) }}</span>
+            <span>{{ momentsStore.currentCapsule.dateContext }}</span>
           </div>
         </div>
       </header>
@@ -48,14 +48,15 @@
     </template>
     <EmptyState
       v-else-if="hasLoadedOnce && !momentsStore.loadingMoment"
-      :title="`This ${momentsStore.railSingularLabel.toLowerCase()} is empty`"
-      :description="`Try another ${momentsStore.railSingularLabel.toLowerCase()} from the homepage.`"
+      :title="t('moments.view.emptyTitle', { label: momentsStore.displayRailSingularLabel.toLowerCase() })"
+      :description="t('moments.view.emptyDescription', { label: momentsStore.displayRailSingularLabel.toLowerCase() })"
     />
   </section>
 </template>
 
 <script setup lang="ts">
 import { onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import EmptyState from '../components/EmptyState.vue';
 import ErrorState from '../components/ErrorState.vue';
@@ -71,6 +72,7 @@ const props = defineProps<{
 const appStore = useAppStore();
 const momentsStore = useMomentsStore();
 const hasLoadedOnce = ref(false);
+const { t } = useI18n();
 
 async function loadMoment() {
   if (appStore.isLibraryUnavailable) {

--- a/client/src/views/PlaceView.vue
+++ b/client/src/views/PlaceView.vue
@@ -3,7 +3,7 @@
     <ErrorState
       v-if="placesStore.placeError"
       class="mx-auto w-[min(100%,56rem)]"
-      title="Could not load place"
+      :title="t('placePage.errors.load')"
       :message="placesStore.placeError"
     />
     <template v-else-if="placesStore.currentPlace">
@@ -24,7 +24,7 @@
                   {{ placesStore.currentPlace.name }}
                 </h1>
                 <span class="inline-flex items-center rounded-lg border border-border bg-surface-hover px-3 py-[0.45rem] text-[0.76rem] font-semibold text-muted">
-                  Offline place
+                  {{ t('placePage.badge') }}
                 </span>
               </div>
 
@@ -33,13 +33,13 @@
               </p>
 
               <div class="flex flex-wrap items-center gap-x-[1.6rem] gap-y-[0.75rem] text-[0.95rem] leading-none max-sm:justify-center">
-                <span><strong class="mr-[0.35rem] font-semibold text-text">{{ formattedPostCount }}</strong>{{ postCountLabel }}</span>
-                <span v-if="coordinateLine"><strong class="mr-[0.35rem] font-semibold text-text">{{ coordinateLine }}</strong>coordinates</span>
-                <span><strong class="mr-[0.35rem] font-semibold text-text">{{ placeKindLabel }}</strong>{{ placeKindDetailLabel }}</span>
+                <span><strong class="mr-[0.35rem] font-semibold text-text">{{ formattedPostCount }}</strong>{{ ` ${postCountLabel}` }}</span>
+                <span v-if="coordinateLine"><strong class="mr-[0.35rem] font-semibold text-text">{{ coordinateLine }}</strong>{{ ` ${t('placePage.coordinatesLabel')}` }}</span>
+                <span><strong class="mr-[0.35rem] font-semibold text-text">{{ placeKindLabel }}</strong>{{ ` ${placeKindDetailLabel}` }}</span>
               </div>
 
               <div class="grid max-w-[34rem] gap-[0.28rem] max-sm:max-w-none">
-                <span class="text-[0.74rem] font-bold text-muted uppercase">Source</span>
+                <span class="text-[0.74rem] font-bold text-muted uppercase">{{ t('placePage.sourceLabel') }}</span>
                 <p class="m-0 text-[0.95rem] leading-[1.45] text-text">
                   {{ heroNote }}
                 </p>
@@ -47,7 +47,7 @@
 
               <div v-if="placesStore.currentPlace.isApproximate" class="flex max-sm:justify-center">
                 <span class="inline-flex items-center rounded-lg border border-accent bg-accent-soft px-3 py-[0.45rem] text-[0.8rem] font-semibold text-accent-strong">
-                  Approximate city match
+                  {{ t('placePage.approximateBadge') }}
                 </span>
               </div>
             </div>
@@ -57,8 +57,8 @@
         <EmptyState
           v-if="!placesStore.loadingPlace && placesStore.currentImages.length === 0"
           class="mx-auto w-[min(100%,56rem)]"
-          title="No posts for this place"
-          description="Place assignments can be rebuilt from Settings after offline place data is prepared."
+          :title="t('placePage.emptyTitle')"
+          :description="t('placePage.emptyDescription')"
         />
         <template v-else>
           <FolderGrid :items="placesStore.currentImages" variant="square" />
@@ -77,6 +77,7 @@
 
 <script setup lang="ts">
   import { computed, onMounted, watch } from "vue"
+  import { useI18n } from "vue-i18n"
 
   import EmptyState from "../components/EmptyState.vue"
   import ErrorState from "../components/ErrorState.vue"
@@ -89,6 +90,7 @@
   }>()
 
   const placesStore = usePlacesStore()
+  const { t, locale } = useI18n()
 
   const metadataLine = computed(() => {
     const place = placesStore.currentPlace
@@ -98,7 +100,7 @@
 
     return [place.cityName, place.admin1Name, place.countryName ?? place.countryCode]
       .filter((part, index, parts) => part && parts.indexOf(part) === index)
-      .join(", ") || "Offline city-level place"
+      .join(", ") || t("placePage.metadataFallback")
   })
 
   const heroNote = computed(() => {
@@ -112,8 +114,8 @@
     }
 
     return place.isApproximate
-      ? "Grouped from stored photo GPS coordinates and matched to the nearest city for offline browsing."
-      : "Resolved from stored photo GPS coordinates and kept available offline."
+      ? t("placePage.heroApproximate")
+      : t("placePage.heroExact")
   })
 
   const coordinateLine = computed(() => {
@@ -126,32 +128,32 @@
   })
 
   const formattedPostCount = computed(() =>
-    new Intl.NumberFormat().format(placesStore.currentPlace?.postCount ?? 0),
+    new Intl.NumberFormat(locale.value).format(placesStore.currentPlace?.postCount ?? 0),
   )
 
   const postCountLabel = computed(() =>
-    placesStore.currentPlace?.postCount === 1 ? "post" : "posts",
+    placesStore.currentPlace?.postCount === 1 ? t("placePage.postCountOne") : t("placePage.postCountOther"),
   )
 
   const placeKindLabel = computed(() => {
     const place = placesStore.currentPlace
     if (!place) {
-      return "Offline"
+      return t("placePage.kind.offline")
     }
 
     if (place.kind === "manual") {
-      return "Manual"
+      return t("placePage.kind.manual")
     }
 
     if (place.kind === "approximate_spot" || place.isApproximate) {
-      return "Nearest city"
+      return t("placePage.kind.nearestCity")
     }
 
-    return "City"
+    return t("placePage.kind.city")
   })
 
   const placeKindDetailLabel = computed(() =>
-    placesStore.currentPlace?.kind === "manual" ? "place" : "match",
+    placesStore.currentPlace?.kind === "manual" ? t("placePage.kind.place") : t("placePage.kind.match"),
   )
 
   async function loadPlace() {

--- a/client/src/views/PlacesView.vue
+++ b/client/src/views/PlacesView.vue
@@ -2,12 +2,12 @@
   <section class="w-[min(100%,72rem)] mx-auto flex flex-col gap-[1.4rem]">
     <header class="flex items-end justify-between gap-4 max-sm:flex-col max-sm:items-start">
       <div>
-        <span class="eyebrow">Places</span>
+        <span class="eyebrow">{{ t("placesPage.eyebrow") }}</span>
         <h1 class="mt-[0.15rem] mb-0 text-[clamp(1.55rem,2.4vw,2rem)] font-medium tracking-[-0.04em]">
-          All places
+          {{ t("placesPage.title") }}
         </h1>
         <p class="m-0 mt-1 text-muted">
-          Browse posts grouped from offline location data.
+          {{ t("placesPage.description") }}
         </p>
       </div>
       <div class="flex items-center gap-[1.4rem] shrink-0 max-sm:w-full max-sm:justify-between">
@@ -16,7 +16,7 @@
             {{ formatCount(placesStore.items.length) }}
           </p>
           <p class="m-0 text-muted text-[0.72rem] uppercase tracking-[0.08em]">
-            Places
+            {{ t("placesPage.stats.places") }}
           </p>
         </div>
         <div class="w-px h-8 bg-border"></div>
@@ -25,7 +25,7 @@
             {{ formatCount(totalPosts) }}
           </p>
           <p class="m-0 text-muted text-[0.72rem] uppercase tracking-[0.08em]">
-            Posts
+            {{ t("placesPage.stats.posts") }}
           </p>
         </div>
       </div>
@@ -33,7 +33,7 @@
 
     <ErrorState
       v-if="placesStore.listError && placesStore.items.length === 0"
-      title="Could not load places"
+      :title="t('placesPage.errors.load')"
       :message="placesStore.listError"
     />
     <template v-else>
@@ -56,7 +56,7 @@
             v-model.trim="searchQuery"
             class="w-full h-10 pl-9 pr-4 border border-border rounded-[0.75rem] text-text text-[0.88rem] bg-surface-alt transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent/40 focus:shadow-[0_0_0_3px_var(--accent-soft)]"
             type="search"
-            placeholder="Search names, regions, or coordinates..."
+            :placeholder="t('placesPage.searchPlaceholder')"
           />
         </div>
 
@@ -65,10 +65,10 @@
             v-model="sortMode"
             class="h-10 pl-3 pr-9 border border-border rounded-[0.75rem] text-text text-[0.82rem] bg-surface-alt cursor-pointer appearance-none focus:outline-none focus:border-accent/40"
           >
-            <option value="posts-desc">Most posts</option>
-            <option value="name-asc">Name A-Z</option>
-            <option value="name-desc">Name Z-A</option>
-            <option value="country-asc">Country A-Z</option>
+            <option value="posts-desc">{{ t("placesPage.sort.postsDesc") }}</option>
+            <option value="name-asc">{{ t("placesPage.sort.nameAsc") }}</option>
+            <option value="name-desc">{{ t("placesPage.sort.nameDesc") }}</option>
+            <option value="country-asc">{{ t("placesPage.sort.countryAsc") }}</option>
           </select>
           <svg
             class="pointer-events-none absolute right-[0.65rem] top-1/2 -translate-y-1/2 w-[0.85rem] h-[0.85rem] text-muted"
@@ -84,7 +84,7 @@
         </div>
 
         <span class="ml-auto text-muted text-[0.8rem] shrink-0">
-          {{ formatCount(filteredPlaces.length) }} result{{ filteredPlaces.length !== 1 ? "s" : "" }}
+          {{ formatResultsCount(filteredPlaces.length) }}
         </span>
       </div>
 
@@ -92,13 +92,13 @@
         v-if="placesStore.loadingList && placesStore.items.length === 0"
         class="card p-12 text-center"
       >
-        <p class="m-0 text-muted">Loading places...</p>
+        <p class="m-0 text-muted">{{ t("placesPage.loading") }}</p>
       </section>
 
       <EmptyState
         v-else-if="placesStore.items.length === 0"
-        title="No places indexed yet"
-        description="Prepare offline place data and rebuild assignments from Settings to group posts by location."
+        :title="t('placesPage.emptyTitle')"
+        :description="t('placesPage.emptyDescription')"
       />
 
       <section
@@ -106,14 +106,14 @@
         class="card p-12 text-center"
       >
         <p class="m-0 text-muted">
-          No places match. Try a different search or sort.
+          {{ t("placesPage.noMatch") }}
         </p>
       </section>
 
       <section
         v-else
         class="bg-surface border border-border rounded-[1.1rem] shadow-[var(--shadow)] overflow-hidden"
-        aria-label="All places"
+        :aria-label="t('placesPage.title')"
       >
         <RouterLink
           v-for="(place, i) in filteredPlaces"
@@ -160,13 +160,13 @@
                 {{ formatPostCount(place) }}
               </span>
               <span class="text-[0.72rem] text-muted">
-                {{ place.kind === "manual" ? "Manual place" : place.isApproximate ? "Nearest city" : "City match" }}
+                {{ formatKindLabel(place) }}
               </span>
             </div>
             <span
               class="w-[7px] h-[7px] rounded-full shrink-0"
               :class="place.postCount > 0 ? 'bg-[#1ca44e]' : 'bg-border'"
-              :title="place.postCount > 0 ? 'Ready' : 'Empty'"
+              :title="place.postCount > 0 ? t('placesPage.readiness.ready') : t('placesPage.readiness.empty')"
             ></span>
           </div>
         </RouterLink>
@@ -177,6 +177,7 @@
 
 <script setup lang="ts">
   import { computed, onMounted, ref } from "vue"
+  import { useI18n } from "vue-i18n"
   import { RouterLink } from "vue-router"
 
   import EmptyState from "../components/EmptyState.vue"
@@ -187,6 +188,7 @@
   type PlacesSort = "posts-desc" | "name-asc" | "name-desc" | "country-asc"
 
   const placesStore = usePlacesStore()
+  const { t, locale } = useI18n()
   const searchQuery = ref("")
   const sortMode = ref<PlacesSort>("posts-desc")
 
@@ -196,13 +198,13 @@
   const normalizedQuery = computed(() => searchQuery.value.trim().toLowerCase())
 
   function formatCount(value: number) {
-    return new Intl.NumberFormat().format(value)
+    return new Intl.NumberFormat(locale.value).format(value)
   }
 
   function formatMetadataLine(place: PlaceDetail) {
     return [place.cityName, place.admin1Name, place.countryName ?? place.countryCode]
       .filter((part, index, parts) => part && parts.indexOf(part) === index)
-      .join(", ") || "Offline city-level place"
+      .join(", ") || t("placesPage.metadataFallback")
   }
 
   function formatCoordinates(place: PlaceDetail) {
@@ -214,7 +216,23 @@
   }
 
   function formatPostCount(place: PlaceDetail) {
-    return `${formatCount(place.postCount)} post${place.postCount === 1 ? "" : "s"}`
+    return place.postCount === 1
+      ? t("placesPage.postCountOne", { count: formatCount(place.postCount) })
+      : t("placesPage.postCountOther", { count: formatCount(place.postCount) })
+  }
+
+  function formatResultsCount(value: number) {
+    return value === 1
+      ? t("placesPage.resultsOne", { count: formatCount(value) })
+      : t("placesPage.resultsOther", { count: formatCount(value) })
+  }
+
+  function formatKindLabel(place: PlaceDetail) {
+    if (place.kind === "manual") {
+      return t("placesPage.kinds.manual")
+    }
+
+    return place.isApproximate ? t("placesPage.kinds.nearestCity") : t("placesPage.kinds.cityMatch")
   }
 
   function matchesSearch(place: PlaceDetail, query: string) {

--- a/client/src/views/ReelsView.vue
+++ b/client/src/views/ReelsView.vue
@@ -1,27 +1,27 @@
 <template>
   <section class="reels-view">
     <section v-if="appStore.isLibraryUnavailable" class="reels-view__message-card">
-      <p class="reels-view__eyebrow">Reels</p>
-      <h1 class="reels-view__title">Library storage unavailable</h1>
+      <p class="reels-view__eyebrow">{{ t('nav.reels') }}</p>
+      <h1 class="reels-view__title">{{ t('reels.view.libraryUnavailableTitle') }}</h1>
       <p class="reels-view__message">{{ appStore.libraryUnavailableReason }}</p>
     </section>
 
     <section v-else-if="reelsStore.error" class="reels-view__message-card">
-      <p class="reels-view__eyebrow">Reels</p>
-      <h1 class="reels-view__title">Could not load reels</h1>
+      <p class="reels-view__eyebrow">{{ t('nav.reels') }}</p>
+      <h1 class="reels-view__title">{{ t('reels.view.loadErrorTitle') }}</h1>
       <p class="reels-view__message">{{ reelsStore.error }}</p>
     </section>
 
     <section v-else-if="showLoadingState" class="reels-view__message-card">
-      <p class="reels-view__eyebrow">Reels</p>
-      <h1 class="reels-view__title">Loading reels</h1>
-      <p class="reels-view__message">Pulling together a video-only queue from your indexed library.</p>
+      <p class="reels-view__eyebrow">{{ t('nav.reels') }}</p>
+      <h1 class="reels-view__title">{{ t('reels.view.loadingTitle') }}</h1>
+      <p class="reels-view__message">{{ t('reels.view.loadingDescription') }}</p>
     </section>
 
     <section v-else-if="reelsStore.initialized && reelsStore.items.length === 0" class="reels-view__message-card">
-      <p class="reels-view__eyebrow">Reels</p>
-      <h1 class="reels-view__title">No reels available</h1>
-      <p class="reels-view__message">Add indexed videos to your library and they will show up here after the next scan.</p>
+      <p class="reels-view__eyebrow">{{ t('nav.reels') }}</p>
+      <h1 class="reels-view__title">{{ t('reels.view.emptyTitle') }}</h1>
+      <p class="reels-view__message">{{ t('reels.view.emptyDescription') }}</p>
     </section>
 
     <div v-else class="reels-view__layout">
@@ -62,11 +62,11 @@
       </div>
 
       <div v-if="!isMobileViewport" class="reels-view__right-column">
-        <div class="reels-view__nav-controls" aria-label="Reel navigation">
+        <div class="reels-view__nav-controls" :aria-label="t('reels.view.navigationAria')">
           <button
             class="reels-view__nav-button"
             type="button"
-            aria-label="Previous reel"
+            :aria-label="t('reels.view.previous')"
             :disabled="!canGoPrevious"
             @click="goToPrevious"
           >
@@ -84,7 +84,7 @@
           <button
             class="reels-view__nav-button"
             type="button"
-            aria-label="Next reel"
+            :aria-label="t('reels.view.next')"
             :disabled="!canGoNext"
             @click="goToNext"
           >
@@ -130,6 +130,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import ReelActionRail from '../components/ReelActionRail.vue';
 import ReelDeck from '../components/ReelDeck.vue';
@@ -141,6 +142,7 @@ import { useReelsStore } from '../stores/reels';
 const appStore = useAppStore();
 const foldersStore = useFoldersStore();
 const reelsStore = useReelsStore();
+const { t } = useI18n();
 const deckElement = ref<InstanceType<typeof ReelDeck> | null>(null);
 const isInfoSidebarOpen = ref(false);
 const viewportWidth = ref(typeof window !== 'undefined' ? window.innerWidth : 0);

--- a/client/src/views/SettingsView.test.ts
+++ b/client/src/views/SettingsView.test.ts
@@ -18,7 +18,8 @@ const scrollIntoViewSpy = vi.fn();
 function createAppStatus(
   defaultHomeFeedMode: AppStatus['preferences']['defaultHomeFeedMode'] = 'rediscover',
   defaultReelsFeedMode: AppStatus['preferences']['defaultReelsFeedMode'] = 'random',
-  defaultFolderImageOrder: NonNullable<AppStatus['preferences']['defaultFolderImageOrder']> = 'newest'
+  defaultFolderImageOrder: NonNullable<AppStatus['preferences']['defaultFolderImageOrder']> = 'newest',
+  defaultLocale: AppStatus['preferences']['defaultLocale'] = 'en'
 ): AppStatus {
   return {
     folders: 3,
@@ -55,6 +56,7 @@ function createAppStatus(
       ignoredRootMediaCount: 0
     },
     preferences: {
+      defaultLocale,
       defaultHomeFeedMode,
       defaultReelsFeedMode,
       defaultFolderImageOrder,
@@ -239,6 +241,76 @@ describe('SettingsView', () => {
     expect(window.localStorage.getItem('foldergram-locale')).toBe('es');
     expect(wrapper.text()).toContain('Idioma de la aplicación');
     expect(wrapper.text()).toContain('Controles de la biblioteca');
+  });
+
+  it('saves the selected app language as the app-wide default from General Settings', async () => {
+    const appStore = useAppStore();
+    appStore.$patch({
+      stats: createAppStatus()
+    });
+
+    vi.spyOn(appStore, 'fetchStats').mockResolvedValue();
+    const updateAppLocaleSpy = vi.spyOn(galleryApi, 'updateAppLocale').mockResolvedValue({
+      defaultLocale: 'zh'
+    });
+
+    const wrapper = mountSettingsView();
+    await flushPromises();
+    await openGeneralSettingsSidebarTab(wrapper);
+
+    await wrapper.get('select').setValue('zh');
+    await flushPromises();
+
+    const saveButton = wrapper
+      .findAll('button')
+      .find((button) => ['Save changes', 'Guardar cambios', '保存更改'].includes(button.text()));
+
+    expect(saveButton).toBeDefined();
+
+    await saveButton!.trigger('click');
+    await flushPromises();
+
+    expect(updateAppLocaleSpy).toHaveBeenCalledWith('zh');
+    expect(appStore.stats?.preferences.defaultLocale).toBe('zh');
+    expect(wrapper.text()).toContain('应用语言默认值已保存为中文。');
+  });
+
+  it('lets admins save an existing browser-local language as the app default without changing the selector again', async () => {
+    const appStore = useAppStore();
+    appStore.$patch({
+      stats: createAppStatus('rediscover', 'random', 'newest', 'zh')
+    });
+    appStore.setLocale('es');
+
+    vi.spyOn(appStore, 'fetchStats').mockResolvedValue();
+    const updateAppLocaleSpy = vi.spyOn(galleryApi, 'updateAppLocale').mockResolvedValue({
+      defaultLocale: 'es'
+    });
+
+    const wrapper = mountSettingsView();
+    await flushPromises();
+    await openGeneralSettingsSidebarTab(wrapper);
+
+    const localeOverrideNotice = wrapper.get('[data-testid="locale-override-notice"]');
+    expect(localeOverrideNotice.attributes('role')).toBe('status');
+    expect(localeOverrideNotice.attributes('class')).toContain('bg-[rgba(24,119,242,0.08)]');
+    expect(localeOverrideNotice.text()).toContain('El valor predeterminado de la app es Chino.');
+    expect(localeOverrideNotice.text()).toContain('Este navegador está usando temporalmente Español');
+    expect(localeOverrideNotice.text()).toContain('configuración solo de este navegador');
+
+    const saveButton = wrapper
+      .findAll('button')
+      .find((button) => ['Save changes', 'Guardar cambios', '保存更改'].includes(button.text()));
+
+    expect(saveButton).toBeDefined();
+    expect(saveButton!.attributes('disabled')).toBeUndefined();
+
+    await saveButton!.trigger('click');
+    await flushPromises();
+
+    expect(updateAppLocaleSpy).toHaveBeenCalledWith('es');
+    expect(appStore.stats?.preferences.defaultLocale).toBe('es');
+    expect(wrapper.text()).toContain('El idioma predeterminado de la app se guardó como Español.');
   });
 
   it('shows the pending legacy derivative migration warning next to the scan action', async () => {
@@ -445,7 +517,7 @@ describe('SettingsView', () => {
   it('keeps partial-save feedback localized after the language is switched', async () => {
     const appStore = useAppStore();
     appStore.$patch({
-      stats: createAppStatus()
+      stats: createAppStatus('rediscover', 'random', 'newest', 'es')
     });
     appStore.setLocale('es');
 

--- a/client/src/views/SettingsView.test.ts
+++ b/client/src/views/SettingsView.test.ts
@@ -125,7 +125,9 @@ function mountSettingsView() {
 async function openGeneralSettingsSidebarTab(wrapper: ReturnType<typeof mountSettingsView>) {
   const generalSettingsButton = wrapper
     .findAll('button')
-    .find((button) => button.text().includes('General Settings'));
+    .find((button) =>
+      ['General Settings', 'Ajustes generales', '通用设置'].some((label) => button.text().includes(label))
+    );
 
   expect(generalSettingsButton).toBeDefined();
 
@@ -215,6 +217,28 @@ describe('SettingsView', () => {
 
     expect(saveButton).toBeDefined();
     expect(saveButton!.attributes('disabled')).toBeDefined();
+  });
+
+  it('switches the client locale from the General Settings language selector', async () => {
+    const appStore = useAppStore();
+    appStore.$patch({
+      stats: createAppStatus()
+    });
+
+    const wrapper = mountSettingsView();
+    await flushPromises();
+    await openGeneralSettingsSidebarTab(wrapper);
+
+    const languageSelect = wrapper.get('select');
+    expect((languageSelect.element as HTMLSelectElement).value).toBe('en');
+
+    await languageSelect.setValue('es');
+    await flushPromises();
+
+    expect(appStore.locale).toBe('es');
+    expect(window.localStorage.getItem('foldergram-locale')).toBe('es');
+    expect(wrapper.text()).toContain('Idioma de la aplicación');
+    expect(wrapper.text()).toContain('Controles de la biblioteca');
   });
 
   it('shows the pending legacy derivative migration warning next to the scan action', async () => {
@@ -416,6 +440,43 @@ describe('SettingsView', () => {
 
     expect(updateExcludedFoldersSpy).toHaveBeenCalledWith(['Archive/cache', 'thumbnails']);
     expect(wrapper.text()).toContain('Excluded folders were saved. Run a library scan to apply them.');
+  });
+
+  it('keeps partial-save feedback localized after the language is switched', async () => {
+    const appStore = useAppStore();
+    appStore.$patch({
+      stats: createAppStatus()
+    });
+    appStore.setLocale('es');
+
+    vi.spyOn(appStore, 'fetchStats').mockRejectedValue(new Error('Network down'));
+    vi.spyOn(galleryApi, 'updateExcludedFolders').mockResolvedValue({
+      envExcludedFolders: ['@eaDir'],
+      customExcludedFolders: ['Archive/cache'],
+      effectiveExcludedFolders: ['@eaDir', 'Archive/cache'],
+      requiresScan: true
+    });
+
+    const wrapper = mountSettingsView();
+    await flushPromises();
+    await openGeneralSettingsSidebarTab(wrapper);
+
+    await wrapper.get('textarea').setValue('Archive/cache');
+    await flushPromises();
+
+    const saveButton = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Guardar'));
+
+    expect(saveButton).toBeDefined();
+
+    await saveButton!.trigger('click');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      'Se guardaron algunos ajustes (carpetas excluidas), pero la actualización no terminó: Network down'
+    );
+    expect(wrapper.text()).not.toContain('excluded folders');
   });
 
   it('dismisses the stories migration notice and scrolls to save when choosing Use Stories Feature', async () => {

--- a/client/src/views/SettingsView.vue
+++ b/client/src/views/SettingsView.vue
@@ -2,9 +2,9 @@
   <section class="w-[min(100%,72rem)] mx-auto flex flex-col gap-[1.2rem]">
     <header class="flex items-end justify-between gap-4 pb-[0.8rem] max-sm:flex-col max-sm:items-start">
       <div>
-        <span class="eyebrow">Settings</span>
-        <h1 class="mt-[0.15rem] mb-0 text-[clamp(1.55rem,2.4vw,2rem)] font-medium tracking-[-0.04em]">Library Controls</h1>
-        <p class="m-0 text-muted">Manage scans, app defaults, access, and the library index.</p>
+        <span class="eyebrow">{{ t('settings.eyebrow') }}</span>
+        <h1 class="mt-[0.15rem] mb-0 text-[clamp(1.55rem,2.4vw,2rem)] font-medium tracking-[-0.04em]">{{ t('settings.title') }}</h1>
+        <p class="m-0 text-muted">{{ t('settings.description') }}</p>
       </div>
     </header>
 
@@ -15,20 +15,20 @@
     >
       <div class="flex items-start justify-between gap-4">
         <div class="grid gap-[0.35rem]">
-          <span class="eyebrow text-[#9f6a00]">Scan Needs Attention</span>
-          <h2 class="m-0 text-[1.1rem]">The last scan completed with errors</h2>
+          <span class="eyebrow text-[#9f6a00]">{{ t('settings.notices.scanError.eyebrow') }}</span>
+          <h2 class="m-0 text-[1.1rem]">{{ t('settings.notices.scanError.title') }}</h2>
           <p class="m-0 text-muted">{{ scanErrorNoticeMessage }}</p>
           <p v-if="scanErrorNoticeDetail" class="m-0 font-mono text-[0.8rem] leading-[1.5] text-[#7c5800] break-all">
             {{ scanErrorNoticeDetail }}
           </p>
           <p v-if="scanErrorReportPath" class="m-0 font-mono text-[0.78rem] leading-[1.5] text-[#7c5800] break-all">
-            Full report: {{ scanErrorReportPath }}
+            {{ t('settings.notices.scanError.fullReportPrefix') }} {{ scanErrorReportPath }}
           </p>
         </div>
         <button
           class="inline-flex h-9 w-9 items-center justify-center rounded-full border-0 bg-[rgba(159,106,0,0.08)] text-[#9f6a00] cursor-pointer transition-colors duration-180 hover:bg-[rgba(159,106,0,0.14)]"
           type="button"
-          aria-label="Dismiss scan warning"
+          :aria-label="t('settings.notices.scanError.dismissAria')"
           @click="dismissScanErrorNotice"
         >
           <span class="i-fluent-dismiss-20-filled h-5 w-5" aria-hidden="true" />
@@ -36,7 +36,7 @@
       </div>
 
       <div class="flex items-center gap-4 max-sm:flex-col-reverse max-sm:items-stretch">
-        <p class="m-0 text-muted">Run a new library scan to retry failed media and fill in any missing thumbnails or previews.</p>
+        <p class="m-0 text-muted">{{ t('settings.notices.scanError.actionNote') }}</p>
         <button class="btn-primary min-w-[11.5rem]" type="button" :disabled="scanActionDisabled" @click="runManualScan">
           {{ scanButtonLabel }}
         </button>
@@ -54,7 +54,7 @@
       <button
         class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-0 bg-[rgba(159,106,0,0.08)] text-[#9f6a00] cursor-pointer transition-colors duration-180 hover:bg-[rgba(159,106,0,0.14)]"
         type="button"
-        aria-label="Dismiss gallery root warning"
+        :aria-label="t('settings.notices.ignoredRootMedia.dismissAria')"
         @click="dismissIgnoredRootMediaNotice"
       >
         <span class="i-fluent-dismiss-20-filled h-5 w-5" aria-hidden="true" />
@@ -67,25 +67,21 @@
       style="background: linear-gradient(135deg, color-mix(in srgb, var(--surface) 97%, #f7fbff 3%) 0%, color-mix(in srgb, var(--surface) 93%, #e6f3ff 7%) 100%);"
       @click="openPlacesTab"
     >
-      <div class="flex items-start justify-between gap-4">
-        <div class="grid gap-[0.3rem]">
-          <div class="flex flex-wrap items-center gap-2">
-            <h2 class="m-0 text-xl">Places from photo GPS data</h2>
-            <span class="eyebrow inline-flex w-fit self-start text-xs">New Feature</span>
+        <div class="flex items-start justify-between gap-4">
+          <div class="grid gap-[0.3rem]">
+            <div class="flex flex-wrap items-center gap-2">
+              <h2 class="m-0 text-xl">{{ t('settings.places.banner.title') }}</h2>
+              <span class="eyebrow inline-flex w-fit self-start text-xs">{{ t('common.newFeature') }}</span>
+            </div>
+          <p class="m-0 text-[0.95rem] font-medium text-text">{{ t('settings.places.banner.description') }}</p>
+          <p class="m-0 text-muted">{{ t('settings.places.banner.helper') }}</p>
           </div>
-          <p class="m-0 text-[0.95rem] font-medium text-text">
-            Group GPS-tagged photos by offline city and location labels.
-          </p>
-          <p class="m-0 text-muted">
-            Prepare the local GeoNames dataset, then rebuild place assignments for the photos already in your library.
-          </p>
-        </div>
-        <button
-          class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-0 bg-[rgba(24,119,242,0.08)] text-accent-strong cursor-pointer transition-colors duration-180 hover:bg-[rgba(24,119,242,0.14)]"
-          type="button"
-          aria-label="Dismiss places announcement"
-          @click.stop="dismissPlacesOnboardingBanner"
-        >
+          <button
+            class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-0 bg-[rgba(24,119,242,0.08)] text-accent-strong cursor-pointer transition-colors duration-180 hover:bg-[rgba(24,119,242,0.14)]"
+            type="button"
+            :aria-label="t('settings.places.banner.dismissAria')"
+            @click.stop="dismissPlacesOnboardingBanner"
+          >
           <span class="i-fluent-dismiss-20-filled h-5 w-5" aria-hidden="true" />
         </button>
       </div>
@@ -96,23 +92,23 @@
           type="button"
           @click.stop="openPlacesTab"
         >
-          Set up Places
+          {{ t('settings.places.banner.setup') }}
         </button>
         <p class="m-0 text-muted">
-          The download is opt-in, and the Places tab stays available in Settings later.
+          {{ t('settings.places.banner.availableLater') }}
         </p>
       </div>
     </section>
 
     <nav
       class="sticky top-3 z-20 grid w-full grid-cols-5 gap-1.5 rounded-[1.2rem] border border-border bg-[color-mix(in_srgb,var(--bg)_90%,var(--surface)_10%)] p-1.5 shadow-[0_12px_34px_rgba(15,20,25,0.08)] backdrop-blur-[18px] md:hidden"
-      aria-label="Settings sections"
+      :aria-label="t('settings.sections.navigation')"
     >
       <button
         @click="currentCategory = 'library'"
         class="flex min-h-[3.15rem] items-center justify-center rounded-[0.95rem] border-0 bg-transparent p-0 text-muted transition-colors duration-150 cursor-pointer"
         :class="currentCategory === 'library' ? 'bg-surface-alt text-text' : 'hover:bg-surface-hover hover:text-text'"
-        aria-label="Scan and Library"
+        :aria-label="t('settings.sections.library.shortLabel')"
       >
         <span class="h-[1.55rem] w-[1.55rem]" :class="currentCategory === 'library' ? 'i-fluent-folder-sync-20-filled' : 'i-fluent-folder-sync-20-regular'" aria-hidden="true"></span>
       </button>
@@ -120,7 +116,7 @@
         @click="currentCategory = 'general'"
         class="flex min-h-[3.15rem] items-center justify-center rounded-[0.95rem] border-0 bg-transparent p-0 text-muted transition-colors duration-150 cursor-pointer"
         :class="currentCategory === 'general' ? 'bg-surface-alt text-text' : 'hover:bg-surface-hover hover:text-text'"
-        aria-label="General Settings"
+        :aria-label="t('settings.sections.general.label')"
       >
         <span class="h-[1.55rem] w-[1.55rem]" :class="currentCategory === 'general' ? 'i-fluent-settings-20-filled' : 'i-fluent-settings-20-regular'" aria-hidden="true"></span>
       </button>
@@ -128,7 +124,7 @@
         @click="currentCategory = 'places'"
         class="flex min-h-[3.15rem] items-center justify-center rounded-[0.95rem] border-0 bg-transparent p-0 text-muted transition-colors duration-150 cursor-pointer"
         :class="currentCategory === 'places' ? 'bg-surface-alt text-text' : 'hover:bg-surface-hover hover:text-text'"
-        aria-label="Places"
+        :aria-label="t('settings.sections.places.label')"
       >
         <span class="h-[1.55rem] w-[1.55rem]" :class="currentCategory === 'places' ? 'i-fluent-location-20-filled' : 'i-fluent-location-20-regular'" aria-hidden="true"></span>
       </button>
@@ -136,7 +132,7 @@
         @click="currentCategory = 'access'"
         class="flex min-h-[3.15rem] items-center justify-center rounded-[0.95rem] border-0 bg-transparent p-0 text-muted transition-colors duration-150 cursor-pointer"
         :class="currentCategory === 'access' ? 'bg-surface-alt text-text' : 'hover:bg-surface-hover hover:text-text'"
-        aria-label="Security and Access"
+        :aria-label="t('settings.sections.access.shortLabel')"
       >
         <span class="h-[1.55rem] w-[1.55rem]" :class="currentCategory === 'access' ? 'i-fluent-lock-shield-20-filled' : 'i-fluent-lock-shield-20-regular'" aria-hidden="true"></span>
       </button>
@@ -144,7 +140,7 @@
         @click="currentCategory = 'status'"
         class="flex min-h-[3.15rem] items-center justify-center rounded-[0.95rem] border-0 bg-transparent p-0 text-muted transition-colors duration-150 cursor-pointer"
         :class="currentCategory === 'status' ? 'bg-surface-alt text-text' : 'hover:bg-surface-hover hover:text-text'"
-        aria-label="System Status"
+        :aria-label="t('settings.sections.status.label')"
       >
         <span class="h-[1.55rem] w-[1.55rem]" :class="currentCategory === 'status' ? 'i-fluent-data-usage-20-filled' : 'i-fluent-data-usage-20-regular'" aria-hidden="true"></span>
       </button>
@@ -154,7 +150,7 @@
       <!-- Navigation Sidebar -->
       <nav
         class="hidden w-full shrink-0 md:flex md:w-[16rem] md:flex-col md:gap-2 md:sticky md:top-[6.5rem]"
-        aria-label="Settings sections"
+        :aria-label="t('settings.sections.navigation')"
       >
         <button
           @click="currentCategory = 'library'"
@@ -163,8 +159,8 @@
         >
           <span class="mt-[0.1rem] h-[1.25rem] w-[1.25rem] shrink-0" :class="currentCategory === 'library' ? 'i-fluent-folder-sync-20-filled' : 'i-fluent-folder-sync-20-regular'" aria-hidden="true"></span>
           <span class="flex min-w-0 flex-col gap-[0.1rem]">
-            <span>Scan & Library</span>
-            <span class="text-[0.75rem] font-normal text-muted">Index media, rebuild thumbnails, and maintain the library index</span>
+            <span>{{ t('settings.sections.library.label') }}</span>
+            <span class="text-[0.75rem] font-normal text-muted">{{ t('settings.sections.library.description') }}</span>
           </span>
         </button>
         <button
@@ -174,8 +170,8 @@
         >
           <span class="mt-[0.1rem] h-[1.25rem] w-[1.25rem] shrink-0" :class="currentCategory === 'general' ? 'i-fluent-settings-20-filled' : 'i-fluent-settings-20-regular'" aria-hidden="true"></span>
           <span class="flex flex-col gap-[0.1rem] min-w-0">
-            <span class="truncate">General Settings</span>
-            <span class="text-[0.75rem] font-normal text-muted">Stories mode, excluded folders, and feed defaults</span>
+            <span class="truncate">{{ t('settings.sections.general.label') }}</span>
+            <span class="text-[0.75rem] font-normal text-muted">{{ t('settings.sections.general.description') }}</span>
           </span>
         </button>
         <button
@@ -185,8 +181,8 @@
         >
           <span class="mt-[0.1rem] h-[1.25rem] w-[1.25rem] shrink-0" :class="currentCategory === 'places' ? 'i-fluent-location-20-filled' : 'i-fluent-location-20-regular'" aria-hidden="true"></span>
           <span class="flex flex-col gap-[0.1rem] min-w-0">
-            <span>Places</span>
-            <span class="text-[0.75rem] font-normal text-muted">Offline city lookup and place assignment</span>
+            <span>{{ t('settings.sections.places.label') }}</span>
+            <span class="text-[0.75rem] font-normal text-muted">{{ t('settings.sections.places.description') }}</span>
           </span>
         </button>
         <button
@@ -196,8 +192,8 @@
         >
           <span class="mt-[0.1rem] h-[1.25rem] w-[1.25rem] shrink-0" :class="currentCategory === 'access' ? 'i-fluent-lock-shield-20-filled' : 'i-fluent-lock-shield-20-regular'" aria-hidden="true"></span>
           <span class="flex flex-col gap-[0.1rem] min-w-0">
-            <span>Security & Access</span>
-            <span class="text-[0.75rem] font-normal text-muted">Password locks & viewer roles</span>
+            <span>{{ t('settings.sections.access.label') }}</span>
+            <span class="text-[0.75rem] font-normal text-muted">{{ t('settings.sections.access.description') }}</span>
           </span>
         </button>
         <button
@@ -207,8 +203,8 @@
         >
           <span class="mt-[0.1rem] h-[1.25rem] w-[1.25rem] shrink-0" :class="currentCategory === 'status' ? 'i-fluent-data-usage-20-filled' : 'i-fluent-data-usage-20-regular'" aria-hidden="true"></span>
           <span class="flex flex-col gap-[0.1rem] min-w-0">
-            <span>System Status</span>
-            <span class="text-[0.75rem] font-normal text-muted">Storage overview & scan history</span>
+            <span>{{ t('settings.sections.status.label') }}</span>
+            <span class="text-[0.75rem] font-normal text-muted">{{ t('settings.sections.status.description') }}</span>
           </span>
         </button>
       </nav>
@@ -221,14 +217,14 @@
           <section class="card grid gap-[1.15rem] p-8">
             <div class="flex items-start justify-between gap-4 max-sm:flex-col max-sm:items-start">
               <div>
-                <h2 class="m-0 text-[1.18rem]">Admin and viewer access</h2>
-                <p class="m-0 mt-[0.35rem] text-muted">Protect admin actions with an admin password, then optionally issue a separate viewer password for browsing-only sessions.</p>
+                <h2 class="m-0 text-[1.18rem]">{{ t('settings.access.section.title') }}</h2>
+                <p class="m-0 mt-[0.35rem] text-muted">{{ t('settings.access.section.description') }}</p>
               </div>
               <span
                 class="inline-flex items-center justify-center min-h-8 px-[0.7rem] py-[0.35rem] rounded-full text-[0.76rem] font-bold whitespace-nowrap"
                 :class="authStore.enabled ? 'text-accent-strong bg-[color-mix(in_srgb,var(--accent-soft)_78%,transparent_22%)]' : 'text-muted bg-surface-alt'"
               >
-                {{ authStore.enabled ? 'Admin Locked' : 'Open Access' }}
+                {{ authStore.enabled ? t('settings.access.section.locked') : t('settings.access.section.open') }}
               </span>
             </div>
 
@@ -243,33 +239,33 @@
             <section v-if="!authStore.enabled" class="grid gap-[1rem]">
               <div class="grid min-w-0 grid-cols-1 gap-4 md:grid-cols-2">
                 <label class="grid min-w-0 gap-[0.45rem]">
-                  <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">Admin password</span>
+                  <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('settings.access.fields.adminPassword') }}</span>
                   <input
                     v-model="enablePassword"
                     class="h-12 min-w-0 w-full rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 text-[0.95rem] text-text outline-none transition-[border-color,box-shadow] duration-180 focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
                     type="password"
                     autocomplete="new-password"
-                    placeholder="Minimum 8 characters"
+                    :placeholder="t('settings.access.placeholders.minimumLength', { count: 8 })"
                     :disabled="authStore.loading"
                   />
                 </label>
                 <label class="grid min-w-0 gap-[0.45rem]">
-                  <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">Confirm password</span>
+                  <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('settings.access.fields.confirmPassword') }}</span>
                   <input
                     v-model="enablePasswordConfirmation"
                     class="h-12 min-w-0 w-full rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 text-[0.95rem] text-text outline-none transition-[border-color,box-shadow] duration-180 focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
                     type="password"
                     autocomplete="new-password"
-                    placeholder="Repeat the password"
+                    :placeholder="t('settings.access.placeholders.repeatPassword')"
                     :disabled="authStore.loading"
                   />
                 </label>
               </div>
 
               <div class="flex flex-col md:flex-row items-center gap-4 max-sm:items-stretch">
-                <p class="m-0 flex-1 text-muted">The admin password is stored as a one-way hash and unlocks this browser with a signed session cookie.</p>
+                <p class="m-0 flex-1 text-muted">{{ t('settings.access.enable.description') }}</p>
                 <button class="btn-primary w-full sm:w-auto sm:min-w-[13rem]" type="button" :disabled="authStore.loading" @click="enableAccessProtection">
-                  {{ authStore.loading ? 'Enabling...' : 'Enable Admin Password' }}
+                  {{ authStore.loading ? t('settings.access.enable.buttonLoading') : t('settings.access.enable.buttonIdle') }}
                 </button>
               </div>
             </section>
@@ -279,8 +275,8 @@
               <div class="grid gap-[0.9rem] rounded-[1.05rem] border border-border p-5">
                 <div class="flex items-start justify-between gap-4 max-sm:flex-col max-sm:items-start">
                   <div>
-                    <h3 class="m-0 text-[1rem]">Change admin password</h3>
-                    <p class="m-0 mt-[0.25rem] text-muted">Update the admin password and invalidate older sessions.</p>
+                    <h3 class="m-0 text-[1rem]">{{ t('settings.access.change.title') }}</h3>
+                    <p class="m-0 mt-[0.25rem] text-muted">{{ t('settings.access.change.description') }}</p>
                   </div>
                   <button
                     class="inline-flex min-h-11 items-center justify-center rounded-[0.95rem] border border-[rgba(24,119,242,0.2)] bg-[rgba(24,119,242,0.08)] px-4 text-[0.9rem] font-semibold text-accent-strong transition-colors duration-180 hover:bg-[rgba(24,119,242,0.16)] disabled:cursor-wait disabled:opacity-60 max-sm:w-full"
@@ -289,14 +285,14 @@
                     :disabled="authStore.loading"
                     @click="toggleChangePasswordForm"
                   >
-                    {{ showChangePasswordForm ? 'Hide Form' : 'Change Password' }}
+                    {{ showChangePasswordForm ? t('settings.access.change.hideForm') : t('settings.access.change.showForm') }}
                   </button>
                 </div>
 
                 <template v-if="showChangePasswordForm">
                   <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
                     <label class="grid gap-[0.45rem]">
-                      <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">Current password</span>
+                      <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('settings.access.fields.currentPassword') }}</span>
                       <input
                         v-model="currentPassword"
                         class="h-12 rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 text-[0.95rem] text-text outline-none transition-[border-color,box-shadow] duration-180 focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
@@ -306,7 +302,7 @@
                       />
                     </label>
                     <label class="grid gap-[0.45rem]">
-                      <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">New password</span>
+                      <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('settings.access.fields.newPassword') }}</span>
                       <input
                         v-model="nextPassword"
                         class="h-12 rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 text-[0.95rem] text-text outline-none transition-[border-color,box-shadow] duration-180 focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
@@ -316,7 +312,7 @@
                       />
                     </label>
                     <label class="grid gap-[0.45rem]">
-                      <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">Confirm new password</span>
+                      <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('settings.access.fields.confirmNewPassword') }}</span>
                       <input
                         v-model="nextPasswordConfirmation"
                         class="h-12 rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 text-[0.95rem] text-text outline-none transition-[border-color,box-shadow] duration-180 focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
@@ -328,9 +324,9 @@
                   </div>
 
                   <div class="flex flex-col md:flex-row items-center gap-4 max-sm:items-stretch">
-                    <p class="m-0 flex-1 text-muted">Use at least 8 characters. Changing the password signs out any older sessions.</p>
+                    <p class="m-0 flex-1 text-muted">{{ t('settings.access.change.helper') }}</p>
                     <button class="btn-primary min-w-[13rem]" type="button" :disabled="authStore.loading" @click="changeAccessPassword">
-                      {{ authStore.loading ? 'Updating...' : 'Change Admin Password' }}
+                      {{ authStore.loading ? t('settings.access.change.buttonLoading') : t('settings.access.change.buttonIdle') }}
                     </button>
                   </div>
                 </template>
@@ -340,8 +336,8 @@
               <div class="grid gap-[0.9rem] rounded-[1.05rem] border border-border p-5">
                 <div class="flex items-start justify-between gap-4 max-sm:flex-col max-sm:items-start">
                   <div>
-                    <h3 class="m-0 text-[1rem]">Viewer access</h3>
-                    <p class="m-0 mt-[0.25rem] text-muted">Issue a browsing-only password for viewer sessions or open the library for anonymous public viewing.</p>
+                    <h3 class="m-0 text-[1rem]">{{ t('settings.access.viewer.title') }}</h3>
+                    <p class="m-0 mt-[0.25rem] text-muted">{{ t('settings.access.viewer.description') }}</p>
                   </div>
                   <span
                     class="inline-flex items-center justify-center min-h-8 px-[0.7rem] py-[0.35rem] rounded-full text-[0.76rem] font-bold whitespace-nowrap"
@@ -363,46 +359,46 @@
                   <label class="flex items-start gap-3 rounded-[0.9rem] border border-border px-4 py-3 cursor-pointer">
                     <input v-model="viewerAccessMode" class="mt-[0.2rem]" type="radio" value="off" :disabled="authStore.loading" />
                     <span class="grid gap-[0.15rem]">
-                      <span class="text-[0.92rem] font-semibold text-text">Admin only</span>
-                      <span class="text-[0.84rem] text-muted">Only the admin password can unlock the app.</span>
+                      <span class="text-[0.92rem] font-semibold text-text">{{ t('settings.access.viewer.modes.adminOnlyTitle') }}</span>
+                      <span class="text-[0.84rem] text-muted">{{ t('settings.access.viewer.modes.adminOnlyDescription') }}</span>
                     </span>
                   </label>
                   <label class="flex items-start gap-3 rounded-[0.9rem] border border-border px-4 py-3 cursor-pointer">
                     <input v-model="viewerAccessMode" class="mt-[0.2rem]" type="radio" value="password" :disabled="authStore.loading" />
                     <span class="grid gap-[0.15rem]">
-                      <span class="text-[0.92rem] font-semibold text-text">Viewer password</span>
-                      <span class="text-[0.84rem] text-muted">Allow a separate viewer login that can browse and use shared likes without seeing admin controls.</span>
+                      <span class="text-[0.92rem] font-semibold text-text">{{ t('settings.access.viewer.modes.viewerPasswordTitle') }}</span>
+                      <span class="text-[0.84rem] text-muted">{{ t('settings.access.viewer.modes.viewerPasswordDescription') }}</span>
                     </span>
                   </label>
                   <label class="flex items-start gap-3 rounded-[0.9rem] border border-border px-4 py-3 cursor-pointer">
                     <input v-model="viewerAccessMode" class="mt-[0.2rem]" type="radio" value="public" :disabled="authStore.loading" />
                     <span class="grid gap-[0.15rem]">
-                      <span class="text-[0.92rem] font-semibold text-text">Public</span>
-                      <span class="text-[0.84rem] text-muted">Allow anonymous browsing with browser-local favorites while keeping admin unlock available from More.</span>
+                      <span class="text-[0.92rem] font-semibold text-text">{{ t('settings.access.viewer.modes.publicTitle') }}</span>
+                      <span class="text-[0.84rem] text-muted">{{ t('settings.access.viewer.modes.publicDescription') }}</span>
                     </span>
                   </label>
                 </div>
 
                 <div v-if="viewerAccessMode === 'password'" class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-2">
                   <label class="grid gap-[0.45rem]">
-                    <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">Viewer password</span>
+                    <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('settings.access.fields.viewerPassword') }}</span>
                     <input
                       v-model="viewerPassword"
                       class="h-12 rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 text-[0.95rem] text-text outline-none transition-[border-color,box-shadow] duration-180 focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
                       type="password"
                       autocomplete="new-password"
-                      :placeholder="viewerAccessEnabled ? 'Enter a new viewer password' : 'Minimum 8 characters'"
+                      :placeholder="viewerAccessEnabled ? t('settings.access.placeholders.enterNewViewerPassword') : t('settings.access.placeholders.minimumLength', { count: 8 })"
                       :disabled="authStore.loading"
                     />
                   </label>
                   <label class="grid gap-[0.45rem]">
-                    <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">Confirm viewer password</span>
+                    <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('settings.access.fields.confirmViewerPassword') }}</span>
                     <input
                       v-model="viewerPasswordConfirmation"
                       class="h-12 rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 text-[0.95rem] text-text outline-none transition-[border-color,box-shadow] duration-180 focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
                       type="password"
                       autocomplete="new-password"
-                      :placeholder="viewerAccessEnabled ? 'Repeat the new viewer password' : 'Repeat the viewer password'"
+                      :placeholder="viewerAccessEnabled ? t('settings.access.placeholders.repeatNewViewerPassword') : t('settings.access.placeholders.repeatViewerPassword')"
                       :disabled="authStore.loading"
                     />
                   </label>
@@ -426,13 +422,13 @@
           <!-- Danger Zone -->
           <div v-if="authStore.enabled" class="border border-[rgba(214,48,49,0.3)] rounded-[1.05rem] overflow-hidden">
             <div class="bg-[rgba(214,48,49,0.04)] px-6 py-4 border-b border-[rgba(214,48,49,0.1)]">
-              <h3 class="m-0 text-[1rem] text-[#c0392b] font-bold">Danger Zone</h3>
+              <h3 class="m-0 text-[1rem] text-[#c0392b] font-bold">{{ t('settings.access.danger.title') }}</h3>
             </div>
             <div class="p-6 grid gap-[0.9rem] bg-surface">
               <div class="flex items-start justify-between gap-4 max-sm:flex-col max-sm:items-start">
                 <div>
-                  <h3 class="m-0 text-[1rem]">Disable admin password</h3>
-                  <p class="m-0 mt-[0.25rem] text-muted">Turn the admin password back off for this Foldergram instance.</p>
+                  <h3 class="m-0 text-[1rem]">{{ t('settings.access.danger.disableTitle') }}</h3>
+                  <p class="m-0 mt-[0.25rem] text-muted">{{ t('settings.access.danger.disableDescription') }}</p>
                 </div>
                 <button
                   class="inline-flex min-h-11 items-center justify-center rounded-[0.95rem] border border-[rgba(214,48,49,0.24)] bg-[rgba(214,48,49,0.08)] px-4 text-[0.9rem] font-semibold text-[#c0392b] transition-colors duration-180 hover:bg-[rgba(214,48,49,0.16)] disabled:cursor-wait disabled:opacity-60 max-sm:w-full"
@@ -441,14 +437,14 @@
                   :disabled="authStore.loading"
                   @click="toggleDisablePasswordForm"
                 >
-                  {{ showDisablePasswordForm ? 'Hide Form' : 'Disable Access' }}
+                  {{ showDisablePasswordForm ? t('settings.access.danger.hideForm') : t('settings.access.danger.showForm') }}
                 </button>
               </div>
 
               <template v-if="showDisablePasswordForm">
                 <div class="grid grid-cols-[minmax(0,1fr)_auto_auto] gap-4 items-end max-lg:grid-cols-1 mt-2">
                   <label class="grid gap-[0.45rem]">
-                    <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">Current password</span>
+                    <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('settings.access.fields.currentPassword') }}</span>
                     <input
                       v-model="disablePassword"
                       class="h-12 rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 text-[0.95rem] text-text outline-none transition-[border-color,box-shadow] duration-180 focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
@@ -458,10 +454,10 @@
                     />
                   </label>
                   <button class="btn-primary min-w-[13rem] bg-[#d93025] hover:bg-[#c5281c] border-transparent text-white" type="button" :disabled="authStore.loading" @click="disableAccessProtection">
-                    {{ authStore.loading ? 'Disabling...' : 'Disable Admin Password' }}
+                    {{ authStore.loading ? t('settings.access.danger.buttonLoading') : t('settings.access.danger.buttonIdle') }}
                   </button>
                   <button class="inline-flex min-h-11 items-center justify-center rounded-[0.95rem] border border-border bg-transparent px-4 text-[0.92rem] font-semibold text-text transition-colors duration-180 hover:bg-surface-alt disabled:cursor-wait disabled:opacity-60" type="button" :disabled="authStore.loading" @click="signOut">
-                    Sign Out
+                    {{ t('settings.access.danger.signOut') }}
                   </button>
                 </div>
               </template>
@@ -478,16 +474,14 @@
           >
             <div class="flex items-start justify-between gap-4">
               <div class="grid gap-[0.3rem]">
-                <span class="eyebrow text-[#9f6a00]">Stories Migration</span>
-                <h2 class="m-0 text-[1.1rem]">This library may already use folders named stories</h2>
-                <p class="m-0 text-muted">
-                  Foldergram can now treat <code>stories/</code> as profile stories and highlights by default. Choose whether to keep legacy folder behavior or switch to the new reserved stories mode, then rescan the library.
-                </p>
+                <span class="eyebrow text-[#9f6a00]">{{ t('settings.general.migration.eyebrow') }}</span>
+                <h2 class="m-0 text-[1.1rem]">{{ t('settings.general.migration.title') }}</h2>
+                <p class="m-0 text-muted">{{ t('settings.general.migration.description') }}</p>
               </div>
               <button
                 class="inline-flex h-9 w-9 items-center justify-center rounded-full border-0 bg-[rgba(159,106,0,0.08)] text-[#9f6a00] cursor-pointer transition-colors duration-180 hover:bg-[rgba(159,106,0,0.14)]"
                 type="button"
-                aria-label="Dismiss stories migration notice"
+                :aria-label="t('settings.general.migration.dismissAria')"
                 @click="dismissStoriesMigrationNotice"
               >
                 <span class="i-fluent-dismiss-20-filled h-5 w-5" aria-hidden="true" />
@@ -501,7 +495,7 @@
                 :disabled="savingGeneralSettings || waitingForInitialStatus"
                 @click="chooseStoriesMigrationMode(false)"
               >
-                Use Stories Feature
+                {{ t('settings.general.migration.useFeature') }}
               </button>
               <button
                 class="inline-flex min-h-11 items-center justify-center rounded-[0.95rem] border border-border bg-transparent px-4 text-[0.92rem] font-semibold text-text transition-colors duration-180 hover:bg-surface-alt disabled:cursor-not-allowed disabled:opacity-60"
@@ -509,7 +503,7 @@
                 :disabled="savingGeneralSettings || waitingForInitialStatus"
                 @click="chooseStoriesMigrationMode(true)"
               >
-                Keep Legacy Behavior
+                {{ t('settings.general.migration.keepLegacy') }}
               </button>
             </div>
             <p class="m-0 text-muted">{{ storiesMigrationActionHelper }}</p>
@@ -523,26 +517,26 @@
             <div class="flex items-start justify-between gap-4">
               <div class="grid gap-[0.3rem]">
                 <div class="flex items-center gap-2">
-                  <h2 class="m-0 text-xl">Stories</h2>
-                  <span class="eyebrow inline-flex w-fit self-start text-xs">New Feature</span>
+                  <h2 class="m-0 text-xl">{{ t('settings.general.announcement.title') }}</h2>
+                  <span class="eyebrow inline-flex w-fit self-start text-xs">{{ t('common.newFeature') }}</span>
                 </div>
-                <p class="m-0 text-[0.95rem] font-medium text-text">Reserved <code>stories/</code> folders can power App Folder stories</p>
+                <p class="m-0 text-[0.95rem] font-medium text-text">{{ t('settings.general.announcement.headline') }}</p>
                 <p class="m-0 text-muted">
-                  Drop direct media into <code>AppFolder/stories</code> for the avatar story set, and use direct child folders for highlight circles. Nested folders stay inside the same highlight capsule.
+                  {{ t('settings.general.announcement.description') }}
                   <button
                     class="ml-1 inline-flex border-0 bg-transparent p-0 text-[0.92em] font-semibold text-accent-strong underline underline-offset-[0.18em] cursor-pointer transition-opacity duration-180 hover:opacity-80"
                     type="button"
                     :aria-expanded="showStoriesAnnouncementStructure"
                     @click="toggleStoriesAnnouncementStructure"
                   >
-                    {{ showStoriesAnnouncementStructure ? 'Hide directory structure' : 'See directory structure' }}
+                    {{ showStoriesAnnouncementStructure ? t('settings.general.announcement.hideStructure') : t('settings.general.announcement.showStructure') }}
                   </button>
                 </p>
               </div>
               <button
                 class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-0 bg-[rgba(24,119,242,0.08)] text-accent-strong cursor-pointer transition-colors duration-180 hover:bg-[rgba(24,119,242,0.14)]"
                 type="button"
-                aria-label="Dismiss stories announcement"
+                :aria-label="t('settings.general.announcement.dismissAria')"
                 @click="dismissStoriesAnnouncement"
               >
                 <span class="i-fluent-dismiss-20-filled h-5 w-5" aria-hidden="true" />
@@ -567,8 +561,8 @@
           <section class="card overflow-visible p-0">
             <div class="border-b border-border px-6 py-5">
               <div>
-                <h2 class="m-0 text-[1.18rem]">General Settings</h2>
-                <p class="m-0 mt-[0.25rem] text-muted">App-wide defaults for stories folders, excluded folders, Home, Reels, and app folders.</p>
+                <h2 class="m-0 text-[1.18rem]">{{ t('settings.general.card.title') }}</h2>
+                <p class="m-0 mt-[0.25rem] text-muted">{{ t('settings.general.card.description') }}</p>
               </div>
             </div>
 
@@ -583,8 +577,36 @@
             <div class="divide-y divide-border">
               <div class="grid gap-3 px-6 py-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
                 <div class="min-w-0">
-                  <p class="m-0 text-[0.96rem] font-semibold text-text">Home feed sort order</p>
-                  <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">Choose the first feed mode shown on Home.</p>
+                  <p class="m-0 text-[0.96rem] font-semibold text-text">{{ t('settings.general.language.label') }}</p>
+                  <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">{{ t('settings.general.language.description') }}</p>
+                  <p class="m-0 mt-[0.4rem] text-[0.78rem] text-muted">{{ t('settings.general.language.helper') }}</p>
+                </div>
+
+                <div class="relative w-full md:w-[18rem] md:justify-self-end">
+                  <label class="sr-only" :for="localeSelectId">{{ t('settings.general.language.selectLabel') }}</label>
+                  <select
+                    :id="localeSelectId"
+                    class="h-[3.2rem] w-full appearance-none rounded-[0.9rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_80%,transparent_20%)] px-3 pr-11 text-[0.9rem] font-semibold text-text outline-none transition-[border-color,box-shadow] duration-180 hover:border-[color-mix(in_srgb,var(--accent)_22%,var(--border)_78%)] hover:bg-surface-hover focus:border-[color-mix(in_srgb,var(--accent)_35%,var(--border)_65%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
+                    :value="appStore.locale"
+                    @change="handleLocaleChange"
+                  >
+                    <option v-for="locale in supportedLocaleOptions" :key="locale.id" :value="locale.id">
+                      {{ locale.label }}
+                    </option>
+                  </select>
+                  <span
+                    class="pointer-events-none absolute right-3 top-1/2 h-5 w-5 -translate-y-1/2 text-muted"
+                    aria-hidden="true"
+                  >
+                    <span class="i-fluent-chevron-down-20-regular block h-5 w-5" />
+                  </span>
+                </div>
+              </div>
+
+              <div class="grid gap-3 px-6 py-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+                <div class="min-w-0">
+                  <p class="m-0 text-[0.96rem] font-semibold text-text">{{ t('settings.general.homeFeed.label') }}</p>
+                  <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">{{ t('settings.general.homeFeed.description') }}</p>
                 </div>
 
                 <div class="relative w-full md:w-[18rem] md:justify-self-end" @keydown.escape.stop.prevent="closeGeneralSettingsMenu">
@@ -609,7 +631,7 @@
                     v-if="activeGeneralSettingsMenu === 'home'"
                     class="fixed inset-0 z-40 border-0 bg-transparent"
                     type="button"
-                    aria-label="Close home feed sort menu"
+                    :aria-label="t('settings.general.homeFeed.closeMenuAria')"
                     @click="closeGeneralSettingsMenu"
                   />
 
@@ -618,7 +640,7 @@
                     class="absolute right-0 top-[calc(100%+0.45rem)] z-50 w-full overflow-hidden rounded-[1rem] border border-border bg-[color-mix(in_srgb,var(--surface)_97%,var(--bg)_3%)] shadow-[0_28px_70px_rgba(0,0,0,0.16)]"
                   >
                     <div class="border-b border-border px-4 py-3">
-                      <p class="m-0 text-[0.83rem] font-semibold text-text">Home feed sort order</p>
+                      <p class="m-0 text-[0.83rem] font-semibold text-text">{{ t('settings.general.homeFeed.label') }}</p>
                     </div>
                     <div class="grid gap-1 p-2">
                       <button
@@ -644,8 +666,8 @@
 
               <div class="grid gap-3 px-6 py-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
                 <div class="min-w-0">
-                  <p class="m-0 text-[0.96rem] font-semibold text-text">Reels feed sort order</p>
-                  <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">Choose the default queue style when Reels opens.</p>
+                  <p class="m-0 text-[0.96rem] font-semibold text-text">{{ t('settings.general.reelsFeed.label') }}</p>
+                  <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">{{ t('settings.general.reelsFeed.description') }}</p>
                 </div>
 
                 <div class="relative w-full md:w-[18rem] md:justify-self-end" @keydown.escape.stop.prevent="closeGeneralSettingsMenu">
@@ -670,7 +692,7 @@
                     v-if="activeGeneralSettingsMenu === 'reels'"
                     class="fixed inset-0 z-40 border-0 bg-transparent"
                     type="button"
-                    aria-label="Close reels feed sort menu"
+                    :aria-label="t('settings.general.reelsFeed.closeMenuAria')"
                     @click="closeGeneralSettingsMenu"
                   />
 
@@ -679,7 +701,7 @@
                     class="absolute right-0 top-[calc(100%+0.45rem)] z-50 w-full overflow-hidden rounded-[1rem] border border-border bg-[color-mix(in_srgb,var(--surface)_97%,var(--bg)_3%)] shadow-[0_28px_70px_rgba(0,0,0,0.16)]"
                   >
                     <div class="border-b border-border px-4 py-3">
-                      <p class="m-0 text-[0.83rem] font-semibold text-text">Reels feed sort order</p>
+                      <p class="m-0 text-[0.83rem] font-semibold text-text">{{ t('settings.general.reelsFeed.label') }}</p>
                     </div>
                     <div class="grid gap-1 p-2">
                       <button
@@ -705,8 +727,8 @@
 
               <div class="grid gap-3 px-6 py-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
                 <div class="min-w-0">
-                  <p class="m-0 text-[0.96rem] font-semibold text-text">App folder photo order</p>
-                  <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">Choose the default order for photos inside app folders.</p>
+                  <p class="m-0 text-[0.96rem] font-semibold text-text">{{ t('settings.general.folderOrder.label') }}</p>
+                  <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">{{ t('settings.general.folderOrder.description') }}</p>
                 </div>
 
                 <div class="relative w-full md:w-[18rem] md:justify-self-end" @keydown.escape.stop.prevent="closeGeneralSettingsMenu">
@@ -731,7 +753,7 @@
                     v-if="activeGeneralSettingsMenu === 'folder'"
                     class="fixed inset-0 z-40 border-0 bg-transparent"
                     type="button"
-                    aria-label="Close app folder photo order menu"
+                    :aria-label="t('settings.general.folderOrder.closeMenuAria')"
                     @click="closeGeneralSettingsMenu"
                   />
 
@@ -740,7 +762,7 @@
                     class="absolute right-0 top-[calc(100%+0.45rem)] z-50 w-full overflow-hidden rounded-[1rem] border border-border bg-[color-mix(in_srgb,var(--surface)_97%,var(--bg)_3%)] shadow-[0_28px_70px_rgba(0,0,0,0.16)]"
                   >
                     <div class="border-b border-border px-4 py-3">
-                      <p class="m-0 text-[0.83rem] font-semibold text-text">App folder photo order</p>
+                      <p class="m-0 text-[0.83rem] font-semibold text-text">{{ t('settings.general.folderOrder.label') }}</p>
                     </div>
                     <div class="grid gap-1 p-2">
                       <button
@@ -767,20 +789,20 @@
               <div class="grid gap-3 px-6 py-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
                 <div class="min-w-0">
                   <div class="flex flex-wrap items-center gap-2">
-                    <p class="m-0 text-[0.96rem] font-semibold text-text">Treat stories folders as normal app folders</p>
+                    <p class="m-0 text-[0.96rem] font-semibold text-text">{{ t('settings.general.storiesMode.label') }}</p>
                     <span class="inline-flex items-center rounded-full bg-surface-alt px-2 py-[0.2rem] text-[0.72rem] font-semibold uppercase tracking-[0.08em] text-muted">
-                      Scan required
+                      {{ t('settings.general.storiesMode.scanRequired') }}
                     </span>
                     <div class="group relative inline-flex">
                       <button
                         class="inline-flex h-6 w-6 items-center justify-center rounded-full border-0 bg-transparent p-0 text-muted cursor-help transition-colors duration-150 hover:text-text focus-visible:text-text"
                         type="button"
-                        aria-label="Explain stories folders setting"
+                        :aria-label="t('settings.general.storiesMode.explainAria')"
                       >
                         <span class="i-fluent-info-16-regular h-4 w-4" aria-hidden="true" />
                       </button>
                       <div class="pointer-events-none absolute left-0 top-[calc(100%+0.55rem)] z-30 hidden w-[min(20rem,calc(100vw-2.5rem))] rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface)_97%,var(--bg)_3%)] px-3 py-3 text-[0.78rem] leading-[1.5] text-muted shadow-[0_20px_50px_rgba(0,0,0,0.16)] group-hover:block group-focus-within:block">
-                        When this stays off, <code>AppFolder/stories</code> becomes the source for avatar stories and highlight circles. Turn it on only if folders literally named <code>stories</code> should continue behaving like normal folders everywhere in the app.
+                        {{ t('settings.general.storiesMode.explainDescription') }}
                       </div>
                     </div>
                   </div>
@@ -795,7 +817,7 @@
                   :disabled="savingGeneralSettings || waitingForInitialStatus"
                   @click="toggleStoriesModeSetting"
                 >
-                  <span class="sr-only">Toggle stories folders behavior</span>
+                  <span class="sr-only">{{ t('settings.general.storiesMode.toggleLabel') }}</span>
                   <span
                     class="inline-flex h-7 w-12 items-center rounded-full p-[0.15rem] transition-colors duration-180"
                     :class="storiesMode ? 'bg-accent' : 'bg-[color-mix(in_srgb,var(--border)_88%,var(--surface-alt)_12%)]'"
@@ -811,18 +833,16 @@
               <div class="grid gap-4 px-6 py-4">
                 <div class="min-w-0">
                   <div class="flex flex-wrap items-center gap-2">
-                    <p class="m-0 text-[0.96rem] font-semibold text-text">Excluded source folders</p>
+                    <p class="m-0 text-[0.96rem] font-semibold text-text">{{ t('settings.general.excludedFolders.label') }}</p>
                     <span class="inline-flex items-center rounded-full bg-surface-alt px-2 py-[0.2rem] text-[0.72rem] font-semibold uppercase tracking-[0.08em] text-muted">
-                      Scan required
+                      {{ t('settings.general.storiesMode.scanRequired') }}
                     </span>
                   </div>
-                  <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">
-                    Skip matching folders anywhere by name or by exact relative path under the gallery root. Hidden paths and app-managed storage stay excluded automatically.
-                  </p>
+                  <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">{{ t('settings.general.excludedFolders.description') }}</p>
                 </div>
 
                 <label class="grid gap-[0.45rem]">
-                  <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">Custom rules</span>
+                  <span class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('settings.general.excludedFolders.customRules') }}</span>
                   <textarea
                     v-model="customExcludedFoldersDraft"
                     class="min-h-[10rem] rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_84%,transparent_16%)] px-4 py-3 text-[0.95rem] leading-[1.55] text-text outline-none transition-[border-color,box-shadow] duration-180 placeholder:text-muted focus:border-[color-mix(in_srgb,var(--accent)_48%,var(--border)_52%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
@@ -836,8 +856,8 @@
 
                 <div class="grid gap-3 lg:grid-cols-2">
                   <div class="rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_78%,transparent_22%)] px-4 py-4">
-                    <p class="m-0 text-[0.82rem] font-semibold uppercase tracking-[0.08em] text-muted">Read-only env rules</p>
-                    <p class="m-0 mt-[0.35rem] text-[0.82rem] text-muted">Change <code>GALLERY_EXCLUDED_FOLDERS</code> in <code>.env</code> or Docker and restart the app to update these.</p>
+                    <p class="m-0 text-[0.82rem] font-semibold uppercase tracking-[0.08em] text-muted">{{ t('settings.general.excludedFolders.envRulesLabel') }}</p>
+                    <p class="m-0 mt-[0.35rem] text-[0.82rem] text-muted">{{ t('settings.general.excludedFolders.envRulesDescription') }}</p>
                     <div v-if="envExcludedFolders.length > 0" class="mt-3 flex flex-wrap gap-2">
                       <span
                         v-for="rule in envExcludedFolders"
@@ -847,12 +867,12 @@
                         {{ rule }}
                       </span>
                     </div>
-                    <p v-else class="m-0 mt-3 text-[0.84rem] text-muted">No env-backed folder exclusions are configured.</p>
+                    <p v-else class="m-0 mt-3 text-[0.84rem] text-muted">{{ t('settings.general.excludedFolders.envRulesEmpty') }}</p>
                   </div>
 
                   <div class="rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_78%,transparent_22%)] px-4 py-4">
-                    <p class="m-0 text-[0.82rem] font-semibold uppercase tracking-[0.08em] text-muted">Currently active saved rules</p>
-                    <p class="m-0 mt-[0.35rem] text-[0.82rem] text-muted">This combines the saved textarea rules with any env-backed entries. New textarea edits appear here after you save them.</p>
+                    <p class="m-0 text-[0.82rem] font-semibold uppercase tracking-[0.08em] text-muted">{{ t('settings.general.excludedFolders.activeRulesLabel') }}</p>
+                    <p class="m-0 mt-[0.35rem] text-[0.82rem] text-muted">{{ t('settings.general.excludedFolders.activeRulesDescription') }}</p>
                     <div v-if="effectiveExcludedFolders.length > 0" class="mt-3 flex flex-wrap gap-2">
                       <span
                         v-for="rule in effectiveExcludedFolders"
@@ -862,7 +882,7 @@
                         {{ rule }}
                       </span>
                     </div>
-                    <p v-else class="m-0 mt-3 text-[0.84rem] text-muted">No saved custom or env-backed folder exclusions are active.</p>
+                    <p v-else class="m-0 mt-3 text-[0.84rem] text-muted">{{ t('settings.general.excludedFolders.activeRulesEmpty') }}</p>
                   </div>
                 </div>
               </div>
@@ -899,30 +919,30 @@
           <section class="card grid gap-[1.15rem] p-8">
             <div class="flex items-start justify-between gap-4 max-sm:flex-col max-sm:items-start">
               <div>
-                <h2 class="m-0 text-[1.18rem]">Offline places</h2>
-                <p class="m-0 mt-[0.35rem] text-muted">Prepare GeoNames city data, then rebuild place links from existing photo coordinates.</p>
+                <h2 class="m-0 text-[1.18rem]">{{ t('settings.places.section.title') }}</h2>
+                <p class="m-0 mt-[0.35rem] text-muted">{{ t('settings.places.section.description') }}</p>
               </div>
               <span
                 class="inline-flex items-center justify-center min-h-8 px-[0.7rem] py-[0.35rem] rounded-full text-[0.76rem] font-bold whitespace-nowrap"
                 :class="placesStore.status?.prepared ? 'text-accent-strong bg-[color-mix(in_srgb,var(--accent-soft)_78%,transparent_22%)]' : 'text-muted bg-surface-alt'"
               >
-                {{ placesStore.status?.prepared ? 'Prepared' : 'Not Prepared' }}
+                {{ placesStore.status?.prepared ? t('settings.places.section.prepared') : t('settings.places.section.notPrepared') }}
               </span>
             </div>
 
             <dl class="grid grid-cols-2 gap-4 m-0 max-sm:grid-cols-1">
               <div class="rounded-[0.95rem] border border-border bg-surface-alt p-4">
-                <dt class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">Dataset</dt>
-                <dd class="m-0 mt-1 text-[0.95rem] font-semibold">{{ placesStore.status?.metadata?.source ?? 'GeoNames cities500' }}</dd>
+                <dt class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('settings.places.section.datasetLabel') }}</dt>
+                <dd class="m-0 mt-1 text-[0.95rem] font-semibold">{{ placesStore.status?.metadata?.source ?? t('settings.places.section.fallbackDataset') }}</dd>
               </div>
               <div class="rounded-[0.95rem] border border-border bg-surface-alt p-4">
-                <dt class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">Rows</dt>
-                <dd class="m-0 mt-1 text-[0.95rem] font-semibold">{{ placesStore.status?.metadata ? formatCount(placesStore.status.metadata.rowCount) : 'Not imported' }}</dd>
+                <dt class="text-[0.76rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('settings.places.section.rowsLabel') }}</dt>
+                <dd class="m-0 mt-1 text-[0.95rem] font-semibold">{{ placesStore.status?.metadata ? formatCount(placesStore.status.metadata.rowCount) : t('settings.places.section.notImported') }}</dd>
               </div>
             </dl>
 
             <p v-if="placesStore.status?.metadata" class="m-0 text-muted">
-              Imported {{ formatDateTime(placesStore.status.metadata.importedAt) }}.
+              {{ t('settings.places.section.importedAt', { value: formatDateTime(placesStore.status.metadata.importedAt) }) }}
             </p>
             <p v-if="placesStore.statusError" class="m-0 text-[#c0392b]">
               {{ placesStore.statusError }}
@@ -938,7 +958,7 @@
                 :disabled="placesStore.preparing"
                 @click="placesStore.prepareGeodata"
               >
-                {{ placesStore.preparing ? 'Preparing...' : 'Prepare Geodata' }}
+                {{ placesStore.preparing ? t('settings.places.section.preparingButton') : t('settings.places.section.prepareButton') }}
               </button>
               <button
                 class="inline-flex min-h-11 w-full items-center justify-center rounded-[0.95rem] border border-border bg-surface-alt px-4 text-center text-[0.9rem] font-semibold text-text transition-colors duration-180 hover:bg-surface-hover disabled:cursor-wait disabled:opacity-60 sm:w-auto"
@@ -946,7 +966,7 @@
                 :disabled="placesStore.rebuilding || !placesStore.status?.prepared"
                 @click="placesStore.rebuildAssignments"
               >
-                {{ placesStore.rebuilding ? 'Rebuilding...' : 'Rebuild Place Assignments' }}
+                {{ placesStore.rebuilding ? t('settings.places.section.rebuildingButton') : t('settings.places.section.rebuildButton') }}
               </button>
             </div>
           </section>
@@ -957,8 +977,8 @@
           <section class="card grid gap-[1.15rem] p-8">
             <div class="flex items-start justify-between gap-4 max-sm:flex-col max-sm:items-start">
               <div>
-                <h2 class="m-0 text-[1.18rem]">Scan Library</h2>
-                <p class="m-0 mt-[0.35rem] text-muted">Run a scan after adding folders or when you want to refresh indexed media.</p>
+                <h2 class="m-0 text-[1.18rem]">{{ t('settings.library.scanCard.title') }}</h2>
+                <p class="m-0 mt-[0.35rem] text-muted">{{ t('settings.library.scanCard.description') }}</p>
               </div>
               <span
                 class="inline-flex items-center justify-center min-h-8 px-[0.7rem] py-[0.35rem] rounded-full text-[0.76rem] font-bold whitespace-nowrap"
@@ -977,7 +997,7 @@
             >
               <div class="flex items-start justify-between gap-3 max-sm:flex-col max-sm:items-start">
                 <div>
-                  <p class="m-0 text-[0.76rem] font-bold tracking-[0.08em] uppercase">Legacy derivative migration pending</p>
+                  <p class="m-0 text-[0.76rem] font-bold tracking-[0.08em] uppercase">{{ t('settings.library.legacyMigration.title') }}</p>
                   <p class="m-0 mt-1 text-[0.9rem] leading-relaxed">{{ legacyDerivativeMigrationMessage }}</p>
                 </div>
                 <span class="inline-flex items-center justify-center min-h-8 px-[0.7rem] py-[0.35rem] rounded-full text-[0.76rem] font-bold whitespace-nowrap text-[#9f6a00] bg-[rgba(210,161,51,0.14)]">
@@ -1004,8 +1024,8 @@
           <section class="card grid gap-[1.15rem] p-8">
              <div class="flex items-start justify-between gap-4 max-sm:flex-col max-sm:items-start">
               <div>
-                <h2 class="m-0 text-[1.18rem]">Regenerate Thumbnails</h2>
-                <p class="m-0 mt-[0.35rem] text-muted">Rebuild feed and profile thumbnails plus video posters from indexed media only. Original files are not affected.</p>
+                <h2 class="m-0 text-[1.18rem]">{{ t('settings.library.thumbnailCard.title') }}</h2>
+                <p class="m-0 mt-[0.35rem] text-muted">{{ t('settings.library.thumbnailCard.description') }}</p>
               </div>
             </div>
 
@@ -1022,29 +1042,29 @@
           <!-- Danger Zone -->
           <div class="border border-[rgba(214,48,49,0.3)] rounded-[1.05rem] overflow-hidden" :class="highlightRebuildAction ? 'ring-2 ring-[color-mix(in_srgb,var(--accent)_45%,transparent_55%)]' : ''">
             <div class="bg-[rgba(214,48,49,0.04)] px-6 py-4 border-b border-[rgba(214,48,49,0.1)] flex items-center justify-between">
-              <h3 class="m-0 text-[1rem] text-[#c0392b] font-bold">Danger Zone</h3>
+              <h3 class="m-0 text-[1rem] text-[#c0392b] font-bold">{{ t('settings.library.dangerZone.title') }}</h3>
               <span
                 v-if="appStore.isLibraryRebuildRequired"
                 class="inline-flex items-center justify-center min-h-8 px-[0.7rem] py-[0.35rem] rounded-full text-[0.76rem] font-bold whitespace-nowrap text-[#9f6a00] bg-[rgba(210,161,51,0.14)]"
               >
-                Recommended
+                {{ t('settings.library.dangerZone.recommended') }}
               </span>
             </div>
             <div class="p-6 grid gap-[1.15rem] bg-surface">
               <div class="flex items-start justify-between gap-4 max-sm:flex-col max-sm:items-start">
                 <div>
-                  <h3 class="m-0 text-[1rem]">Rebuild Library Index</h3>
-                  <p class="m-0 mt-[0.25rem] text-muted">Reset the library index, reuse matching cached media, and generate only missing derivatives from the current gallery root.</p>
+                  <h3 class="m-0 text-[1rem]">{{ t('settings.library.dangerZone.rebuildTitle') }}</h3>
+                  <p class="m-0 mt-[0.25rem] text-muted">{{ t('settings.library.dangerZone.rebuildDescription') }}</p>
                 </div>
               </div>
 
               <dl class="grid gap-[0.8rem] m-0 mb-2">
                 <div class="px-4 py-[0.85rem] rounded-[0.85rem] border border-border bg-surface-alt">
-                  <dt class="m-0 mb-[0.25rem] text-muted text-[0.72rem] font-bold tracking-[0.08em] uppercase">Current gallery root</dt>
-                  <dd class="m-0 text-[0.92rem] font-semibold break-all">{{ adminStats?.libraryIndex.currentGalleryRoot ?? 'Unavailable' }}</dd>
+                  <dt class="m-0 mb-[0.25rem] text-muted text-[0.72rem] font-bold tracking-[0.08em] uppercase">{{ t('settings.library.dangerZone.currentGalleryRoot') }}</dt>
+                  <dd class="m-0 text-[0.92rem] font-semibold break-all">{{ adminStats?.libraryIndex.currentGalleryRoot ?? t('settings.status.storage.unavailable') }}</dd>
                 </div>
                 <div v-if="adminStats?.libraryIndex.previousGalleryRoot" class="px-4 py-[0.85rem] rounded-[0.85rem] border border-[#d2a133] bg-[rgba(210,161,51,0.04)]">
-                  <dt class="m-0 mb-[0.25rem] text-[#b76e00] text-[0.72rem] font-bold tracking-[0.08em] uppercase">Previous gallery root</dt>
+                  <dt class="m-0 mb-[0.25rem] text-[#b76e00] text-[0.72rem] font-bold tracking-[0.08em] uppercase">{{ t('settings.library.dangerZone.previousGalleryRoot') }}</dt>
                   <dd class="m-0 text-[0.92rem] font-semibold break-all">{{ adminStats.libraryIndex.previousGalleryRoot }}</dd>
                 </div>
               </dl>
@@ -1065,25 +1085,25 @@
           <section class="card grid gap-[1.15rem] p-8">
             <div class="flex items-start justify-between gap-4">
               <div>
-                <h2 class="m-0 text-[1.18rem]">Library Status</h2>
-                <p class="m-0 mt-[0.35rem] text-muted">Current storage and index state.</p>
+                <h2 class="m-0 text-[1.18rem]">{{ t('settings.status.libraryStatus.title') }}</h2>
+                <p class="m-0 mt-[0.35rem] text-muted">{{ t('settings.status.libraryStatus.description') }}</p>
               </div>
             </div>
             <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4 m-0 mt-4">
               <div class="flex flex-col gap-1 py-3 border-b border-border">
-                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">Storage</dt>
+                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">{{ t('settings.status.libraryStatus.storage') }}</dt>
                 <dd class="m-0 text-[1.45rem] font-medium tracking-tight" :class="appStore.isLibraryUnavailable ? 'text-[#c0392b]' : 'text-text'">{{ storageLabel }}</dd>
               </div>
               <div class="flex flex-col gap-1 py-3 border-b border-border">
-                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">Folders</dt>
+                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">{{ t('settings.status.libraryStatus.folders') }}</dt>
                 <dd class="m-0 text-[1.45rem] font-medium tracking-tight">{{ formatCount(appStore.stats?.folders ?? 0) }}</dd>
               </div>
               <div class="flex flex-col gap-1 py-3 border-b border-border md:border-b-0">
-                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">Indexed posts</dt>
+                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">{{ t('settings.status.libraryStatus.indexedPosts') }}</dt>
                 <dd class="m-0 text-[1.45rem] font-medium tracking-tight">{{ formatCount(appStore.stats?.indexedImages ?? 0) }}</dd>
               </div>
               <div class="flex flex-col gap-1 py-3 border-b-0">
-                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">Indexed videos</dt>
+                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">{{ t('settings.status.libraryStatus.indexedVideos') }}</dt>
                 <dd class="m-0 text-[1.45rem] font-medium tracking-tight">{{ formatCount(appStore.stats?.indexedVideos ?? 0) }}</dd>
               </div>
             </dl>
@@ -1092,25 +1112,25 @@
           <section class="card grid gap-[1.15rem] p-8">
             <div class="flex items-start justify-between gap-4">
               <div>
-                <h2 class="m-0 text-[1.18rem]">Last Scan</h2>
-                <p class="m-0 mt-[0.35rem] text-muted">Most recent completed run tracked by the app.</p>
+                <h2 class="m-0 text-[1.18rem]">{{ t('settings.status.lastScan.title') }}</h2>
+                <p class="m-0 mt-[0.35rem] text-muted">{{ t('settings.status.lastScan.description') }}</p>
               </div>
             </div>
             <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4 m-0 mt-4">
               <div class="flex flex-col gap-1 py-3 border-b border-border">
-                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">Status</dt>
+                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">{{ t('settings.status.lastScan.status') }}</dt>
                 <dd class="m-0 text-[1.2rem] font-medium tracking-tight capitalize">{{ lastScanStatus }}</dd>
               </div>
               <div class="flex flex-col gap-1 py-3 border-b border-border">
-                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">Finished</dt>
+                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">{{ t('settings.status.lastScan.finished') }}</dt>
                 <dd class="m-0 text-[1.2rem] font-medium tracking-tight">{{ lastScanFinishedAt }}</dd>
               </div>
               <div class="flex flex-col gap-1 py-3 border-b border-border md:border-b-0">
-                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">Files scanned</dt>
+                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">{{ t('settings.status.lastScan.filesScanned') }}</dt>
                 <dd class="m-0 text-[1.45rem] font-medium tracking-tight">{{ formatCount(lastCompletedScan?.scanned_files ?? 0) }}</dd>
               </div>
               <div class="flex flex-col gap-1 py-3 border-b-0">
-                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">Changes</dt>
+                <dt class="m-0 text-muted text-[0.76rem] font-bold tracking-[0.08em] uppercase">{{ t('settings.status.lastScan.changes') }}</dt>
                 <dd class="m-0 text-[1rem] font-medium leading-relaxed whitespace-pre-line">{{ lastScanChangeSummary }}</dd>
               </div>
             </dl>
@@ -1122,20 +1142,20 @@
     <!-- Dialogs -->
     <ConfirmDialog
       v-if="confirmRebuildOpen"
-      title="Rebuild the current library index?"
-      message="This will clear the indexed database tables for folders, posts, likes, and scan history, then rescan the active gallery root. Existing thumbnails and previews from the previous index will be reused when they still match the current files, and only missing or changed derivatives will be generated. Original files in the gallery will not be deleted."
-      confirm-label="Rebuild Library Index"
-      loading-label="Rebuilding..."
+      :title="t('settings.library.dialogs.rebuildTitle')"
+      :message="t('settings.library.dialogs.rebuildMessage')"
+      :confirm-label="t('settings.library.dialogs.rebuildConfirm')"
+      :loading-label="t('settings.library.dialogs.rebuildLoading')"
       :loading="rebuilding"
       @cancel="confirmRebuildOpen = false"
       @confirm="runLibraryRebuild"
     />
     <ConfirmDialog
       v-if="confirmThumbnailRebuildOpen"
-      title="Regenerate thumbnails only?"
-      message="This will remove generated feed and profile thumbnails plus video poster images, then rebuild them from the current indexed library using each item's current thumbnail path. Previews, likes, scan history, and indexed library records will not be changed. Original files in the gallery will not be deleted."
-      confirm-label="Regenerate Thumbnails"
-      loading-label="Regenerating..."
+      :title="t('settings.library.dialogs.thumbnailsTitle')"
+      :message="t('settings.library.dialogs.thumbnailsMessage')"
+      :confirm-label="t('settings.library.dialogs.thumbnailsConfirm')"
+      :loading-label="t('settings.library.dialogs.thumbnailsLoading')"
       :loading="rebuildingThumbnails"
       @cancel="confirmThumbnailRebuildOpen = false"
       @confirm="runThumbnailRebuild"
@@ -1144,6 +1164,7 @@
 </template>
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 
 import ConfirmDialog from '../components/ConfirmDialog.vue';
@@ -1158,6 +1179,7 @@ import {
   updateReelsFeedDefault,
   updateStoriesMode
 } from '../api/gallery';
+import { SUPPORTED_LOCALES, type SupportedLocale } from '../locales';
 import { useAppStore } from '../stores/app';
 import { useAuthStore } from '../stores/auth';
 import { useFeedStore } from '../stores/feed';
@@ -1168,6 +1190,7 @@ import { usePlacesStore } from '../stores/places';
 import { useViewerStore } from '../stores/viewer';
 import type { AppStats, FeedMode, FolderImageOrder, ReelsFeedMode, ViewerAccessMode } from '../types/api';
 
+const { t, locale } = useI18n();
 const appStore = useAppStore();
 const authStore = useAuthStore();
 const feedStore = useFeedStore();
@@ -1208,6 +1231,7 @@ const storiesModeHydrated = ref(false);
 const activeGeneralSettingsMenu = ref<'home' | 'reels' | 'folder' | null>(null);
 const showStoriesAnnouncementStructure = ref(false);
 const generalSettingsSaveArea = ref<HTMLElement | null>(null);
+const localeSelectId = 'settings-language-select';
 const acknowledgedStoriesMigrationChoice = ref(false);
 const viewerAccessMode = ref<ViewerAccessMode>(authStore.accessMode);
 const viewerPassword = ref('');
@@ -1310,15 +1334,15 @@ function wait(milliseconds: number) {
 }
 
 function formatCount(value: number) {
-  return new Intl.NumberFormat().format(value);
+  return new Intl.NumberFormat(locale.value).format(value);
 }
 
 function formatDateTime(value: string | null | undefined) {
   if (!value) {
-    return 'Never';
+    return t('settings.status.never');
   }
 
-  return new Intl.DateTimeFormat(undefined, {
+  return new Intl.DateTimeFormat(locale.value, {
     dateStyle: 'medium',
     timeStyle: 'short'
   }).format(new Date(value));
@@ -1336,6 +1360,11 @@ function clearViewerFeedback() {
 
 function clearGeneralSettingsFeedback() {
   generalSettingsFeedback.value = null;
+}
+
+function handleLocaleChange(event: Event) {
+  const nextLocale = (event.target as HTMLSelectElement).value as SupportedLocale;
+  appStore.setLocale(nextLocale);
 }
 
 async function scrollToGeneralSettingsSaveArea() {
@@ -1407,15 +1436,15 @@ function toggleDisablePasswordForm() {
 
 function validatePasswordConfirmation(password: string, confirmation: string): string | null {
   if (password.length < MIN_PASSWORD_LENGTH) {
-    return `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`;
+    return t('settings.access.validation.minLength', { count: MIN_PASSWORD_LENGTH });
   }
 
   if (password.trim().length === 0) {
-    return 'Password cannot be empty.';
+    return t('settings.access.validation.empty');
   }
 
   if (password !== confirmation) {
-    return 'The password confirmation does not match.';
+    return t('settings.access.validation.mismatch');
   }
 
   return null;
@@ -1441,52 +1470,58 @@ function syncExcludedFoldersFromSaved() {
 const scan = computed(() => appStore.stats?.scan ?? null);
 const lastCompletedScan = computed(() => scan.value?.lastCompletedScan ?? adminStats.value?.lastScan ?? null);
 const activeScanReason = computed(() => scan.value?.scanReason ?? null);
-const homeFeedDefaultOptions: Array<{ id: FeedMode; label: string; description: string }> = [
+const supportedLocaleOptions = computed<Array<{ id: SupportedLocale; label: string }>>(() =>
+  SUPPORTED_LOCALES.map((locale) => ({
+    id: locale,
+    label: t(`settings.general.language.options.${locale}`)
+  }))
+);
+const homeFeedDefaultOptions = computed<Array<{ id: FeedMode; label: string; description: string }>>(() => [
   {
     id: 'random',
-    label: 'Random',
-    description: 'Steady shuffle.'
+    label: t('settings.general.homeFeed.options.random.label'),
+    description: t('settings.general.homeFeed.options.random.description')
   },
   {
     id: 'recent',
-    label: 'Recent',
-    description: 'Newest first.'
+    label: t('settings.general.homeFeed.options.recent.label'),
+    description: t('settings.general.homeFeed.options.recent.description')
   },
   {
     id: 'rediscover',
-    label: 'Rediscover',
-    description: 'Bring older picks back.'
+    label: t('settings.general.homeFeed.options.rediscover.label'),
+    description: t('settings.general.homeFeed.options.rediscover.description')
   }
-];
-const reelsFeedDefaultOptions: Array<{ id: ReelsFeedMode; label: string; description: string }> = [
+]);
+const reelsFeedDefaultOptions = computed<Array<{ id: ReelsFeedMode; label: string; description: string }>>(() => [
   {
     id: 'random',
-    label: 'Random',
-    description: 'Stable session shuffle.'
+    label: t('settings.general.reelsFeed.options.random.label'),
+    description: t('settings.general.reelsFeed.options.random.description')
   },
   {
     id: 'recent',
-    label: 'Recent',
-    description: 'Newest videos first.'
+    label: t('settings.general.reelsFeed.options.recent.label'),
+    description: t('settings.general.reelsFeed.options.recent.description')
   },
   {
     id: 'recommended',
-    label: 'Recommended',
-    description: 'Affinity-ranked mix.'
+    label: t('settings.general.reelsFeed.options.recommended.label'),
+    description: t('settings.general.reelsFeed.options.recommended.description')
   }
-];
-const folderImageOrderOptions: Array<{ id: FolderImageOrder; label: string; description: string }> = [
+]);
+const folderImageOrderOptions = computed<Array<{ id: FolderImageOrder; label: string; description: string }>>(() => [
   {
     id: 'newest',
-    label: 'Newest First',
-    description: 'Recent photos appear first.'
+    label: t('settings.general.folderOrder.options.newest.label'),
+    description: t('settings.general.folderOrder.options.newest.description')
   },
   {
     id: 'oldest',
-    label: 'Oldest First',
-    description: 'Earlier photos appear first.'
+    label: t('settings.general.folderOrder.options.oldest.label'),
+    description: t('settings.general.folderOrder.options.oldest.description')
   }
-];
+]);
 const isLibraryRebuildActive = computed(
   () => rebuilding.value || (appStore.isScanning && activeScanReason.value === 'rebuild')
 );
@@ -1510,22 +1545,22 @@ const legacyDerivativeMigrationPending = computed(
 const legacyDerivativeMigrationCount = computed(() => adminStats.value?.libraryIndex.pendingDerivativeMigrationRows ?? 0);
 const storiesModeRequiresDecision = computed(() => appStore.stats?.storiesMigration.decisionPending === true);
 const savedHomeFeedDefaultModeLabel = computed(
-  () => homeFeedDefaultOptions.find((mode) => mode.id === savedHomeFeedDefaultMode.value)?.label ?? 'Random'
+  () => homeFeedDefaultOptions.value.find((mode) => mode.id === savedHomeFeedDefaultMode.value)?.label ?? t('settings.general.homeFeed.options.random.label')
 );
 const savedReelsFeedDefaultModeLabel = computed(
-  () => reelsFeedDefaultOptions.find((mode) => mode.id === savedReelsFeedDefaultMode.value)?.label ?? 'Random'
+  () => reelsFeedDefaultOptions.value.find((mode) => mode.id === savedReelsFeedDefaultMode.value)?.label ?? t('settings.general.reelsFeed.options.random.label')
 );
 const savedFolderImageOrderDefaultLabel = computed(
-  () => folderImageOrderOptions.find((mode) => mode.id === savedFolderImageOrderDefault.value)?.label ?? 'Newest First'
+  () => folderImageOrderOptions.value.find((mode) => mode.id === savedFolderImageOrderDefault.value)?.label ?? t('settings.general.folderOrder.options.newest.label')
 );
 const selectedHomeFeedDefaultOption = computed(
-  () => homeFeedDefaultOptions.find((mode) => mode.id === homeFeedDefaultMode.value) ?? homeFeedDefaultOptions[0]
+  () => homeFeedDefaultOptions.value.find((mode) => mode.id === homeFeedDefaultMode.value) ?? homeFeedDefaultOptions.value[0]
 );
 const selectedReelsFeedDefaultOption = computed(
-  () => reelsFeedDefaultOptions.find((mode) => mode.id === reelsFeedDefaultMode.value) ?? reelsFeedDefaultOptions[0]
+  () => reelsFeedDefaultOptions.value.find((mode) => mode.id === reelsFeedDefaultMode.value) ?? reelsFeedDefaultOptions.value[0]
 );
 const selectedFolderImageOrderOption = computed(
-  () => folderImageOrderOptions.find((mode) => mode.id === folderImageOrderDefault.value) ?? folderImageOrderOptions[0]
+  () => folderImageOrderOptions.value.find((mode) => mode.id === folderImageOrderDefault.value) ?? folderImageOrderOptions.value[0]
 );
 const homeFeedDefaultDirty = computed(
   () => feedDefaultsHydrated.value && homeFeedDefaultMode.value !== savedHomeFeedDefaultMode.value
@@ -1561,75 +1596,75 @@ const generalSettingsSaveDisabled = computed(
 );
 const generalSettingsButtonLabel = computed(() => {
   if (savingGeneralSettings.value) {
-    return 'Saving...';
+    return t('common.saving');
   }
 
-  return generalSettingsDirty.value ? 'Save changes' : 'Saved';
+  return generalSettingsDirty.value ? t('common.saveChanges') : t('common.saved');
 });
 const generalSettingsButtonStyle = computed(() =>
   generalSettingsSaveDisabled.value ? { cursor: savingGeneralSettings.value ? 'wait' : 'not-allowed' } : undefined
 );
 const generalSettingsActionNote = computed(() => {
   if (waitingForInitialStatus.value) {
-    return 'Loading the current app preferences...';
+    return t('settings.general.actionNote.loading');
   }
 
   if (excludedFoldersDirty.value && (storiesModeDirty.value || storiesModeRequiresDecision.value || feedDefaultsDirty.value)) {
-    return 'Save the folder exclusion rules with the other app-wide changes. Run a library scan afterward so stories and excluded folders reindex correctly.';
+    return t('settings.general.actionNote.excludedAndOther');
   }
 
   if (excludedFoldersDirty.value) {
-    return 'This saves the custom excluded folders only. Run a library scan afterward so those folders disappear from the index.';
+    return t('settings.general.actionNote.excludedOnly');
   }
 
   if (storiesModeDirty.value && feedDefaultsDirty.value) {
-    return 'Save the new stories rule and the updated browsing defaults together.';
+    return t('settings.general.actionNote.storiesAndDefaults');
   }
 
   if (storiesModeDirty.value || storiesModeRequiresDecision.value) {
-    return 'This saves the stories folders rule only. Run a library scan afterward to reindex with the new behavior.';
+    return t('settings.general.actionNote.storiesOnly');
   }
 
   if ([homeFeedDefaultDirty.value, reelsFeedDefaultDirty.value, folderImageOrderDirty.value].filter(Boolean).length > 1) {
-    return 'Save these browsing defaults together. Home visitors can still switch modes on the homepage; Reels and app folders use app defaults.';
+    return t('settings.general.actionNote.multipleDefaults');
   }
 
   if (homeFeedDefaultDirty.value) {
-    return 'This updates the first feed mode shown on Home for this app. Visitors can still switch modes from the homepage.';
+    return t('settings.general.actionNote.homeOnly');
   }
 
   if (reelsFeedDefaultDirty.value) {
-    return 'This updates the queue style used when Reels opens for this app. Visitors cannot switch modes from the reels page.';
+    return t('settings.general.actionNote.reelsOnly');
   }
 
   if (folderImageOrderDirty.value) {
-    return 'This updates the default photo order used by app folder grids.';
+    return t('settings.general.actionNote.folderOnly');
   }
 
-  return 'These are the current app-wide defaults for Home, Reels, app folders, stories folders, and excluded folders.';
+  return t('settings.general.actionNote.idle');
 });
 const generalSettingsRescanNotice = computed(() => {
   if (excludedFoldersDirty.value && (storiesModeDirty.value || storiesModeRequiresDecision.value)) {
-    return 'Save these changes, then run a library scan before expecting stories folders and excluded folders to update.';
+    return t('settings.general.rescanNotice.excludedAndStories');
   }
 
   if (excludedFoldersDirty.value) {
-    return 'Save this change, then run a library scan before excluded folders disappear from the index.';
+    return t('settings.general.rescanNotice.excludedOnly');
   }
 
-  return 'Save this change, then run a library scan before expecting stories folders, avatar stories, or highlights to update.';
+  return t('settings.general.rescanNotice.storiesOnly');
 });
 const storiesModeLabelDescription = computed(() =>
   storiesMode.value
-    ? 'Legacy mode is enabled. stories folders remain ordinary app folders everywhere.'
-    : 'Reserved stories mode is enabled. AppFolder/stories powers avatar stories and highlight circles.'
+    ? t('settings.general.storiesMode.enabledDescription')
+    : t('settings.general.storiesMode.disabledDescription')
 );
 const storiesMigrationActionHelper = computed(() => {
   if (savingGeneralSettings.value) {
-    return 'Wait for the current settings update to finish first.';
+    return t('settings.general.migration.helperSaving');
   }
 
-  return 'Choose a mode here, then save it below. Run a library scan afterward so the indexed folder structure matches.';
+  return t('settings.general.migration.helper');
 });
 const showStoriesMigrationNotice = computed(
   () =>
@@ -1701,29 +1736,29 @@ const statusTone = computed(() => {
 });
 const statusLabel = computed(() => {
   if (appStore.isLibraryUnavailable) {
-    return 'Storage unavailable';
+    return t('settings.library.statusLabel.storageUnavailable');
   }
 
   if (scanProgressActive.value) {
-    return 'Scan in progress';
+    return t('settings.library.statusLabel.scanInProgress');
   }
 
   if (isRebuildOperationActive.value) {
-    return 'Rebuild active';
+    return t('settings.library.statusLabel.rebuildActive');
   }
 
-  return 'Ready';
+  return t('settings.library.statusLabel.ready');
 });
 const scanButtonLabel = computed(() => {
   if (scanProgressActive.value) {
-    return 'Scanning library...';
+    return t('settings.library.scanButton.active');
   }
 
-  return 'Run Scan Library';
+  return t('settings.library.scanButton.idle');
 });
 const scanActionNote = computed(() => {
   if (waitingForInitialStatus.value) {
-    return 'Loading current library status...';
+    return t('settings.library.scanActionNote.loading');
   }
 
   if (appStore.isLibraryUnavailable) {
@@ -1731,40 +1766,40 @@ const scanActionNote = computed(() => {
   }
 
   if (appStore.isLibraryRebuildRequired) {
-    return 'Rebuild the library index first because the gallery location changed.';
+    return t('settings.library.scanActionNote.rebuildRequired');
   }
 
   if (isRebuildOperationActive.value) {
-    return 'Another library task is running. Live progress appears in the sticky status bar.';
+    return t('settings.library.scanActionNote.otherTaskActive');
   }
 
   if (scanProgressActive.value) {
-    return 'Live progress appears in the sticky status bar.';
+    return t('settings.library.scanActionNote.progress');
   }
 
   if (legacyDerivativeMigrationPending.value) {
-    return 'Run Scan Library to move legacy mirrored thumbnails and previews into the asset-key storage layout.';
+    return t('settings.library.scanActionNote.legacyMigration');
   }
 
-  return 'Scans check for added, updated, or missing media.';
+  return t('settings.library.scanActionNote.idle');
 });
 const rebuildButtonLabel = computed(() => {
   if (isLibraryRebuildActive.value) {
-    return 'Rebuilding now...';
+    return t('settings.library.rebuildButton.active');
   }
 
-  return 'Rebuild Library Index';
+  return t('settings.library.rebuildButton.idle');
 });
 const thumbnailRebuildButtonLabel = computed(() => {
   if (isThumbnailRebuildActive.value) {
-    return 'Regenerating now...';
+    return t('settings.library.thumbnailButton.active');
   }
 
-  return 'Regenerate Thumbnails';
+  return t('settings.library.thumbnailButton.idle');
 });
 const rebuildActionNote = computed(() => {
   if (waitingForInitialStatus.value) {
-    return 'Loading current library status...';
+    return t('settings.library.rebuildActionNote.loading');
   }
 
   if (appStore.isLibraryUnavailable) {
@@ -1772,26 +1807,26 @@ const rebuildActionNote = computed(() => {
   }
 
   if (isLibraryRebuildActive.value) {
-    return 'Live progress appears in the sticky status bar.';
+    return t('settings.library.rebuildActionNote.progress');
   }
 
   if (isThumbnailRebuildActive.value) {
-    return 'Wait for thumbnail regeneration to finish first.';
+    return t('settings.library.rebuildActionNote.thumbnailActive');
   }
 
   if (appStore.isScanning) {
-    return 'Wait for the current scan to finish first.';
+    return t('settings.library.rebuildActionNote.scanActive');
   }
 
   if (appStore.isLibraryRebuildRequired) {
-    return 'Recommended because the gallery location changed.';
+    return t('settings.library.rebuildActionNote.rebuildRequired');
   }
 
-  return 'Use this to reset the index and reuse matching derivatives from the previous library index.';
+  return t('settings.library.rebuildActionNote.idle');
 });
 const thumbnailRebuildActionNote = computed(() => {
   if (waitingForInitialStatus.value) {
-    return 'Loading current library status...';
+    return t('settings.library.thumbnailActionNote.loading');
   }
 
   if (appStore.isLibraryUnavailable) {
@@ -1799,48 +1834,48 @@ const thumbnailRebuildActionNote = computed(() => {
   }
 
   if (appStore.isLibraryRebuildRequired) {
-    return 'Unavailable until the library index is rebuilt for the new gallery location.';
+    return t('settings.library.thumbnailActionNote.rebuildRequired');
   }
 
   if (isThumbnailRebuildActive.value) {
-    return 'Live progress appears in the sticky status bar.';
+    return t('settings.library.thumbnailActionNote.progress');
   }
 
   if (isLibraryRebuildActive.value) {
-    return 'Wait for the full rebuild to finish first.';
+    return t('settings.library.thumbnailActionNote.rebuildActive');
   }
 
   if (appStore.isScanning) {
-    return 'Wait for the current scan to finish first.';
+    return t('settings.library.thumbnailActionNote.scanActive');
   }
 
   if (legacyDerivativeMigrationPending.value) {
-    return 'This keeps the current thumbnail paths and does not migrate legacy mirrored derivatives. Run Scan Library instead to move them into asset-key storage.';
+    return t('settings.library.thumbnailActionNote.legacyMigration');
   }
 
-  return 'Use this for a faster thumbnail-only refresh.';
+  return t('settings.library.thumbnailActionNote.idle');
 });
 const authProtectionDescription = computed(() =>
   authStore.enabled
-    ? 'Admin protection is active for this browser session. Use the controls below to rotate the admin password, configure viewer access, sign out, or turn protection off again.'
-    : 'Protection is currently off. Anyone who can reach this app on your network can browse the library with full local access until you enable an admin password.'
+    ? t('settings.access.authProtection.enabled')
+    : t('settings.access.authProtection.disabled')
 );
 const viewerAccessActive = computed(() => authStore.enabled && authStore.accessMode !== 'off');
 const viewerAccessEnabled = computed(() => authStore.enabled && authStore.accessMode === 'password');
 const viewerAccessStatusLabel = computed(() => {
   if (!authStore.enabled) {
-    return 'Admin Password Off';
+    return t('settings.access.viewer.status.adminPasswordOff');
   }
 
   if (authStore.accessMode === 'password') {
-    return 'Viewer Password On';
+    return t('settings.access.viewer.status.viewerPasswordOn');
   }
 
   if (authStore.accessMode === 'public') {
-    return 'Public Viewer On';
+    return t('settings.access.viewer.status.publicViewerOn');
   }
 
-  return 'Admin Only';
+  return t('settings.access.viewer.status.adminOnly');
 });
 const viewerAccessStatusTone = computed(() => {
   if (!authStore.enabled) {
@@ -1859,77 +1894,96 @@ const viewerAccessStatusTone = computed(() => {
 });
 const viewerAccessSummaryTitle = computed(() => {
   if (!authStore.enabled) {
-    return 'Enable the admin password first';
+    return t('settings.access.viewer.summary.enableAdminFirst');
   }
 
   if (authStore.accessMode === 'password') {
-    return 'Viewer password access is enabled';
+    return t('settings.access.viewer.summary.viewerPasswordEnabled');
   }
 
   if (authStore.accessMode === 'public') {
-    return 'Public viewer access is enabled';
+    return t('settings.access.viewer.summary.publicEnabled');
   }
 
-  return 'Viewer access is currently off';
+  return t('settings.access.viewer.summary.off');
 });
 const viewerAccessSummary = computed(() => {
   if (!authStore.enabled) {
-    return 'Viewer access settings become available after the admin password is enabled.';
+    return t('settings.access.viewer.summaryCopy.enableAdminFirst');
   }
 
   if (authStore.accessMode === 'password') {
-    return 'Viewers can sign in with the separate viewer password, use shared likes, and browse without admin controls. To replace that password, enter a new one below. The current viewer password is not required.';
+    return t('settings.access.viewer.summaryCopy.viewerPasswordEnabled');
   }
 
   if (authStore.accessMode === 'public') {
-    return 'Anyone who can reach this Foldergram can browse without logging in. Favorites stay in the current browser only, and admins can elevate from More with the admin password.';
+    return t('settings.access.viewer.summaryCopy.publicEnabled');
   }
 
-  return 'Only the admin password can unlock the app right now. Turn on viewer password mode below if you want a browsing-only login.';
+  return t('settings.access.viewer.summaryCopy.off');
 });
 const viewerAccessDescription = computed(() => {
   if (viewerAccessMode.value === 'password') {
     return viewerAccessEnabled.value
-      ? 'Enter a new viewer password below to rotate it. You do not need the current viewer password.'
-      : 'Viewer logins get shared likes but cannot reach Settings, Trash, or any destructive action.';
+      ? t('settings.access.viewer.helper.viewerPasswordRotate')
+      : t('settings.access.viewer.helper.viewerPasswordNew');
   }
 
   if (viewerAccessMode.value === 'public') {
-    return 'Anonymous visitors can browse immediately, use browser-local favorites, and unlock admin access from More when needed.';
+    return t('settings.access.viewer.helper.public');
   }
 
   return authStore.accessMode === 'password'
-    ? 'Saving this will turn off viewer logins and return the app to admin-only access.'
+    ? t('settings.access.viewer.helper.disableFromPassword')
     : authStore.accessMode === 'public'
-      ? 'Saving this will disable public browsing and return the app to admin-only access.'
-    : 'Viewer access is currently off, so only the admin password can unlock the app.';
+      ? t('settings.access.viewer.helper.disableFromPublic')
+    : t('settings.access.viewer.helper.off');
 });
 const viewerAccessButtonLabel = computed(() => {
   if (viewerAccessMode.value === 'password') {
-    return viewerAccessEnabled.value ? 'Update Viewer Password' : 'Enable Viewer Access';
+    return viewerAccessEnabled.value
+      ? t('settings.access.viewer.buttons.updateViewerPassword')
+      : t('settings.access.viewer.buttons.enableViewerAccess');
   }
 
   if (viewerAccessMode.value === 'public') {
-    return authStore.accessMode === 'public' ? 'Save Public Access' : 'Enable Public Access';
+    return authStore.accessMode === 'public'
+      ? t('settings.access.viewer.buttons.savePublicAccess')
+      : t('settings.access.viewer.buttons.enablePublicAccess');
   }
 
-  return authStore.accessMode === 'password' || authStore.accessMode === 'public' ? 'Disable Viewer Access' : 'Save Viewer Access';
+  return authStore.accessMode === 'password' || authStore.accessMode === 'public'
+    ? t('settings.access.viewer.buttons.disableViewerAccess')
+    : t('settings.access.viewer.buttons.saveViewerAccess');
 });
-const storageLabel = computed(() => (appStore.isLibraryUnavailable ? 'Unavailable' : 'Available'));
+const storageLabel = computed(() =>
+  appStore.isLibraryUnavailable ? t('settings.status.storage.unavailable') : t('settings.status.storage.available')
+);
 const lastScanStatus = computed(() => {
   if (!lastCompletedScan.value) {
-    return 'No completed scans yet';
+    return t('settings.status.lastScan.statusValues.none');
   }
 
-  return lastCompletedScan.value.status.replaceAll('_', ' ');
+  switch (lastCompletedScan.value.status) {
+    case 'completed':
+      return t('settings.status.lastScan.statusValues.completed');
+    case 'completed_with_errors':
+      return t('settings.status.lastScan.statusValues.completedWithErrors');
+    case 'failed':
+      return t('settings.status.lastScan.statusValues.failed');
+    case 'running':
+      return t('settings.status.lastScan.statusValues.running');
+    default:
+      return lastCompletedScan.value.status.replaceAll('_', ' ');
+  }
 });
 const lastScanFinishedAt = computed(() => formatDateTime(lastCompletedScan.value?.finished_at));
 const lastScanChangeSummary = computed(() => {
   if (!lastCompletedScan.value) {
-    return '0 new\n0 updated\n0 removed';
+    return `${formatCount(0)} ${t('settings.status.lastScan.changeValues.new')}\n${formatCount(0)} ${t('settings.status.lastScan.changeValues.updated')}\n${formatCount(0)} ${t('settings.status.lastScan.changeValues.removed')}`;
   }
 
-  return `${lastCompletedScan.value.new_files} new\n${lastCompletedScan.value.updated_files} updated\n${lastCompletedScan.value.removed_files} removed`;
+  return `${formatCount(lastCompletedScan.value.new_files)} ${t('settings.status.lastScan.changeValues.new')}\n${formatCount(lastCompletedScan.value.updated_files)} ${t('settings.status.lastScan.changeValues.updated')}\n${formatCount(lastCompletedScan.value.removed_files)} ${t('settings.status.lastScan.changeValues.removed')}`;
 });
 const showScanErrorNotice = computed(() => {
   if (appStore.isLibraryUnavailable || appStore.isScanning) {
@@ -1976,18 +2030,18 @@ const showIgnoredRootMediaNotice = computed(() => {
 const scanErrorNoticeMessage = computed(() => {
   const errorText = lastCompletedScan.value?.error_text?.trim() ?? '';
   if (errorText.length === 0) {
-    return 'Some media failed during the last run. Scan the library again to retry any missed files and derivative generation.';
+    return t('settings.notices.scanError.messages.genericNoDetails');
   }
 
   if (/spawn ffprobe ENOENT/i.test(errorText) || /spawn ffmpeg ENOENT/i.test(errorText)) {
-    return 'Video processing tools are missing from the server environment. Install FFmpeg so scans can read video metadata and generate video derivatives.';
+    return t('settings.notices.scanError.messages.ffmpegMissing');
   }
 
   if (scanErrorReportPath.value) {
-    return 'Some media failed during the last run. Review the sample error and full report path below, then scan the library again to retry failed media and derivative generation.';
+    return t('settings.notices.scanError.messages.withReport');
   }
 
-  return 'Some media failed during the last run. Review the sample error below, then scan the library again to retry any missed files and derivative generation.';
+  return t('settings.notices.scanError.messages.withSample');
 });
 const scanErrorReportPath = computed(() => {
   const errorText = lastCompletedScan.value?.error_text?.trim() ?? '';
@@ -2010,16 +2064,18 @@ const scanErrorNoticeDetail = computed(() => {
     return firstLine;
   }
 
-  return `${firstLine} (+${remainingCount} more)`;
+  return t('settings.notices.scanError.detailMore', { line: firstLine, count: formatCount(remainingCount) });
 });
 const ignoredRootMediaNoticeMessage = computed(() => {
-  const supportedFileLabel = ignoredRootMediaCount.value === 1 ? 'supported file is' : 'supported files are';
-  return `${formatCount(ignoredRootMediaCount.value)} ${supportedFileLabel} being ignored in the gallery root. Move them into a folder inside your gallery root to create App Folders. Files placed directly in the gallery root are ignored.`;
+  return ignoredRootMediaCount.value === 1
+    ? t('settings.notices.ignoredRootMedia.messageOne', { count: formatCount(ignoredRootMediaCount.value) })
+    : t('settings.notices.ignoredRootMedia.messageOther', { count: formatCount(ignoredRootMediaCount.value) });
 });
 const legacyDerivativeMigrationMessage = computed(() => {
   const count = legacyDerivativeMigrationCount.value;
-  const recordLabel = count === 1 ? 'indexed media record still uses' : 'indexed media records still use';
-  return `${formatCount(count)} ${recordLabel} the old mirrored thumbnail and preview paths. Run Scan Library to move them into asset-key storage.`;
+  return count === 1
+    ? t('settings.library.legacyMigration.messageOne', { count: formatCount(count) })
+    : t('settings.library.legacyMigration.messageOther', { count: formatCount(count) });
 });
 
 function dismissScanErrorNotice() {
@@ -2148,9 +2204,9 @@ async function enableAccessProtection() {
     await authStore.enablePassword(enablePassword.value);
     enablePassword.value = '';
     enablePasswordConfirmation.value = '';
-    setAuthSuccess('The admin password is now enabled for this Foldergram instance.');
+    setAuthSuccess(t('settings.access.enable.success'));
   } catch (error) {
-    setAuthError(error instanceof Error ? error.message : 'Unable to enable the admin password.');
+    setAuthError(error instanceof Error ? error.message : t('settings.access.enable.error'));
   }
 }
 
@@ -2162,7 +2218,7 @@ async function changeAccessPassword() {
   clearAuthFeedback();
   clearViewerFeedback();
   if (currentPassword.value.length === 0) {
-    setAuthError('Enter the current password to change it.');
+    setAuthError(t('settings.access.change.missingCurrent'));
     return;
   }
 
@@ -2176,9 +2232,9 @@ async function changeAccessPassword() {
     await authStore.changePassword(currentPassword.value, nextPassword.value);
     resetChangePasswordFields();
     showChangePasswordForm.value = false;
-    setAuthSuccess('The admin password was updated and existing sessions were invalidated.');
+    setAuthSuccess(t('settings.access.change.success'));
   } catch (error) {
-    setAuthError(error instanceof Error ? error.message : 'Unable to change the admin password.');
+    setAuthError(error instanceof Error ? error.message : t('settings.access.change.error'));
   }
 }
 
@@ -2190,7 +2246,7 @@ async function disableAccessProtection() {
   clearAuthFeedback();
   clearViewerFeedback();
   if (disablePassword.value.length === 0) {
-    setAuthError('Enter the current password to disable protection.');
+    setAuthError(t('settings.access.danger.missingCurrent'));
     return;
   }
 
@@ -2203,9 +2259,9 @@ async function disableAccessProtection() {
     viewerAccessMode.value = 'off';
     viewerPassword.value = '';
     viewerPasswordConfirmation.value = '';
-    setAuthSuccess('The admin password has been disabled.');
+    setAuthSuccess(t('settings.access.danger.success'));
   } catch (error) {
-    setAuthError(error instanceof Error ? error.message : 'Unable to disable the admin password.');
+    setAuthError(error instanceof Error ? error.message : t('settings.access.danger.error'));
   }
 }
 
@@ -2234,13 +2290,13 @@ async function saveViewerAccess() {
     viewerPasswordConfirmation.value = '';
     setViewerSuccess(
       viewerAccessMode.value === 'password'
-        ? 'Viewer password access is enabled. The viewer password was saved.'
+        ? t('settings.access.viewer.success.password')
         : viewerAccessMode.value === 'public'
-          ? 'Public viewer access is enabled. Anonymous visitors can now browse with browser-local favorites.'
-        : 'Viewer access has been turned off. Only admin logins are allowed now.'
+          ? t('settings.access.viewer.success.public')
+        : t('settings.access.viewer.success.off')
     );
   } catch (error) {
-    setViewerError(error instanceof Error ? error.message : 'Unable to update viewer access.');
+    setViewerError(error instanceof Error ? error.message : t('settings.access.viewer.error'));
   }
 }
 
@@ -2254,7 +2310,7 @@ async function signOut() {
   try {
     await authStore.logout();
   } catch (error) {
-    setAuthError(error instanceof Error ? error.message : 'Unable to sign out.');
+    setAuthError(error instanceof Error ? error.message : t('settings.access.danger.signOutError'));
   }
 }
 
@@ -2335,7 +2391,7 @@ async function saveGeneralSettings() {
     try {
       nextExcludedFolders = parseExcludedFolderRulesDraft(customExcludedFoldersDraft.value);
     } catch (error) {
-      setGeneralSettingsFeedback('error', error instanceof Error ? error.message : 'Unable to validate the excluded folder rules.');
+      setGeneralSettingsFeedback('error', error instanceof Error ? error.message : t('settings.general.errors.validateExcludedFolders'));
       return;
     }
   }
@@ -2347,7 +2403,7 @@ async function saveGeneralSettings() {
   try {
     if (shouldSaveExcludedFolders) {
       const payload = await updateExcludedFolders(nextExcludedFolders);
-      savedParts.push('excluded folders');
+      savedParts.push(t('settings.general.feedback.parts.excludedFolders'));
       customExcludedFoldersDraft.value = formatExcludedFolderRules(payload.customExcludedFolders);
 
       if (adminStats.value) {
@@ -2364,7 +2420,7 @@ async function saveGeneralSettings() {
 
     if (shouldSaveStories) {
       const payload = await updateStoriesMode(storiesMode.value);
-      savedParts.push('stories folder handling');
+      savedParts.push(t('settings.general.feedback.parts.storiesFolderHandling'));
       storiesMode.value = payload.treatStoriesAsFolders;
 
       if (appStore.stats) {
@@ -2375,7 +2431,7 @@ async function saveGeneralSettings() {
 
     if (shouldSaveHome) {
       const payload = await updateHomeFeedDefault(homeFeedDefaultMode.value);
-      savedParts.push('Home feed default');
+      savedParts.push(t('settings.general.feedback.parts.homeFeedDefault'));
       if (appStore.stats) {
         appStore.stats.preferences.defaultHomeFeedMode = payload.defaultMode;
       }
@@ -2384,7 +2440,7 @@ async function saveGeneralSettings() {
 
     if (shouldSaveReels) {
       const payload = await updateReelsFeedDefault(reelsFeedDefaultMode.value);
-      savedParts.push('Reels feed default');
+      savedParts.push(t('settings.general.feedback.parts.reelsFeedDefault'));
       if (appStore.stats) {
         appStore.stats.preferences.defaultReelsFeedMode = payload.defaultMode;
       }
@@ -2393,7 +2449,7 @@ async function saveGeneralSettings() {
 
     if (shouldSaveFolderOrder) {
       const payload = await updateFolderImageOrderDefault(folderImageOrderDefault.value);
-      savedParts.push('app folder order');
+      savedParts.push(t('settings.general.feedback.parts.appFolderOrder'));
       if (appStore.stats) {
         appStore.stats.preferences.defaultFolderImageOrder = payload.defaultOrder;
       }
@@ -2407,31 +2463,31 @@ async function saveGeneralSettings() {
     }
 
     if ((shouldSaveStories || shouldSaveExcludedFolders) && (shouldSaveHome || shouldSaveReels || shouldSaveFolderOrder)) {
-      setGeneralSettingsFeedback('success', 'Settings were saved. Run a library scan to apply the folder rule changes.');
+      setGeneralSettingsFeedback('success', t('settings.general.feedback.settingsAndFolderRulesSaved'));
     } else if (shouldSaveExcludedFolders && shouldSaveStories) {
-      setGeneralSettingsFeedback('success', 'Folder exclusion rules and stories folder behavior were saved. Run a library scan to apply them.');
+      setGeneralSettingsFeedback('success', t('settings.general.feedback.folderRulesAndStoriesSaved'));
     } else if (shouldSaveExcludedFolders) {
-      setGeneralSettingsFeedback('success', 'Excluded folders were saved. Run a library scan to apply them.');
+      setGeneralSettingsFeedback('success', t('settings.general.feedback.excludedFoldersSaved'));
     } else if (shouldSaveStories && (shouldSaveHome || shouldSaveReels || shouldSaveFolderOrder)) {
-      setGeneralSettingsFeedback('success', 'Settings were saved. Run a library scan to apply the stories folder change.');
+      setGeneralSettingsFeedback('success', t('settings.general.feedback.settingsAndStoriesSaved'));
     } else if (shouldSaveStories) {
-      setGeneralSettingsFeedback('success', 'Stories folder behavior was saved. Run a library scan to apply it.');
+      setGeneralSettingsFeedback('success', t('settings.general.feedback.storiesSaved'));
     } else if ([shouldSaveHome, shouldSaveReels, shouldSaveFolderOrder].filter(Boolean).length > 1) {
-      setGeneralSettingsFeedback('success', 'App-wide browsing defaults were updated.');
+      setGeneralSettingsFeedback('success', t('settings.general.feedback.defaultsSaved'));
     } else if (shouldSaveHome) {
       setGeneralSettingsFeedback(
         'success',
-        `The homepage now opens with ${selectedHomeFeedDefaultOption.value.label}.`
+        t('settings.general.feedback.homeSaved', { label: selectedHomeFeedDefaultOption.value.label })
       );
     } else if (shouldSaveReels) {
       setGeneralSettingsFeedback(
         'success',
-        `Reels now opens with ${selectedReelsFeedDefaultOption.value.label}.`
+        t('settings.general.feedback.reelsSaved', { label: selectedReelsFeedDefaultOption.value.label })
       );
     } else if (shouldSaveFolderOrder) {
       setGeneralSettingsFeedback(
         'success',
-        `App folders now open with ${selectedFolderImageOrderOption.value.label}.`
+        t('settings.general.feedback.folderOrderSaved', { label: selectedFolderImageOrderOption.value.label })
       );
     }
   } catch (error) {
@@ -2440,11 +2496,11 @@ async function saveGeneralSettings() {
       await loadAdminStats().catch(() => {});
     }
 
-    const message = error instanceof Error ? error.message : 'Unable to update the general settings.';
+    const message = error instanceof Error ? error.message : t('settings.general.errors.update');
     if (savedParts.length > 0) {
       setGeneralSettingsFeedback(
         'error',
-        `Some settings were saved (${savedParts.join(', ')}), but the update did not finish: ${message}`
+        t('settings.general.errors.partialUpdate', { parts: savedParts.join(', '), message })
       );
     } else {
       setGeneralSettingsFeedback('error', message);
@@ -2494,7 +2550,7 @@ async function runManualScan() {
     await loadAdminStats().catch(() => {});
     await Promise.all([foldersStore.fetchFolders(true), feedStore.loadInitial(true)]);
   } catch (error) {
-    scanError.value = error instanceof Error ? error.message : 'Unable to start a library scan.';
+    scanError.value = error instanceof Error ? error.message : t('settings.library.errors.startScan');
   } finally {
     requestingScan.value = false;
   }
@@ -2528,7 +2584,7 @@ async function runLibraryRebuild() {
       momentsStore.fetchMoments(true)
     ]);
   } catch (error) {
-    rebuildError.value = error instanceof Error ? error.message : 'Unable to rebuild the current library index.';
+    rebuildError.value = error instanceof Error ? error.message : t('settings.library.errors.rebuild');
     await appStore.fetchStats({ background: true });
     await loadAdminStats().catch(() => {});
   } finally {
@@ -2558,7 +2614,7 @@ async function runThumbnailRebuild() {
       momentsStore.fetchMoments(true)
     ]);
   } catch (error) {
-    thumbnailRebuildError.value = error instanceof Error ? error.message : 'Unable to regenerate thumbnails.';
+    thumbnailRebuildError.value = error instanceof Error ? error.message : t('settings.library.errors.regenerate');
     await appStore.fetchStats({ background: true });
     await loadAdminStats().catch(() => {});
   } finally {

--- a/client/src/views/SettingsView.vue
+++ b/client/src/views/SettingsView.vue
@@ -575,31 +575,43 @@
             </div>
 
             <div class="divide-y divide-border">
-              <div class="grid gap-3 px-6 py-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
-                <div class="min-w-0">
-                  <p class="m-0 text-[0.96rem] font-semibold text-text">{{ t('settings.general.language.label') }}</p>
-                  <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">{{ t('settings.general.language.description') }}</p>
-                  <p class="m-0 mt-[0.4rem] text-[0.78rem] text-muted">{{ t('settings.general.language.helper') }}</p>
+              <div class="px-6 py-4">
+                <div class="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+                  <div class="min-w-0">
+                    <p class="m-0 text-[0.96rem] font-semibold text-text">{{ t('settings.general.language.label') }}</p>
+                    <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">{{ t('settings.general.language.description') }}</p>
+                    <p class="m-0 mt-[0.4rem] text-[0.78rem] text-muted">{{ t('settings.general.language.helper') }}</p>
+                  </div>
+
+                  <div class="relative w-full md:w-[18rem] md:justify-self-end">
+                    <label class="sr-only" :for="localeSelectId">{{ t('settings.general.language.selectLabel') }}</label>
+                    <select
+                      :id="localeSelectId"
+                      class="h-[3.2rem] w-full appearance-none rounded-[0.9rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_80%,transparent_20%)] px-3 pr-11 text-[0.9rem] font-semibold text-text outline-none transition-[border-color,box-shadow] duration-180 hover:border-[color-mix(in_srgb,var(--accent)_22%,var(--border)_78%)] hover:bg-surface-hover focus:border-[color-mix(in_srgb,var(--accent)_35%,var(--border)_65%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
+                      :disabled="savingGeneralSettings || waitingForInitialStatus"
+                      :value="appStore.locale"
+                      @change="handleLocaleChange"
+                    >
+                      <option v-for="locale in supportedLocaleOptions" :key="locale.id" :value="locale.id">
+                        {{ locale.label }}
+                      </option>
+                    </select>
+                    <span
+                      class="pointer-events-none absolute right-3 top-1/2 h-5 w-5 -translate-y-1/2 text-muted"
+                      aria-hidden="true"
+                    >
+                      <span class="i-fluent-chevron-down-20-regular block h-5 w-5" />
+                    </span>
+                  </div>
                 </div>
 
-                <div class="relative w-full md:w-[18rem] md:justify-self-end">
-                  <label class="sr-only" :for="localeSelectId">{{ t('settings.general.language.selectLabel') }}</label>
-                  <select
-                    :id="localeSelectId"
-                    class="h-[3.2rem] w-full appearance-none rounded-[0.9rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_80%,transparent_20%)] px-3 pr-11 text-[0.9rem] font-semibold text-text outline-none transition-[border-color,box-shadow] duration-180 hover:border-[color-mix(in_srgb,var(--accent)_22%,var(--border)_78%)] hover:bg-surface-hover focus:border-[color-mix(in_srgb,var(--accent)_35%,var(--border)_65%)] focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
-                    :value="appStore.locale"
-                    @change="handleLocaleChange"
-                  >
-                    <option v-for="locale in supportedLocaleOptions" :key="locale.id" :value="locale.id">
-                      {{ locale.label }}
-                    </option>
-                  </select>
-                  <span
-                    class="pointer-events-none absolute right-3 top-1/2 h-5 w-5 -translate-y-1/2 text-muted"
-                    aria-hidden="true"
-                  >
-                    <span class="i-fluent-chevron-down-20-regular block h-5 w-5" />
-                  </span>
+                <div
+                  v-if="showSavedDefaultLocaleNotice"
+                  data-testid="locale-override-notice"
+                  role="status"
+                  class="mt-3 rounded-[0.95rem] border border-[rgba(24,119,242,0.2)] bg-[rgba(24,119,242,0.08)] px-4 py-3 text-[0.82rem] leading-[1.5] text-accent-strong"
+                >
+                  {{ t('settings.general.language.overrideNotice', { savedLabel: savedLocaleOptionLabel, currentLabel: selectedLocaleOptionLabel }) }}
                 </div>
               </div>
 
@@ -1173,6 +1185,7 @@ import {
   triggerLibraryRebuild,
   triggerManualScan,
   triggerThumbnailRebuild,
+  updateAppLocale,
   updateExcludedFolders,
   updateFolderImageOrderDefault,
   updateHomeFeedDefault,
@@ -1225,6 +1238,8 @@ const disablePassword = ref('');
 const homeFeedDefaultMode = ref<FeedMode>('random');
 const reelsFeedDefaultMode = ref<ReelsFeedMode>('random');
 const folderImageOrderDefault = ref<FolderImageOrder>('newest');
+const savedLocaleSelection = ref<SupportedLocale | null>(appStore.savedDefaultLocale);
+const localeSelectionHydrated = ref(false);
 const storiesMode = ref(false);
 const feedDefaultsHydrated = ref(false);
 const storiesModeHydrated = ref(false);
@@ -1364,6 +1379,8 @@ function clearGeneralSettingsFeedback() {
 
 function handleLocaleChange(event: Event) {
   const nextLocale = (event.target as HTMLSelectElement).value as SupportedLocale;
+  clearGeneralSettingsFeedback();
+  closeGeneralSettingsMenu();
   appStore.setLocale(nextLocale);
 }
 
@@ -1457,6 +1474,11 @@ function syncFeedDefaultsFromSaved() {
   feedDefaultsHydrated.value = true;
 }
 
+function syncLocaleSelectionFromSaved() {
+  savedLocaleSelection.value = appStore.savedDefaultLocale;
+  localeSelectionHydrated.value = true;
+}
+
 function syncStoriesModeFromSaved() {
   storiesMode.value = appStore.treatStoriesAsFolders;
   storiesModeHydrated.value = true;
@@ -1547,6 +1569,14 @@ const storiesModeRequiresDecision = computed(() => appStore.stats?.storiesMigrat
 const savedHomeFeedDefaultModeLabel = computed(
   () => homeFeedDefaultOptions.value.find((mode) => mode.id === savedHomeFeedDefaultMode.value)?.label ?? t('settings.general.homeFeed.options.random.label')
 );
+const selectedLocaleOptionLabel = computed(
+  () => supportedLocaleOptions.value.find((option) => option.id === appStore.locale)?.label ?? t('settings.general.language.options.en')
+);
+const savedLocaleOptionLabel = computed(
+  () =>
+    supportedLocaleOptions.value.find((option) => option.id === savedLocaleSelection.value)?.label ??
+    t('settings.general.language.options.en')
+);
 const savedReelsFeedDefaultModeLabel = computed(
   () => reelsFeedDefaultOptions.value.find((mode) => mode.id === savedReelsFeedDefaultMode.value)?.label ?? t('settings.general.reelsFeed.options.random.label')
 );
@@ -1562,6 +1592,9 @@ const selectedReelsFeedDefaultOption = computed(
 const selectedFolderImageOrderOption = computed(
   () => folderImageOrderOptions.value.find((mode) => mode.id === folderImageOrderDefault.value) ?? folderImageOrderOptions.value[0]
 );
+const localeDirty = computed(
+  () => localeSelectionHydrated.value && (savedLocaleSelection.value === null || appStore.locale !== savedLocaleSelection.value)
+);
 const homeFeedDefaultDirty = computed(
   () => feedDefaultsHydrated.value && homeFeedDefaultMode.value !== savedHomeFeedDefaultMode.value
 );
@@ -1570,6 +1603,9 @@ const reelsFeedDefaultDirty = computed(
 );
 const folderImageOrderDirty = computed(
   () => feedDefaultsHydrated.value && folderImageOrderDefault.value !== savedFolderImageOrderDefault.value
+);
+const defaultSettingsDirtyCount = computed(
+  () => [localeDirty.value, homeFeedDefaultDirty.value, reelsFeedDefaultDirty.value, folderImageOrderDirty.value].filter(Boolean).length
 );
 const feedDefaultsDirty = computed(() => homeFeedDefaultDirty.value || reelsFeedDefaultDirty.value || folderImageOrderDirty.value);
 const storiesModeDirty = computed(() => storiesModeHydrated.value && storiesMode.value !== savedStoriesMode.value);
@@ -1586,7 +1622,10 @@ const excludedFoldersDirty = computed(() => {
   }
 });
 const generalSettingsDirty = computed(
-  () => feedDefaultsDirty.value || storiesModeDirty.value || excludedFoldersDirty.value || storiesModeRequiresDecision.value
+  () => localeDirty.value || feedDefaultsDirty.value || storiesModeDirty.value || excludedFoldersDirty.value || storiesModeRequiresDecision.value
+);
+const showSavedDefaultLocaleNotice = computed(
+  () => savedLocaleSelection.value !== null && appStore.locale !== savedLocaleSelection.value
 );
 const showGeneralSettingsRescanNotice = computed(
   () => storiesModeDirty.value || storiesModeRequiresDecision.value || excludedFoldersDirty.value
@@ -1609,7 +1648,7 @@ const generalSettingsActionNote = computed(() => {
     return t('settings.general.actionNote.loading');
   }
 
-  if (excludedFoldersDirty.value && (storiesModeDirty.value || storiesModeRequiresDecision.value || feedDefaultsDirty.value)) {
+  if (excludedFoldersDirty.value && (storiesModeDirty.value || storiesModeRequiresDecision.value || defaultSettingsDirtyCount.value > 0)) {
     return t('settings.general.actionNote.excludedAndOther');
   }
 
@@ -1617,7 +1656,7 @@ const generalSettingsActionNote = computed(() => {
     return t('settings.general.actionNote.excludedOnly');
   }
 
-  if (storiesModeDirty.value && feedDefaultsDirty.value) {
+  if (storiesModeDirty.value && defaultSettingsDirtyCount.value > 0) {
     return t('settings.general.actionNote.storiesAndDefaults');
   }
 
@@ -1625,8 +1664,12 @@ const generalSettingsActionNote = computed(() => {
     return t('settings.general.actionNote.storiesOnly');
   }
 
-  if ([homeFeedDefaultDirty.value, reelsFeedDefaultDirty.value, folderImageOrderDirty.value].filter(Boolean).length > 1) {
+  if (defaultSettingsDirtyCount.value > 1) {
     return t('settings.general.actionNote.multipleDefaults');
+  }
+
+  if (localeDirty.value) {
+    return t('settings.general.actionNote.languageOnly');
   }
 
   if (homeFeedDefaultDirty.value) {
@@ -2379,11 +2422,14 @@ async function saveGeneralSettings() {
     return;
   }
 
+  const shouldSaveLocale = localeDirty.value;
   const shouldSaveExcludedFolders = excludedFoldersDirty.value;
   const shouldSaveStories = storiesModeDirty.value || storiesModeRequiresDecision.value;
   const shouldSaveHome = homeFeedDefaultDirty.value;
   const shouldSaveReels = reelsFeedDefaultDirty.value;
   const shouldSaveFolderOrder = folderImageOrderDirty.value;
+  const shouldSaveAnyDefault = shouldSaveLocale || shouldSaveHome || shouldSaveReels || shouldSaveFolderOrder;
+  const savedDefaultCount = [shouldSaveLocale, shouldSaveHome, shouldSaveReels, shouldSaveFolderOrder].filter(Boolean).length;
   const savedParts: string[] = [];
   let nextExcludedFolders: string[] = [];
 
@@ -2401,6 +2447,17 @@ async function saveGeneralSettings() {
   clearGeneralSettingsFeedback();
 
   try {
+    if (shouldSaveLocale) {
+      const payload = await updateAppLocale(appStore.locale);
+      savedParts.push(t('settings.general.feedback.parts.appLanguage'));
+
+      if (appStore.stats) {
+        appStore.stats.preferences.defaultLocale = payload.defaultLocale;
+      }
+
+      savedLocaleSelection.value = payload.defaultLocale;
+    }
+
     if (shouldSaveExcludedFolders) {
       const payload = await updateExcludedFolders(nextExcludedFolders);
       savedParts.push(t('settings.general.feedback.parts.excludedFolders'));
@@ -2462,18 +2519,23 @@ async function saveGeneralSettings() {
       await loadAdminStats().catch(() => {});
     }
 
-    if ((shouldSaveStories || shouldSaveExcludedFolders) && (shouldSaveHome || shouldSaveReels || shouldSaveFolderOrder)) {
+    if ((shouldSaveStories || shouldSaveExcludedFolders) && shouldSaveAnyDefault) {
       setGeneralSettingsFeedback('success', t('settings.general.feedback.settingsAndFolderRulesSaved'));
     } else if (shouldSaveExcludedFolders && shouldSaveStories) {
       setGeneralSettingsFeedback('success', t('settings.general.feedback.folderRulesAndStoriesSaved'));
     } else if (shouldSaveExcludedFolders) {
       setGeneralSettingsFeedback('success', t('settings.general.feedback.excludedFoldersSaved'));
-    } else if (shouldSaveStories && (shouldSaveHome || shouldSaveReels || shouldSaveFolderOrder)) {
+    } else if (shouldSaveStories && shouldSaveAnyDefault) {
       setGeneralSettingsFeedback('success', t('settings.general.feedback.settingsAndStoriesSaved'));
     } else if (shouldSaveStories) {
       setGeneralSettingsFeedback('success', t('settings.general.feedback.storiesSaved'));
-    } else if ([shouldSaveHome, shouldSaveReels, shouldSaveFolderOrder].filter(Boolean).length > 1) {
+    } else if (savedDefaultCount > 1) {
       setGeneralSettingsFeedback('success', t('settings.general.feedback.defaultsSaved'));
+    } else if (shouldSaveLocale) {
+      setGeneralSettingsFeedback(
+        'success',
+        t('settings.general.feedback.languageSaved', { label: selectedLocaleOptionLabel.value })
+      );
     } else if (shouldSaveHome) {
       setGeneralSettingsFeedback(
         'success',
@@ -2628,6 +2690,7 @@ onMounted(async () => {
   }
 
   if (appStore.stats) {
+    syncLocaleSelectionFromSaved();
     syncFeedDefaultsFromSaved();
     syncStoriesModeFromSaved();
   }
@@ -2648,6 +2711,10 @@ watch(
   ([stats, loadingStats]) => {
     if (!stats || loadingStats) {
       return;
+    }
+
+    if (!localeSelectionHydrated.value || savingGeneralSettings.value || !localeDirty.value) {
+      syncLocaleSelectionFromSaved();
     }
 
     if (!feedDefaultsHydrated.value || savingGeneralSettings.value || !feedDefaultsDirty.value) {

--- a/client/src/views/TrashView.test.ts
+++ b/client/src/views/TrashView.test.ts
@@ -34,13 +34,35 @@ vi.mock('../components/ConfirmDialog.vue', async () => {
     default: defineComponent({
       name: 'ConfirmDialog',
       props: {
+        title: {
+          type: String,
+          default: ''
+        },
+        message: {
+          type: String,
+          default: ''
+        },
+        confirmLabel: {
+          type: String,
+          default: ''
+        },
+        cancelLabel: {
+          type: String,
+          default: ''
+        },
+        loadingLabel: {
+          type: String,
+          default: ''
+        },
         loading: Boolean
       },
       emits: ['cancel', 'confirm'],
       template: `
         <div data-test="confirm-dialog">
-          <button data-test="confirm-button" type="button" :disabled="loading" @click="$emit('confirm')">Confirm</button>
-          <button data-test="cancel-button" type="button" @click="$emit('cancel')">Cancel</button>
+          <h2 data-test="confirm-title">{{ title }}</h2>
+          <p data-test="confirm-message">{{ message }}</p>
+          <button data-test="confirm-button" type="button" :disabled="loading" @click="$emit('confirm')">{{ loading ? loadingLabel : confirmLabel }}</button>
+          <button data-test="cancel-button" type="button" @click="$emit('cancel')">{{ cancelLabel }}</button>
           <slot />
           <slot name="details" />
         </div>
@@ -52,7 +74,17 @@ vi.mock('../components/ConfirmDialog.vue', async () => {
 vi.mock('../components/EmptyState.vue', async () => ({
   default: defineComponent({
     name: 'EmptyState',
-    template: '<div data-test="empty-state" />'
+    props: {
+      title: {
+        type: String,
+        default: ''
+      },
+      description: {
+        type: String,
+        default: ''
+      }
+    },
+    template: '<div data-test="empty-state"><h2>{{ title }}</h2><p>{{ description }}</p></div>'
   })
 }));
 
@@ -333,5 +365,141 @@ describe('TrashView', () => {
 
     expect(wrapper.text()).toContain('Fog lifting over the ridge');
     expect(wrapper.text()).not.toContain('photo 52');
+  });
+
+  it('localizes the trash page and dialogs after the app language changes', async () => {
+    const appStore = useAppStore();
+    const trashStore = useTrashStore();
+    appStore.setLocale('es');
+
+    appStore.$patch({
+      stats: {
+        folders: 1,
+        indexedImages: 1,
+        indexedVideos: 0,
+        scan: {
+          isScanning: false,
+          lastCompletedScan: null
+        },
+        storage: {
+          available: true,
+          reason: null
+        },
+        libraryIndex: {
+          rebuildRequired: false,
+          reason: null,
+          ignoredRootMediaCount: 0
+        },
+        preferences: {
+          defaultHomeFeedMode: 'random',
+          defaultReelsFeedMode: 'recommended',
+          treatStoriesAsFolders: false
+        },
+        storiesMigration: {
+          hasLegacyStoriesCandidates: false,
+          decisionPending: false
+        }
+      } as never
+    });
+
+    trashStore.$patch({
+      items: [createTrashItem(73)],
+      initialized: true,
+      loading: false,
+      hasMore: false,
+      error: null
+    });
+
+    vi.spyOn(trashStore, 'loadInitial').mockResolvedValue(undefined);
+
+    const wrapper = mount(TrashView, {
+      global: {
+        stubs: {
+          RouterLink: {
+            template: '<a><slot /></a>'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Papelera');
+    expect(wrapper.text()).toContain('Publicaciones eliminadas');
+    expect(wrapper.text()).toContain('0 publicaciones seleccionadas');
+    expect(wrapper.text()).toContain('Restaurar');
+    expect(wrapper.text()).toContain('Eliminar permanentemente');
+    expect(wrapper.text()).toContain('En papelera');
+    expect(wrapper.text()).toContain('Abrir carpeta');
+    expect(wrapper.text()).not.toContain('Deleted posts');
+    expect(wrapper.text()).not.toContain('Permanently Delete');
+
+    await wrapper.get('input[type="checkbox"]').setValue(true);
+
+    const restoreButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'Restaurar');
+
+    expect(restoreButton).toBeDefined();
+
+    await restoreButton!.trigger('click');
+    await flushPromises();
+
+    expect(wrapper.get('[data-test="confirm-title"]').text()).toBe('¿Restaurar las publicaciones seleccionadas?');
+    expect(wrapper.get('[data-test="confirm-message"]').text()).toBe('¿Restaurar 1 publicación seleccionada en la app?');
+    expect(wrapper.get('[data-test="cancel-button"]').text()).toBe('Cancelar');
+  });
+
+  it('shows the backend-provided library unavailable reason on trash', async () => {
+    const appStore = useAppStore();
+    const trashStore = useTrashStore();
+
+    appStore.$patch({
+      stats: {
+        folders: 0,
+        indexedImages: 0,
+        indexedVideos: 0,
+        scan: {
+          isScanning: false,
+          lastCompletedScan: null
+        },
+        storage: {
+          available: false,
+          reason: 'Library root /mnt/gallery is unavailable.'
+        },
+        libraryIndex: {
+          rebuildRequired: false,
+          reason: null,
+          ignoredRootMediaCount: 0
+        },
+        preferences: {
+          defaultHomeFeedMode: 'random',
+          defaultReelsFeedMode: 'recommended',
+          treatStoriesAsFolders: false
+        },
+        storiesMigration: {
+          hasLegacyStoriesCandidates: false,
+          decisionPending: false
+        }
+      } as never
+    });
+
+    vi.spyOn(trashStore, 'loadInitial').mockResolvedValue(undefined);
+
+    const wrapper = mount(TrashView, {
+      global: {
+        stubs: {
+          RouterLink: {
+            template: '<a><slot /></a>'
+          }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    expect(wrapper.get('[data-test="empty-state"]').text()).toContain('Library storage unavailable');
+    expect(wrapper.get('[data-test="empty-state"]').text()).toContain('Library root /mnt/gallery is unavailable.');
+    expect(trashStore.loadInitial).not.toHaveBeenCalled();
   });
 });

--- a/client/src/views/TrashView.vue
+++ b/client/src/views/TrashView.vue
@@ -2,21 +2,21 @@
   <section class="w-[min(100%,72rem)] mx-auto grid gap-[1.1rem]">
     <header class="flex items-end justify-between gap-4 max-sm:flex-col max-sm:items-start">
       <div class="flex flex-col items-start gap-[0.25rem]">
-        <span class="eyebrow">Trash</span>
-        <h1 class="m-0 text-[clamp(1.5rem,2.2vw,1.9rem)] tracking-[-0.03em]">Deleted posts</h1>
+        <span class="eyebrow">{{ t('trashPage.eyebrow') }}</span>
+        <h1 class="m-0 text-[clamp(1.5rem,2.2vw,1.9rem)] tracking-[-0.03em]">{{ t('trashPage.title') }}</h1>
         <p class="m-0 text-muted">
-          Posts moved here stay on disk until you permanently delete them.
+          {{ t('trashPage.description') }}
         </p>
       </div>
       <div class="flex items-center gap-3">
-        <span class="text-[0.82rem] text-muted tabular-nums">{{ selectedCount }} selected</span>
+        <span class="text-[0.82rem] text-muted tabular-nums">{{ selectedCountLabel }}</span>
         <button
           class="min-h-[2.35rem] px-4 py-[0.6rem] rounded-[0.75rem] border border-border bg-surface text-text font-semibold disabled:opacity-55 disabled:cursor-not-allowed"
           type="button"
           :disabled="selectedCount === 0 || processing"
           @click="restoreConfirmOpen = true"
         >
-          Restore
+          {{ t('trashPage.restoreButton') }}
         </button>
         <button
           class="min-h-[2.35rem] px-4 py-[0.6rem] rounded-[0.75rem] border border-transparent bg-[#b42318] text-white font-semibold disabled:opacity-55 disabled:cursor-not-allowed"
@@ -24,19 +24,19 @@
           :disabled="selectedCount === 0 || processing"
           @click="permanentConfirmOpen = true"
         >
-          Permanently Delete
+          {{ t('trashPage.deleteButton') }}
         </button>
       </div>
     </header>
 
     <EmptyState
       v-if="appStore.isLibraryUnavailable"
-      title="Library storage unavailable"
-      :description="appStore.libraryUnavailableReason"
+      :title="t('trashPage.libraryUnavailableTitle')"
+      :description="libraryUnavailableDescription"
     />
     <ErrorState
       v-else-if="trashStore.error && trashStore.items.length === 0"
-      title="Could not load trash"
+      :title="t('trashPage.loadErrorTitle')"
       :message="trashStore.error"
     />
     <template v-else>
@@ -47,13 +47,16 @@
         {{ actionError }}
       </p>
 
-      <section v-if="trashStore.loading && !trashStore.initialized && trashStore.items.length === 0" class="card p-8 text-center">
-        <p class="m-0 text-muted">Loading trash...</p>
+      <section
+        v-if="trashStore.loading && !trashStore.initialized && trashStore.items.length === 0"
+        class="card p-8 text-center"
+      >
+        <p class="m-0 text-muted">{{ t('trashPage.loading') }}</p>
       </section>
       <EmptyState
         v-else-if="trashStore.initialized && trashStore.items.length === 0"
-        title="Trash is empty"
-        description="Deleted posts will appear here so you can restore them or remove them permanently."
+        :title="t('trashPage.emptyTitle')"
+        :description="t('trashPage.emptyDescription')"
       />
       <template v-else>
         <section class="grid gap-3 grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
@@ -83,7 +86,7 @@
               class="relative block w-full aspect-square overflow-hidden border-0 p-0 text-left cursor-pointer bg-surface-alt"
               type="button"
               :aria-pressed="isSelected(item.id)"
-              :aria-label="`${isSelected(item.id) ? 'Deselect' : 'Select'} ${displayCaption(item)}`"
+              :aria-label="itemSelectionAriaLabel(item.id, displayCaption(item))"
               @click="toggleSelected(item.id)"
             >
               <ResilientImage
@@ -125,9 +128,9 @@
 
             <div class="grid gap-[0.35rem] px-3 py-3">
               <p class="m-0 text-[0.84rem] truncate">{{ displayCaption(item) }}</p>
-              <p class="m-0 text-[0.74rem] text-muted">Trashed {{ formatTrashedAt(item.trashedAt) }}</p>
+              <p class="m-0 text-[0.74rem] text-muted">{{ t('trashPage.trashedAt', { date: formatTrashedAt(item.trashedAt) }) }}</p>
               <RouterLink class="text-[0.74rem] font-semibold text-accent-strong" :to="{ name: 'folder', params: { slug: item.folderSlug } }">
-                Open folder
+                {{ t('trashPage.openFolder') }}
               </RouterLink>
             </div>
           </article>
@@ -139,10 +142,11 @@
 
     <ConfirmDialog
       v-if="restoreConfirmOpen"
-      title="Restore selected posts?"
-      :message="`Restore ${selectedCount} selected post${selectedCount === 1 ? '' : 's'} to the app?`"
-      confirm-label="Restore"
-      loading-label="Restoring..."
+      :title="t('trashPage.restoreDialog.title')"
+      :message="restoreDialogMessage"
+      :confirm-label="t('trashPage.restoreDialog.confirm')"
+      :cancel-label="t('common.cancel')"
+      :loading-label="t('trashPage.restoreDialog.loading')"
       :loading="processing"
       @cancel="restoreConfirmOpen = false"
       @confirm="handleRestore"
@@ -150,17 +154,18 @@
 
     <ConfirmDialog
       v-if="permanentConfirmOpen"
-      title="Permanently delete selected posts?"
-      :message="`This will permanently delete ${selectedCount} selected post${selectedCount === 1 ? '' : 's'} and remove original files from disk.`"
-      confirm-label="Permanently Delete"
-      loading-label="Deleting..."
+      :title="t('trashPage.deleteDialog.title')"
+      :message="permanentDeleteDialogMessage"
+      :confirm-label="t('trashPage.deleteDialog.confirm')"
+      :cancel-label="t('common.cancel')"
+      :loading-label="t('trashPage.deleteDialog.loading')"
       :loading="processing"
       @cancel="permanentConfirmOpen = false"
       @confirm="handlePermanentDelete"
     >
       <template #details>
         <p class="m-0 mt-3 px-3 py-[0.8rem] rounded-[0.9rem] border border-[rgba(217,48,37,0.24)] text-[0.84rem] text-[#b42318] bg-[rgba(217,48,37,0.08)]">
-          Original files, thumbnails, and previews will be removed permanently. This action cannot be undone.
+          {{ t('trashPage.deleteDialog.warning') }}
         </p>
       </template>
     </ConfirmDialog>
@@ -169,6 +174,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { RouterLink } from 'vue-router';
 
 import { deleteImage, restoreImage } from '../api/gallery';
@@ -185,6 +191,7 @@ import { useMomentsStore } from '../stores/moments';
 import { useTrashStore } from '../stores/trash';
 import { resolveDisplayCaption } from '../utils/caption';
 
+const { t, locale } = useI18n();
 const appStore = useAppStore();
 const feedStore = useFeedStore();
 const foldersStore = useFoldersStore();
@@ -198,6 +205,23 @@ const restoreConfirmOpen = ref(false);
 const permanentConfirmOpen = ref(false);
 
 const selectedCount = computed(() => selectedIds.value.length);
+const libraryUnavailableDescription = computed(() => appStore.stats?.storage.reason ?? t('trashPage.libraryUnavailableDescription'));
+const selectedCountLabel = computed(() => {
+  const count = formatCount(selectedCount.value);
+  return selectedCount.value === 1 ? t('trashPage.selectedOne', { count }) : t('trashPage.selectedOther', { count });
+});
+const restoreDialogMessage = computed(() => {
+  const count = formatCount(selectedCount.value);
+  return selectedCount.value === 1
+    ? t('trashPage.restoreDialog.messageOne', { count })
+    : t('trashPage.restoreDialog.messageOther', { count });
+});
+const permanentDeleteDialogMessage = computed(() => {
+  const count = formatCount(selectedCount.value);
+  return selectedCount.value === 1
+    ? t('trashPage.deleteDialog.messageOne', { count })
+    : t('trashPage.deleteDialog.messageOther', { count });
+});
 
 function isSelected(id: number): boolean {
   return selectedIds.value.includes(id);
@@ -216,18 +240,26 @@ function displayCaption(item: { filename: string; caption?: string | null }) {
   return resolveDisplayCaption(item);
 }
 
+function formatCount(value: number) {
+  return new Intl.NumberFormat(locale.value).format(value);
+}
+
 function formatTrashedAt(value: string | null) {
   if (!value) {
-    return 'recently';
+    return t('trashPage.recently');
   }
 
-  return new Date(value).toLocaleString(undefined, {
+  return new Date(value).toLocaleString(locale.value, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
     hour: 'numeric',
     minute: '2-digit'
   });
+}
+
+function itemSelectionAriaLabel(id: number, label: string) {
+  return isSelected(id) ? t('trashPage.deselectItem', { label }) : t('trashPage.selectItem', { label });
 }
 
 async function refreshVisibleData() {
@@ -242,7 +274,7 @@ async function refreshVisibleData() {
 
 function refreshVisibleDataInBackground() {
   void refreshVisibleData().catch((error) => {
-    actionError.value = error instanceof Error ? error.message : 'Unable to refresh the updated library state.';
+    actionError.value = error instanceof Error ? error.message : t('trashPage.errors.refresh');
   });
 }
 
@@ -279,7 +311,9 @@ async function processSelection(action: 'restore' | 'delete') {
   }
 
   if (failedCount > 0) {
-    actionError.value = `${failedCount} post${failedCount === 1 ? '' : 's'} could not be processed.`;
+    const count = formatCount(failedCount);
+    actionError.value =
+      failedCount === 1 ? t('trashPage.errors.processOne', { count }) : t('trashPage.errors.processOther', { count });
   }
 
   processing.value = false;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -58,7 +58,10 @@ export default defineConfig(async ({ command, mode }) => {
   return {
     envDir: repositoryRoot,
     define: {
-      __APP_VERSION__: JSON.stringify(appPackage.version)
+      __APP_VERSION__: JSON.stringify(appPackage.version),
+      __VUE_I18N_FULL_INSTALL__: JSON.stringify(true),
+      __VUE_I18N_LEGACY_API__: JSON.stringify(false),
+      __INTLIFY_PROD_DEVTOOLS__: JSON.stringify(false)
     },
     plugins: [
       UnoCSS(),
@@ -73,6 +76,11 @@ export default defineConfig(async ({ command, mode }) => {
         }
       })
     ],
+    resolve: {
+      alias: {
+        'vue-i18n': 'vue-i18n/dist/vue-i18n.esm-bundler.js'
+      }
+    },
     server: {
       host: devHost,
       port: resolvedDevClientPort,

--- a/client/vitest.setup.ts
+++ b/client/vitest.setup.ts
@@ -1,4 +1,7 @@
+import { config } from '@vue/test-utils';
 import { afterEach } from 'vitest';
+
+import { DEFAULT_LOCALE, i18n, syncDocumentLanguage } from './src/locales';
 
 function createMemoryStorage(): Storage {
   const values = new Map<string, string>();
@@ -80,6 +83,10 @@ Object.defineProperty(globalThis, 'scrollTo', {
   value: () => {}
 });
 
+config.global.plugins = [...(config.global.plugins ?? []), i18n];
+
 afterEach(() => {
   window.localStorage.clear();
+  i18n.global.locale.value = DEFAULT_LOCALE;
+  syncDocumentLanguage(DEFAULT_LOCALE);
 });

--- a/docs/api.md
+++ b/docs/api.md
@@ -97,6 +97,7 @@ Example shape:
   "role": "anonymous",
   "accessMode": "public",
   "likesMode": "local",
+  "defaultLocale": "zh",
   "capabilities": {
     "canManageLibrary": false,
     "canDeleteMedia": false,
@@ -108,6 +109,12 @@ Example shape:
   }
 }
 ```
+
+Notable field:
+
+| Field | Notes |
+| --- | --- |
+| `defaultLocale` | Saved app-wide default locale used to localize the auth gate and other pre-auth UI when the browser does not already have its own local override. |
 
 ### `GET /api/feed`
 
@@ -696,6 +703,7 @@ Notable fields:
 | `scan` | Viewer-safe live scan progress snapshot. It uses the same shape as `GET /api/scan-progress`, with `currentFolder` and `currentFile` redacted and `lastCompletedScan.error_text` forced to `null`. Scan-report paths never appear here. |
 | `storage` | Availability with a generic unavailable message only. |
 | `libraryIndex` | Rebuild requirement plus ignored root-media count. Gallery-root paths are omitted. |
+| `preferences.defaultLocale` | Saved app-wide default locale when configured. Browsers can still keep their own local override. |
 | `preferences.defaultHomeFeedMode` | Current app-wide default home feed mode. |
 | `preferences.defaultReelsFeedMode` | Current app-wide default reels mode used when `/reels` opens. |
 | `preferences.defaultFolderImageOrder` | Current app-wide default order used for folder grids and folder detail navigation. |
@@ -989,6 +997,33 @@ Success:
 ```json
 {
   "defaultMode": "recent"
+}
+```
+
+### `PUT /api/admin/settings/app-locale`
+
+Sets the saved app-wide default language used by browsers that do not already
+have their own local override.
+
+Body:
+
+```json
+{
+  "defaultLocale": "zh"
+}
+```
+
+Allowed values:
+
+- `en`
+- `es`
+- `zh`
+
+Success:
+
+```json
+{
+  "defaultLocale": "zh"
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -206,6 +206,27 @@ Response shape:
 }
 ```
 
+Each capsule item includes:
+
+- `id`
+- `title`
+- `subtitle`
+- `dateContext`
+- `imageCount`
+- `coverImage`
+
+Date-driven Moment capsules also include `momentDate`, which carries the
+server-selected calendar data the client uses for localization without
+rebuilding the date windows locally.
+
+`momentDate` can be:
+
+- `{"type":"on-this-day","date":{"year":2026,"month":5,"day":31}}`
+- `{"type":"this-week-previous-years","startDate":{"year":2026,"month":5,"day":24},"endDate":{"year":2026,"month":6,"day":7}}`
+- `{"type":"from-last-year","referenceDate":{"year":2025,"month":5,"day":31},"startDate":{"year":2025,"month":4,"day":16},"endDate":{"year":2025,"month":7,"day":15}}`
+
+Highlight capsules omit `momentDate`.
+
 ### `GET /api/feed/moments/:id`
 
 Path parameters:
@@ -223,6 +244,10 @@ Query parameters:
 
 Returns `404` with `{"message":"Feed capsule not found"}` when the ID does not
 exist in the currently selected set.
+
+The `moment` object in the response uses the same capsule shape as
+`GET /api/feed/moments`, including `momentDate` when the active rail is
+date-driven Moments.
 
 ### `GET /api/folders`
 
@@ -405,8 +430,9 @@ Notes:
 
 - `items` contains the avatar story first when one exists, followed by highlight capsules.
 - `highlights` contains only highlight capsules.
-- each capsule item includes `id`, `title`, `subtitle`, `dateContext`, `imageCount`, `coverImage`, and `presentation`
+- each capsule item includes `id`, `title`, `subtitle`, `dateContext`, `imageCount`, `coverImage`, `presentation`, and `latestActivityTimestamp`
 - `presentation` is `avatar` or `highlight`
+- `latestActivityTimestamp` is the latest effective media timestamp for that story capsule, exposed so clients can localize story activity labels without parsing the English fallback copy
 - `avatarStoryId` can be a synthetic fallback id when the folder has highlight media but no direct avatar-story files
 
 Errors:
@@ -442,6 +468,7 @@ Response shape:
     "title": "AnimalPlanet",
     "subtitle": "AnimalPlanet story set",
     "dateContext": "Today",
+    "latestActivityTimestamp": 1774713600000,
     "imageCount": 8,
     "presentation": "avatar",
     "coverImage": {}
@@ -457,6 +484,7 @@ Response shape:
 Notes:
 
 - the paginated `items` array contains normal feed-item payloads
+- the `story` object uses the same capsule shape as `GET /api/folders/:slug/stories`, including `latestActivityTimestamp`
 - if the requested avatar story is a fallback capsule, the server returns recent highlight media for that synthetic capsule
 
 Errors:

--- a/docs/development.md
+++ b/docs/development.md
@@ -119,9 +119,19 @@ Use `pnpm migrate` to apply pending migrations without starting the app.
 ## Client behavior worth knowing
 
 - theme selection is stored in `localStorage`
+- locale preference is stored in `localStorage`
 - video mute preference is stored in `localStorage`
 - the client disables previously registered service workers in development
 - the client registers `/sw.js` in production when the browser supports service workers
+
+## Client localization
+
+Foldergram's client locale files live in `client/src/locales/`.
+
+- `en.json` is the canonical locale tree for app-owned UI copy
+- `es.json` and `zh.json` are shipped locales and must stay key-aligned with `en.json`
+- `index.ts` resolves stored and browser locales, registers Vue I18n, and syncs `document.documentElement.lang`
+- the client Vitest suite validates locale key parity against `en.json`
 
 ## Docs workflow
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -119,7 +119,8 @@ Use `pnpm migrate` to apply pending migrations without starting the app.
 ## Client behavior worth knowing
 
 - theme selection is stored in `localStorage`
-- locale preference is stored in `localStorage`
+- explicit locale selection is stored in `localStorage`
+- the saved app-language default is stored in the database and applies when no local browser override exists
 - video mute preference is stored in `localStorage`
 - the client disables previously registered service workers in development
 - the client registers `/sw.js` in production when the browser supports service workers
@@ -130,7 +131,7 @@ Foldergram's client locale files live in `client/src/locales/`.
 
 - `en.json` is the canonical locale tree for app-owned UI copy
 - `es.json` and `zh.json` are shipped locales and must stay key-aligned with `en.json`
-- `index.ts` resolves stored and browser locales, registers Vue I18n, and syncs `document.documentElement.lang`
+- `index.ts` resolves local overrides, saved app defaults, and browser locales, registers Vue I18n, and syncs `document.documentElement.lang`
 - the client Vitest suite validates locale key parity against `en.json`
 
 ## Docs workflow

--- a/docs/features.md
+++ b/docs/features.md
@@ -236,14 +236,15 @@ Its left sidebar is split into:
 | Section | What it contains |
 | --- | --- |
 | `Scan & Library` | Phase-aware live scan state, manual scan, thumbnail-only rebuild, and library-index rebuild actions. Admins also see the full report path when a scan finishes with skipped media errors. |
-| `General Settings` | Home and Reels default feed modes, the default App Folder photo order, stories-folders mode, excluded-folder rules, migration notices, and save-and-rescan prompts for those app-wide changes. |
+| `General Settings` | Client-side language selection, Home and Reels default feed modes, the default App Folder photo order, stories-folders mode, excluded-folder rules, migration notices, and save-and-rescan prompts for those app-wide changes. |
 | `Places` | Offline GeoNames preparation status plus place-assignment rebuild actions for GPS-tagged photos. |
 | `Security & Access` | Admin password, viewer password, public mode, sign-out, and related auth controls. |
 | `System Status` | Storage and index state plus last completed scan details, including whether the last run completed with errors. |
 
-In `General Settings`, env-backed excluded-folder rules are shown read-only and
-custom rules are saved at runtime. Changing stories mode or excluded folders
-still requires a follow-up scan from `Scan & Library`.
+In `General Settings`, the language selector applies immediately in the current
+browser and persists locally. Env-backed excluded-folder rules are shown
+read-only and custom rules are saved at runtime. Changing stories mode or
+excluded folders still requires a follow-up scan from `Scan & Library`.
 
 On mobile, Settings uses a dedicated sticky top icon bar instead of the desktop
 sidebar.

--- a/docs/features.md
+++ b/docs/features.md
@@ -236,15 +236,19 @@ Its left sidebar is split into:
 | Section | What it contains |
 | --- | --- |
 | `Scan & Library` | Phase-aware live scan state, manual scan, thumbnail-only rebuild, and library-index rebuild actions. Admins also see the full report path when a scan finishes with skipped media errors. |
-| `General Settings` | Client-side language selection, Home and Reels default feed modes, the default App Folder photo order, stories-folders mode, excluded-folder rules, migration notices, and save-and-rescan prompts for those app-wide changes. |
+| `General Settings` | App-language selection with instant local switching plus saved app-wide defaults, Home and Reels default feed modes, the default App Folder photo order, stories-folders mode, excluded-folder rules, migration notices, and save-and-rescan prompts for those app-wide changes. |
 | `Places` | Offline GeoNames preparation status plus place-assignment rebuild actions for GPS-tagged photos. |
 | `Security & Access` | Admin password, viewer password, public mode, sign-out, and related auth controls. |
 | `System Status` | Storage and index state plus last completed scan details, including whether the last run completed with errors. |
 
 In `General Settings`, the language selector applies immediately in the current
-browser and persists locally. Env-backed excluded-folder rules are shown
-read-only and custom rules are saved at runtime. Changing stories mode or
-excluded folders still requires a follow-up scan from `Scan & Library`.
+browser. That browser-local override is stored locally, and clicking `Save
+changes` also stores the selected language as the app-wide default for browsers
+without their own override. That saved default also reaches the login gate and
+other pre-auth translated UI on devices that are using the app-wide language.
+Env-backed excluded-folder rules are shown read-only and custom rules are saved
+at runtime. Changing stories mode or excluded folders still requires a follow-up
+scan from `Scan & Library`.
 
 On mobile, Settings uses a dedicated sticky top icon bar instead of the desktop
 sidebar.
@@ -282,17 +286,23 @@ Current non-admin behavior:
 | Regenerate Thumbnails | Clears generated thumbnails and video poster images, then rebuilds them from indexed media only. |
 | Rebuild Library Index | Clears indexed folders, posts, likes, folder scan state, and scan history, then rescans the active gallery root and reuses matching cached derivatives when possible. In lazy derivative mode it does not pre-generate missing thumbnails or previews. |
 
-## Theme and local UI preferences
+## Theme, language, and local UI preferences
 
 The client also persists a few local browser preferences:
 
+- selected language override
 - light or dark theme
 - whether videos start muted
 - last opened folder
 - recently opened folders
 - recent explore searches
 
-These are stored in `localStorage` and are not synced anywhere else.
+These are stored in `localStorage`.
+
+The selected language also has one extra layer:
+
+- changing the language updates the current browser immediately
+- saving `General Settings` stores that language in the app database as the default for browsers without a local override
 
 ## What is intentionally missing
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -237,6 +237,10 @@ The current date-driven capsules are:
 - This Week
 - Last Year Around Now
 
+These date-driven capsule payloads also include structured calendar parts so
+the client can localize their labels from the server-selected dates instead of
+rebuilding the windows in the browser.
+
 ### Highlights
 
 When date coverage is too sparse, Foldergram falls back to curated sets:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -121,7 +121,7 @@ mode with admin unlock.
 
 The Settings sidebar separates app-wide preferences from maintenance actions:
 
-- `General Settings` contains stories mode, excluded folders, Home/Reels defaults, and the default folder photo order
+- `General Settings` contains app language, stories mode, excluded folders, Home/Reels defaults, and the default folder photo order
 - `Places` contains offline place-data preparation and place-assignment rebuilds for GPS-tagged photos
 - `Scan & Library` contains manual scan plus rebuild actions
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       vue:
         specifier: ^3.5.13
         version: 3.5.29(typescript@5.9.3)
+      vue-i18n:
+        specifier: ^11.1.11
+        version: 11.4.4(vue@3.5.29(typescript@5.9.3))
       vue-router:
         specifier: ^4.5.0
         version: 4.6.4(vue@3.5.29(typescript@5.9.3))
@@ -919,6 +922,22 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@intlify/core-base@11.4.4':
+    resolution: {integrity: sha512-w/vItlylrAmhebkIbVl5YY8XMCtj8Mb2g70ttxktMYuf5AuRahgEHL2iLgLIsZBIbTSgs4hkUo7ucCL0uTJvOg==}
+    engines: {node: '>= 22'}
+
+  '@intlify/devtools-types@11.4.4':
+    resolution: {integrity: sha512-PcBLmGmDQsTSVV911P8upzpcLJO1CNVYi/IH6bGnLR2nA+0L963+kXN1ZrisTEnbtw2ewN6HMMSldqzjronA0Q==}
+    engines: {node: '>= 22'}
+
+  '@intlify/message-compiler@11.4.4':
+    resolution: {integrity: sha512-vn0OAV9pYkJlPPmgnsSm5eAG3mL0+9C/oaded2JY9jmxBbhmUXT3TcAUY8WRgLY9Hte7lkUJKpXrVlYjMXBD2w==}
+    engines: {node: '>= 22'}
+
+  '@intlify/shared@11.4.4':
+    resolution: {integrity: sha512-QRUCHqda1U6aR14FR0vvXD4+4gj6+fm0AhAozvSuRCw0fCvrmCugWpgiR4xH2NI6s8am6N9p5OhirplsX8ZS3g==}
+    engines: {node: '>= 22'}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2697,6 +2716,12 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
+  vue-i18n@11.4.4:
+    resolution: {integrity: sha512-gIbXVSFQV4jcSJxfwdZ5zSZmZ+12CnX0K3vBkRSd6Zn+HSzCp+QwUgPwpD/uN0oKNKI9RzlUXPKVedEuMgNG0A==}
+    engines: {node: '>= 22'}
+    peerDependencies:
+      vue: ^3.0.0
+
   vue-router@4.6.4:
     resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
     peerDependencies:
@@ -3372,6 +3397,24 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@intlify/core-base@11.4.4':
+    dependencies:
+      '@intlify/devtools-types': 11.4.4
+      '@intlify/message-compiler': 11.4.4
+      '@intlify/shared': 11.4.4
+
+  '@intlify/devtools-types@11.4.4':
+    dependencies:
+      '@intlify/core-base': 11.4.4
+      '@intlify/shared': 11.4.4
+
+  '@intlify/message-compiler@11.4.4':
+    dependencies:
+      '@intlify/shared': 11.4.4
+      source-map-js: 1.2.1
+
+  '@intlify/shared@11.4.4': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -5376,6 +5419,14 @@ snapshots:
   vscode-uri@3.1.0: {}
 
   vue-component-type-helpers@2.2.12: {}
+
+  vue-i18n@11.4.4(vue@3.5.29(typescript@5.9.3)):
+    dependencies:
+      '@intlify/core-base': 11.4.4
+      '@intlify/devtools-types': 11.4.4
+      '@intlify/shared': 11.4.4
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.29(typescript@5.9.3)
 
   vue-router@4.6.4(vue@3.5.29(typescript@5.9.3)):
     dependencies:

--- a/server/src/constants/app-setting-keys.ts
+++ b/server/src/constants/app-setting-keys.ts
@@ -12,6 +12,7 @@ export const STORIES_MIGRATION_DECISION_SETTING_KEY = 'library.stories_migration
 export const HOME_FEED_DEFAULT_MODE_SETTING_KEY = 'feed.default_home_mode';
 export const REELS_FEED_DEFAULT_MODE_SETTING_KEY = 'feed.default_reels_mode';
 export const FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY = 'folder.default_image_order';
+export const APP_DEFAULT_LOCALE_SETTING_KEY = 'app.default_locale';
 export const AUTH_PASSWORD_HASH_SETTING_KEY = 'auth.password_hash';
 export const AUTH_PASSWORD_SALT_SETTING_KEY = 'auth.password_salt';
 export const AUTH_SESSION_SECRET_SETTING_KEY = 'auth.session_secret';

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -68,6 +68,9 @@ const mediaSearchQuerySchema = paginationQuerySchema.extend({
 const homeFeedDefaultBodySchema = z.object({
   defaultMode: z.enum(['recent', 'rediscover', 'random'])
 });
+const appLocaleBodySchema = z.object({
+  defaultLocale: z.enum(['en', 'es', 'zh'])
+});
 const reelsFeedDefaultBodySchema = z.object({
   defaultMode: z.enum(['recommended', 'recent', 'random'])
 });
@@ -169,6 +172,7 @@ export const authRequestBodySchemas = {
 
 export const settingsRequestBodySchemas = {
   homeFeedDefault: homeFeedDefaultBodySchema,
+  appLocale: appLocaleBodySchema,
   reelsFeedDefault: reelsFeedDefaultBodySchema,
   folderImageOrderDefault: folderImageOrderDefaultBodySchema,
   storiesMode: storiesModeBodySchema,
@@ -378,6 +382,15 @@ router.get('/scan-progress', (_request, response) => {
 router.get('/admin/scan-progress', requireCapability('canAccessSettings', 'Admin access is required.'), (_request, response) => {
   response.json(galleryService.getAdminScanProgress());
 });
+
+router.put(
+  '/admin/settings/app-locale',
+  requireCapability('canAccessSettings', 'Admin access is required.'),
+  (request, response) => {
+    const body = appLocaleBodySchema.parse(request.body);
+    response.json(galleryService.setDefaultLocale(body.defaultLocale));
+  }
+);
 
 router.put(
   '/admin/settings/home-feed-default',

--- a/server/src/services/auth-service.ts
+++ b/server/src/services/auth-service.ts
@@ -3,6 +3,7 @@ import { createHmac, randomBytes, scryptSync, timingSafeEqual } from 'node:crypt
 import type express from 'express';
 
 import {
+  APP_DEFAULT_LOCALE_SETTING_KEY,
   AUTH_PASSWORD_HASH_SETTING_KEY,
   AUTH_PASSWORD_SALT_SETTING_KEY,
   AUTH_SESSION_SECRET_SETTING_KEY,
@@ -17,6 +18,7 @@ export type AuthRole = 'admin' | 'viewer' | 'anonymous';
 export type SessionRole = Exclude<AuthRole, 'anonymous'>;
 export type ViewerAccessMode = 'off' | 'password' | 'public';
 export type LikesMode = 'shared' | 'local';
+type SupportedLocale = 'en' | 'es' | 'zh';
 
 export interface AuthCapabilities {
   canManageLibrary: boolean;
@@ -51,6 +53,7 @@ export interface AuthStatus {
   role: AuthRole;
   accessMode: ViewerAccessMode;
   likesMode: LikesMode;
+  defaultLocale: SupportedLocale | null;
   capabilities: AuthCapabilities;
 }
 
@@ -59,6 +62,19 @@ export const AUTH_PASSWORD_MIN_LENGTH = 8;
 export const AUTH_PASSWORD_MAX_LENGTH = 256;
 const PASSWORD_HASH_LENGTH = 64;
 const SESSION_DURATION_MS = 30 * 24 * 60 * 60 * 1000;
+const SUPPORTED_LOCALES = ['en', 'es', 'zh'] as const;
+
+function parseSupportedLocale(value: string | null): SupportedLocale | null {
+  if (!value) {
+    return null;
+  }
+
+  return (SUPPORTED_LOCALES as readonly string[]).includes(value) ? (value as SupportedLocale) : null;
+}
+
+function getDefaultLocale(): SupportedLocale | null {
+  return parseSupportedLocale(appSettingsRepository.get(APP_DEFAULT_LOCALE_SETTING_KEY));
+}
 
 function decodeBase64Url(value: string | null): Buffer | null {
   if (!value) {
@@ -135,6 +151,7 @@ function createStatus(role: AuthRole, authenticated: boolean, enabled: boolean, 
     role,
     accessMode,
     likesMode: capabilities.canUseSharedLikes ? 'shared' : 'local',
+    defaultLocale: getDefaultLocale(),
     capabilities
   };
 }

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -63,10 +63,34 @@ interface FeedCapsuleDefinition {
   title: string;
   subtitle: string;
   dateContext: string;
+  momentDate?: MomentDateMetadata;
   minimumImageCount: number;
   count: () => number;
   list: (page: number, limit: number) => FeedImage[];
 }
+
+interface CalendarDateParts {
+  year: number;
+  month: number;
+  day: number;
+}
+
+type MomentDateMetadata =
+  | {
+      type: 'on-this-day';
+      date: CalendarDateParts;
+    }
+  | {
+      type: 'this-week-previous-years';
+      startDate: CalendarDateParts;
+      endDate: CalendarDateParts;
+    }
+  | {
+      type: 'from-last-year';
+      referenceDate: CalendarDateParts;
+      startDate: CalendarDateParts;
+      endDate: CalendarDateParts;
+    };
 
 interface FeedRailDefinition {
   kind: FeedRailKind;
@@ -698,6 +722,14 @@ function createDailySeed(now = new Date()): number {
   return Number(`${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}`);
 }
 
+function toCalendarDateParts(date: Date): CalendarDateParts {
+  return {
+    year: date.getFullYear(),
+    month: date.getMonth() + 1,
+    day: date.getDate()
+  };
+}
+
 function getHighlightFeedOverlapImageIds(): Set<number> {
   const recentFeedItems = imageRepository.listRecentCandidates(0, HIGHLIGHT_FEED_OVERLAP_WINDOW);
 
@@ -753,6 +785,10 @@ function buildMomentRailDefinition(now = new Date()): FeedRailDefinition {
         title: 'On This Day',
         subtitle: `${formatMonthDay(now)} across previous years`,
         dateContext: formatMonthDay(now),
+        momentDate: {
+          type: 'on-this-day',
+          date: toCalendarDateParts(now)
+        },
         minimumImageCount: 1,
         count: () => imageRepository.countByMonthDayKeys(onThisDayKeys, currentYear),
         list: (page, limit) => imageRepository.listByMonthDayKeys(onThisDayKeys, currentYear, page, limit)
@@ -762,6 +798,11 @@ function buildMomentRailDefinition(now = new Date()): FeedRailDefinition {
         title: 'This Week',
         subtitle: `${formatShortRange(thisWeekStart, thisWeekEnd)} from previous years`,
         dateContext: formatShortRange(thisWeekStart, thisWeekEnd),
+        momentDate: {
+          type: 'this-week-previous-years',
+          startDate: toCalendarDateParts(thisWeekStart),
+          endDate: toCalendarDateParts(thisWeekEnd)
+        },
         minimumImageCount: 2,
         count: () => imageRepository.countByMonthDayKeys(weekKeys, currentYear),
         list: (page, limit) => imageRepository.listByMonthDayKeys(weekKeys, currentYear, page, limit)
@@ -771,6 +812,12 @@ function buildMomentRailDefinition(now = new Date()): FeedRailDefinition {
         title: 'Last Year Around Now',
         subtitle: `A revisit to ${formatMonthYear(lastYearReference)}`,
         dateContext: formatShortRange(lastYearStart, lastYearEnd),
+        momentDate: {
+          type: 'from-last-year',
+          referenceDate: toCalendarDateParts(lastYearReference),
+          startDate: toCalendarDateParts(lastYearStart),
+          endDate: toCalendarDateParts(lastYearEnd)
+        },
         minimumImageCount: 1,
         count: () => imageRepository.countByEffectiveTimeRange(lastYearStart.getTime(), lastYearEnd.getTime()),
         list: (page, limit) => imageRepository.listByEffectiveTimeRange(lastYearStart.getTime(), lastYearEnd.getTime(), page, limit)
@@ -876,6 +923,7 @@ function materializeRailDefinition(definition: FeedRailDefinition) {
           title: capsule.title,
           subtitle: capsule.subtitle,
           dateContext: capsule.dateContext,
+          momentDate: capsule.momentDate,
           imageCount,
           coverImage: mapFeedImage(coverImage, derivativeVersion)
         };

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -3,6 +3,7 @@ import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 
 import {
+  APP_DEFAULT_LOCALE_SETTING_KEY,
   EXCLUDED_FOLDERS_SETTING_KEY,
   FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY,
   HOME_FEED_DEFAULT_MODE_SETTING_KEY,
@@ -57,6 +58,7 @@ import { geodataService, placeResolutionService } from './place-service.js';
 
 type FeedMode = 'recent' | 'rediscover' | 'random';
 type ReelsFeedMode = 'recommended' | 'recent' | 'random';
+type SupportedLocale = 'en' | 'es' | 'zh';
 
 interface FeedCapsuleDefinition {
   id: string;
@@ -139,6 +141,7 @@ const HIGHLIGHT_FEED_OVERLAP_WINDOW = 18;
 const RAIL_COVER_CANDIDATE_LIMIT = 12;
 const FALLBACK_AVATAR_STORY_LIMIT = 10;
 const FALLBACK_AVATAR_STORY_ID = '__story-avatar-fallback__';
+const SUPPORTED_LOCALES = ['en', 'es', 'zh'] as const;
 
 interface PlaceRowFields {
   placeId?: number | null;
@@ -174,6 +177,18 @@ function parseFeedMode(value: string | null): FeedMode {
 
 function getDefaultHomeFeedMode(): FeedMode {
   return parseFeedMode(appSettingsRepository.get(HOME_FEED_DEFAULT_MODE_SETTING_KEY));
+}
+
+function parseSupportedLocale(value: string | null): SupportedLocale | null {
+  if (!value) {
+    return null;
+  }
+
+  return (SUPPORTED_LOCALES as readonly string[]).includes(value) ? (value as SupportedLocale) : null;
+}
+
+function getDefaultLocale(): SupportedLocale | null {
+  return parseSupportedLocale(appSettingsRepository.get(APP_DEFAULT_LOCALE_SETTING_KEY));
 }
 
 function parseReelsFeedMode(value: string | null): ReelsFeedMode {
@@ -1808,6 +1823,7 @@ export const galleryService = {
     const storageState = storageService.getState();
     const rebuildRequired = appSettingsRepository.get(LIBRARY_REBUILD_REQUIRED_SETTING_KEY) === '1';
     const defaultHomeFeedMode = getDefaultHomeFeedMode();
+    const defaultLocale = getDefaultLocale();
     const defaultReelsFeedMode = getDefaultReelsFeedMode();
     const defaultFolderImageOrder = getDefaultFolderImageOrder();
     const treatStoriesAsFolders = getTreatStoriesAsFolders();
@@ -1828,6 +1844,7 @@ export const galleryService = {
         ignoredRootMediaCount: storageState.libraryAvailable ? countSupportedRootMediaFiles(appConfig.galleryRoot) : 0
       },
       preferences: {
+        defaultLocale,
         defaultHomeFeedMode,
         defaultReelsFeedMode,
         defaultFolderImageOrder,
@@ -1868,6 +1885,7 @@ export const galleryService = {
     const lastSuccessfulGalleryRoot = appSettingsRepository.get(LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY);
     const pendingDerivativeMigrationRows = storageState.libraryAvailable ? imageRepository.countPendingDerivativeMigrationRows() : 0;
     const defaultHomeFeedMode = getDefaultHomeFeedMode();
+    const defaultLocale = getDefaultLocale();
     const defaultReelsFeedMode = getDefaultReelsFeedMode();
     const defaultFolderImageOrder = getDefaultFolderImageOrder();
     const treatStoriesAsFolders = getTreatStoriesAsFolders();
@@ -1899,6 +1917,7 @@ export const galleryService = {
         ignoredRootMediaCount: storageState.libraryAvailable ? countSupportedRootMediaFiles(currentGalleryRoot) : 0
       },
       preferences: {
+        defaultLocale,
         defaultHomeFeedMode,
         defaultReelsFeedMode,
         defaultFolderImageOrder,
@@ -1914,6 +1933,14 @@ export const galleryService = {
 
     return {
       defaultMode: mode
+    };
+  },
+
+  setDefaultLocale(defaultLocale: SupportedLocale) {
+    appSettingsRepository.set(APP_DEFAULT_LOCALE_SETTING_KEY, defaultLocale);
+
+    return {
+      defaultLocale
     };
   },
 

--- a/server/test/auth-route-validation.test.ts
+++ b/server/test/auth-route-validation.test.ts
@@ -99,6 +99,24 @@ describe.sequential('auth route validation', () => {
     });
   });
 
+  it('accepts zh as a valid app locale default', () => {
+    expect(
+      settingsRequestBodySchemas.appLocale.parse({
+        defaultLocale: 'zh'
+      })
+    ).toEqual({
+      defaultLocale: 'zh'
+    });
+  });
+
+  it('rejects invalid app locale defaults', () => {
+    expect(() =>
+      settingsRequestBodySchemas.appLocale.parse({
+        defaultLocale: 'fr'
+      })
+    ).toThrowError();
+  });
+
   it('rejects invalid reels-feed default modes', () => {
     expect(() =>
       settingsRequestBodySchemas.reelsFeedDefault.parse({

--- a/server/test/auth-service.test.ts
+++ b/server/test/auth-service.test.ts
@@ -6,6 +6,8 @@ import type express from 'express';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 type AuthServiceModule = typeof import('../src/services/auth-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type AppSettingKeysModule = typeof import('../src/constants/app-setting-keys.js');
 
 function createRequest(method: string, routePath: string): express.Request {
   return {
@@ -21,6 +23,8 @@ function createRequest(method: string, routePath: string): express.Request {
 describe.sequential('auth service roles', () => {
   let tempRoot = '';
   let authService: AuthServiceModule['authService'];
+  let appSettingsRepository: RepositoriesModule['appSettingsRepository'];
+  let APP_DEFAULT_LOCALE_SETTING_KEY: AppSettingKeysModule['APP_DEFAULT_LOCALE_SETTING_KEY'];
 
   beforeAll(async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-auth-service-'));
@@ -39,6 +43,8 @@ describe.sequential('auth service roles', () => {
 
     vi.resetModules();
     ({ authService } = await import('../src/services/auth-service.js'));
+    ({ appSettingsRepository } = await import('../src/db/repositories.js'));
+    ({ APP_DEFAULT_LOCALE_SETTING_KEY } = await import('../src/constants/app-setting-keys.js'));
   });
 
   afterAll(async () => {
@@ -90,6 +96,19 @@ describe.sequential('auth service roles', () => {
         canUseSharedLikes: false,
         canUseLocalFavorites: true
       }
+    });
+  });
+
+  it('includes the saved app default locale in public auth status', () => {
+    appSettingsRepository.set(APP_DEFAULT_LOCALE_SETTING_KEY, 'zh');
+    authService.setAdminPassword('admin-pass-123');
+
+    expect(authService.getStatus(createRequest('GET', '/auth/status'))).toMatchObject({
+      enabled: true,
+      authenticated: false,
+      role: 'anonymous',
+      accessMode: 'off',
+      defaultLocale: 'zh'
     });
   });
 });

--- a/server/test/moment-rail-localization-data.test.ts
+++ b/server/test/moment-rail-localization-data.test.ts
@@ -1,0 +1,182 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createFingerprint,
+  getMediaTypeFromExtension,
+  getMimeTypeFromExtension,
+  getPreviewRelativePath,
+  getThumbnailRelativePath
+} from '../src/utils/image-utils.js';
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type GalleryServiceModule = typeof import('../src/services/gallery-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type ModelsModule = typeof import('../src/types/models.js');
+
+type FolderRecord = ModelsModule['FolderRecord'];
+
+describe.sequential('moment rail localization data', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let galleryService: GalleryServiceModule['galleryService'];
+  let folderRepository: RepositoriesModule['folderRepository'];
+  let imageRepository: RepositoriesModule['imageRepository'];
+  let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-moment-rail-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+
+    vi.resetModules();
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ galleryService } = await import('../src/services/gallery-service.js'));
+    ({ folderRepository, imageRepository, maintenanceRepository } = await import('../src/db/repositories.js'));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    maintenanceRepository.resetLibraryIndex();
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+  });
+
+  it('returns structured date metadata for date-driven moment capsules and feeds', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-31T12:00:00.000Z'));
+
+    try {
+      await createExifIndexedFolder(
+        'memories',
+        Array.from({ length: 30 }, (_, index) => new Date(2025, 4, 31, 12, index).getTime())
+      );
+
+      const rail = galleryService.listMoments();
+
+      expect(rail.railKind).toBe('moments');
+      expect(rail.items.find((capsule) => capsule.id === 'on-this-day')).toMatchObject({
+        momentDate: {
+          type: 'on-this-day',
+          date: {
+            year: 2026,
+            month: 5,
+            day: 31
+          }
+        }
+      });
+      expect(rail.items.find((capsule) => capsule.id === 'this-week-previous-years')).toMatchObject({
+        momentDate: {
+          type: 'this-week-previous-years',
+          startDate: {
+            year: 2026,
+            month: 5,
+            day: 24
+          },
+          endDate: {
+            year: 2026,
+            month: 6,
+            day: 7
+          }
+        }
+      });
+
+      const fromLastYear = {
+        type: 'from-last-year' as const,
+        referenceDate: {
+          year: 2025,
+          month: 5,
+          day: 31
+        },
+        startDate: {
+          year: 2025,
+          month: 4,
+          day: 16
+        },
+        endDate: {
+          year: 2025,
+          month: 7,
+          day: 15
+        }
+      };
+
+      expect(rail.items.find((capsule) => capsule.id === 'from-last-year')).toMatchObject({
+        momentDate: fromLastYear
+      });
+      expect(galleryService.getMomentFeed('from-last-year', 1, 10)?.moment).toMatchObject({
+        momentDate: fromLastYear
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  async function createExifIndexedFolder(relativeFolderPath: string, timestamps: number[]): Promise<{
+    folder: FolderRecord;
+  }> {
+    const slug = relativeFolderPath.replaceAll('/', '-');
+    const folderName = path.posix.basename(relativeFolderPath);
+    const folder = folderRepository.upsert({
+      slug,
+      name: folderName,
+      folderPath: relativeFolderPath
+    });
+
+    for (const [index, capturedAt] of timestamps.entries()) {
+      const filename = `photo-${String(index + 1).padStart(2, '0')}.jpg`;
+      const relativePath = `${relativeFolderPath}/${filename}`;
+      const absolutePath = path.join(appConfig.galleryRoot, relativePath);
+      const extension = path.extname(filename).toLowerCase();
+      const mediaType = getMediaTypeFromExtension(extension);
+      const thumbnailRelativePath = getThumbnailRelativePath(relativePath);
+      const previewRelativePath = getPreviewRelativePath(relativePath, mediaType);
+      const fileSize = 1_000 + index;
+
+      const image = imageRepository.upsert({
+        folderId: folder.id,
+        filename,
+        extension,
+        relativePath,
+        absolutePath,
+        fileSize,
+        width: 1200,
+        height: 800,
+        mediaType,
+        mimeType: getMimeTypeFromExtension(extension),
+        durationMs: null,
+        fingerprint: createFingerprint(relativePath, fileSize, capturedAt),
+        mtimeMs: capturedAt,
+        firstSeenAt: '2026-03-01T00:00:00.000Z',
+        sortTimestamp: capturedAt,
+        takenAt: capturedAt,
+        takenAtSource: 'exif',
+        exifJson: '{}',
+        thumbnailPath: thumbnailRelativePath,
+        previewPath: previewRelativePath
+      });
+
+      if (index === 0) {
+        folderRepository.setAvatar(folder.id, image.id);
+      }
+    }
+
+    return { folder };
+  }
+});

--- a/server/test/stories-feature.test.ts
+++ b/server/test/stories-feature.test.ts
@@ -142,10 +142,13 @@ describe.sequential('stories feature', () => {
     expect(stories?.highlights).toHaveLength(1);
     expect(stories?.items[0]?.presentation).toBe('avatar');
     expect(stories?.highlights[0]?.presentation).toBe('highlight');
+    expect(stories?.items.every((capsule) => typeof capsule.latestActivityTimestamp === 'number')).toBe(true);
+    expect(typeof stories?.highlights[0]?.latestActivityTimestamp).toBe('number');
 
     const avatarFeed = galleryService.getFolderStoryFeed(folder.slug, stories!.avatarStoryId!, 1, 20);
     expect(avatarFeed).not.toBeNull();
     expect(avatarFeed?.story.presentation).toBe('avatar');
+    expect(typeof avatarFeed?.story.latestActivityTimestamp).toBe('number');
     expect(avatarFeed?.items.map((item) => item.mediaType)).toEqual(['video', 'image']);
     expect(avatarFeed?.items.every((item) => item.folderSlug === folder.slug)).toBe(true);
     expect(avatarFeed?.items.every((item) => item.folderPath === folder.folderPath)).toBe(true);
@@ -153,6 +156,7 @@ describe.sequential('stories feature', () => {
     const highlightFeed = galleryService.getFolderStoryFeed(folder.slug, stories!.highlights[0]!.id, 1, 20);
     expect(highlightFeed).not.toBeNull();
     expect(highlightFeed?.story.presentation).toBe('highlight');
+    expect(typeof highlightFeed?.story.latestActivityTimestamp).toBe('number');
     expect(highlightFeed?.total).toBe(2);
     expect(highlightFeed?.items.every((item) => item.folderSlug === folder.slug)).toBe(true);
 

--- a/server/test/viewer-status.test.ts
+++ b/server/test/viewer-status.test.ts
@@ -21,6 +21,7 @@ describe.sequential('viewer-safe status payload', () => {
   let appSettingsRepository: RepositoriesModule['appSettingsRepository'];
   let scanRunRepository: RepositoriesModule['scanRunRepository'];
   let storageService: StorageServiceModule['storageService'];
+  let APP_DEFAULT_LOCALE_SETTING_KEY: AppSettingKeysModule['APP_DEFAULT_LOCALE_SETTING_KEY'];
   let HOME_FEED_DEFAULT_MODE_SETTING_KEY: AppSettingKeysModule['HOME_FEED_DEFAULT_MODE_SETTING_KEY'];
   let REELS_FEED_DEFAULT_MODE_SETTING_KEY: AppSettingKeysModule['REELS_FEED_DEFAULT_MODE_SETTING_KEY'];
   let FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY: AppSettingKeysModule['FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY'];
@@ -42,11 +43,17 @@ describe.sequential('viewer-safe status payload', () => {
     ({ scannerService } = await import('../src/services/scanner-service.js'));
     ({ imageRepository, maintenanceRepository, appSettingsRepository, scanRunRepository } = await import('../src/db/repositories.js'));
     ({ storageService } = await import('../src/services/storage-service.js'));
-    ({ HOME_FEED_DEFAULT_MODE_SETTING_KEY, REELS_FEED_DEFAULT_MODE_SETTING_KEY, FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY } = await import('../src/constants/app-setting-keys.js'));
+    ({
+      APP_DEFAULT_LOCALE_SETTING_KEY,
+      HOME_FEED_DEFAULT_MODE_SETTING_KEY,
+      REELS_FEED_DEFAULT_MODE_SETTING_KEY,
+      FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY
+    } = await import('../src/constants/app-setting-keys.js'));
   });
 
   beforeEach(async () => {
     maintenanceRepository.resetLibraryIndex();
+    appSettingsRepository.remove(APP_DEFAULT_LOCALE_SETTING_KEY);
     appSettingsRepository.remove(HOME_FEED_DEFAULT_MODE_SETTING_KEY);
     appSettingsRepository.remove(REELS_FEED_DEFAULT_MODE_SETTING_KEY);
     appSettingsRepository.remove(FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY);
@@ -181,6 +188,7 @@ describe.sequential('viewer-safe status payload', () => {
     const status = galleryService.getStatus();
 
     expect(status.preferences).toEqual({
+      defaultLocale: null,
       defaultHomeFeedMode: 'random',
       defaultReelsFeedMode: 'random',
       defaultFolderImageOrder: 'newest',
@@ -189,6 +197,7 @@ describe.sequential('viewer-safe status payload', () => {
   });
 
   it('includes configured home, reels, and folder defaults in the viewer-safe status payload', () => {
+    appSettingsRepository.set(APP_DEFAULT_LOCALE_SETTING_KEY, 'zh');
     appSettingsRepository.set(HOME_FEED_DEFAULT_MODE_SETTING_KEY, 'rediscover');
     appSettingsRepository.set(REELS_FEED_DEFAULT_MODE_SETTING_KEY, 'recommended');
     appSettingsRepository.set(FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY, 'oldest');
@@ -196,6 +205,7 @@ describe.sequential('viewer-safe status payload', () => {
     const status = galleryService.getStatus();
 
     expect(status.preferences).toEqual({
+      defaultLocale: 'zh',
       defaultHomeFeedMode: 'rediscover',
       defaultReelsFeedMode: 'recommended',
       defaultFolderImageOrder: 'oldest',


### PR DESCRIPTION
This PR adds app-wide localization support to Foldergram and introduces English, Spanish, and Chinese language coverage.

It allows users to select and persist their preferred language, localizes major user-facing app surfaces and accessibility copy, and keeps localized date/number presentation consistent across the experience.

It also includes regression coverage and documentation updates for the shipped localization behavior.

Closes #74 