### PR TITLE
Add nested folder title format setting for sub-folder albums

### DIFF
--- a/client/src/api/gallery.ts
+++ b/client/src/api/gallery.ts
@@ -14,6 +14,7 @@ import type {
   HomeFeedDefaultSetting,
   UpdateCollectionResult,
   UpdateExcludedFoldersSettingResult,
+  NestedFolderTitleFormatSetting,
   ReelsFeedDefaultSetting,
   StoriesModeSetting,
   ViewerAccessMode,
@@ -22,6 +23,7 @@ import type {
   FeedMode,
   FolderImageOrder,
   FolderImageOrderDefaultSetting,
+  NestedFolderTitleFormat,
   ImageCaptionMutationResult,
   ImageDetail,
   ImageCollectionsPayload,
@@ -461,6 +463,14 @@ export function updateFolderImageOrderDefault(defaultOrder: FolderImageOrder) {
     method: 'PUT',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ defaultOrder })
+  });
+}
+
+export function updateNestedFolderTitleFormat(titleFormat: NestedFolderTitleFormat) {
+  return requestJson<NestedFolderTitleFormatSetting>('/api/admin/settings/nested-folder-title-format', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ titleFormat })
   });
 }
 

--- a/client/src/components/FeedCard.vue
+++ b/client/src/components/FeedCard.vue
@@ -12,7 +12,7 @@
         >
           <div class="rounded-full p-[0.1rem] shadow-[0_10px_22px_rgba(246,106,61,0.16)]" style="background: var(--story-ring);">
             <div class="rounded-full bg-bg p-[0.1rem]">
-              <Avatar class="w-8 h-8" :name="item.folderName" :src="avatarUrl" />
+              <Avatar class="w-8 h-8" :name="displayFolderTitle" :src="avatarUrl" />
             </div>
           </div>
         </button>
@@ -23,12 +23,12 @@
           :aria-label="folderAvatarLabel"
           :title="folderAvatarLabel"
         >
-          <Avatar class="w-8 h-8" :name="item.folderName" :src="avatarUrl" />
+          <Avatar class="w-8 h-8" :name="displayFolderTitle" :src="avatarUrl" />
         </RouterLink>
         <div class="min-w-0">
           <RouterLink class="block min-w-0 text-inherit no-underline" :to="{ name: 'folder', params: { slug: item.folderSlug } }">
             <h3 class="m-0 text-[0.88rem] font-semibold truncate">
-              {{ item.folderName }}
+              {{ displayFolderTitle }}
             </h3>
           </RouterLink>
           <RouterLink
@@ -290,7 +290,7 @@
       </div>
 
       <p class="m-0 text-[0.88rem]">
-        <strong class="mr-[0.35rem]">{{ item.folderName }}</strong>
+        <strong class="mr-[0.35rem]">{{ displayFolderTitle }}</strong>
         {{ caption }}
       </p>
       <p class="m-0 text-muted text-[0.72rem] uppercase tracking-[0.05em]">
@@ -434,6 +434,7 @@ import { useLikesStore } from '../stores/likes';
 import { useMomentsStore } from '../stores/moments';
 import type { FeedItem } from '../types/api';
 import { resolveDisplayCaption } from '../utils/caption';
+import { formatFolderTitle } from '../utils/folder-titles';
 import { formatMediaDuration, formatVideoTimestamp } from '../utils/media';
 import { resolveFeedAspectRatio } from '../utils/media-layout';
 import { getOriginalMediaDownloadUrl, getOriginalMediaUrl } from '../utils/original-media';
@@ -517,8 +518,9 @@ const imageRoute = computed(() => ({
 const isHomeContext = computed(() => props.context === 'home');
 const showHomeStoryAvatar = computed(() => isHomeContext.value && props.hasAvatarStory);
 const shouldOpenPostInModal = computed(() => props.context !== 'home');
-const folderStoriesLabel = computed(() => t('post.feedCard.openStories', { name: props.item.folderName }));
-const folderAvatarLabel = computed(() => t('post.feedCard.openFolderAvatar', { name: props.item.folderName }));
+const displayFolderTitle = computed(() => formatFolderTitle(props.item, appStore.nestedFolderTitleFormat));
+const folderStoriesLabel = computed(() => t('post.feedCard.openStories', { name: displayFolderTitle.value }));
+const folderAvatarLabel = computed(() => t('post.feedCard.openFolderAvatar', { name: displayFolderTitle.value }));
 const likeActionLabel = computed(() => likesStore.toggleAriaLabel(likesStore.isLiked(props.item.id)));
 const openMediaLabel = computed(() =>
   props.item.mediaType === 'video' ? t('post.feedCard.openReel') : t('post.feedCard.openPost')

--- a/client/src/components/FolderHeader.vue
+++ b/client/src/components/FolderHeader.vue
@@ -10,7 +10,7 @@
       >
         <div class="rounded-full p-[0.22rem] shadow-[0_16px_34px_rgba(246,106,61,0.12)] transition-transform duration-[180ms] hover:scale-[1.02]" style="background: var(--story-ring);">
           <div class="rounded-full bg-bg p-[0.22rem]">
-            <Avatar class="w-[9.35rem] h-[9.35rem] max-md:w-[7.75rem] max-md:h-[7.75rem]" :name="folder.name" :src="folder.avatarUrl" />
+            <Avatar class="w-[9.35rem] h-[9.35rem] max-md:w-[7.75rem] max-md:h-[7.75rem]" :name="displayFolderTitle" :src="folder.avatarUrl" />
           </div>
         </div>
       </button>
@@ -23,20 +23,20 @@
         >
           <div class="rounded-full p-[0.22rem] shadow-[0_12px_24px_rgba(99,115,129,0.12)] transition-transform duration-[180ms] hover:scale-[1.02]" style="background: rgba(43, 48, 54, 0.8);">
             <div class="rounded-full bg-bg p-[0.22rem]">
-              <Avatar class="w-[9.35rem] h-[9.35rem] max-md:w-[7.75rem] max-md:h-[7.75rem]" :name="folder.name" :src="folder.avatarUrl" />
+              <Avatar class="w-[9.35rem] h-[9.35rem] max-md:w-[7.75rem] max-md:h-[7.75rem]" :name="displayFolderTitle" :src="folder.avatarUrl" />
             </div>
           </div>
         </a>
       </RouterLink>
       <div v-else class="rounded-full p-[0.22rem] shadow-[0_12px_24px_rgba(99,115,129,0.12)]" style="background: rgba(43, 48, 54, 0.8);">
         <div class="rounded-full bg-bg p-[0.22rem]">
-          <Avatar class="w-[9.35rem] h-[9.35rem] max-md:w-[7.75rem] max-md:h-[7.75rem]" :name="folder.name" :src="folder.avatarUrl" />
+          <Avatar class="w-[9.35rem] h-[9.35rem] max-md:w-[7.75rem] max-md:h-[7.75rem]" :name="displayFolderTitle" :src="folder.avatarUrl" />
         </div>
       </div>
     </div>
     <div class="grid gap-[1rem] pt-[0.35rem]">
       <div class="flex items-center gap-[0.75rem] flex-wrap max-sm:justify-center">
-        <h1 class="m-0 text-[clamp(1.6rem,2.4vw,2rem)] font-medium leading-none tracking-[-0.04em]">{{ folder.name }}</h1>
+        <h1 class="m-0 text-[clamp(1.6rem,2.4vw,2rem)] font-medium leading-none tracking-[-0.04em]">{{ displayFolderTitle }}</h1>
         <button
           v-if="authStore.canManageLibrary"
           type="button"
@@ -106,6 +106,7 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n';
 import { RouterLink, useRoute } from 'vue-router';
 import type { FolderSummary } from '../types/api';
+import { formatFolderTitle } from '../utils/folder-titles';
 import Avatar from './Avatar.vue';
 import FolderProfileModal from './FolderProfileModal.vue';
 import { useAppStore } from '../stores/app';
@@ -138,6 +139,7 @@ const descriptionId = `folder-description-${Math.random().toString(36).slice(2, 
 let descriptionResizeObserver: ResizeObserver | null = null;
 let syncingDescriptionOverflow = false;
 
+const displayFolderTitle = computed(() => formatFolderTitle(props.folder, appStore.nestedFolderTitleFormat));
 const formattedUpdatedDate = computed(() =>
   props.folder.latestImageMtimeMs
     ? new Date(props.folder.latestImageMtimeMs).toLocaleDateString(locale.value, {

--- a/client/src/components/PostViewer.vue
+++ b/client/src/components/PostViewer.vue
@@ -312,12 +312,12 @@
           >
             <Avatar
               class="h-[2.65rem] w-[2.65rem]"
-              :name="image.folderName"
+              :name="displayFolderTitle"
               :src="folderAvatar"
             />
             <div class="viewer__sidebar-folder-meta min-w-0">
               <h2 class="viewer__sidebar-title m-0 text-[0.9rem] font-semibold truncate">
-                {{ image.folderName }}
+                {{ displayFolderTitle }}
               </h2>
               <p class="viewer__sidebar-breadcrumb m-0 text-muted truncate">
                 {{ folderBreadcrumbLabel }}
@@ -333,7 +333,7 @@
         <div class="viewer__sidebar-summary grid gap-[0.3rem] px-5 pt-[1.1rem]">
           <div class="flex items-start gap-[0.35rem]">
             <p class="viewer__sidebar-caption m-0 text-text">
-              <strong class="mr-[0.35rem]">{{ image.folderName }}</strong>
+              <strong class="mr-[0.35rem]">{{ displayFolderTitle }}</strong>
               {{ caption }}
             </p>
             <button
@@ -593,6 +593,7 @@
   import { useLikesStore } from "../stores/likes"
   import { useFoldersStore } from "../stores/folders"
   import { resolveDisplayCaption } from "../utils/caption"
+  import { formatFolderTitle } from "../utils/folder-titles"
   import { getOriginalMediaDownloadUrl, getOriginalMediaUrl } from "../utils/original-media"
   import Avatar from "./Avatar.vue"
   import CollectionBookmark from "./CollectionBookmark.vue"
@@ -748,6 +749,9 @@
 
   const folderAvatar = computed(() => props.folder?.avatarUrl ?? null)
   const caption = computed(() => (props.image ? resolveDisplayCaption(props.image) : ""))
+  const displayFolderTitle = computed(() =>
+    props.image ? formatFolderTitle(props.folder ?? props.image, appStore.nestedFolderTitleFormat) : "",
+  )
   const folderBreadcrumbLabel = computed(() =>
     props.folder?.breadcrumb ?? props.image?.folderBreadcrumb ?? t('folder.shared.topLevelSourceFolder'),
   )

--- a/client/src/components/ReelInfoSidebar.test.ts
+++ b/client/src/components/ReelInfoSidebar.test.ts
@@ -1,3 +1,4 @@
+import { createPinia, setActivePinia } from 'pinia';
 import { flushPromises, mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -66,6 +67,7 @@ describe('ReelInfoSidebar', () => {
   const fetchImageMock = vi.mocked(fetchImage);
 
   beforeEach(() => {
+    setActivePinia(createPinia());
     fetchImageMock.mockReset();
   });
 

--- a/client/src/components/ReelInfoSidebar.vue
+++ b/client/src/components/ReelInfoSidebar.vue
@@ -35,12 +35,12 @@
       >
         <Avatar
           class="reels-info-sidebar__avatar"
-          :name="folder?.name ?? item.folderName"
+          :name="displayFolderTitle"
           :src="folder?.avatarUrl ?? null"
         />
         <div class="min-w-0">
           <p class="reels-info-sidebar__folder-name">
-            {{ folder?.name ?? item.folderName }}
+            {{ displayFolderTitle }}
           </p>
           <p class="reels-info-sidebar__folder-breadcrumb">
             {{ folderBreadcrumb }}
@@ -105,8 +105,10 @@ import { useI18n } from 'vue-i18n';
 import { RouterLink } from 'vue-router';
 
 import { fetchImage } from '../api/gallery';
+import { useAppStore } from '../stores/app';
 import type { FeedItem, FolderSummary, ImageDetail } from '../types/api';
 import { resolveDisplayCaption } from '../utils/caption';
+import { formatFolderTitle } from '../utils/folder-titles';
 import { formatMediaDuration } from '../utils/media';
 import Avatar from './Avatar.vue';
 
@@ -124,6 +126,7 @@ defineEmits<{
 }>();
 
 const { t, locale } = useI18n();
+const appStore = useAppStore();
 const detail = ref<ImageDetail | null>(null);
 const loading = ref(false);
 const error = ref<string | null>(null);
@@ -151,6 +154,7 @@ const formattedDate = computed(() =>
 const folderBreadcrumb = computed(
   () => props.folder?.breadcrumb ?? detail.value?.folderBreadcrumb ?? props.item.folderBreadcrumb ?? t('reels.info.topLevelSourceFolder')
 );
+const displayFolderTitle = computed(() => formatFolderTitle(props.folder ?? props.item, appStore.nestedFolderTitleFormat));
 const dimensionsLabel = computed(() => `${detail.value?.width ?? props.item.width} x ${detail.value?.height ?? props.item.height}`);
 const durationLabel = computed(() => formatMediaDuration(detail.value?.durationMs ?? props.item.durationMs) || t('reels.info.unavailable'));
 const formatLabel = computed(() => {

--- a/client/src/components/ReelPlayerCard.vue
+++ b/client/src/components/ReelPlayerCard.vue
@@ -66,12 +66,12 @@
             >
               <Avatar
                 class="reel-player-card__avatar"
-                :name="folder?.name ?? item.folderName"
+                :name="displayFolderTitle"
                 :src="folder?.avatarUrl ?? null"
               />
               <div class="reel-player-card__text">
                 <strong class="reel-player-card__folder-name">
-                  {{ folder?.name ?? item.folderName }}
+                  {{ displayFolderTitle }}
                 </strong>
                 <p class="reel-player-card__folder-description">
                   {{ folderDescription }}
@@ -121,6 +121,7 @@ import type { MediaPlayerElement } from 'vidstack/elements';
 
 import { useAppStore } from '../stores/app';
 import type { FeedItem, FolderSummary } from '../types/api';
+import { formatFolderTitle } from '../utils/folder-titles';
 import { getOriginalMediaUrl } from '../utils/original-media';
 import Avatar from './Avatar.vue';
 
@@ -141,6 +142,7 @@ const videoSource = computed<PlayerSrc>(() => ({
   type: 'video/mp4'
 }));
 const showPausedIndicator = computed(() => props.active && isPaused.value);
+const displayFolderTitle = computed(() => formatFolderTitle(props.folder ?? props.item, appStore.nestedFolderTitleFormat));
 const folderDescription = computed(() => {
   const normalizedFolderPath = props.item.folderPath.replace(/\\/g, '/');
   const folderSegments = normalizedFolderPath.split('/').filter(Boolean);

--- a/client/src/components/SidebarNav.vue
+++ b/client/src/components/SidebarNav.vue
@@ -280,7 +280,7 @@
             @click="navigate"
           >
             <Avatar
-              :name="folder.name"
+              :name="formatFeaturedFolderTitle(folder)"
               :src="folder.avatarUrl"
               class="h-[1.75rem] w-[1.75rem]"
             />
@@ -292,7 +292,7 @@
                   max-width 0.22s ease;
               "
             >
-              <strong class="truncate text-[0.82rem]">{{ folder.name }}</strong>
+              <strong class="truncate text-[0.82rem]">{{ formatFeaturedFolderTitle(folder) }}</strong>
               <small class="truncate text-[0.68rem] text-muted">{{
                 folder.breadcrumb ?? t('nav.folderPosts', { count: folder.imageCount })
               }}</small>
@@ -425,6 +425,7 @@
   import { useLikesStore } from "../stores/likes"
   import { useFoldersStore } from "../stores/folders"
   import { usePlacesStore } from "../stores/places"
+  import { formatFolderTitle } from "../utils/folder-titles"
   import { buildLikedCountByFolder } from "../utils/home-recommendations"
   import { selectSidebarFolders } from "../utils/sidebar-folders"
   import Avatar from "./Avatar.vue"
@@ -456,6 +457,9 @@
   const showPlacesNav = computed(() =>
     placesStore.items.length > 0 && placesStore.listError === null,
   )
+  function formatFeaturedFolderTitle(folder: (typeof featuredFolders.value)[number]) {
+    return formatFolderTitle(folder, appStore.nestedFolderTitleFormat)
+  }
   const isPlacesRoute = computed(() =>
     route.name === "places" || route.name === "place",
   )

--- a/client/src/components/StoriesModal.vue
+++ b/client/src/components/StoriesModal.vue
@@ -199,7 +199,7 @@
               </button>
             </div>
             <div class="grid gap-[0.18rem]">
-              <strong class="text-[0.92rem]">{{ activeCapsule?.title ?? displayImage?.folderName }}</strong>
+              <strong class="text-[0.92rem]">{{ activeCapsule?.title ?? displayFolderTitle }}</strong>
               <p class="m-0 text-[0.8rem] text-white/70">{{ footerMeta }}</p>
             </div>
           </footer>
@@ -261,6 +261,7 @@ import { useHorizontalSwipe } from '../composables/useHorizontalSwipe';
 import { i18n } from '../locales';
 import type { FeedItem, RailCapsule, RailViewerStoreContract } from '../types/api';
 import { useAppStore } from '../stores/app';
+import { formatFolderTitle } from '../utils/folder-titles';
 import { getOriginalMediaDownloadUrl } from '../utils/original-media';
 import Avatar from './Avatar.vue';
 import ResilientImage from './ResilientImage.vue';
@@ -335,6 +336,9 @@ const activeImages = computed(() =>
   props.store.currentCapsule?.id === activeCapsuleId.value ? props.store.currentImages : []
 );
 const displayImage = computed<FeedItem | null>(() => activeImages.value[activeImageIndex.value] ?? activeCapsule.value?.coverImage ?? null);
+const displayFolderTitle = computed(() =>
+  displayImage.value ? formatFolderTitle(displayImage.value, appStore.nestedFolderTitleFormat) : ''
+);
 const downloadOriginalMediaUrl = computed(() =>
   displayImage.value ? getOriginalMediaDownloadUrl(displayImage.value.id) : null
 );

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -158,7 +158,7 @@
       },
       "card": {
         "title": "General Settings",
-        "description": "App-wide defaults for language, stories folders, excluded folders, Home, Reels, and app folders."
+        "description": "App-wide defaults for language, nested folder titles, stories folders, excluded folders, Home, Reels, and app folders."
       },
       "language": {
         "label": "App language",
@@ -225,6 +225,21 @@
           }
         }
       },
+      "nestedFolderTitle": {
+        "label": "Nested folder title format",
+        "description": "Choose how nested app folders are labeled throughout the app. This changes presentation only.",
+        "closeMenuAria": "Close nested folder title format menu",
+        "options": {
+          "folder": {
+            "label": "Folder name only",
+            "description": "Show only the current folder name."
+          },
+          "parentPlusFolder": {
+            "label": "Parent + folder name",
+            "description": "Prefix nested folders with their immediate parent."
+          }
+        }
+      },
       "storiesMode": {
         "label": "Treat stories folders as normal app folders",
         "scanRequired": "Scan required",
@@ -251,12 +266,13 @@
         "excludedOnly": "This saves the custom excluded folders only. Run a library scan afterward so those folders disappear from the index.",
         "storiesAndDefaults": "Save the new stories rule and the updated app defaults together.",
         "storiesOnly": "This saves the stories folders rule only. Run a library scan afterward to reindex with the new behavior.",
-        "multipleDefaults": "Save these app defaults together. Language applies immediately in this browser; Home visitors can still switch modes on the homepage; Reels and app folders use app defaults.",
+        "multipleDefaults": "Save these app defaults together. Language applies immediately in this browser; Home visitors can still switch modes on the homepage; Reels, app folders, and nested folder titles use app defaults.",
         "languageOnly": "This changes the language immediately in this browser. Save it too if you want the selected language to become the app-wide default.",
         "homeOnly": "This updates the first feed mode shown on Home for this app. Visitors can still switch modes from the homepage.",
         "reelsOnly": "This updates the queue style used when Reels opens for this app. Visitors cannot switch modes from the reels page.",
         "folderOnly": "This updates the default photo order used by app folder grids.",
-        "idle": "These are the current app-wide defaults for language, Home, Reels, app folders, stories folders, and excluded folders."
+        "nestedFolderTitleOnly": "This updates how nested app folders are labeled throughout the app.",
+        "idle": "These are the current app-wide defaults for language, Home, Reels, app folders, nested folder titles, stories folders, and excluded folders."
       },
       "rescanNotice": {
         "excludedAndStories": "Save these changes, then run a library scan before expecting stories folders and excluded folders to update.",
@@ -274,13 +290,15 @@
         "homeSaved": "The homepage now opens with {label}.",
         "reelsSaved": "Reels now opens with {label}.",
         "folderOrderSaved": "App folders now open with {label}.",
+        "nestedFolderTitleSaved": "Nested app folders now use {label}.",
         "parts": {
           "appLanguage": "app language",
           "excludedFolders": "excluded folders",
           "storiesFolderHandling": "stories folder handling",
           "homeFeedDefault": "Home feed default",
           "reelsFeedDefault": "Reels feed default",
-          "appFolderOrder": "app folder order"
+          "appFolderOrder": "app folder order",
+          "nestedFolderTitles": "nested folder titles"
         }
       },
       "errors": {

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -158,7 +158,7 @@
       },
       "card": {
         "title": "Ajustes generales",
-        "description": "Valores predeterminados de toda la app para idioma, carpetas stories, carpetas excluidas, Inicio, Reels y carpetas de la app."
+        "description": "Valores predeterminados de toda la app para idioma, títulos de carpetas anidadas, carpetas stories, carpetas excluidas, Inicio, Reels y carpetas de la app."
       },
       "language": {
         "label": "Idioma de la aplicación",
@@ -225,6 +225,21 @@
           }
         }
       },
+      "nestedFolderTitle": {
+        "label": "Formato del título de carpetas anidadas",
+        "description": "Elige cómo se nombran las carpetas anidadas de la app en toda la aplicación. Solo cambia la presentación.",
+        "closeMenuAria": "Cerrar menú del formato de título de carpetas anidadas",
+        "options": {
+          "folder": {
+            "label": "Solo nombre de la carpeta",
+            "description": "Muestra solo el nombre de la carpeta actual."
+          },
+          "parentPlusFolder": {
+            "label": "Padre + nombre de la carpeta",
+            "description": "Añade el padre inmediato como prefijo de las carpetas anidadas."
+          }
+        }
+      },
       "storiesMode": {
         "label": "Tratar las carpetas stories como carpetas normales de la app",
         "scanRequired": "Requiere escaneo",
@@ -251,12 +266,13 @@
         "excludedOnly": "Esto solo guarda las carpetas excluidas personalizadas. Después ejecuta un escaneo de la biblioteca para que esas carpetas desaparezcan del índice.",
         "storiesAndDefaults": "Guarda juntos la nueva regla de stories y los valores globales actualizados.",
         "storiesOnly": "Esto solo guarda la regla de carpetas stories. Después ejecuta un escaneo de la biblioteca para reindexar con el nuevo comportamiento.",
-        "multipleDefaults": "Guarda juntos estos valores globales. El idioma se aplica de inmediato en este navegador; los visitantes de Inicio aún pueden cambiar de modo en la página principal; Reels y las carpetas de la app usan los valores predeterminados de la app.",
+        "multipleDefaults": "Guarda juntos estos valores globales. El idioma se aplica de inmediato en este navegador; los visitantes de Inicio aún pueden cambiar de modo en la página principal; Reels, las carpetas de la app y los títulos de carpetas anidadas usan los valores predeterminados de la app.",
         "languageOnly": "Esto cambia el idioma de inmediato en este navegador. Guárdalo también si quieres que el idioma seleccionado se convierta en el predeterminado de toda la app.",
         "homeOnly": "Esto actualiza el primer modo de feed que se muestra en Inicio para esta app. Los visitantes aún pueden cambiar de modo desde la página principal.",
         "reelsOnly": "Esto actualiza el estilo de cola usado cuando se abre Reels para esta app. Los visitantes no pueden cambiar de modo desde la página de Reels.",
         "folderOnly": "Esto actualiza el orden de fotos predeterminado usado por las cuadrículas de carpetas de la app.",
-        "idle": "Estos son los valores actuales de toda la app para idioma, Inicio, Reels, carpetas de la app, carpetas stories y carpetas excluidas."
+        "nestedFolderTitleOnly": "Esto actualiza cómo se etiquetan las carpetas anidadas de la app en toda la aplicación.",
+        "idle": "Estos son los valores actuales de toda la app para idioma, Inicio, Reels, carpetas de la app, títulos de carpetas anidadas, carpetas stories y carpetas excluidas."
       },
       "rescanNotice": {
         "excludedAndStories": "Guarda estos cambios y luego ejecuta un escaneo de la biblioteca antes de esperar que se actualicen las carpetas stories y las carpetas excluidas.",
@@ -274,13 +290,15 @@
         "homeSaved": "La página de Inicio ahora se abre con {label}.",
         "reelsSaved": "Reels ahora se abre con {label}.",
         "folderOrderSaved": "Las carpetas de la app ahora se abren con {label}.",
+        "nestedFolderTitleSaved": "Las carpetas anidadas de la app ahora usan {label}.",
         "parts": {
           "appLanguage": "idioma de la app",
           "excludedFolders": "carpetas excluidas",
           "storiesFolderHandling": "comportamiento de las carpetas stories",
           "homeFeedDefault": "predeterminado del feed de Inicio",
           "reelsFeedDefault": "predeterminado de Reels",
-          "appFolderOrder": "orden de las carpetas de la app"
+          "appFolderOrder": "orden de las carpetas de la app",
+          "nestedFolderTitles": "títulos de carpetas anidadas"
         }
       },
       "errors": {

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -158,7 +158,7 @@
       },
       "card": {
         "title": "常规设置",
-        "description": "适用于语言、stories 文件夹、排除文件夹、首页、短片和应用文件夹的全局默认项。"
+        "description": "适用于语言、嵌套文件夹标题、stories 文件夹、排除文件夹、首页、短片和应用文件夹的全局默认项。"
       },
       "language": {
         "label": "应用语言",
@@ -225,6 +225,21 @@
           }
         }
       },
+      "nestedFolderTitle": {
+        "label": "嵌套文件夹标题格式",
+        "description": "选择整个应用中嵌套应用文件夹的显示名称方式。此项只影响展示。",
+        "closeMenuAria": "关闭嵌套文件夹标题格式菜单",
+        "options": {
+          "folder": {
+            "label": "仅文件夹名称",
+            "description": "只显示当前文件夹名称。"
+          },
+          "parentPlusFolder": {
+            "label": "父级 + 文件夹名称",
+            "description": "为嵌套文件夹加上其直接父级前缀。"
+          }
+        }
+      },
       "storiesMode": {
         "label": "将 stories 文件夹视为普通应用文件夹",
         "scanRequired": "需要扫描",
@@ -251,12 +266,13 @@
         "excludedOnly": "这只会保存自定义排除文件夹。随后运行一次图库扫描，以便这些文件夹从索引中消失。",
         "storiesAndDefaults": "将新的 stories 规则与更新后的全局默认项一起保存。",
         "storiesOnly": "这只会保存 stories 文件夹规则。随后运行一次图库扫描，以新行为重新建立索引。",
-        "multipleDefaults": "一起保存这些全局默认项。语言会立即在当前浏览器中生效；首页访问者仍可在主页上切换模式；短片和应用文件夹使用应用默认项。",
+        "multipleDefaults": "一起保存这些全局默认项。语言会立即在当前浏览器中生效；首页访问者仍可在主页上切换模式；短片、应用文件夹和嵌套文件夹标题使用应用默认项。",
         "languageOnly": "这会立即更改当前浏览器中的语言。如需让所选语言也成为整个应用的默认语言，请再保存一次。",
         "homeOnly": "这会更新此应用首页打开时显示的首个动态流模式。访问者仍可从主页切换模式。",
         "reelsOnly": "这会更新此应用打开短片时使用的队列样式。访问者无法从短片页面切换模式。",
         "folderOnly": "这会更新应用文件夹网格使用的默认照片顺序。",
-        "idle": "这些是当前适用于语言、首页、短片、应用文件夹、stories 文件夹和排除文件夹的全局默认项。"
+        "nestedFolderTitleOnly": "这会更新整个应用中嵌套应用文件夹的标签显示方式。",
+        "idle": "这些是当前适用于语言、首页、短片、应用文件夹、嵌套文件夹标题、stories 文件夹和排除文件夹的全局默认项。"
       },
       "rescanNotice": {
         "excludedAndStories": "保存这些更改后，请先运行一次图库扫描，再期待 stories 文件夹和排除文件夹更新。",
@@ -274,13 +290,15 @@
         "homeSaved": "首页现在会以 {label} 打开。",
         "reelsSaved": "短片现在会以 {label} 打开。",
         "folderOrderSaved": "应用文件夹现在会以 {label} 打开。",
+        "nestedFolderTitleSaved": "嵌套应用文件夹现在使用 {label}。",
         "parts": {
           "appLanguage": "应用语言",
           "excludedFolders": "排除文件夹",
           "storiesFolderHandling": "stories 文件夹行为",
           "homeFeedDefault": "首页动态默认项",
           "reelsFeedDefault": "短片默认项",
-          "appFolderOrder": "应用文件夹顺序"
+          "appFolderOrder": "应用文件夹顺序",
+          "nestedFolderTitles": "嵌套文件夹标题"
         }
       },
       "errors": {

--- a/client/src/stores/app.ts
+++ b/client/src/stores/app.ts
@@ -108,6 +108,7 @@ export const useAppStore = defineStore('app', {
     savedDefaultLocale: (state): SupportedLocale | null => resolveSupportedLocale(state.stats?.preferences.defaultLocale ?? null),
     defaultReelsFeedMode: (state): ReelsFeedMode => state.stats?.preferences.defaultReelsFeedMode ?? 'random',
     defaultFolderImageOrder: (state): FolderImageOrder => state.stats?.preferences.defaultFolderImageOrder ?? 'newest',
+    nestedFolderTitleFormat: (state) => state.stats?.preferences.nestedFolderTitleFormat ?? 'folder',
     treatStoriesAsFolders: (state) => state.stats?.preferences.treatStoriesAsFolders === true
   },
   actions: {

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -3,6 +3,7 @@ import type { SupportedLocale } from '../locales';
 export type FeedMode = 'recent' | 'rediscover' | 'random';
 export type ReelsFeedMode = 'recommended' | 'recent' | 'random';
 export type FolderImageOrder = 'newest' | 'oldest';
+export type NestedFolderTitleFormat = 'folder' | 'parent-plus-folder';
 export type FeedRailKind = 'moments' | 'highlights';
 export type StoryCapsulePresentation = 'avatar' | 'highlight';
 export type ScanOperation =
@@ -34,6 +35,10 @@ export interface FolderImageOrderDefaultSetting {
   defaultOrder: FolderImageOrder;
 }
 
+export interface NestedFolderTitleFormatSetting {
+  titleFormat: NestedFolderTitleFormat;
+}
+
 export interface StoriesModeSetting {
   treatStoriesAsFolders: boolean;
 }
@@ -53,6 +58,7 @@ export interface FeedItem {
   folderId: number;
   folderSlug: string;
   folderName: string;
+  folderParentName?: string | null;
   folderPath: string;
   folderBreadcrumb: string | null;
   filename: string;
@@ -96,6 +102,7 @@ export interface FolderSummary {
   slug: string;
   name: string;
   description: string | null;
+  parentFolderName?: string | null;
   folderPath: string;
   breadcrumb: string | null;
   imageCount: number;
@@ -422,6 +429,7 @@ export interface AppStatus {
     defaultHomeFeedMode: FeedMode;
     defaultReelsFeedMode: ReelsFeedMode;
     defaultFolderImageOrder?: FolderImageOrder;
+    nestedFolderTitleFormat?: NestedFolderTitleFormat;
     treatStoriesAsFolders: boolean;
   };
   storiesMigration: {

--- a/client/src/utils/folder-titles.test.ts
+++ b/client/src/utils/folder-titles.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatFolderTitle } from './folder-titles';
+
+describe('formatFolderTitle', () => {
+  it('returns the raw folder name when the default format is selected', () => {
+    expect(
+      formatFolderTitle(
+        {
+          name: '2022',
+          breadcrumb: 'Italy',
+          folderPath: 'Italy/2022'
+        },
+        'folder'
+      )
+    ).toBe('2022');
+  });
+
+  it('prefixes nested folders with their immediate parent when requested', () => {
+    expect(
+      formatFolderTitle(
+        {
+          name: '2022',
+          breadcrumb: 'Trips / Italy',
+          folderPath: 'Trips/Italy/2022'
+        },
+        'parent-plus-folder'
+      )
+    ).toBe('Italy - 2022');
+  });
+
+  it('prefers the parent folder display name when one is provided', () => {
+    expect(
+      formatFolderTitle(
+        {
+          name: '2022',
+          parentFolderName: 'Italia',
+          breadcrumb: 'Italy',
+          folderPath: 'Italy/2022'
+        },
+        'parent-plus-folder'
+      )
+    ).toBe('Italia - 2022');
+  });
+
+  it('falls back to folderPath when breadcrumb is unavailable', () => {
+    expect(
+      formatFolderTitle(
+        {
+          folderName: '2022',
+          folderBreadcrumb: null,
+          folderPath: 'Spain/2022'
+        },
+        'parent-plus-folder'
+      )
+    ).toBe('Spain - 2022');
+  });
+
+  it('keeps top-level folders unchanged when there is no parent folder', () => {
+    expect(
+      formatFolderTitle(
+        {
+          folderName: '2022',
+          folderParentName: null,
+          folderBreadcrumb: null,
+          folderPath: '2022'
+        },
+        'parent-plus-folder'
+      )
+    ).toBe('2022');
+  });
+});

--- a/client/src/utils/folder-titles.ts
+++ b/client/src/utils/folder-titles.ts
@@ -1,0 +1,49 @@
+import type { FeedItem, FolderSummary, ImageDetail, NestedFolderTitleFormat } from '../types/api';
+
+type FolderTitleSource =
+  | Pick<FolderSummary, 'name' | 'parentFolderName' | 'breadcrumb' | 'folderPath'>
+  | Pick<FeedItem, 'folderName' | 'folderParentName' | 'folderBreadcrumb' | 'folderPath'>
+  | Pick<ImageDetail, 'folderName' | 'folderParentName' | 'folderBreadcrumb' | 'folderPath'>;
+
+function getImmediateParentName(breadcrumb: string | null | undefined, folderPath: string): string | null {
+  if (typeof breadcrumb === 'string' && breadcrumb.trim().length > 0) {
+    const segments = breadcrumb
+      .split('/')
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+
+    const parentFromBreadcrumb = segments.at(-1);
+    if (parentFromBreadcrumb) {
+      return parentFromBreadcrumb;
+    }
+  }
+
+  const segments = folderPath
+    .replace(/\\/g, '/')
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  return segments.length > 1 ? (segments.at(-2) ?? null) : null;
+}
+
+export function formatFolderTitle(source: FolderTitleSource, titleFormat: NestedFolderTitleFormat): string {
+  const isFolderSummary = 'name' in source;
+  const name = isFolderSummary ? source.name : source.folderName;
+  const parentFolderName = isFolderSummary ? source.parentFolderName : source.folderParentName;
+  const breadcrumb = isFolderSummary ? source.breadcrumb : source.folderBreadcrumb;
+
+  if (titleFormat !== 'parent-plus-folder') {
+    return name;
+  }
+
+  const parentName =
+    typeof parentFolderName === 'string' && parentFolderName.trim().length > 0
+      ? parentFolderName.trim()
+      : getImmediateParentName(breadcrumb, source.folderPath);
+  if (!parentName) {
+    return name;
+  }
+
+  return `${parentName} - ${name}`;
+}

--- a/client/src/views/ExploreView.vue
+++ b/client/src/views/ExploreView.vue
@@ -257,14 +257,14 @@
             >
               <Avatar
                 class="h-12 w-12 flex-shrink-0"
-                :name="folder.name"
+                :name="formatDisplayFolderTitle(folder)"
                 :src="folder.avatarUrl"
               />
               <span class="min-w-0 flex-1 text-left">
                 <strong
                   class="block truncate text-[0.96rem] font-semibold text-text"
                 >
-                  {{ folder.name }}
+                  {{ formatDisplayFolderTitle(folder) }}
                 </strong>
                 <span class="block truncate text-[0.84rem] text-muted">
                   {{ describeFolder(folder) }}
@@ -346,6 +346,7 @@ import { useFoldersStore } from '../stores/folders';
 import { useLikesStore } from '../stores/likes';
 import type { FolderSummary } from '../types/api';
 import { searchFolders, rankExploreItems } from '../utils/explore';
+import { formatFolderTitle } from '../utils/folder-titles';
 import { buildLikedCountByFolder } from '../utils/home-recommendations';
 
 type SearchTab = 'media' | 'folders';
@@ -409,6 +410,10 @@ const showSearchLoading = computed(
     exploreStore.searchItems.length === 0 &&
     !exploreStore.searchError
 );
+
+function formatDisplayFolderTitle(folder: FolderSummary) {
+  return formatFolderTitle(folder, appStore.nestedFolderTitleFormat);
+}
 
 watch(
   () => [route.query.q, route.query.tab] as const,

--- a/client/src/views/HomeView.vue
+++ b/client/src/views/HomeView.vue
@@ -227,9 +227,9 @@
       :aria-label="t('home.sidebar.ariaLabel')"
     >
       <div class="flex items-center gap-[0.8rem]">
-        <Avatar class="w-11 h-11" :name="homeSummaryFolder.name" :src="homeSummaryFolder.avatarUrl" />
+        <Avatar class="w-11 h-11" :name="formatDisplayFolderTitle(homeSummaryFolder)" :src="homeSummaryFolder.avatarUrl" />
         <div class="flex-1 min-w-0">
-          <strong class="block text-text text-[0.87rem] font-bold">{{ homeSummaryFolder.name }}</strong>
+          <strong class="block text-text text-[0.87rem] font-bold">{{ formatDisplayFolderTitle(homeSummaryFolder) }}</strong>
           <p class="m-0 mt-[0.12rem] text-[0.79rem] truncate">{{ homeSummaryFolder.breadcrumb ?? t('folder.shared.topLevelSourceFolder') }}</p>
         </div>
         <RouterLink class="ml-auto text-accent-strong text-[0.76rem] font-bold" :to="{ name: 'folder', params: { slug: homeSummaryFolder.slug } }">{{ t('home.sidebar.openFolder') }}</RouterLink>
@@ -247,9 +247,9 @@
           class="flex items-center gap-[0.8rem]"
           :to="{ name: 'folder', params: { slug: folder.slug } }"
         >
-          <Avatar class="w-11 h-11" :name="folder.name" :src="folder.avatarUrl" />
+          <Avatar class="w-11 h-11" :name="formatDisplayFolderTitle(folder)" :src="folder.avatarUrl" />
           <div class="flex-1 min-w-0">
-            <strong class="block text-text text-[0.87rem] font-bold">{{ folder.name }}</strong>
+            <strong class="block text-text text-[0.87rem] font-bold">{{ formatDisplayFolderTitle(folder) }}</strong>
             <p class="m-0 mt-[0.12rem] text-[0.79rem] truncate">{{ folder.breadcrumb ?? t('folder.shared.topLevelSourceFolder') }}</p>
           </div>
           <span class="ml-auto text-accent-strong text-[0.76rem] font-bold">{{ t('home.sidebar.openFolder') }}</span>
@@ -291,6 +291,7 @@ import { useLikesStore } from '../stores/likes';
 import { useFoldersStore } from '../stores/folders';
 import { useMomentsStore } from '../stores/moments';
 import type { FeedMode } from '../types/api';
+import { formatFolderTitle } from '../utils/folder-titles';
 import { buildLikedCountByFolder, selectHomeRecommendations } from '../utils/home-recommendations';
 import { getInitialScanStats, getScanActionLine, getScanPhaseLabel, getScanSummary } from '../utils/scan-progress';
 
@@ -316,6 +317,10 @@ const isCompactHomeLayout = ref(false);
 const requestingHomeScan = ref(false);
 const homeScanError = ref<string | null>(null);
 const feedStoryError = ref<string | null>(null);
+
+function formatDisplayFolderTitle(folder: NonNullable<typeof homeSummaryFolder.value> | (typeof recommendedFolders.value)[number]) {
+  return formatFolderTitle(folder, appStore.nestedFolderTitleFormat);
+}
 
 const HOME_RIGHT_RAIL_BREAKPOINT = 960;
 let homeLayoutResizeObserver: ResizeObserver | null = null;

--- a/client/src/views/LibraryView.vue
+++ b/client/src/views/LibraryView.vue
@@ -140,13 +140,13 @@
           >
             <Avatar
               class="w-10 h-10 shrink-0"
-              :name="folder.name"
+              :name="formatDisplayFolderTitle(folder)"
               :src="folder.avatarUrl"
             />
 
             <div class="flex-1 min-w-0">
               <p class="m-0 text-[0.9rem] font-semibold leading-[1.25] break-words sm:truncate">
-                {{ folder.name }}
+                {{ formatDisplayFolderTitle(folder) }}
               </p>
               <p class="m-0 text-muted text-[0.76rem] truncate">
                 {{ folder.breadcrumb ?? t('libraryPage.topLevelSourceFolder') }}
@@ -342,6 +342,7 @@
   import { useFoldersStore } from "../stores/folders"
   import { useMomentsStore } from "../stores/moments"
   import type { FolderSummary } from "../types/api"
+  import { formatFolderTitle } from "../utils/folder-titles"
 
   type LibrarySort =
     | "recent-desc"
@@ -461,9 +462,14 @@
     return [
       folder.slug,
       folder.name,
+      formatDisplayFolderTitle(folder),
       folder.breadcrumb ?? "",
       folder.folderPath,
     ].some(value => value.toLowerCase().includes(query))
+  }
+
+  function formatDisplayFolderTitle(folder: FolderSummary) {
+    return formatFolderTitle(folder, appStore.nestedFolderTitleFormat)
   }
 
   function sortFolders(left: FolderSummary, right: FolderSummary) {

--- a/client/src/views/SettingsView.test.ts
+++ b/client/src/views/SettingsView.test.ts
@@ -60,6 +60,7 @@ function createAppStatus(
       defaultHomeFeedMode,
       defaultReelsFeedMode,
       defaultFolderImageOrder,
+      nestedFolderTitleFormat: 'folder',
       treatStoriesAsFolders: false
     },
     storiesMigration: {
@@ -478,6 +479,48 @@ describe('SettingsView', () => {
     expect(updateExcludedFoldersSpy).not.toHaveBeenCalled();
     expect(appStore.stats?.preferences.defaultFolderImageOrder).toBe('oldest');
     expect(wrapper.text()).toContain('App folders now open with Oldest First.');
+  });
+
+  it('saves the nested folder title format from the general settings card', async () => {
+    const appStore = useAppStore();
+    appStore.$patch({
+      stats: createAppStatus()
+    });
+
+    vi.spyOn(appStore, 'fetchStats').mockResolvedValue();
+    const updateNestedFolderTitleFormatSpy = vi
+      .spyOn(galleryApi, 'updateNestedFolderTitleFormat')
+      .mockResolvedValue({
+        titleFormat: 'parent-plus-folder'
+      });
+
+    const wrapper = mountSettingsView();
+
+    await flushPromises();
+    await openGeneralSettingsSidebarTab(wrapper);
+
+    const [, , , nestedTitleButton] = wrapper.findAll('button[aria-expanded]');
+    expect(nestedTitleButton).toBeDefined();
+
+    await nestedTitleButton!.trigger('click');
+    await flushPromises();
+    const parentPlusFolderOption = wrapper.findAll('button').find((button) => button.text().includes('Parent + folder name'));
+    expect(parentPlusFolderOption).toBeDefined();
+    await parentPlusFolderOption!.trigger('click');
+    await flushPromises();
+
+    const saveButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'Save changes');
+
+    expect(saveButton).toBeDefined();
+
+    await saveButton!.trigger('click');
+    await flushPromises();
+
+    expect(updateNestedFolderTitleFormatSpy).toHaveBeenCalledWith('parent-plus-folder');
+    expect(appStore.stats?.preferences.nestedFolderTitleFormat).toBe('parent-plus-folder');
+    expect(wrapper.text()).toContain('Nested app folders now use Parent + folder name.');
   });
 
   it('saves custom excluded folder rules from the settings textarea', async () => {

--- a/client/src/views/SettingsView.vue
+++ b/client/src/views/SettingsView.vue
@@ -800,6 +800,67 @@
 
               <div class="grid gap-3 px-6 py-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
                 <div class="min-w-0">
+                  <p class="m-0 text-[0.96rem] font-semibold text-text">{{ t('settings.general.nestedFolderTitle.label') }}</p>
+                  <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">{{ t('settings.general.nestedFolderTitle.description') }}</p>
+                </div>
+
+                <div class="relative w-full md:w-[18rem] md:justify-self-end" @keydown.escape.stop.prevent="closeGeneralSettingsMenu">
+                  <button
+                    class="inline-flex w-full items-center justify-between gap-3 rounded-[0.9rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_80%,transparent_20%)] px-3 py-[0.85rem] text-left transition-[border-color,box-shadow] duration-180 hover:border-[color-mix(in_srgb,var(--accent)_22%,var(--border)_78%)] hover:bg-surface-hover focus-visible:border-[color-mix(in_srgb,var(--accent)_35%,var(--border)_65%)] focus-visible:shadow-[0_0_0_4px_color-mix(in_srgb,var(--accent-soft)_76%,transparent_24%)]"
+                    type="button"
+                    :aria-expanded="activeGeneralSettingsMenu === 'nestedTitle'"
+                    :disabled="savingGeneralSettings || waitingForInitialStatus"
+                    @click="toggleGeneralSettingsMenu('nestedTitle')"
+                  >
+                    <span class="min-w-0 truncate text-[0.9rem] font-semibold text-text">
+                      {{ selectedNestedFolderTitleOption.label }}
+                    </span>
+                    <span
+                      class="i-fluent-chevron-down-20-regular h-5 w-5 shrink-0 text-muted transition-transform duration-180"
+                      :class="activeGeneralSettingsMenu === 'nestedTitle' ? 'rotate-180 text-text' : ''"
+                      aria-hidden="true"
+                    />
+                  </button>
+
+                  <button
+                    v-if="activeGeneralSettingsMenu === 'nestedTitle'"
+                    class="fixed inset-0 z-40 border-0 bg-transparent"
+                    type="button"
+                    :aria-label="t('settings.general.nestedFolderTitle.closeMenuAria')"
+                    @click="closeGeneralSettingsMenu"
+                  />
+
+                  <div
+                    v-if="activeGeneralSettingsMenu === 'nestedTitle'"
+                    class="absolute right-0 top-[calc(100%+0.45rem)] z-50 w-full overflow-hidden rounded-[1rem] border border-border bg-[color-mix(in_srgb,var(--surface)_97%,var(--bg)_3%)] shadow-[0_28px_70px_rgba(0,0,0,0.16)]"
+                  >
+                    <div class="border-b border-border px-4 py-3">
+                      <p class="m-0 text-[0.83rem] font-semibold text-text">{{ t('settings.general.nestedFolderTitle.label') }}</p>
+                    </div>
+                    <div class="grid gap-1 p-2">
+                      <button
+                        v-for="option in nestedFolderTitleOptions"
+                        :key="option.id"
+                        class="flex items-start gap-3 rounded-[0.85rem] border-0 px-3 py-3 text-left cursor-pointer transition-colors duration-150 hover:bg-surface-hover"
+                        :class="nestedFolderTitleFormat === option.id ? 'bg-[color-mix(in_srgb,var(--accent-soft)_72%,transparent_28%)]' : 'bg-transparent'"
+                        type="button"
+                        @click="selectNestedFolderTitleFormat(option.id)"
+                      >
+                        <span class="mt-[0.05rem] inline-flex h-5 w-5 items-center justify-center shrink-0 text-accent-strong">
+                          <span v-if="nestedFolderTitleFormat === option.id" class="i-fluent-checkmark-20-filled h-4 w-4" aria-hidden="true" />
+                        </span>
+                        <span class="grid min-w-0 gap-[0.08rem]">
+                          <span class="text-[0.9rem] font-semibold text-text">{{ option.label }}</span>
+                          <span class="text-[0.78rem] text-muted">{{ option.description }}</span>
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="grid gap-3 px-6 py-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+                <div class="min-w-0">
                   <div class="flex flex-wrap items-center gap-2">
                     <p class="m-0 text-[0.96rem] font-semibold text-text">{{ t('settings.general.storiesMode.label') }}</p>
                     <span class="inline-flex items-center rounded-full bg-surface-alt px-2 py-[0.2rem] text-[0.72rem] font-semibold uppercase tracking-[0.08em] text-muted">
@@ -1189,6 +1250,7 @@ import {
   updateExcludedFolders,
   updateFolderImageOrderDefault,
   updateHomeFeedDefault,
+  updateNestedFolderTitleFormat,
   updateReelsFeedDefault,
   updateStoriesMode
 } from '../api/gallery';
@@ -1201,7 +1263,7 @@ import { useLikesStore } from '../stores/likes';
 import { useMomentsStore } from '../stores/moments';
 import { usePlacesStore } from '../stores/places';
 import { useViewerStore } from '../stores/viewer';
-import type { AppStats, FeedMode, FolderImageOrder, ReelsFeedMode, ViewerAccessMode } from '../types/api';
+import type { AppStats, FeedMode, FolderImageOrder, NestedFolderTitleFormat, ReelsFeedMode, ViewerAccessMode } from '../types/api';
 
 const { t, locale } = useI18n();
 const appStore = useAppStore();
@@ -1238,12 +1300,13 @@ const disablePassword = ref('');
 const homeFeedDefaultMode = ref<FeedMode>('random');
 const reelsFeedDefaultMode = ref<ReelsFeedMode>('random');
 const folderImageOrderDefault = ref<FolderImageOrder>('newest');
+const nestedFolderTitleFormat = ref<NestedFolderTitleFormat>('folder');
 const savedLocaleSelection = ref<SupportedLocale | null>(appStore.savedDefaultLocale);
 const localeSelectionHydrated = ref(false);
 const storiesMode = ref(false);
 const feedDefaultsHydrated = ref(false);
 const storiesModeHydrated = ref(false);
-const activeGeneralSettingsMenu = ref<'home' | 'reels' | 'folder' | null>(null);
+const activeGeneralSettingsMenu = ref<'home' | 'reels' | 'folder' | 'nestedTitle' | null>(null);
 const showStoriesAnnouncementStructure = ref(false);
 const generalSettingsSaveArea = ref<HTMLElement | null>(null);
 const localeSelectId = 'settings-language-select';
@@ -1471,6 +1534,7 @@ function syncFeedDefaultsFromSaved() {
   homeFeedDefaultMode.value = appStore.defaultHomeFeedMode;
   reelsFeedDefaultMode.value = appStore.defaultReelsFeedMode;
   folderImageOrderDefault.value = appStore.defaultFolderImageOrder;
+  nestedFolderTitleFormat.value = appStore.nestedFolderTitleFormat;
   feedDefaultsHydrated.value = true;
 }
 
@@ -1544,6 +1608,18 @@ const folderImageOrderOptions = computed<Array<{ id: FolderImageOrder; label: st
     description: t('settings.general.folderOrder.options.oldest.description')
   }
 ]);
+const nestedFolderTitleOptions = computed<Array<{ id: NestedFolderTitleFormat; label: string; description: string }>>(() => [
+  {
+    id: 'folder',
+    label: t('settings.general.nestedFolderTitle.options.folder.label'),
+    description: t('settings.general.nestedFolderTitle.options.folder.description')
+  },
+  {
+    id: 'parent-plus-folder',
+    label: t('settings.general.nestedFolderTitle.options.parentPlusFolder.label'),
+    description: t('settings.general.nestedFolderTitle.options.parentPlusFolder.description')
+  }
+]);
 const isLibraryRebuildActive = computed(
   () => rebuilding.value || (appStore.isScanning && activeScanReason.value === 'rebuild')
 );
@@ -1557,6 +1633,7 @@ const waitingForInitialStatus = computed(() => !appStore.stats || appStore.loadi
 const savedHomeFeedDefaultMode = computed(() => appStore.defaultHomeFeedMode);
 const savedReelsFeedDefaultMode = computed(() => appStore.defaultReelsFeedMode);
 const savedFolderImageOrderDefault = computed(() => appStore.defaultFolderImageOrder);
+const savedNestedFolderTitleFormat = computed(() => appStore.nestedFolderTitleFormat);
 const savedStoriesMode = computed(() => appStore.treatStoriesAsFolders);
 const savedCustomExcludedFolders = computed(() => adminStats.value?.excludedFolders.customExcludedFolders ?? []);
 const envExcludedFolders = computed(() => adminStats.value?.excludedFolders.envExcludedFolders ?? []);
@@ -1592,6 +1669,9 @@ const selectedReelsFeedDefaultOption = computed(
 const selectedFolderImageOrderOption = computed(
   () => folderImageOrderOptions.value.find((mode) => mode.id === folderImageOrderDefault.value) ?? folderImageOrderOptions.value[0]
 );
+const selectedNestedFolderTitleOption = computed(
+  () => nestedFolderTitleOptions.value.find((option) => option.id === nestedFolderTitleFormat.value) ?? nestedFolderTitleOptions.value[0]
+);
 const localeDirty = computed(
   () => localeSelectionHydrated.value && (savedLocaleSelection.value === null || appStore.locale !== savedLocaleSelection.value)
 );
@@ -1604,10 +1684,22 @@ const reelsFeedDefaultDirty = computed(
 const folderImageOrderDirty = computed(
   () => feedDefaultsHydrated.value && folderImageOrderDefault.value !== savedFolderImageOrderDefault.value
 );
-const defaultSettingsDirtyCount = computed(
-  () => [localeDirty.value, homeFeedDefaultDirty.value, reelsFeedDefaultDirty.value, folderImageOrderDirty.value].filter(Boolean).length
+const nestedFolderTitleDirty = computed(
+  () => feedDefaultsHydrated.value && nestedFolderTitleFormat.value !== savedNestedFolderTitleFormat.value
 );
-const feedDefaultsDirty = computed(() => homeFeedDefaultDirty.value || reelsFeedDefaultDirty.value || folderImageOrderDirty.value);
+const defaultSettingsDirtyCount = computed(
+  () =>
+    [
+      localeDirty.value,
+      homeFeedDefaultDirty.value,
+      reelsFeedDefaultDirty.value,
+      folderImageOrderDirty.value,
+      nestedFolderTitleDirty.value
+    ].filter(Boolean).length
+);
+const feedDefaultsDirty = computed(
+  () => homeFeedDefaultDirty.value || reelsFeedDefaultDirty.value || folderImageOrderDirty.value || nestedFolderTitleDirty.value
+);
 const storiesModeDirty = computed(() => storiesModeHydrated.value && storiesMode.value !== savedStoriesMode.value);
 const excludedFoldersDirty = computed(() => {
   if (!excludedFoldersHydrated.value) {
@@ -1682,6 +1774,10 @@ const generalSettingsActionNote = computed(() => {
 
   if (folderImageOrderDirty.value) {
     return t('settings.general.actionNote.folderOnly');
+  }
+
+  if (nestedFolderTitleDirty.value) {
+    return t('settings.general.actionNote.nestedFolderTitleOnly');
   }
 
   return t('settings.general.actionNote.idle');
@@ -2361,7 +2457,7 @@ function closeGeneralSettingsMenu() {
   activeGeneralSettingsMenu.value = null;
 }
 
-function toggleGeneralSettingsMenu(menu: 'home' | 'reels' | 'folder') {
+function toggleGeneralSettingsMenu(menu: 'home' | 'reels' | 'folder' | 'nestedTitle') {
   clearGeneralSettingsFeedback();
   activeGeneralSettingsMenu.value = activeGeneralSettingsMenu.value === menu ? null : menu;
 }
@@ -2417,6 +2513,12 @@ function selectFolderImageOrderDefault(order: FolderImageOrder) {
   closeGeneralSettingsMenu();
 }
 
+function selectNestedFolderTitleFormat(value: NestedFolderTitleFormat) {
+  clearGeneralSettingsFeedback();
+  nestedFolderTitleFormat.value = value;
+  closeGeneralSettingsMenu();
+}
+
 async function saveGeneralSettings() {
   if (generalSettingsSaveDisabled.value) {
     return;
@@ -2428,8 +2530,16 @@ async function saveGeneralSettings() {
   const shouldSaveHome = homeFeedDefaultDirty.value;
   const shouldSaveReels = reelsFeedDefaultDirty.value;
   const shouldSaveFolderOrder = folderImageOrderDirty.value;
-  const shouldSaveAnyDefault = shouldSaveLocale || shouldSaveHome || shouldSaveReels || shouldSaveFolderOrder;
-  const savedDefaultCount = [shouldSaveLocale, shouldSaveHome, shouldSaveReels, shouldSaveFolderOrder].filter(Boolean).length;
+  const shouldSaveNestedFolderTitle = nestedFolderTitleDirty.value;
+  const shouldSaveAnyDefault =
+    shouldSaveLocale || shouldSaveHome || shouldSaveReels || shouldSaveFolderOrder || shouldSaveNestedFolderTitle;
+  const savedDefaultCount = [
+    shouldSaveLocale,
+    shouldSaveHome,
+    shouldSaveReels,
+    shouldSaveFolderOrder,
+    shouldSaveNestedFolderTitle
+  ].filter(Boolean).length;
   const savedParts: string[] = [];
   let nextExcludedFolders: string[] = [];
 
@@ -2513,6 +2623,15 @@ async function saveGeneralSettings() {
       folderImageOrderDefault.value = payload.defaultOrder;
     }
 
+    if (shouldSaveNestedFolderTitle) {
+      const payload = await updateNestedFolderTitleFormat(nestedFolderTitleFormat.value);
+      savedParts.push(t('settings.general.feedback.parts.nestedFolderTitles'));
+      if (appStore.stats) {
+        appStore.stats.preferences.nestedFolderTitleFormat = payload.titleFormat;
+      }
+      nestedFolderTitleFormat.value = payload.titleFormat;
+    }
+
     await appStore.fetchStats({ background: true });
 
     if (shouldSaveStories || shouldSaveExcludedFolders) {
@@ -2550,6 +2669,11 @@ async function saveGeneralSettings() {
       setGeneralSettingsFeedback(
         'success',
         t('settings.general.feedback.folderOrderSaved', { label: selectedFolderImageOrderOption.value.label })
+      );
+    } else if (shouldSaveNestedFolderTitle) {
+      setGeneralSettingsFeedback(
+        'success',
+        t('settings.general.feedback.nestedFolderTitleSaved', { label: selectedNestedFolderTitleOption.value.label })
       );
     }
   } catch (error) {

--- a/client/src/views/TrashView.vue
+++ b/client/src/views/TrashView.vue
@@ -72,7 +72,7 @@
           >
             <label class="flex items-center justify-between gap-2 px-3 py-2 cursor-pointer select-none border-b border-border">
               <span class="text-[0.8rem] font-semibold text-text truncate">
-                {{ item.folderName }}
+                {{ formatDisplayFolderTitle(item) }}
               </span>
               <input
                 class="cursor-pointer"
@@ -190,6 +190,7 @@ import { useLikesStore } from '../stores/likes';
 import { useMomentsStore } from '../stores/moments';
 import { useTrashStore } from '../stores/trash';
 import { resolveDisplayCaption } from '../utils/caption';
+import { formatFolderTitle } from '../utils/folder-titles';
 
 const { t, locale } = useI18n();
 const appStore = useAppStore();
@@ -238,6 +239,10 @@ function toggleSelected(id: number) {
 
 function displayCaption(item: { filename: string; caption?: string | null }) {
   return resolveDisplayCaption(item);
+}
+
+function formatDisplayFolderTitle(item: { folderName: string; folderBreadcrumb: string | null; folderPath: string }) {
+  return formatFolderTitle(item, appStore.nestedFolderTitleFormat);
 }
 
 function formatCount(value: number) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,20 @@ Instead:
 - the default is `Newest First`
 - this setting changes app-folder grids and previous/next navigation inside the post viewer when browsing within a folder
 
+## Nested folder title format
+
+Nested folder title format is **not** configured in `.env`.
+
+Instead:
+
+- Foldergram stores the current nested-folder title preference in SQLite `app_settings`
+- `Settings -> General Settings` exposes `Nested folder title format`
+- available options are `Folder name only` and `Parent + folder name`
+- the default is `Folder name only`
+- this setting changes presentation only for nested app-folder titles
+- renamed parent folders use their saved app title as the prefix when available
+- it does not change scans, slugs, folder paths, or saved folder metadata
+
 ## Places setup
 
 Offline places support is **not** configured in `.env`.
@@ -124,7 +138,7 @@ Behavior:
 The Settings sidebar is split into:
 
 - `Scan & Library` for manual scans, thumbnail rebuilds, and library-index rebuilds
-- `General Settings` for Home/Reels defaults, default folder order, stories-folders mode, excluded folders, and any save-and-rescan notices tied to those app-wide rules
+- `General Settings` for Home/Reels defaults, default folder order, nested folder title format, stories-folders mode, excluded folders, and any save-and-rescan notices tied to those app-wide rules
 - `Places` for offline GeoNames preparation status and place-assignment rebuilds
 - `Security & Access` for admin, viewer, and public-mode controls
 - `System Status` for storage, index, and last-scan details

--- a/docs/features.md
+++ b/docs/features.md
@@ -236,7 +236,7 @@ Its left sidebar is split into:
 | Section | What it contains |
 | --- | --- |
 | `Scan & Library` | Phase-aware live scan state, manual scan, thumbnail-only rebuild, and library-index rebuild actions. Admins also see the full report path when a scan finishes with skipped media errors. |
-| `General Settings` | App-language selection with instant local switching plus saved app-wide defaults, Home and Reels default feed modes, the default App Folder photo order, stories-folders mode, excluded-folder rules, migration notices, and save-and-rescan prompts for those app-wide changes. |
+| `General Settings` | App-language selection with instant local switching plus saved app-wide defaults, Home and Reels default feed modes, the default App Folder photo order, nested folder title format, stories-folders mode, excluded-folder rules, migration notices, and save-and-rescan prompts for those app-wide changes. |
 | `Places` | Offline GeoNames preparation status plus place-assignment rebuild actions for GPS-tagged photos. |
 | `Security & Access` | Admin password, viewer password, public mode, sign-out, and related auth controls. |
 | `System Status` | Storage and index state plus last completed scan details, including whether the last run completed with errors. |
@@ -246,9 +246,10 @@ browser. That browser-local override is stored locally, and clicking `Save
 changes` also stores the selected language as the app-wide default for browsers
 without their own override. That saved default also reaches the login gate and
 other pre-auth translated UI on devices that are using the app-wide language.
-Env-backed excluded-folder rules are shown read-only and custom rules are saved
-at runtime. Changing stories mode or excluded folders still requires a follow-up
-scan from `Scan & Library`.
+Nested folder title format changes are presentation-only and update without a
+rescan. Env-backed excluded-folder rules are shown read-only and custom rules
+are saved at runtime. Changing stories mode or excluded folders still requires
+a follow-up scan from `Scan & Library`.
 
 On mobile, Settings uses a dedicated sticky top icon bar instead of the desktop
 sidebar.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -121,7 +121,7 @@ mode with admin unlock.
 
 The Settings sidebar separates app-wide preferences from maintenance actions:
 
-- `General Settings` contains app language, stories mode, excluded folders, Home/Reels defaults, and the default folder photo order
+- `General Settings` contains app language, stories mode, nested folder title format, excluded folders, Home/Reels defaults, and the default folder photo order
 - `Places` contains offline place-data preparation and place-assignment rebuilds for GPS-tagged photos
 - `Scan & Library` contains manual scan plus rebuild actions
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -143,7 +143,7 @@ access, add a separate viewer password, or switch to public browse mode.
 
 Inside Settings:
 
-- `General Settings` contains stories mode, excluded folders, Home/Reels defaults, and the default folder photo order
+- `General Settings` contains stories mode, nested folder title format, excluded folders, Home/Reels defaults, and the default folder photo order
 - `Places` contains offline place-data preparation and place-assignment rebuilds for GPS-tagged photos
 - `Scan & Library` contains manual scan plus rebuild actions
 

--- a/server/src/constants/app-setting-keys.ts
+++ b/server/src/constants/app-setting-keys.ts
@@ -12,6 +12,7 @@ export const STORIES_MIGRATION_DECISION_SETTING_KEY = 'library.stories_migration
 export const HOME_FEED_DEFAULT_MODE_SETTING_KEY = 'feed.default_home_mode';
 export const REELS_FEED_DEFAULT_MODE_SETTING_KEY = 'feed.default_reels_mode';
 export const FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY = 'folder.default_image_order';
+export const NESTED_FOLDER_TITLE_FORMAT_SETTING_KEY = 'folder.nested_title_format';
 export const APP_DEFAULT_LOCALE_SETTING_KEY = 'app.default_locale';
 export const AUTH_PASSWORD_HASH_SETTING_KEY = 'auth.password_hash';
 export const AUTH_PASSWORD_SALT_SETTING_KEY = 'auth.password_salt';

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -77,6 +77,9 @@ const reelsFeedDefaultBodySchema = z.object({
 const folderImageOrderDefaultBodySchema = z.object({
   defaultOrder: z.enum(['newest', 'oldest'])
 });
+const nestedFolderTitleFormatBodySchema = z.object({
+  titleFormat: z.enum(['folder', 'parent-plus-folder'])
+});
 const storiesModeBodySchema = z.object({
   treatStoriesAsFolders: z.boolean()
 });
@@ -175,6 +178,7 @@ export const settingsRequestBodySchemas = {
   appLocale: appLocaleBodySchema,
   reelsFeedDefault: reelsFeedDefaultBodySchema,
   folderImageOrderDefault: folderImageOrderDefaultBodySchema,
+  nestedFolderTitleFormat: nestedFolderTitleFormatBodySchema,
   storiesMode: storiesModeBodySchema,
   excludedFolders: excludedFoldersBodySchema
 };
@@ -416,6 +420,15 @@ router.put(
   (request, response) => {
     const body = folderImageOrderDefaultBodySchema.parse(request.body);
     response.json(galleryService.setDefaultFolderImageOrder(body.defaultOrder));
+  }
+);
+
+router.put(
+  '/admin/settings/nested-folder-title-format',
+  requireCapability('canAccessSettings', 'Admin access is required.'),
+  (request, response) => {
+    const body = nestedFolderTitleFormatBodySchema.parse(request.body);
+    response.json(galleryService.setNestedFolderTitleFormat(body.titleFormat));
   }
 );
 

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -9,6 +9,7 @@ import {
   HOME_FEED_DEFAULT_MODE_SETTING_KEY,
   LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY,
   LIBRARY_REBUILD_REQUIRED_SETTING_KEY,
+  NESTED_FOLDER_TITLE_FORMAT_SETTING_KEY,
   PREVIOUS_GALLERY_ROOT_SETTING_KEY,
   REELS_FEED_DEFAULT_MODE_SETTING_KEY,
   STORIES_MIGRATION_DECISION_SETTING_KEY,
@@ -31,6 +32,7 @@ import type {
   CollectionSummaryRecord,
   FeedImage,
   FolderImageOrder,
+  NestedFolderTitleFormat,
   FolderRecord,
   FolderSummaryRecord,
   ImageDetail,
@@ -47,9 +49,10 @@ import {
 import { deserializeImageExifData } from '../utils/exif-utils.js';
 import { buildMonthDayKey, countFeedBursts, diversifyFeedCandidates, groupFeedBursts, listMonthDayKeysAroundDate } from '../utils/feed-utils.js';
 import { shouldPreferMomentRail, type FeedRailKind } from '../utils/feed-rail-utils.js';
+import { parseNestedFolderTitleFormatSetting, serializeNestedFolderTitleFormatSetting } from '../utils/folder-title-format.js';
 import { countSupportedRootMediaFiles } from '../utils/gallery-root-utils.js';
 import { resolveOriginalPath } from '../utils/media-paths.js';
-import { getPathBreadcrumb } from '../utils/path-utils.js';
+import { getLeafPathName, getParentRelativePath, getPathBreadcrumb } from '../utils/path-utils.js';
 import { buildReelQueue, shuffleReelCandidates, type ReelAffinitySignals } from '../utils/reels-utils.js';
 import { parseTreatStoriesAsFoldersSetting, serializeTreatStoriesAsFoldersSetting } from '../utils/stories-utils.js';
 import { scannerService } from './scanner-service.js';
@@ -205,6 +208,10 @@ function parseFolderImageOrder(value: string | null): FolderImageOrder {
 
 function getDefaultFolderImageOrder(): FolderImageOrder {
   return parseFolderImageOrder(appSettingsRepository.get(FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY));
+}
+
+function getNestedFolderTitleFormat(): NestedFolderTitleFormat {
+  return parseNestedFolderTitleFormatSetting(appSettingsRepository.get(NESTED_FOLDER_TITLE_FORMAT_SETTING_KEY));
 }
 
 function getTreatStoriesAsFolders(): boolean {
@@ -443,12 +450,27 @@ function isSameOrDescendantFolderPath(rootFolderPath: string, candidateFolderPat
   return candidateFolderPath === rootFolderPath || candidateFolderPath.startsWith(`${rootFolderPath}/`);
 }
 
+function getParentFolderDisplayName(folderPath: string): string | null {
+  const parentFolderPath = getParentRelativePath(folderPath);
+  if (!parentFolderPath) {
+    return null;
+  }
+
+  const parentFolder = folderRepository.getByFolderPath(parentFolderPath);
+  if (parentFolder?.name.trim()) {
+    return parentFolder.name.trim();
+  }
+
+  return getLeafPathName(parentFolderPath);
+}
+
 function mapFeedImage(image: IndexedFeedImage, derivativeVersion = getDerivativeAssetVersion()): FeedImage {
   const { playbackStrategy, placeId, placeSlug, placeName, placeKind, placeIsApproximate, isSaved, ...rest } = image;
   return {
     ...rest,
     isAnimated: Boolean(rest.isAnimated),
     isSaved: Boolean(isSaved),
+    folderParentName: getParentFolderDisplayName(rest.folderPath),
     folderBreadcrumb: getPathBreadcrumb(rest.folderPath),
     thumbnailUrl: toPublicMediaUrl('/thumbnails', rest.thumbnailUrl, derivativeVersion),
     previewUrl: buildPreviewUrl({
@@ -468,6 +490,7 @@ function mapImageDetail(image: IndexedImageDetail, derivativeVersion = getDeriva
     isAnimated: Boolean(rest.isAnimated),
     isSaved: Boolean(isSaved),
     exif: deserializeImageExifData(exifJson),
+    folderParentName: getParentFolderDisplayName(rest.folderPath),
     folderBreadcrumb: getPathBreadcrumb(rest.folderPath),
     thumbnailUrl: toPublicMediaUrl('/thumbnails', rest.thumbnailUrl, derivativeVersion),
     previewUrl: buildPreviewUrl({
@@ -487,6 +510,7 @@ function mapTrashImage(image: IndexedTrashImage, derivativeVersion = getDerivati
     ...rest,
     isAnimated: Boolean(rest.isAnimated),
     isSaved: Boolean(isSaved),
+    folderParentName: getParentFolderDisplayName(rest.folderPath),
     folderBreadcrumb: getPathBreadcrumb(rest.folderPath),
     thumbnailUrl: toPublicMediaUrl('/thumbnails', rest.thumbnailUrl, derivativeVersion),
     previewUrl: buildPreviewUrl({
@@ -509,6 +533,7 @@ function buildFolderSummary(folder: FolderSummaryRecord) {
       slug: folder.slug,
       name: folder.name,
       description: folder.description,
+      parentFolderName: getParentFolderDisplayName(folder.folder_path),
       folderPath: folder.folder_path,
       breadcrumb: getPathBreadcrumb(folder.folder_path),
       imageCount: folder.image_count,
@@ -535,6 +560,7 @@ function buildFolderSummary(folder: FolderSummaryRecord) {
     slug: folder.slug,
     name: folder.name,
     description: folder.description,
+    parentFolderName: getParentFolderDisplayName(folder.folder_path),
     folderPath: folder.folder_path,
     breadcrumb: getPathBreadcrumb(folder.folder_path),
     imageCount: folder.image_count,
@@ -556,6 +582,7 @@ function mapFeedImageForOwnerFolder(
     folderId: ownerFolder.id,
     folderSlug: ownerFolder.slug,
     folderName: ownerFolder.name,
+    folderParentName: ownerFolder.parentFolderName,
     folderPath: ownerFolder.folderPath,
     folderBreadcrumb: ownerFolder.breadcrumb
   };
@@ -1826,6 +1853,7 @@ export const galleryService = {
     const defaultLocale = getDefaultLocale();
     const defaultReelsFeedMode = getDefaultReelsFeedMode();
     const defaultFolderImageOrder = getDefaultFolderImageOrder();
+    const nestedFolderTitleFormat = getNestedFolderTitleFormat();
     const treatStoriesAsFolders = getTreatStoriesAsFolders();
     const storiesMigration = getStoriesMigrationStatus();
 
@@ -1848,6 +1876,7 @@ export const galleryService = {
         defaultHomeFeedMode,
         defaultReelsFeedMode,
         defaultFolderImageOrder,
+        nestedFolderTitleFormat,
         treatStoriesAsFolders
       },
       storiesMigration
@@ -1888,6 +1917,7 @@ export const galleryService = {
     const defaultLocale = getDefaultLocale();
     const defaultReelsFeedMode = getDefaultReelsFeedMode();
     const defaultFolderImageOrder = getDefaultFolderImageOrder();
+    const nestedFolderTitleFormat = getNestedFolderTitleFormat();
     const treatStoriesAsFolders = getTreatStoriesAsFolders();
     const storiesMigration = getStoriesMigrationStatus();
     const excludedFolders = getExcludedFolderSettings();
@@ -1921,6 +1951,7 @@ export const galleryService = {
         defaultHomeFeedMode,
         defaultReelsFeedMode,
         defaultFolderImageOrder,
+        nestedFolderTitleFormat,
         treatStoriesAsFolders
       },
       storiesMigration,
@@ -1957,6 +1988,17 @@ export const galleryService = {
 
     return {
       defaultOrder: order
+    };
+  },
+
+  setNestedFolderTitleFormat(titleFormat: NestedFolderTitleFormat) {
+    appSettingsRepository.set(
+      NESTED_FOLDER_TITLE_FORMAT_SETTING_KEY,
+      serializeNestedFolderTitleFormatSetting(titleFormat)
+    );
+
+    return {
+      titleFormat
     };
   },
 

--- a/server/src/types/models.ts
+++ b/server/src/types/models.ts
@@ -1,5 +1,6 @@
 export type MediaType = 'image' | 'video';
 export type FolderImageOrder = 'newest' | 'oldest';
+export type NestedFolderTitleFormat = 'folder' | 'parent-plus-folder';
 export type TakenAtSource = 'exif' | 'mtime' | 'first_seen' | 'sort_timestamp';
 export type PlaybackStrategy = 'preview' | 'original';
 export type FolderAvatarSource = 'auto' | 'manual' | 'cover';
@@ -166,6 +167,7 @@ export interface FeedImage {
   folderId: number;
   folderSlug: string;
   folderName: string;
+  folderParentName?: string | null;
   folderPath: string;
   folderBreadcrumb?: string | null;
   filename: string;

--- a/server/src/utils/folder-title-format.ts
+++ b/server/src/utils/folder-title-format.ts
@@ -1,0 +1,11 @@
+import type { NestedFolderTitleFormat } from '../types/models.js';
+
+export const DEFAULT_NESTED_FOLDER_TITLE_FORMAT: NestedFolderTitleFormat = 'folder';
+
+export function parseNestedFolderTitleFormatSetting(value: string | null): NestedFolderTitleFormat {
+  return value === 'parent-plus-folder' ? 'parent-plus-folder' : DEFAULT_NESTED_FOLDER_TITLE_FORMAT;
+}
+
+export function serializeNestedFolderTitleFormatSetting(value: NestedFolderTitleFormat): string {
+  return value;
+}

--- a/server/src/utils/path-utils.ts
+++ b/server/src/utils/path-utils.ts
@@ -99,6 +99,15 @@ export function getPathBreadcrumb(relativePath: string): string | null {
   return segments.slice(0, -1).join(' / ');
 }
 
+export function getParentRelativePath(relativePath: string): string | null {
+  const segments = splitPathSegments(relativePath);
+  if (segments.length <= 1) {
+    return null;
+  }
+
+  return segments.slice(0, -1).join('/');
+}
+
 export function getFolderDisplayInfo(relativePath: string): { name: string; breadcrumb: string | null } {
   return {
     name: getLeafPathName(relativePath),

--- a/server/test/auth-route-validation.test.ts
+++ b/server/test/auth-route-validation.test.ts
@@ -153,6 +153,24 @@ describe.sequential('auth route validation', () => {
     });
   });
 
+  it('accepts parent-plus-folder as a valid nested folder title format', () => {
+    expect(
+      settingsRequestBodySchemas.nestedFolderTitleFormat.parse({
+        titleFormat: 'parent-plus-folder'
+      })
+    ).toEqual({
+      titleFormat: 'parent-plus-folder'
+    });
+  });
+
+  it('rejects invalid nested folder title formats', () => {
+    expect(() =>
+      settingsRequestBodySchemas.nestedFolderTitleFormat.parse({
+        titleFormat: 'full-path'
+      })
+    ).toThrowError();
+  });
+
   it('accepts long story ids up to the folder-slug route limit', () => {
     expect(
       routeParamSchemas.storyId.parse({

--- a/server/test/folder-customization.test.ts
+++ b/server/test/folder-customization.test.ts
@@ -269,6 +269,69 @@ describe.sequential('folder customization', () => {
       expect(folderSummary?.avatarUrl).toBe('/thumbnails/t/clip1.webp');
     });
 
+    it('exposes customized parent folder display names for nested folders', () => {
+      const parentFolder = folderRepository.upsert({ slug: 'italy', name: 'Italy', folderPath: 'Italy' });
+      const childFolder = folderRepository.upsert({ slug: 'italy-2022', name: '2022', folderPath: 'Italy/2022' });
+
+      imageRepository.upsert({
+        folderId: parentFolder.id,
+        filename: 'rome.jpg',
+        relativePath: 'Italy/rome.jpg',
+        absolutePath: '/dummy/Italy/rome.jpg',
+        fileSize: 120,
+        mtimeMs: 1_000,
+        width: 100,
+        height: 100,
+        mediaType: getMediaTypeFromExtension('.jpg'),
+        mimeType: getMimeTypeFromExtension('.jpg'),
+        fingerprint: createFingerprint('Italy/rome.jpg', 120, 1_000),
+        sortTimestamp: 1_000,
+        takenAt: 1_000,
+        takenAtSource: 'mtime',
+        extension: '.jpg',
+        firstSeenAt: new Date().toISOString(),
+        thumbnailPath: 't/rome.webp',
+        previewPath: 'p/rome.webp',
+        playbackStrategy: 'preview',
+        durationMs: null,
+        exifJson: null
+      });
+
+      const childImage = imageRepository.upsert({
+        folderId: childFolder.id,
+        filename: 'venice.jpg',
+        relativePath: 'Italy/2022/venice.jpg',
+        absolutePath: '/dummy/Italy/2022/venice.jpg',
+        fileSize: 240,
+        mtimeMs: 2_000,
+        width: 100,
+        height: 100,
+        mediaType: getMediaTypeFromExtension('.jpg'),
+        mimeType: getMimeTypeFromExtension('.jpg'),
+        fingerprint: createFingerprint('Italy/2022/venice.jpg', 240, 2_000),
+        sortTimestamp: 2_000,
+        takenAt: 2_000,
+        takenAtSource: 'mtime',
+        extension: '.jpg',
+        firstSeenAt: new Date().toISOString(),
+        thumbnailPath: 't/venice.webp',
+        previewPath: 'p/venice.webp',
+        playbackStrategy: 'preview',
+        durationMs: null,
+        exifJson: null
+      });
+
+      expect(galleryService.updateFolderMetadata('italy', 'Italia', null)?.name).toBe('Italia');
+
+      const childSummary = galleryService.getFolderBySlug('italy-2022');
+      const childFeedItem = galleryService.getFeed(1, 10, 'recent').items.find((item) => item.folderSlug === 'italy-2022');
+      const childDetail = galleryService.getImageDetail(childImage.id);
+
+      expect(childSummary?.parentFolderName).toBe('Italia');
+      expect(childFeedItem?.folderParentName).toBe('Italia');
+      expect(childDetail?.folderParentName).toBe('Italia');
+    });
+
     it('returns null when setting cover for non-existent items', () => {
       expect(galleryService.setFolderAvatar('non-existent', 123)).toBeNull();
       

--- a/server/test/viewer-status.test.ts
+++ b/server/test/viewer-status.test.ts
@@ -25,6 +25,7 @@ describe.sequential('viewer-safe status payload', () => {
   let HOME_FEED_DEFAULT_MODE_SETTING_KEY: AppSettingKeysModule['HOME_FEED_DEFAULT_MODE_SETTING_KEY'];
   let REELS_FEED_DEFAULT_MODE_SETTING_KEY: AppSettingKeysModule['REELS_FEED_DEFAULT_MODE_SETTING_KEY'];
   let FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY: AppSettingKeysModule['FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY'];
+  let NESTED_FOLDER_TITLE_FORMAT_SETTING_KEY: AppSettingKeysModule['NESTED_FOLDER_TITLE_FORMAT_SETTING_KEY'];
 
   beforeAll(async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-viewer-status-'));
@@ -47,7 +48,8 @@ describe.sequential('viewer-safe status payload', () => {
       APP_DEFAULT_LOCALE_SETTING_KEY,
       HOME_FEED_DEFAULT_MODE_SETTING_KEY,
       REELS_FEED_DEFAULT_MODE_SETTING_KEY,
-      FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY
+      FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY,
+      NESTED_FOLDER_TITLE_FORMAT_SETTING_KEY
     } = await import('../src/constants/app-setting-keys.js'));
   });
 
@@ -57,6 +59,7 @@ describe.sequential('viewer-safe status payload', () => {
     appSettingsRepository.remove(HOME_FEED_DEFAULT_MODE_SETTING_KEY);
     appSettingsRepository.remove(REELS_FEED_DEFAULT_MODE_SETTING_KEY);
     appSettingsRepository.remove(FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY);
+    appSettingsRepository.remove(NESTED_FOLDER_TITLE_FORMAT_SETTING_KEY);
     await Promise.all([
       fs.rm(appConfig.galleryRoot, { recursive: true, force: true }),
       fs.rm(appConfig.thumbnailsDir, { recursive: true, force: true }),
@@ -119,6 +122,15 @@ describe.sequential('viewer-safe status payload', () => {
     });
 
     pendingSpy.mockRestore();
+  });
+
+  it('includes the nested folder title format preference in viewer and admin status payloads', () => {
+    expect(galleryService.getStatus().preferences.nestedFolderTitleFormat).toBe('folder');
+
+    galleryService.setNestedFolderTitleFormat('parent-plus-folder');
+
+    expect(galleryService.getStatus().preferences.nestedFolderTitleFormat).toBe('parent-plus-folder');
+    expect(galleryService.getStats().preferences.nestedFolderTitleFormat).toBe('parent-plus-folder');
   });
 
   it('keeps detailed file and folder context in the admin-only scan progress payload', () => {
@@ -192,6 +204,7 @@ describe.sequential('viewer-safe status payload', () => {
       defaultHomeFeedMode: 'random',
       defaultReelsFeedMode: 'random',
       defaultFolderImageOrder: 'newest',
+      nestedFolderTitleFormat: 'folder',
       treatStoriesAsFolders: false
     });
   });
@@ -209,6 +222,7 @@ describe.sequential('viewer-safe status payload', () => {
       defaultHomeFeedMode: 'rediscover',
       defaultReelsFeedMode: 'recommended',
       defaultFolderImageOrder: 'oldest',
+      nestedFolderTitleFormat: 'folder',
       treatStoriesAsFolders: false
     });
   });


### PR DESCRIPTION
Adds a new General Settings option, `Nested folder title format`, to improve browsing when many sub-folder albums share the same leaf name.

This is presentation-only and does not change scan behavior, folder metadata, slugs, routes, or database identity. When enabled, nested albums can render as `Parent - Folder`, and the prefix uses the parent folder's saved display name when available.

Also includes client/server test coverage and docs updates.

Closes #53 