### PR TITLE
Reload Home feed when default Recent mode changes during startup

### DIFF
--- a/client/src/stores/feed.test.ts
+++ b/client/src/stores/feed.test.ts
@@ -25,6 +25,17 @@ function createFeedItem(id: number): FeedItem {
   };
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
 describe('feed store', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
@@ -76,6 +87,75 @@ describe('feed store', () => {
     await feedStore.loadInitial();
 
     expect(fetchFeedSpy).toHaveBeenCalledWith(1, 18, 'recent', undefined);
+    expect(feedStore.loadedMode).toBe('recent');
+    expect(feedStore.items.map((item) => item.id)).toEqual([21]);
+  });
+
+  it('reloads with the updated mode when the mode changes during an in-flight request', async () => {
+    const randomRequest = createDeferred<{
+      mode: 'random';
+      items: FeedItem[];
+      page: number;
+      limit: number;
+      total: number;
+      hasMore: boolean;
+    }>();
+    const recentRequest = createDeferred<{
+      mode: 'recent';
+      items: FeedItem[];
+      page: number;
+      limit: number;
+      total: number;
+      hasMore: boolean;
+    }>();
+    const fetchFeedSpy = vi.spyOn(galleryApi, 'fetchFeed').mockImplementation((_page, _limit, mode) => {
+      if (mode === 'random') {
+        return randomRequest.promise;
+      }
+
+      if (mode === 'recent') {
+        return recentRequest.promise;
+      }
+
+      throw new Error(`Unexpected mode ${mode}`);
+    });
+
+    const feedStore = useFeedStore();
+    const initialLoadPromise = feedStore.loadInitial();
+
+    feedStore.initializeMode('recent');
+    const pendingRecentLoadPromise = feedStore.loadInitial();
+
+    expect(fetchFeedSpy).toHaveBeenCalledTimes(1);
+    expect(fetchFeedSpy).toHaveBeenNthCalledWith(1, 1, 18, 'random', expect.any(Number));
+
+    randomRequest.resolve({
+      mode: 'random',
+      items: [createFeedItem(5)],
+      page: 1,
+      limit: 18,
+      total: 1,
+      hasMore: false
+    });
+
+    await vi.waitFor(() => {
+      expect(fetchFeedSpy).toHaveBeenCalledTimes(2);
+    });
+
+    expect(fetchFeedSpy).toHaveBeenNthCalledWith(2, 1, 18, 'recent', undefined);
+
+    recentRequest.resolve({
+      mode: 'recent',
+      items: [createFeedItem(21)],
+      page: 1,
+      limit: 18,
+      total: 1,
+      hasMore: false
+    });
+
+    await Promise.all([initialLoadPromise, pendingRecentLoadPromise]);
+
+    expect(feedStore.mode).toBe('recent');
     expect(feedStore.loadedMode).toBe('recent');
     expect(feedStore.items.map((item) => item.id)).toEqual([21]);
   });

--- a/client/src/stores/feed.ts
+++ b/client/src/stores/feed.ts
@@ -15,6 +15,7 @@ interface FeedState {
   error: string | null;
   initialized: boolean;
   randomSeed: number | null;
+  reloadRequested: boolean;
 }
 
 function createRandomSeed(): number {
@@ -37,7 +38,8 @@ export const useFeedStore = defineStore('feed', {
     loading: false,
     error: null,
     initialized: false,
-    randomSeed: null
+    randomSeed: null,
+    reloadRequested: false
   }),
   actions: {
     initializeMode(mode: FeedMode = 'random') {
@@ -87,15 +89,19 @@ export const useFeedStore = defineStore('feed', {
       this.loading = false;
       this.error = null;
       this.initialized = false;
+      this.reloadRequested = false;
     },
 
     async loadInitial(force = false) {
-      if (this.loading) {
-        return;
-      }
-
       const queueRequiresSeed = this.mode === 'random';
       const queueMatchesMode = this.loadedMode === this.mode && (!queueRequiresSeed || this.randomSeed !== null);
+
+      if (this.loading) {
+        if (force || !queueMatchesMode) {
+          this.reloadRequested = true;
+        }
+        return;
+      }
 
       if (this.initialized && !force && queueMatchesMode) {
         return;
@@ -106,6 +112,7 @@ export const useFeedStore = defineStore('feed', {
       this.page = 1;
       this.hasMore = true;
       this.initialized = false;
+      this.reloadRequested = false;
       await this.loadMore();
     },
 
@@ -116,12 +123,23 @@ export const useFeedStore = defineStore('feed', {
 
       this.loading = true;
       this.error = null;
+      const requestMode = this.mode;
+      const requestPage = this.page;
+      const requestSeed = requestMode === 'random' ? this.ensureRandomSeed() : undefined;
 
       try {
-        const seed = this.mode === 'random' ? this.ensureRandomSeed() : undefined;
-        const payload = await fetchFeed(this.page, this.limit, this.mode, seed);
+        const payload = await fetchFeed(requestPage, this.limit, requestMode, requestSeed);
+
+        const modeChanged = this.mode !== requestMode;
+        const seedChanged = requestMode === 'random' && this.randomSeed !== requestSeed;
+        const pageChanged = this.page !== requestPage;
+
+        if (modeChanged || seedChanged || pageChanged) {
+          return;
+        }
+
         this.items.push(...payload.items);
-        this.loadedMode = payload.mode ?? this.mode;
+        this.loadedMode = payload.mode ?? requestMode;
         this.page += 1;
         this.hasMore = payload.hasMore;
         this.initialized = true;
@@ -129,6 +147,11 @@ export const useFeedStore = defineStore('feed', {
         this.error = error instanceof Error ? error.message : 'Unable to load feed';
       } finally {
         this.loading = false;
+
+        if (this.reloadRequested) {
+          this.reloadRequested = false;
+          await this.loadInitial(true);
+        }
       }
     }
   }


### PR DESCRIPTION
This fixes a startup issue where the Home feed could load with `random` ordering while the `Recent` is selected as the default mode. The feed store now ignores stale responses and triggers a reload when the active/default feed mode changes during initial load.

Closes #73 