### PR TITLE
Add secure folder-scoped sharing

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -10,6 +10,7 @@
       <p class="m-0 text-muted">{{ t('app.authLoading.description') }}</p>
     </div>
   </section>
+  <RouterView v-else-if="isPublicShareRoute" />
   <AuthGate v-else-if="authStore.requiresLogin" />
   <AppShell v-else>
     <RouterView :route="displayRoute" />
@@ -28,7 +29,7 @@ import { RouterView, useRoute, useRouter, type RouteLocationNormalizedLoaded } f
 import AppShell from './components/AppShell.vue';
 import AdminUnlockDialog from './components/AdminUnlockDialog.vue';
 import AuthGate from './components/AuthGate.vue';
-import { canAccessRoute } from './router';
+import { canAccessRoute, routeAllowsPublicShareAccess } from './router';
 import PostView from './views/PostView.vue';
 import { useAppStore } from './stores/app';
 import { useAuthStore } from './stores/auth';
@@ -93,6 +94,7 @@ const modalBackgroundRoute = computed<RouteLocationNormalizedLoaded | null>(() =
 const showImageModal = computed(
   () => route.name === 'image' && modalBackgroundRoute.value !== null && modalBackgroundRoute.value.fullPath !== route.fullPath
 );
+const isPublicShareRoute = computed(() => routeAllowsPublicShareAccess(route));
 const displayRoute = computed<RouteLocationNormalizedLoaded | undefined>(() =>
   showImageModal.value ? modalBackgroundRoute.value ?? undefined : route
 );

--- a/client/src/api/gallery.ts
+++ b/client/src/api/gallery.ts
@@ -8,7 +8,13 @@ import type {
   CollectionMutationResult,
   CollectionsPayload,
   CreateCollectionResult,
+  CreateFolderShareLinkInput,
+  CreateFolderShareLinkResult,
   DeleteCollectionResult,
+  FolderShareAccessState,
+  FolderShareLinksPayload,
+  FolderSharePasswordMutationResult,
+  FolderShareUnlockResult,
   FolderStoriesPayload,
   FolderStoryFeedPayload,
   HomeFeedDefaultSetting,
@@ -16,6 +22,9 @@ import type {
   UpdateExcludedFoldersSettingResult,
   NestedFolderTitleFormatSetting,
   ReelsFeedDefaultSetting,
+  SharedFolderImagesPayload,
+  SharedFolderSummary,
+  SharedImageDetail,
   StoriesModeSetting,
   ViewerAccessMode,
   DeleteImageResult,
@@ -181,6 +190,88 @@ export function setFolderCover(slug: string, imageId: number) {
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ imageId })
   });
+}
+
+export function fetchFolderShareLinks(slug: string) {
+  return requestJson<FolderShareLinksPayload>(`/api/admin/folders/${encodeURIComponent(slug)}/share-links`);
+}
+
+export function createFolderShareLink(slug: string, input: CreateFolderShareLinkInput) {
+  return requestJson<CreateFolderShareLinkResult>(`/api/admin/folders/${encodeURIComponent(slug)}/share-links`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(input)
+  });
+}
+
+export function revokeFolderShareLink(slug: string, linkId: number) {
+  return requestJson<{ ok: boolean; link: CreateFolderShareLinkResult['link'] }>(
+    `/api/admin/folders/${encodeURIComponent(slug)}/share-links/${linkId}`,
+    {
+      method: 'DELETE'
+    }
+  );
+}
+
+export function setFolderSharePassword(slug: string, password: string) {
+  return requestJson<FolderSharePasswordMutationResult>(`/api/admin/folders/${encodeURIComponent(slug)}/share-password`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ password })
+  });
+}
+
+export function removeFolderSharePassword(slug: string) {
+  return requestJson<FolderSharePasswordMutationResult>(`/api/admin/folders/${encodeURIComponent(slug)}/share-password`, {
+    method: 'DELETE'
+  });
+}
+
+export function fetchSharedFolderAccess(slug: string) {
+  return requestJson<FolderShareAccessState>(`/api/share/folders/${encodeURIComponent(slug)}/access`);
+}
+
+export function unlockSharedFolderLink(slug: string, token: string) {
+  return requestJson<FolderShareUnlockResult>(`/api/share/folders/${encodeURIComponent(slug)}/unlock-link`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ token })
+  });
+}
+
+export function unlockSharedFolderPassword(slug: string, password: string) {
+  return requestJson<FolderShareUnlockResult>(`/api/share/folders/${encodeURIComponent(slug)}/unlock-password`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ password })
+  });
+}
+
+export function fetchSharedFolder(slug: string) {
+  return requestJson<SharedFolderSummary>(`/api/share/folders/${encodeURIComponent(slug)}`);
+}
+
+export function fetchSharedFolderImages(slug: string, page = 1, limit = 24, mediaType?: 'image' | 'video') {
+  const params = new URLSearchParams({
+    page: String(page),
+    limit: String(limit)
+  });
+
+  if (mediaType) {
+    params.set('mediaType', mediaType);
+  }
+
+  return requestJson<SharedFolderImagesPayload>(`/api/share/folders/${encodeURIComponent(slug)}/images?${params.toString()}`);
+}
+
+export function fetchSharedImage(id: number, mediaType?: 'image' | 'video') {
+  const params = new URLSearchParams();
+  if (mediaType) {
+    params.set('mediaType', mediaType);
+  }
+
+  const suffix = params.size > 0 ? `?${params.toString()}` : '';
+  return requestJson<SharedImageDetail>(`/api/share/images/${id}${suffix}`);
 }
 
 export function fetchImage(id: number, mediaType?: 'image' | 'video') {

--- a/client/src/components/FolderGrid.vue
+++ b/client/src/components/FolderGrid.vue
@@ -30,19 +30,21 @@
 import { RouterLink, useRoute } from 'vue-router';
 
 import { useAppStore } from '../stores/app';
-import type { FeedItem } from '../types/api';
+import type { FeedItem, SharedFeedItem } from '../types/api';
 import { formatMediaDuration } from '../utils/media';
 import ResilientImage from './ResilientImage.vue';
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
-    items: FeedItem[];
+    items: Array<FeedItem | SharedFeedItem>;
     variant?: 'square' | 'posts' | 'reels';
     columns?: 'adaptive' | 'three';
+    sharedSlug?: string | null;
   }>(),
   {
     variant: 'square',
-    columns: 'adaptive'
+    columns: 'adaptive',
+    sharedSlug: null
   }
 );
 
@@ -50,6 +52,17 @@ const appStore = useAppStore();
 const route = useRoute();
 
 function buildImageRoute(id: number) {
+  if (props.sharedSlug) {
+    return {
+      name: 'shared-image',
+      params: {
+        slug: props.sharedSlug,
+        id: String(id)
+      },
+      query: route.query
+    };
+  }
+
   return {
     name: 'image',
     params: { id: String(id) },
@@ -63,6 +76,11 @@ function handleImageNavigation(event: MouseEvent, navigate: () => void) {
   }
 
   event.preventDefault();
+  if (props.sharedSlug) {
+    navigate();
+    return;
+  }
+
   appStore.setImageModalBackground(route.fullPath);
   navigate();
 }

--- a/client/src/components/FolderHeader.test.ts
+++ b/client/src/components/FolderHeader.test.ts
@@ -3,6 +3,7 @@ import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { FolderSummary } from '../types/api';
+import { useAuthStore } from '../stores/auth';
 import FolderHeader from './FolderHeader.vue';
 
 vi.mock('vue-router', async () => {
@@ -37,6 +38,76 @@ function createFolder(overrides: Partial<FolderSummary> = {}): FolderSummary {
 describe('FolderHeader', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+  });
+
+  it('shows the share button only to admins', async () => {
+    const adminWrapper = mount(FolderHeader, {
+      props: {
+        folder: createFolder()
+      },
+      global: {
+        stubs: {
+          Avatar: {
+            template: '<div data-test="avatar" />'
+          },
+          FolderProfileModal: {
+            template: '<div data-test="folder-profile-modal" />'
+          },
+          FolderShareModal: {
+            template: '<div data-test="folder-share-modal" />'
+          },
+          RouterLink: {
+            template: '<a><slot /></a>'
+          }
+        }
+      }
+    });
+
+    expect(adminWrapper.find('button[aria-label="Share folder"]').exists()).toBe(true);
+
+    setActivePinia(createPinia());
+    const authStore = useAuthStore();
+    authStore.applyStatus({
+      enabled: true,
+      authenticated: false,
+      role: 'anonymous',
+      accessMode: 'off',
+      likesMode: 'local',
+      defaultLocale: null,
+      capabilities: {
+        canManageLibrary: false,
+        canDeleteMedia: false,
+        canAccessSettings: false,
+        canUseSharedLikes: false,
+        canUseLocalFavorites: true,
+        canUseSharedCollections: false,
+        canUseLocalCollections: true
+      }
+    });
+
+    const viewerWrapper = mount(FolderHeader, {
+      props: {
+        folder: createFolder()
+      },
+      global: {
+        stubs: {
+          Avatar: {
+            template: '<div data-test="avatar" />'
+          },
+          FolderProfileModal: {
+            template: '<div data-test="folder-profile-modal" />'
+          },
+          FolderShareModal: {
+            template: '<div data-test="folder-share-modal" />'
+          },
+          RouterLink: {
+            template: '<a><slot /></a>'
+          }
+        }
+      }
+    });
+
+    expect(viewerWrapper.find('button[aria-label="Share folder"]').exists()).toBe(false);
   });
 
   it('keeps the description expanded during same-folder description edits', async () => {

--- a/client/src/components/FolderHeader.vue
+++ b/client/src/components/FolderHeader.vue
@@ -45,6 +45,16 @@
         >
           {{ t('folder.header.editButton') }}
         </button>
+        <button
+          v-if="authStore.canManageLibrary"
+          type="button"
+          class="inline-flex h-[2.1rem] w-[2.1rem] items-center justify-center rounded-lg border border-border bg-surface-hover text-text transition-colors hover:bg-border"
+          :aria-label="t('folder.header.shareButton')"
+          :title="t('folder.header.shareButton')"
+          @click="openShareModal"
+        >
+          <span class="i-fluent-share-20-regular h-5 w-5" aria-hidden="true" />
+        </button>
       </div>
       <p v-if="folder.breadcrumb" class="m-0 text-[0.84rem] font-medium tracking-[0.02em] text-muted">{{ folder.breadcrumb }}</p>
       <div class="flex items-center gap-[1.6rem] flex-wrap text-[0.95rem] leading-none max-sm:justify-center">
@@ -97,6 +107,11 @@
         @cancel="closeProfileEditor"
         @save="handleSaveProfile"
       />
+      <FolderShareModal
+        v-if="isSharingFolder"
+        :folder="folder"
+        @cancel="closeShareModal"
+      />
     </Teleport>
   </section>
 </template>
@@ -109,6 +124,7 @@ import type { FolderSummary } from '../types/api';
 import { formatFolderTitle } from '../utils/folder-titles';
 import Avatar from './Avatar.vue';
 import FolderProfileModal from './FolderProfileModal.vue';
+import FolderShareModal from './FolderShareModal.vue';
 import { useAppStore } from '../stores/app';
 import { useAuthStore } from '../stores/auth';
 import { useFoldersStore } from '../stores/folders';
@@ -129,6 +145,7 @@ const route = useRoute();
 const { locale, t } = useI18n();
 
 const isEditingProfile = ref(false);
+const isSharingFolder = ref(false);
 const savingProfile = ref(false);
 const profileError = ref<string | null>(null);
 const descriptionElement = ref<HTMLElement | null>(null);
@@ -171,6 +188,14 @@ function openProfileEditor() {
 function closeProfileEditor() {
   profileError.value = null;
   isEditingProfile.value = false;
+}
+
+function openShareModal() {
+  isSharingFolder.value = true;
+}
+
+function closeShareModal() {
+  isSharingFolder.value = false;
 }
 
 function disconnectDescriptionObserver() {

--- a/client/src/components/FolderShareModal.test.ts
+++ b/client/src/components/FolderShareModal.test.ts
@@ -1,0 +1,126 @@
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { FolderSummary } from '../types/api';
+import FolderShareModal from './FolderShareModal.vue';
+
+function createFolder(overrides: Partial<FolderSummary> = {}): FolderSummary {
+  return {
+    id: 1,
+    slug: 'travel-2024',
+    name: 'Travel 2024',
+    description: 'Vacation photos.',
+    folderPath: 'travel-2024',
+    breadcrumb: 'Travel 2024',
+    imageCount: 10,
+    videoCount: 2,
+    latestImageMtimeMs: Date.now(),
+    avatarImageId: null,
+    avatarUrl: null,
+    ...overrides
+  };
+}
+
+describe('FolderShareModal', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('renders modal in protected mode with link and password controls', () => {
+    const wrapper = mount(FolderShareModal, {
+      props: {
+        folder: createFolder()
+      }
+    });
+
+    expect(wrapper.text()).toContain('Share Folder');
+    expect(wrapper.text()).toContain('Share links and password access work independently');
+    expect(wrapper.text()).toContain('Share links');
+    expect(wrapper.text()).toContain('Password access');
+    expect(wrapper.text()).toContain('does not add password protection to share links');
+  });
+
+  it('summarizes simultaneous link and password access', async () => {
+    const { useFoldersStore } = await import('../stores/folders');
+    const foldersStore = useFoldersStore();
+    foldersStore.shareLinks = [
+      {
+        id: 7,
+        folderId: 1,
+        tokenPrefix: 'abcdefgh',
+        expiresAt: null,
+        revokedAt: null,
+        createdAt: new Date().toISOString(),
+        lastUsedAt: null,
+        status: 'active'
+      }
+    ];
+    foldersStore.sharePassword = { enabled: true, updatedAt: new Date().toISOString() };
+    foldersStore.loadShareLinks = vi.fn().mockResolvedValue(undefined);
+
+    const wrapper = mount(FolderShareModal, {
+      props: {
+        folder: createFolder()
+      }
+    });
+
+    expect(wrapper.text()).toContain('Active share links: 1. Password access: enabled.');
+    expect(wrapper.text()).toContain('Copy Folder Address');
+  });
+
+  it('renders public mode information when global public access is enabled', async () => {
+    const { useFoldersStore } = await import('../stores/folders');
+    const foldersStore = useFoldersStore();
+    foldersStore.shareLinks = [];
+    foldersStore.sharePassword = { enabled: false, updatedAt: null };
+    foldersStore.sharePublicFolderUrl = '/folders/travel-2024';
+    foldersStore.sharePublicAccess = true;
+
+    const wrapper = mount(FolderShareModal, {
+      props: {
+        folder: createFolder()
+      }
+    });
+
+    expect(wrapper.text()).toContain('Public folder URL');
+    expect((wrapper.find('input.share-url-input').element as HTMLInputElement).value).toContain('/folders/travel-2024');
+  });
+
+  it('copies share link to clipboard when copy button is clicked', async () => {
+    const { vi } = await import('vitest');
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: writeTextMock },
+      configurable: true
+    });
+
+    const { useFoldersStore } = await import('../stores/folders');
+    const foldersStore = useFoldersStore();
+    foldersStore.shareLinks = [];
+    foldersStore.sharePassword = { enabled: false, updatedAt: null };
+    foldersStore.sharePublicAccess = false;
+    foldersStore.loadShareLinks = vi.fn().mockResolvedValue(undefined);
+    foldersStore.lastCreatedShareUrl = '/share/travel-2024#token=test-token';
+
+    const wrapper = mount(FolderShareModal, {
+      props: {
+        folder: createFolder()
+      }
+    });
+
+    const expectedShareUrl = new URL('/share/travel-2024#token=test-token', window.location.origin).toString();
+    const createdLinkInput = wrapper
+      .findAll('input.share-url-input')
+      .find((input) => (input.element as HTMLInputElement).value === expectedShareUrl);
+    expect(createdLinkInput).toBeDefined();
+
+    const copyButton = wrapper
+      .findAll('button.share-icon-button')
+      .find((button) => createdLinkInput!.element.parentElement?.contains(button.element));
+    expect(copyButton).toBeDefined();
+
+    await copyButton!.trigger('click');
+    expect(writeTextMock).toHaveBeenCalledWith(expectedShareUrl);
+  });
+});

--- a/client/src/components/FolderShareModal.vue
+++ b/client/src/components/FolderShareModal.vue
@@ -1,0 +1,469 @@
+<template>
+  <div class="fixed inset-0 z-60 flex items-center justify-center bg-black/60 backdrop-blur-xs p-4 sm:p-6" @click.self="$emit('cancel')">
+    <section
+      class="flex flex-col w-[min(100%,48rem)] max-h-[min(44rem,calc(100dvh-2rem))] rounded-[1.25rem] border border-border bg-surface text-text shadow-[var(--shadow)] overflow-hidden"
+      role="dialog"
+      aria-modal="true"
+      :aria-labelledby="titleId"
+    >
+      <header class="flex items-center justify-between gap-4 border-b border-border/80 bg-surface/95 backdrop-blur-md px-5 py-4 sm:px-6">
+        <div class="grid gap-[0.15rem]">
+          <h2 :id="titleId" class="m-0 text-[1.15rem] sm:text-[1.25rem] font-bold tracking-[-0.02em] text-text">{{ t('folder.shareModal.title') }}</h2>
+          <p class="m-0 text-[0.84rem] text-muted truncate max-w-sm sm:max-w-md">{{ folder.name }}</p>
+        </div>
+        <button
+          class="inline-flex h-8.5 w-8.5 items-center justify-center rounded-full border border-border/80 bg-surface-alt/60 text-muted transition-all hover:bg-surface-hover hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text/30 cursor-pointer"
+          type="button"
+          :aria-label="t('common.close')"
+          @click="$emit('cancel')"
+        >
+          <span class="i-fluent-dismiss-20-regular h-5 w-5" aria-hidden="true" />
+        </button>
+      </header>
+
+      <div class="flex-1 overflow-y-auto p-5 sm:p-6 grid gap-5 min-h-0">
+        <p
+          v-if="foldersStore.shareError || localError"
+          class="m-0 rounded-[0.85rem] border border-rose-500/30 bg-rose-500/10 dark:bg-rose-500/15 px-4 py-3 text-[0.88rem] text-rose-700 dark:text-rose-300 font-medium"
+        >
+          {{ localError ?? foldersStore.shareError }}
+        </p>
+
+        <p
+          v-if="localNotice"
+          class="m-0 rounded-[0.85rem] border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-[0.88rem] font-medium text-emerald-800 dark:bg-emerald-500/15 dark:text-emerald-300"
+          role="status"
+        >
+          {{ localNotice }}
+        </p>
+
+        <section class="grid gap-1 rounded-[1rem] border border-accent/25 bg-accent-soft/50 p-4 sm:p-4.5">
+          <div class="flex items-center gap-2 text-text">
+            <span class="i-fluent-shield-keyhole-20-regular h-5 w-5 text-accent-strong" aria-hidden="true" />
+            <h3 class="m-0 text-[0.92rem] font-semibold">{{ t('folder.shareModal.accessSummaryTitle') }}</h3>
+          </div>
+          <p class="m-0 text-[0.84rem] leading-relaxed text-muted">{{ accessSummary }}</p>
+          <p class="m-0 text-[0.78rem] leading-relaxed text-muted">{{ t('folder.shareModal.independentMethods') }}</p>
+        </section>
+
+        <section v-if="foldersStore.sharePublicAccess" class="grid gap-[0.75rem] rounded-[1rem] border border-border/70 bg-surface-alt/50 p-4 sm:p-4.5">
+          <div class="flex items-center justify-between gap-3">
+            <h3 class="m-0 text-[0.92rem] sm:text-[0.95rem] font-semibold text-text">{{ t('folder.shareModal.publicUrl') }}</h3>
+            <button class="share-icon-button cursor-pointer" type="button" :title="t('common.copy')" @click="copyText(publicFolderUrl)">
+              <span class="i-fluent-copy-20-regular h-4.5 w-4.5" aria-hidden="true" />
+            </button>
+          </div>
+          <input class="share-url-input" type="text" :value="publicFolderUrl" readonly />
+        </section>
+
+        <section class="grid gap-[1rem] rounded-[1rem] border border-border/70 bg-surface-alt/50 p-4 sm:p-4.5">
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <div class="grid max-w-[34rem] gap-1">
+              <h3 class="m-0 text-[0.92rem] sm:text-[0.95rem] font-semibold text-text">{{ t('folder.shareModal.linkSection') }}</h3>
+              <p class="m-0 text-[0.8rem] leading-relaxed text-muted">{{ t('folder.shareModal.linkDescription') }}</p>
+            </div>
+            <span class="rounded-full border border-border/60 bg-surface-hover px-2.5 py-0.5 text-[0.74rem] font-semibold text-muted">
+              {{ activeLinkCountLabel }}
+            </span>
+          </div>
+
+          <div class="grid gap-[0.75rem]">
+            <div class="flex flex-wrap items-center gap-2.5 sm:gap-3">
+              <div class="flex flex-wrap items-center gap-2" role="group" :aria-label="t('folder.shareModal.expiration')">
+                <button
+                  v-for="preset in expirationPresets"
+                  :key="preset.value"
+                  class="min-h-9 rounded-[0.75rem] border px-3.5 text-[0.82rem] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text/30 cursor-pointer"
+                  :class="selectedPreset === preset.value ? 'border-text bg-text text-bg font-semibold shadow-xs' : 'border-border/80 bg-surface text-text hover:bg-surface-hover font-medium'"
+                  type="button"
+                  @click="selectedPreset = preset.value"
+                >
+                  {{ preset.label }}
+                </button>
+              </div>
+
+              <button
+                class="inline-flex min-h-9 items-center justify-center gap-2 rounded-[0.75rem] border border-transparent bg-text px-4 text-[0.85rem] font-semibold text-bg transition-all hover:opacity-90 active:scale-[0.98] disabled:cursor-wait disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text/30 cursor-pointer sm:ml-2.5"
+                type="button"
+                :disabled="foldersStore.loadingShare"
+                @click="createLink"
+              >
+                <span class="i-fluent-link-add-20-regular h-4.5 w-4.5" aria-hidden="true" />
+                {{ foldersStore.loadingShare ? t('folder.shareModal.creating') : t('folder.shareModal.createLink') }}
+              </button>
+            </div>
+
+            <label v-if="selectedPreset === 'custom'" class="grid gap-[0.35rem] text-[0.85rem] font-semibold text-text max-w-xs">
+              {{ t('folder.shareModal.customExpiration') }}
+              <input v-model="customExpiresAtLocal" class="share-url-input" type="datetime-local" />
+            </label>
+          </div>
+
+          <div v-if="createdShareUrl" class="grid gap-[0.55rem] rounded-[0.85rem] border border-emerald-500/30 bg-emerald-500/10 dark:bg-emerald-500/15 p-3.5">
+            <div class="flex items-center justify-between gap-3">
+              <strong class="text-[0.84rem] text-emerald-800 dark:text-emerald-300 font-semibold">{{ t('folder.shareModal.createdLink') }}</strong>
+              <button class="share-icon-button share-icon-button--emerald cursor-pointer" type="button" :title="t('common.copy')" @click="copyText(createdShareUrl)">
+                <span class="i-fluent-copy-20-regular h-4.5 w-4.5" aria-hidden="true" />
+              </button>
+            </div>
+            <input class="share-url-input share-url-input--emerald" type="text" :value="createdShareUrl" readonly />
+          </div>
+
+          <div class="grid gap-[0.55rem]">
+            <article
+              v-for="link in foldersStore.shareLinks"
+              :key="link.id"
+              class="grid gap-3 rounded-[0.85rem] border border-border/80 bg-surface p-3.5 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center shadow-xs"
+            >
+              <div class="grid gap-[0.2rem]">
+                <div class="flex flex-wrap items-center gap-2">
+                  <span class="text-[0.88rem] font-semibold text-text">{{ formatExpiration(link.expiresAt) }}</span>
+                  <span class="rounded-full border px-2.5 py-[0.18rem] text-[0.7rem] font-bold uppercase tracking-wider" :class="statusClass(link.status)">
+                    {{ t(`folder.shareModal.status.${link.status}`) }}
+                  </span>
+                </div>
+                <p class="m-0 text-[0.78rem] text-muted">
+                  {{ t('folder.shareModal.linkMeta', { prefix: link.tokenPrefix ?? 'unknown', date: formatDate(link.createdAt) }) }}
+                </p>
+              </div>
+              <button
+                class="inline-flex min-h-9 items-center justify-center gap-1.5 rounded-[0.7rem] border border-rose-500/25 bg-surface px-3 text-[0.82rem] font-semibold text-rose-600 dark:text-rose-400 transition-all hover:bg-rose-500/10 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-45 disabled:transform-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500/30 cursor-pointer"
+                type="button"
+                :disabled="link.status === 'revoked' || foldersStore.loadingShare"
+                @click="revokeLink(link.id)"
+              >
+                <span class="i-fluent-prohibited-20-regular h-4.5 w-4.5" aria-hidden="true" />
+                {{ t('folder.shareModal.revoke') }}
+              </button>
+            </article>
+            <p v-if="!foldersStore.loadingShare && foldersStore.shareLinks.length === 0" class="m-0 py-1 text-[0.86rem] text-muted text-center">
+              {{ t('folder.shareModal.noLinks') }}
+            </p>
+          </div>
+        </section>
+
+        <section class="grid gap-[0.9rem] rounded-[1rem] border border-border/70 bg-surface-alt/50 p-4 sm:p-4.5">
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <div class="grid max-w-[34rem] gap-1">
+              <h3 class="m-0 text-[0.92rem] sm:text-[0.95rem] font-semibold text-text">{{ t('folder.shareModal.passwordSection') }}</h3>
+              <p class="m-0 text-[0.8rem] leading-relaxed text-muted">{{ t('folder.shareModal.passwordDescription') }}</p>
+            </div>
+            <span class="rounded-full border border-border/60 bg-surface-hover px-2.5 py-0.5 text-[0.74rem] font-semibold text-muted">
+              {{ foldersStore.sharePassword.enabled ? t('folder.shareModal.passwordEnabled') : t('folder.shareModal.passwordOff') }}
+            </span>
+          </div>
+
+          <div class="grid gap-[0.6rem] sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
+            <label class="grid gap-[0.35rem] text-[0.85rem] font-semibold text-text">
+              {{ t('folder.shareModal.passwordLabel') }}
+              <input
+                v-model="password"
+                class="share-url-input"
+                type="password"
+                autocomplete="new-password"
+                maxlength="256"
+                :placeholder="t('folder.shareModal.passwordPlaceholder')"
+              />
+            </label>
+            <button
+              class="inline-flex min-h-10 items-center justify-center gap-2 rounded-[0.75rem] border border-transparent bg-text px-4.5 text-[0.88rem] font-semibold text-bg transition-all hover:opacity-90 active:scale-[0.98] disabled:cursor-wait disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text/30 cursor-pointer"
+              type="button"
+              :disabled="foldersStore.loadingShare"
+              @click="savePassword"
+            >
+              <span class="i-fluent-key-20-regular h-5 w-5" aria-hidden="true" />
+              {{ foldersStore.sharePassword.enabled ? t('folder.shareModal.changePassword') : t('folder.shareModal.setPassword') }}
+            </button>
+          </div>
+
+          <div class="flex flex-wrap gap-2 pt-1">
+            <button
+              class="inline-flex min-h-9 items-center justify-center gap-1.5 rounded-[0.7rem] border border-border/80 bg-surface px-3 text-[0.82rem] font-semibold text-text transition-all hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text/30 cursor-pointer"
+              type="button"
+              @click="copyText(passwordShareUrl)"
+            >
+              <span class="i-fluent-copy-20-regular h-4.5 w-4.5" aria-hidden="true" />
+              {{ t('folder.shareModal.copyPasswordUrl') }}
+            </button>
+            <button
+              v-if="foldersStore.sharePassword.enabled"
+              class="inline-flex min-h-9 items-center justify-center gap-1.5 rounded-[0.7rem] border border-rose-500/25 bg-surface px-3 text-[0.82rem] font-semibold text-rose-600 dark:text-rose-400 transition-all hover:bg-rose-500/10 disabled:cursor-wait disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500/30 cursor-pointer"
+              type="button"
+              :disabled="foldersStore.loadingShare"
+              @click="removePassword"
+            >
+              <span class="i-fluent-delete-20-regular h-4.5 w-4.5" aria-hidden="true" />
+              {{ t('folder.shareModal.removePassword') }}
+            </button>
+          </div>
+          <p class="m-0 text-[0.78rem] leading-relaxed text-muted">{{ t('folder.shareModal.passwordSharingHint') }}</p>
+        </section>
+      </div>
+
+      <footer class="flex justify-end border-t border-border/80 bg-surface/95 backdrop-blur-md px-5 py-3.5 sm:px-6">
+        <button class="min-h-9.5 rounded-[0.75rem] border border-border/80 bg-surface-alt/60 px-4.5 text-[0.88rem] font-semibold text-text transition-all hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text/30 cursor-pointer" type="button" @click="$emit('cancel')">
+          {{ t('common.close') }}
+        </button>
+      </footer>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { useFoldersStore } from '../stores/folders';
+import type { FolderShareExpirationPreset, FolderShareLinkStatus, FolderSummary } from '../types/api';
+
+const props = defineProps<{
+  folder: FolderSummary;
+}>();
+
+defineEmits<{
+  cancel: [];
+}>();
+
+const foldersStore = useFoldersStore();
+const { locale, t } = useI18n();
+const titleId = `folder-share-dialog-title-${Math.random().toString(36).slice(2, 10)}`;
+const selectedPreset = ref<FolderShareExpirationPreset>('24h');
+const customExpiresAtLocal = ref('');
+const password = ref('');
+const localError = ref<string | null>(null);
+const localNotice = ref<string | null>(null);
+
+const expirationPresets: Array<{ label: string; value: FolderShareExpirationPreset }> = [
+  { label: t('folder.shareModal.presets.oneHour'), value: '1h' },
+  { label: t('folder.shareModal.presets.day'), value: '24h' },
+  { label: t('folder.shareModal.presets.week'), value: '7d' },
+  { label: t('folder.shareModal.presets.custom'), value: 'custom' },
+  { label: t('folder.shareModal.presets.unlimited'), value: 'unlimited' }
+];
+
+const activeLinkCount = computed(() => foldersStore.shareLinks.filter((link) => link.status === 'active').length);
+const activeLinkCountLabel = computed(() =>
+  t('folder.shareModal.activeLinks', {
+    count: activeLinkCount.value
+  })
+);
+const accessSummary = computed(() => {
+  if (activeLinkCount.value > 0 && foldersStore.sharePassword.enabled) {
+    return t('folder.shareModal.accessSummaryBoth', { count: activeLinkCount.value });
+  }
+
+  if (activeLinkCount.value > 0) {
+    return t('folder.shareModal.accessSummaryLinks', { count: activeLinkCount.value });
+  }
+
+  if (foldersStore.sharePassword.enabled) {
+    return t('folder.shareModal.accessSummaryPassword');
+  }
+
+  return t('folder.shareModal.accessSummaryNone');
+});
+const createdShareUrl = computed(() => (foldersStore.lastCreatedShareUrl ? toAbsoluteUrl(foldersStore.lastCreatedShareUrl) : null));
+const publicFolderUrl = computed(() => toAbsoluteUrl(foldersStore.sharePublicFolderUrl ?? `/folders/${props.folder.slug}`));
+const passwordShareUrl = computed(() => toAbsoluteUrl(`/share/${encodeURIComponent(props.folder.slug)}`));
+
+function toAbsoluteUrl(url: string): string {
+  if (typeof window === 'undefined') {
+    return url;
+  }
+
+  return new URL(url, window.location.origin).toString();
+}
+
+function formatDate(value: string | null): string {
+  if (!value) {
+    return t('settings.status.never');
+  }
+
+  return new Intl.DateTimeFormat(locale.value, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(new Date(value));
+}
+
+function formatExpiration(value: string | null): string {
+  return value ? t('folder.shareModal.expiresAt', { date: formatDate(value) }) : t('folder.shareModal.neverExpires');
+}
+
+function statusClass(status: FolderShareLinkStatus) {
+  if (status === 'active') {
+    return 'bg-emerald-500/12 text-emerald-700 dark:text-emerald-300 border-emerald-500/25';
+  }
+
+  if (status === 'expired') {
+    return 'bg-amber-500/12 text-amber-700 dark:text-amber-300 border-amber-500/25';
+  }
+
+  return 'bg-rose-500/12 text-rose-700 dark:text-rose-300 border-rose-500/25';
+}
+
+async function copyText(value: string | null) {
+  if (!value) {
+    return;
+  }
+
+  try {
+    await navigator.clipboard.writeText(value);
+    localError.value = null;
+  } catch {
+    const textArea = document.createElement('textarea');
+    textArea.value = value;
+    textArea.style.position = 'fixed';
+    textArea.style.opacity = '0';
+    document.body.append(textArea);
+    textArea.select();
+    document.execCommand('copy');
+    textArea.remove();
+  }
+}
+
+async function createLink() {
+  localError.value = null;
+  localNotice.value = null;
+
+  try {
+    await foldersStore.createShareLink(props.folder.slug, {
+      expiresIn: selectedPreset.value,
+      unlimited: selectedPreset.value === 'unlimited',
+      customExpiresAt: selectedPreset.value === 'custom' ? new Date(customExpiresAtLocal.value).toISOString() : null
+    });
+    localNotice.value = t('folder.shareModal.notices.linkCreated');
+  } catch (error) {
+    localError.value = error instanceof Error ? error.message : t('folder.shareModal.errors.createLink');
+  }
+}
+
+async function savePassword() {
+  localError.value = null;
+  localNotice.value = null;
+
+  try {
+    await foldersStore.setSharePassword(props.folder.slug, password.value);
+    password.value = '';
+    localNotice.value = t(
+      activeLinkCount.value > 0
+        ? 'folder.shareModal.notices.passwordEnabledWithLinks'
+        : 'folder.shareModal.notices.passwordEnabled'
+    );
+  } catch (error) {
+    localError.value = error instanceof Error ? error.message : t('folder.shareModal.errors.savePassword');
+  }
+}
+
+async function revokeLink(linkId: number) {
+  localError.value = null;
+  localNotice.value = null;
+
+  try {
+    await foldersStore.revokeShareLink(props.folder.slug, linkId);
+    localNotice.value = t(
+      foldersStore.sharePassword.enabled
+        ? 'folder.shareModal.notices.linkRevokedWithPassword'
+        : 'folder.shareModal.notices.linkRevoked'
+    );
+  } catch (error) {
+    localError.value = error instanceof Error ? error.message : t('folder.shareModal.errors.revokeLink');
+  }
+}
+
+async function removePassword() {
+  localError.value = null;
+  localNotice.value = null;
+
+  try {
+    await foldersStore.removeSharePassword(props.folder.slug);
+    localNotice.value = t(
+      activeLinkCount.value > 0
+        ? 'folder.shareModal.notices.passwordRemovedWithLinks'
+        : 'folder.shareModal.notices.passwordRemoved'
+    );
+  } catch (error) {
+    localError.value = error instanceof Error ? error.message : t('folder.shareModal.errors.removePassword');
+  }
+}
+
+async function loadShareState() {
+  try {
+    await foldersStore.loadShareLinks(props.folder.slug);
+  } catch {
+    // The store-owned error is rendered in the dialog.
+  }
+}
+
+onMounted(loadShareState);
+
+watch(
+  () => props.folder.slug,
+  async () => {
+    password.value = '';
+    localError.value = null;
+    localNotice.value = null;
+    await loadShareState();
+  }
+);
+</script>
+
+<style scoped>
+.share-url-input {
+  width: 100%;
+  min-height: 2.5rem;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.88rem;
+  padding: 0.58rem 0.75rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  color-scheme: light dark;
+}
+
+.share-url-input:focus-visible,
+.share-url-input:focus {
+  outline: none;
+  border-color: var(--text);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--text) 18%, transparent);
+}
+
+.share-url-input--emerald {
+  background: color-mix(in srgb, var(--surface) 90%, #10b981 10%);
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
+.share-icon-button {
+  display: inline-flex;
+  width: 2.25rem;
+  height: 2.25rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.12s ease;
+}
+
+.share-icon-button:hover {
+  background: var(--surface-hover);
+  transform: translateY(-1px);
+}
+
+.share-icon-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--text) 24%, transparent);
+}
+
+.share-icon-button--emerald {
+  background: color-mix(in srgb, var(--surface) 90%, #10b981 10%);
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
+.share-icon-button--emerald:hover {
+  background: color-mix(in srgb, var(--surface-hover) 85%, #10b981 15%);
+}
+</style>

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -2,6 +2,7 @@
   "common": {
     "cancel": "Cancel",
     "close": "Close",
+    "copy": "Copy",
     "description": "Description",
     "loadMore": "Load more",
     "loadingMore": "Loading more...",
@@ -673,6 +674,7 @@
       "openStories": "Open folder stories",
       "openAvatar": "Open folder avatar",
       "editButton": "Edit App Folder",
+      "shareButton": "Share folder",
       "posts": "{count} posts",
       "reels": "{count} reels",
       "updated": "{date} updated",
@@ -691,11 +693,89 @@
         "nameRequired": "Name is required."
       }
     },
+    "shareModal": {
+      "title": "Share Folder",
+      "publicUrl": "Public folder URL",
+      "accessSummaryTitle": "Current access",
+      "accessSummaryBoth": "Active share links: {count}. Password access: enabled.",
+      "accessSummaryLinks": "Active share links: {count}. Password access: off.",
+      "accessSummaryPassword": "Active share links: 0. Password access: enabled.",
+      "accessSummaryNone": "Active share links: 0. Password access: off.",
+      "independentMethods": "Share links and password access work independently. You can enable one or both.",
+      "linkSection": "Share links",
+      "linkDescription": "Anyone with an active link can open this folder without a password. Each link expires or can be revoked independently.",
+      "activeLinks": "{count} active",
+      "expiration": "Share link expiration",
+      "customExpiration": "Custom expiration",
+      "createLink": "Create Link",
+      "creating": "Creating...",
+      "createdLink": "Copy this link now",
+      "revoke": "Revoke",
+      "noLinks": "No share links yet.",
+      "passwordSection": "Password access",
+      "passwordDescription": "Anyone with the folder address and password can open it. This does not add password protection to share links.",
+      "passwordEnabled": "Enabled",
+      "passwordOff": "Off",
+      "passwordLabel": "Password",
+      "passwordPlaceholder": "Minimum 8 characters",
+      "setPassword": "Set Password",
+      "changePassword": "Change Password",
+      "removePassword": "Remove Password",
+      "copyPasswordUrl": "Copy Folder Address",
+      "passwordSharingHint": "Send the folder address and password separately.",
+      "neverExpires": "Never expires",
+      "expiresAt": "Expires {date}",
+      "linkMeta": "Token prefix {prefix}. Created {date}.",
+      "presets": {
+        "oneHour": "1 hour",
+        "day": "24 hours",
+        "week": "7 days",
+        "custom": "Custom",
+        "unlimited": "No expiry"
+      },
+      "status": {
+        "active": "Active",
+        "expired": "Expired",
+        "revoked": "Revoked"
+      },
+      "notices": {
+        "linkCreated": "Share link created. It opens without a password until it expires or is revoked.",
+        "linkRevoked": "Share link revoked.",
+        "linkRevokedWithPassword": "Share link revoked. Password access remains enabled.",
+        "passwordEnabled": "Password access enabled.",
+        "passwordEnabledWithLinks": "Password access enabled. Existing share links still work without a password.",
+        "passwordRemoved": "Password access removed.",
+        "passwordRemovedWithLinks": "Password access removed. Active share links still work."
+      },
+      "errors": {
+        "createLink": "Unable to create share link.",
+        "savePassword": "Unable to save folder password.",
+        "revokeLink": "Unable to revoke share link.",
+        "removePassword": "Unable to remove password access."
+      }
+    },
     "tabs": {
       "posts": "Posts",
       "reels": "Reels",
       "sections": "Folder sections"
     }
+  },
+  "share": {
+    "loadingEyebrow": "Folder Share",
+    "loadingTitle": "Opening shared folder",
+    "passwordEyebrow": "Folder Share",
+    "passwordTitle": "Enter folder password",
+    "passwordDescription": "Enter the reusable folder password to continue.",
+    "passwordFallbackDescription": "This share link is no longer available. If you know the folder password, you can still access this folder.",
+    "passwordLabel": "Password",
+    "unlocking": "Unlocking...",
+    "unlock": "Unlock Folder",
+    "expiredTitle": "This share link is not available",
+    "expiredDescription": "The link may be expired, revoked, or missing its token.",
+    "errorTitle": "Could not open folder share",
+    "errorDescription": "Unable to load this folder share.",
+    "backToFolder": "Back to shared folder",
+    "postErrorTitle": "Could not load shared post"
   },
   "reels": {
     "view": {

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -2,6 +2,7 @@
   "common": {
     "cancel": "Cancelar",
     "close": "Cerrar",
+    "copy": "Copiar",
     "description": "Descripción",
     "loadMore": "Cargar más",
     "loadingMore": "Cargando más...",
@@ -673,6 +674,7 @@
       "openStories": "Abrir stories de la carpeta",
       "openAvatar": "Abrir avatar de la carpeta",
       "editButton": "Editar carpeta de la app",
+      "shareButton": "Compartir carpeta",
       "posts": "{count} publicaciones",
       "reels": "{count} reels",
       "updated": "{date} actualizado",
@@ -691,11 +693,89 @@
         "nameRequired": "El nombre es obligatorio."
       }
     },
+    "shareModal": {
+      "title": "Compartir carpeta",
+      "publicUrl": "URL pública de la carpeta",
+      "accessSummaryTitle": "Acceso actual",
+      "accessSummaryBoth": "Enlaces activos: {count}. Acceso con contraseña: habilitado.",
+      "accessSummaryLinks": "Enlaces activos: {count}. Acceso con contraseña: desactivado.",
+      "accessSummaryPassword": "Enlaces activos: 0. Acceso con contraseña: habilitado.",
+      "accessSummaryNone": "Enlaces activos: 0. Acceso con contraseña: desactivado.",
+      "independentMethods": "Los enlaces y el acceso con contraseña funcionan de forma independiente. Puedes habilitar uno o ambos.",
+      "linkSection": "Enlaces compartidos",
+      "linkDescription": "Cualquiera que tenga un enlace activo puede abrir esta carpeta sin contraseña. Cada enlace caduca o puede revocarse de forma independiente.",
+      "activeLinks": "{count} activos",
+      "expiration": "Caducidad del enlace",
+      "customExpiration": "Caducidad personalizada",
+      "createLink": "Crear enlace",
+      "creating": "Creando...",
+      "createdLink": "Copia este enlace ahora",
+      "revoke": "Revocar",
+      "noLinks": "Todavía no hay enlaces compartidos.",
+      "passwordSection": "Acceso con contraseña",
+      "passwordDescription": "Cualquiera que tenga la dirección de la carpeta y la contraseña puede abrirla. Esto no protege los enlaces compartidos con contraseña.",
+      "passwordEnabled": "Activada",
+      "passwordOff": "Desactivada",
+      "passwordLabel": "Contraseña",
+      "passwordPlaceholder": "Mínimo 8 caracteres",
+      "setPassword": "Establecer contraseña",
+      "changePassword": "Cambiar contraseña",
+      "removePassword": "Quitar contraseña",
+      "copyPasswordUrl": "Copiar dirección de la carpeta",
+      "passwordSharingHint": "Envía la dirección de la carpeta y la contraseña por separado.",
+      "neverExpires": "No caduca",
+      "expiresAt": "Caduca {date}",
+      "linkMeta": "Prefijo del token {prefix}. Creado {date}.",
+      "presets": {
+        "oneHour": "1 hora",
+        "day": "24 horas",
+        "week": "7 días",
+        "custom": "Personalizada",
+        "unlimited": "Sin caducidad"
+      },
+      "status": {
+        "active": "Activo",
+        "expired": "Caducado",
+        "revoked": "Revocado"
+      },
+      "notices": {
+        "linkCreated": "Enlace creado. Se abre sin contraseña hasta que caduque o sea revocado.",
+        "linkRevoked": "Enlace compartido revocado.",
+        "linkRevokedWithPassword": "Enlace compartido revocado. El acceso con contraseña sigue habilitado.",
+        "passwordEnabled": "Acceso con contraseña habilitado.",
+        "passwordEnabledWithLinks": "Acceso con contraseña habilitado. Los enlaces existentes siguen funcionando sin contraseña.",
+        "passwordRemoved": "Acceso con contraseña eliminado.",
+        "passwordRemovedWithLinks": "Acceso con contraseña eliminado. Los enlaces activos siguen funcionando."
+      },
+      "errors": {
+        "createLink": "No se pudo crear el enlace.",
+        "savePassword": "No se pudo guardar la contraseña de la carpeta.",
+        "revokeLink": "No se pudo revocar el enlace compartido.",
+        "removePassword": "No se pudo eliminar el acceso con contraseña."
+      }
+    },
     "tabs": {
       "posts": "Publicaciones",
       "reels": "Reels",
       "sections": "Secciones de carpeta"
     }
+  },
+  "share": {
+    "loadingEyebrow": "Carpeta compartida",
+    "loadingTitle": "Abriendo carpeta compartida",
+    "passwordEyebrow": "Carpeta compartida",
+    "passwordTitle": "Introduce la contraseña de la carpeta",
+    "passwordDescription": "Introduce la contraseña reutilizable de la carpeta para continuar.",
+    "passwordFallbackDescription": "Este enlace compartido ya no está disponible. Si conoces la contraseña de la carpeta, todavía puedes acceder a ella.",
+    "passwordLabel": "Contraseña",
+    "unlocking": "Desbloqueando...",
+    "unlock": "Desbloquear carpeta",
+    "expiredTitle": "Este enlace compartido no está disponible",
+    "expiredDescription": "El enlace puede estar caducado, revocado o sin token.",
+    "errorTitle": "No se pudo abrir la carpeta compartida",
+    "errorDescription": "No se pudo cargar esta carpeta compartida.",
+    "backToFolder": "Volver a la carpeta compartida",
+    "postErrorTitle": "No se pudo cargar la publicación compartida"
   },
   "reels": {
     "view": {

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -2,6 +2,7 @@
   "common": {
     "cancel": "取消",
     "close": "关闭",
+    "copy": "复制",
     "description": "描述",
     "loadMore": "加载更多",
     "loadingMore": "正在加载更多...",
@@ -673,6 +674,7 @@
       "openStories": "打开文件夹 stories",
       "openAvatar": "打开文件夹头像",
       "editButton": "编辑应用文件夹",
+      "shareButton": "共享文件夹",
       "posts": "{count} 个帖子",
       "reels": "{count} 条短片",
       "updated": "{date} 已更新",
@@ -691,11 +693,89 @@
         "nameRequired": "名称为必填项。"
       }
     },
+    "shareModal": {
+      "title": "共享文件夹",
+      "publicUrl": "公开文件夹 URL",
+      "accessSummaryTitle": "当前访问方式",
+      "accessSummaryBoth": "有效共享链接：{count}。密码访问：已启用。",
+      "accessSummaryLinks": "有效共享链接：{count}。密码访问：已关闭。",
+      "accessSummaryPassword": "有效共享链接：0。密码访问：已启用。",
+      "accessSummaryNone": "有效共享链接：0。密码访问：已关闭。",
+      "independentMethods": "共享链接和密码访问彼此独立。你可以启用其中一种或同时启用两种。",
+      "linkSection": "共享链接",
+      "linkDescription": "任何拥有有效链接的人无需密码即可打开此文件夹。每个链接会独立过期，也可单独撤销。",
+      "activeLinks": "{count} 个有效",
+      "expiration": "共享链接过期时间",
+      "customExpiration": "自定义过期时间",
+      "createLink": "创建链接",
+      "creating": "正在创建...",
+      "createdLink": "现在复制此链接",
+      "revoke": "撤销",
+      "noLinks": "还没有共享链接。",
+      "passwordSection": "密码访问",
+      "passwordDescription": "任何拥有文件夹地址和密码的人都可以打开它。这不会为共享链接添加密码保护。",
+      "passwordEnabled": "已启用",
+      "passwordOff": "已关闭",
+      "passwordLabel": "密码",
+      "passwordPlaceholder": "至少 8 个字符",
+      "setPassword": "设置密码",
+      "changePassword": "更改密码",
+      "removePassword": "移除密码",
+      "copyPasswordUrl": "复制文件夹地址",
+      "passwordSharingHint": "请分别发送文件夹地址和密码。",
+      "neverExpires": "永不过期",
+      "expiresAt": "{date} 过期",
+      "linkMeta": "令牌前缀 {prefix}。创建于 {date}。",
+      "presets": {
+        "oneHour": "1 小时",
+        "day": "24 小时",
+        "week": "7 天",
+        "custom": "自定义",
+        "unlimited": "不过期"
+      },
+      "status": {
+        "active": "有效",
+        "expired": "已过期",
+        "revoked": "已撤销"
+      },
+      "notices": {
+        "linkCreated": "共享链接已创建。在过期或撤销之前，该链接无需密码即可打开。",
+        "linkRevoked": "共享链接已撤销。",
+        "linkRevokedWithPassword": "共享链接已撤销。密码访问仍然启用。",
+        "passwordEnabled": "密码访问已启用。",
+        "passwordEnabledWithLinks": "密码访问已启用。现有共享链接仍无需密码即可使用。",
+        "passwordRemoved": "密码访问已移除。",
+        "passwordRemovedWithLinks": "密码访问已移除。有效共享链接仍可使用。"
+      },
+      "errors": {
+        "createLink": "无法创建共享链接。",
+        "savePassword": "无法保存文件夹密码。",
+        "revokeLink": "无法撤销共享链接。",
+        "removePassword": "无法移除密码访问。"
+      }
+    },
     "tabs": {
       "posts": "帖子",
       "reels": "短片",
       "sections": "文件夹分区"
     }
+  },
+  "share": {
+    "loadingEyebrow": "文件夹共享",
+    "loadingTitle": "正在打开共享文件夹",
+    "passwordEyebrow": "文件夹共享",
+    "passwordTitle": "输入文件夹密码",
+    "passwordDescription": "输入可重复使用的文件夹密码以继续。",
+    "passwordFallbackDescription": "此共享链接已不可用。如果你知道文件夹密码，仍可访问此文件夹。",
+    "passwordLabel": "密码",
+    "unlocking": "正在解锁...",
+    "unlock": "解锁文件夹",
+    "expiredTitle": "此共享链接不可用",
+    "expiredDescription": "此链接可能已过期、已撤销或缺少令牌。",
+    "errorTitle": "无法打开文件夹共享",
+    "errorDescription": "无法加载此文件夹共享。",
+    "backToFolder": "返回共享文件夹",
+    "postErrorTitle": "无法加载共享帖子"
   },
   "reels": {
     "view": {

--- a/client/src/router/index.test.ts
+++ b/client/src/router/index.test.ts
@@ -137,6 +137,28 @@ vi.mock('../views/ReelsView.vue', async () => {
   };
 });
 
+vi.mock('../views/SharedFolderView.vue', async () => {
+  const { defineComponent } = await import('vue');
+
+  return {
+    default: defineComponent({
+      name: 'SharedFolderView',
+      template: '<div data-test="shared-folder-view">shared-folder-view</div>'
+    })
+  };
+});
+
+vi.mock('../views/SharedPostView.vue', async () => {
+  const { defineComponent } = await import('vue');
+
+  return {
+    default: defineComponent({
+      name: 'SharedPostView',
+      template: '<div data-test="shared-post-view">shared-post-view</div>'
+    })
+  };
+});
+
 vi.mock('../views/TrashView.vue', async () => {
   const { defineComponent } = await import('vue');
 
@@ -291,5 +313,24 @@ describe('router', () => {
     await flushPromises();
     expect(router.currentRoute.value.name).toBe('collection');
     expect(router.currentRoute.value.params.slug).toBe('saved');
+  });
+
+  it('keeps shared folder routes outside normal app capability checks', () => {
+    const authStore = useAuthStore(pinia);
+    authStore.$patch({
+      ready: true,
+      capabilities: {
+        canManageLibrary: false,
+        canDeleteMedia: false,
+        canAccessSettings: false,
+        canUseSharedLikes: false,
+        canUseLocalFavorites: false,
+        canUseSharedCollections: false,
+        canUseLocalCollections: false
+      }
+    });
+
+    expect(canAccessRoute(router.resolve('/share/family'))).toBe(true);
+    expect(canAccessRoute(router.resolve('/share/family/images/42'))).toBe(true);
   });
 });

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -12,6 +12,8 @@ import MomentView from '../views/MomentView.vue';
 import PlaceView from '../views/PlaceView.vue';
 import PlacesView from '../views/PlacesView.vue';
 import ReelsView from '../views/ReelsView.vue';
+import SharedFolderView from '../views/SharedFolderView.vue';
+import SharedPostView from '../views/SharedPostView.vue';
 import TrashView from '../views/TrashView.vue';
 import { useAppStore } from '../stores/app';
 import { useAuthStore } from '../stores/auth';
@@ -136,6 +138,24 @@ export const router = createRouter({
       name: 'folder',
       component: FolderView,
       props: true
+    },
+    {
+      path: '/share/:slug',
+      name: 'shared-folder',
+      component: SharedFolderView,
+      props: true,
+      meta: {
+        publicShare: true
+      }
+    },
+    {
+      path: '/share/:slug/images/:id',
+      name: 'shared-image',
+      component: SharedPostView,
+      props: true,
+      meta: {
+        publicShare: true
+      }
     }
   ],
   scrollBehavior(to, from, savedPosition) {
@@ -160,7 +180,15 @@ export function routeRequiresSavedItems(route: Pick<RouteLocationNormalized, 'me
   return route.meta.requiresSavedItems === true;
 }
 
+export function routeAllowsPublicShareAccess(route: Pick<RouteLocationNormalized, 'meta'>): boolean {
+  return route.meta.publicShare === true;
+}
+
 export function canAccessRoute(route: Pick<RouteLocationNormalized, 'meta'>): boolean {
+  if (routeAllowsPublicShareAccess(route)) {
+    return true;
+  }
+
   const authStore = useAuthStore(pinia);
   const requiredCapability = getRouteRequiredCapability(route);
 

--- a/client/src/stores/folders.ts
+++ b/client/src/stores/folders.ts
@@ -1,7 +1,23 @@
 import { defineStore } from 'pinia';
 
-import { fetchFolderImages, fetchFolders, updateFolderProfile, setFolderCover } from '../api/gallery';
-import type { FeedItem, FolderSummary } from '../types/api';
+import {
+  createFolderShareLink,
+  fetchFolderImages,
+  fetchFolderShareLinks,
+  fetchFolders,
+  removeFolderSharePassword,
+  revokeFolderShareLink,
+  setFolderCover,
+  setFolderSharePassword,
+  updateFolderProfile
+} from '../api/gallery';
+import type {
+  CreateFolderShareLinkInput,
+  FeedItem,
+  FolderShareLink,
+  FolderSharePasswordStatus,
+  FolderSummary
+} from '../types/api';
 import { updateCaptionInItems } from '../utils/caption';
 
 type FolderMediaFilter = 'all' | 'video';
@@ -19,6 +35,13 @@ interface FoldersState {
   currentHasMore: boolean;
   loadingFolder: boolean;
   folderError: string | null;
+  shareLinks: FolderShareLink[];
+  sharePassword: FolderSharePasswordStatus;
+  sharePublicFolderUrl: string | null;
+  sharePublicAccess: boolean;
+  loadingShare: boolean;
+  shareError: string | null;
+  lastCreatedShareUrl: string | null;
 }
 
 export const useFoldersStore = defineStore('folders', {
@@ -34,7 +57,17 @@ export const useFoldersStore = defineStore('folders', {
     currentLimit: 24,
     currentHasMore: true,
     loadingFolder: false,
-    folderError: null
+    folderError: null,
+    shareLinks: [],
+    sharePassword: {
+      enabled: false,
+      updatedAt: null
+    },
+    sharePublicFolderUrl: null,
+    sharePublicAccess: false,
+    loadingShare: false,
+    shareError: null,
+    lastCreatedShareUrl: null
   }),
   actions: {
     removeImage(imageId: number, folderSlug: string, mediaType: FeedItem['mediaType'] = 'image') {
@@ -109,6 +142,16 @@ export const useFoldersStore = defineStore('folders', {
       this.currentHasMore = true;
       this.loadingFolder = false;
       this.folderError = null;
+      this.shareLinks = [];
+      this.sharePassword = {
+        enabled: false,
+        updatedAt: null
+      };
+      this.sharePublicFolderUrl = null;
+      this.sharePublicAccess = false;
+      this.loadingShare = false;
+      this.shareError = null;
+      this.lastCreatedShareUrl = null;
     },
 
     async fetchFolders(force = false) {
@@ -187,6 +230,90 @@ export const useFoldersStore = defineStore('folders', {
       if (this.currentFolder?.slug === slug) {
         const payload = await fetchFolderImages(slug, 1, this.currentLimit, this.currentFilter === 'video' ? 'video' : undefined);
         this.currentFolder = payload.folder;
+      }
+    },
+
+    async loadShareLinks(slug: string) {
+      this.loadingShare = true;
+      this.shareError = null;
+      this.lastCreatedShareUrl = null;
+
+      try {
+        const payload = await fetchFolderShareLinks(slug);
+        this.shareLinks = payload.links;
+        this.sharePassword = payload.password;
+        this.sharePublicFolderUrl = payload.publicFolderUrl;
+        this.sharePublicAccess = payload.publicAccess;
+      } catch (error) {
+        this.shareError = error instanceof Error ? error.message : 'Unable to load folder sharing';
+        throw error;
+      } finally {
+        this.loadingShare = false;
+      }
+    },
+
+    async createShareLink(slug: string, input: CreateFolderShareLinkInput) {
+      this.loadingShare = true;
+      this.shareError = null;
+
+      try {
+        const payload = await createFolderShareLink(slug, input);
+        this.shareLinks = [payload.link, ...this.shareLinks.filter((link) => link.id !== payload.link.id)];
+        this.lastCreatedShareUrl = payload.shareUrl;
+        return payload;
+      } catch (error) {
+        this.shareError = error instanceof Error ? error.message : 'Unable to create share link';
+        throw error;
+      } finally {
+        this.loadingShare = false;
+      }
+    },
+
+    async revokeShareLink(slug: string, linkId: number) {
+      this.loadingShare = true;
+      this.shareError = null;
+
+      try {
+        const payload = await revokeFolderShareLink(slug, linkId);
+        this.shareLinks = this.shareLinks.map((link) => (link.id === payload.link.id ? payload.link : link));
+        if (this.lastCreatedShareUrl) {
+          this.lastCreatedShareUrl = null;
+        }
+      } catch (error) {
+        this.shareError = error instanceof Error ? error.message : 'Unable to revoke share link';
+        throw error;
+      } finally {
+        this.loadingShare = false;
+      }
+    },
+
+    async setSharePassword(slug: string, password: string) {
+      this.loadingShare = true;
+      this.shareError = null;
+
+      try {
+        const payload = await setFolderSharePassword(slug, password);
+        this.sharePassword = payload.password;
+      } catch (error) {
+        this.shareError = error instanceof Error ? error.message : 'Unable to save folder password';
+        throw error;
+      } finally {
+        this.loadingShare = false;
+      }
+    },
+
+    async removeSharePassword(slug: string) {
+      this.loadingShare = true;
+      this.shareError = null;
+
+      try {
+        const payload = await removeFolderSharePassword(slug);
+        this.sharePassword = payload.password;
+      } catch (error) {
+        this.shareError = error instanceof Error ? error.message : 'Unable to remove folder password';
+        throw error;
+      } finally {
+        this.loadingShare = false;
       }
     }
   }

--- a/client/src/stores/share.ts
+++ b/client/src/stores/share.ts
@@ -1,0 +1,159 @@
+import { defineStore } from 'pinia';
+
+import {
+  fetchSharedFolderAccess,
+  fetchSharedFolderImages,
+  fetchSharedImage,
+  unlockSharedFolderLink,
+  unlockSharedFolderPassword
+} from '../api/gallery';
+import type {
+  FolderShareAccessState,
+  SharedFeedItem,
+  SharedFolderSummary,
+  SharedImageDetail
+} from '../types/api';
+
+interface ShareState {
+  access: FolderShareAccessState | null;
+  folder: SharedFolderSummary | null;
+  images: SharedFeedItem[];
+  image: SharedImageDetail | null;
+  page: number;
+  limit: number;
+  hasMore: boolean;
+  loading: boolean;
+  unlocking: boolean;
+  error: string | null;
+  unlockError: string | null;
+}
+
+let shareLoadToken = 0;
+
+export const useShareStore = defineStore('share', {
+  state: (): ShareState => ({
+    access: null,
+    folder: null,
+    images: [],
+    image: null,
+    page: 1,
+    limit: 24,
+    hasMore: true,
+    loading: false,
+    unlocking: false,
+    error: null,
+    unlockError: null
+  }),
+  actions: {
+    reset() {
+      shareLoadToken += 1;
+      this.access = null;
+      this.folder = null;
+      this.images = [];
+      this.image = null;
+      this.page = 1;
+      this.hasMore = true;
+      this.loading = false;
+      this.unlocking = false;
+      this.error = null;
+      this.unlockError = null;
+    },
+
+    async loadAccess(slug: string) {
+      this.access = await fetchSharedFolderAccess(slug);
+      return this.access;
+    },
+
+    async unlockLink(slug: string, token: string) {
+      this.unlocking = true;
+      this.unlockError = null;
+
+      try {
+        await unlockSharedFolderLink(slug, token);
+        await this.loadAccess(slug);
+      } catch (error) {
+        this.unlockError = error instanceof Error ? error.message : 'Unable to unlock this folder share.';
+        throw error;
+      } finally {
+        this.unlocking = false;
+      }
+    },
+
+    async unlockPassword(slug: string, password: string) {
+      this.unlocking = true;
+      this.unlockError = null;
+
+      try {
+        await unlockSharedFolderPassword(slug, password);
+        await this.loadAccess(slug);
+      } catch (error) {
+        this.unlockError = error instanceof Error ? error.message : 'Unable to unlock this folder share.';
+        throw error;
+      } finally {
+        this.unlocking = false;
+      }
+    },
+
+    async loadFolder(slug: string, reset = true) {
+      const requestToken = ++shareLoadToken;
+
+      if (reset) {
+        this.folder = null;
+        this.images = [];
+        this.page = 1;
+        this.hasMore = true;
+      }
+
+      this.loading = true;
+      this.error = null;
+
+      try {
+        const payload = await fetchSharedFolderImages(slug, this.page, this.limit);
+        if (requestToken !== shareLoadToken) {
+          return;
+        }
+
+        this.folder = payload.folder;
+        this.images.push(...payload.items);
+        this.page += 1;
+        this.hasMore = payload.hasMore;
+      } catch (error) {
+        if (requestToken !== shareLoadToken) {
+          return;
+        }
+
+        this.error = error instanceof Error ? error.message : 'Unable to load this folder share.';
+      } finally {
+        if (requestToken === shareLoadToken) {
+          this.loading = false;
+        }
+      }
+    },
+
+    async loadImage(id: number, mediaType?: 'image' | 'video') {
+      const requestToken = ++shareLoadToken;
+      this.loading = true;
+      this.error = null;
+
+      try {
+        const image = await fetchSharedImage(id, mediaType);
+        if (requestToken !== shareLoadToken) {
+          return;
+        }
+
+        this.image = image;
+      } catch (error) {
+        if (requestToken !== shareLoadToken) {
+          return;
+        }
+
+        this.image = null;
+        this.error = error instanceof Error ? error.message : 'Unable to load this shared post.';
+      } finally {
+        if (requestToken === shareLoadToken) {
+          this.loading = false;
+        }
+      }
+    }
+  }
+});

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -6,6 +6,8 @@ export type FolderImageOrder = 'newest' | 'oldest';
 export type NestedFolderTitleFormat = 'folder' | 'parent-plus-folder';
 export type FeedRailKind = 'moments' | 'highlights';
 export type StoryCapsulePresentation = 'avatar' | 'highlight';
+export type MediaType = 'image' | 'video';
+
 export type ScanOperation =
   | 'checking_derivatives'
   | 'backfilling_asset_key'
@@ -220,6 +222,117 @@ export interface FolderStoryFeedPayload extends PaginatedFeed {
 
 export interface FolderImagesPayload extends PaginatedFeed {
   folder: FolderSummary;
+}
+
+export type FolderShareLinkStatus = 'active' | 'expired' | 'revoked';
+export type FolderShareExpirationPreset = '1h' | '24h' | '7d' | 'custom' | 'unlimited';
+
+export interface FolderShareLink {
+  id: number;
+  folderId: number;
+  tokenPrefix: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+  lastUsedAt: string | null;
+  status: FolderShareLinkStatus;
+}
+
+export interface FolderSharePasswordStatus {
+  enabled: boolean;
+  updatedAt: string | null;
+}
+
+export interface FolderShareLinksPayload {
+  links: FolderShareLink[];
+  password: FolderSharePasswordStatus;
+  publicFolderUrl: string;
+  publicAccess: boolean;
+}
+
+export interface CreateFolderShareLinkInput {
+  expiresIn: FolderShareExpirationPreset;
+  customExpiresAt?: string | null;
+  unlimited?: boolean;
+}
+
+export interface CreateFolderShareLinkResult {
+  ok: boolean;
+  shareUrl: string;
+  link: FolderShareLink;
+}
+
+export interface FolderSharePasswordMutationResult {
+  ok: boolean;
+  password: FolderSharePasswordStatus;
+}
+
+export interface FolderShareAccessState {
+  exists: boolean;
+  granted: boolean;
+  hasPassword: boolean;
+  publicAccess: boolean;
+}
+
+export interface SharedFolderSummary {
+  id: number;
+  slug: string;
+  name: string;
+  description: string | null;
+  imageCount: number;
+  videoCount: number;
+  avatarThumbnailUrl: string | null;
+  sortTimestamp: number;
+}
+
+export interface SharedFeedItem {
+  id: number;
+  folderId: number;
+  folderSlug: string;
+  folderName: string;
+  filename: string;
+  caption: string | null;
+  width: number;
+  height: number;
+  mediaType: MediaType;
+  durationMs: number | null;
+  isAnimated?: boolean | null;
+  thumbnailUrl: string;
+  previewUrl: string;
+  sortTimestamp: number;
+}
+
+export interface SharedImageDetail {
+  id: number;
+  folderId: number;
+  folderSlug: string;
+  folderName: string;
+  filename: string;
+  caption: string | null;
+  mediaType: MediaType;
+  mimeType: string;
+  width: number;
+  height: number;
+  durationMs: number | null;
+  isAnimated?: boolean | null;
+  thumbnailUrl: string;
+  previewUrl: string;
+  sortTimestamp: number;
+  nextImageId: number | null;
+  previousImageId: number | null;
+}
+
+export interface SharedFolderImagesPayload {
+  items: SharedFeedItem[];
+  page: number;
+  limit: number;
+  total: number;
+  hasMore: boolean;
+  folder: SharedFolderSummary;
+}
+
+export interface FolderShareUnlockResult {
+  ok: boolean;
 }
 
 export interface PlaceImagesPayload extends PaginatedFeed {

--- a/client/src/views/SharedFolderView.test.ts
+++ b/client/src/views/SharedFolderView.test.ts
@@ -1,0 +1,169 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SharedFolderView from './SharedFolderView.vue';
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router');
+  return {
+    ...actual,
+    useRoute: () => ({
+      fullPath: '/share/travel-2024',
+      hash: '',
+      query: {}
+    })
+  };
+});
+
+describe('SharedFolderView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('renders password prompt when access is not yet granted and folder requires password', async () => {
+    const { useShareStore } = await import('../stores/share');
+    const shareStore = useShareStore();
+    shareStore.access = {
+      exists: true,
+      granted: false,
+      hasPassword: true,
+      publicAccess: false
+    };
+
+    const wrapper = mount(SharedFolderView, {
+      props: {
+        slug: 'travel-2024'
+      },
+      global: {
+        stubs: {
+          Avatar: true,
+          EmptyState: true,
+          ErrorState: true,
+          FolderGrid: true,
+          InfiniteLoader: true,
+          RouterLink: { template: '<a><slot /></a>' }
+        }
+      }
+    });
+
+    expect(wrapper.text()).toContain('Folder Share');
+    expect(wrapper.text()).toContain('Enter the reusable folder password to continue.');
+    expect(wrapper.find('input[type="password"]').exists()).toBe(true);
+    expect(wrapper.find('button[type="submit"]').exists()).toBe(true);
+  });
+
+  it('renders expired state when link is expired or revoked', async () => {
+    const { useShareStore } = await import('../stores/share');
+    const shareStore = useShareStore();
+    shareStore.access = {
+      exists: true,
+      granted: false,
+      hasPassword: false,
+      publicAccess: false
+    };
+    shareStore.error = 'This folder share is expired, revoked, or locked.';
+
+    const wrapper = mount(SharedFolderView, {
+      props: {
+        slug: 'travel-2024'
+      },
+      global: {
+        stubs: {
+          Avatar: true,
+          EmptyState: true,
+          ErrorState: {
+            props: ['title', 'message'],
+            template: '<div class="error-state"><h1>{{ title }}</h1><p>{{ message }}</p></div>'
+          },
+          FolderGrid: true,
+          InfiniteLoader: true,
+          RouterLink: { template: '<a><slot /></a>' }
+        }
+      }
+    });
+
+    expect(wrapper.text()).toContain('Could not open folder share');
+    expect(wrapper.text()).toContain('This folder share is expired, revoked, or locked.');
+  });
+
+  it('explains password fallback after a share link is rejected', async () => {
+    window.history.replaceState(null, '', '/share/travel-2024#token=expired-token');
+
+    const { useShareStore } = await import('../stores/share');
+    const shareStore = useShareStore();
+    shareStore.unlockLink = vi.fn().mockRejectedValue(new Error('Share link rejected.'));
+    shareStore.loadAccess = vi.fn(async () => {
+      shareStore.access = {
+        exists: true,
+        granted: false,
+        hasPassword: true,
+        publicAccess: false
+      };
+      return shareStore.access;
+    });
+
+    const wrapper = mount(SharedFolderView, {
+      props: {
+        slug: 'travel-2024'
+      },
+      global: {
+        stubs: {
+          Avatar: true,
+          EmptyState: true,
+          ErrorState: true,
+          FolderGrid: true,
+          InfiniteLoader: true,
+          RouterLink: { template: '<a><slot /></a>' }
+        }
+      }
+    });
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('This share link is no longer available.');
+    expect(wrapper.text()).toContain('you can still access this folder');
+    expect(wrapper.text()).not.toContain('Share link rejected.');
+  });
+
+  it('does not display any admin actions or settings controls when viewing shared folder', async () => {
+    const { useShareStore } = await import('../stores/share');
+    const shareStore = useShareStore();
+    shareStore.access = {
+      exists: true,
+      granted: true,
+      hasPassword: false,
+      publicAccess: false
+    };
+    shareStore.folder = {
+      id: 1,
+      slug: 'travel-2024',
+      name: 'Travel 2024',
+      description: 'Shared vacation pics',
+      imageCount: 5,
+      avatarThumbnailUrl: null,
+      sortTimestamp: Date.now()
+    };
+    shareStore.images = [];
+
+    const wrapper = mount(SharedFolderView, {
+      props: {
+        slug: 'travel-2024'
+      },
+      global: {
+        stubs: {
+          Avatar: true,
+          EmptyState: true,
+          ErrorState: true,
+          FolderGrid: true,
+          InfiniteLoader: true,
+          RouterLink: { template: '<a><slot /></a>' }
+        }
+      }
+    });
+
+    expect(wrapper.find('button[aria-label="Edit folder"]').exists()).toBe(false);
+    expect(wrapper.find('button[aria-label="Share folder"]').exists()).toBe(false);
+    expect(wrapper.find('button[aria-label="Settings"]').exists()).toBe(false);
+  });
+});

--- a/client/src/views/SharedFolderView.vue
+++ b/client/src/views/SharedFolderView.vue
@@ -1,0 +1,189 @@
+<template>
+  <main class="min-h-screen bg-bg px-5 py-6 text-text sm:px-8 sm:py-8">
+    <section class="mx-auto grid w-full max-w-[66rem] gap-6">
+      <header class="flex items-center justify-between gap-4 border-b border-border pb-4">
+        <RouterLink class="inline-flex items-center gap-2 text-text no-underline" :to="{ name: 'home' }">
+          <span class="i-fluent-folder-24-filled h-6 w-6 text-accent" aria-hidden="true" />
+          <span class="text-[1rem] font-semibold tracking-[-0.02em]">Foldergram</span>
+        </RouterLink>
+      </header>
+
+      <section v-if="shareStore.access?.granted && shareStore.folder" class="grid gap-6">
+        <div class="grid grid-cols-[7.5rem_minmax(0,1fr)] items-center gap-6 max-sm:grid-cols-1 max-sm:text-center">
+          <div class="grid place-items-center">
+            <Avatar class="h-[7.25rem] w-[7.25rem]" :name="displayFolderTitle" :src="shareStore.folder.avatarThumbnailUrl" />
+          </div>
+          <div class="grid gap-3">
+            <h1 class="m-0 text-[clamp(1.6rem,3vw,2.15rem)] font-semibold tracking-[-0.04em]">{{ displayFolderTitle }}</h1>
+            <p v-if="shareStore.folder.description" class="m-0 max-w-[36rem] whitespace-pre-wrap text-[0.96rem] leading-[1.45] text-muted max-sm:mx-auto">
+              {{ shareStore.folder.description }}
+            </p>
+            <div class="flex flex-wrap gap-4 text-[0.92rem] text-muted max-sm:justify-center">
+              <span>{{ t('folder.header.posts', { count: shareStore.folder.imageCount }) }}</span>
+              <span>{{ t('folder.header.reels', { count: shareStore.folder.videoCount }) }}</span>
+            </div>
+          </div>
+        </div>
+
+        <EmptyState
+          v-if="!shareStore.loading && shareStore.images.length === 0"
+          title="No posts in this shared folder"
+          description="This folder share is valid, but there are no visible posts right now."
+        />
+        <section v-else class="grid gap-5">
+          <FolderGrid :items="shareStore.images" variant="posts" :shared-slug="slug" />
+          <InfiniteLoader :loading="shareStore.loading" :has-more="shareStore.hasMore" @load-more="loadMore" />
+        </section>
+      </section>
+
+      <section
+        v-else-if="isAccessPending || shareStore.loading || shareStore.unlocking"
+        class="mx-auto grid w-[min(100%,28rem)] gap-3 rounded-[1rem] border border-border bg-surface p-7 text-center"
+      >
+        <p class="m-0 text-[0.78rem] font-bold uppercase tracking-[0.08em] text-accent-strong">{{ t('share.loadingEyebrow') }}</p>
+        <h1 class="m-0 text-[1.45rem] font-semibold tracking-[-0.04em]">{{ t('share.loadingTitle') }}</h1>
+      </section>
+
+      <section
+        v-else-if="shareStore.access?.hasPassword"
+        class="mx-auto grid w-[min(100%,28rem)] gap-4 rounded-[1rem] border border-border bg-surface p-7"
+      >
+        <div class="grid gap-2 text-center">
+          <p class="m-0 text-[0.78rem] font-bold uppercase tracking-[0.08em] text-accent-strong">{{ t('share.passwordEyebrow') }}</p>
+          <h1 class="m-0 text-[1.45rem] font-semibold tracking-[-0.04em]">{{ t('share.passwordTitle') }}</h1>
+          <p class="m-0 text-[0.88rem] leading-relaxed text-muted">
+            {{ t(linkUnlockFailed ? 'share.passwordFallbackDescription' : 'share.passwordDescription') }}
+          </p>
+        </div>
+        <form class="grid gap-3" @submit.prevent="unlockPassword">
+          <label class="grid gap-[0.35rem] text-[0.85rem] font-semibold">
+            {{ t('share.passwordLabel') }}
+            <input
+              v-model="password"
+              class="min-h-11 rounded-[0.8rem] border border-border bg-bg px-3 text-text outline-none focus:border-text"
+              type="password"
+              autocomplete="current-password"
+              required
+            />
+          </label>
+          <p v-if="shareStore.unlockError && !linkUnlockFailed" class="m-0 rounded-[0.85rem] border border-[rgba(214,48,49,0.24)] bg-[rgba(214,48,49,0.08)] px-3 py-2 text-[0.84rem] text-[#c0392b]">
+            {{ shareStore.unlockError }}
+          </p>
+          <button
+            class="min-h-11 rounded-[0.8rem] border border-transparent bg-text px-4 font-semibold text-bg disabled:cursor-wait disabled:opacity-70"
+            type="submit"
+            :disabled="shareStore.unlocking"
+          >
+            {{ shareStore.unlocking ? t('share.unlocking') : t('share.unlock') }}
+          </button>
+        </form>
+      </section>
+
+      <ErrorState
+        v-else
+        class="mx-auto w-[min(100%,34rem)]"
+        :title="shareStore.error ? t('share.errorTitle') : t('share.expiredTitle')"
+        :message="shareStore.error ?? t('share.expiredDescription')"
+      />
+    </section>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { RouterLink } from 'vue-router';
+
+import Avatar from '../components/Avatar.vue';
+import EmptyState from '../components/EmptyState.vue';
+import ErrorState from '../components/ErrorState.vue';
+import FolderGrid from '../components/FolderGrid.vue';
+import InfiniteLoader from '../components/InfiniteLoader.vue';
+import { useShareStore } from '../stores/share';
+
+const props = defineProps<{
+  slug: string;
+}>();
+
+const { t } = useI18n();
+const shareStore = useShareStore();
+const password = ref('');
+const linkUnlockFailed = ref(false);
+const displayFolderTitle = computed(() => (shareStore.folder ? shareStore.folder.name : 'Shared folder'));
+const isAccessPending = computed(() => shareStore.access === null && !shareStore.error);
+
+function extractFragmentToken(): string | null {
+  if (typeof window === 'undefined' || !window.location.hash) {
+    return null;
+  }
+
+  const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+  return params.get('token');
+}
+
+function clearFragmentToken() {
+  if (typeof window === 'undefined' || !window.location.hash) {
+    return;
+  }
+
+  window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}`);
+}
+
+async function initializeShare() {
+  shareStore.reset();
+  linkUnlockFailed.value = false;
+  const token = extractFragmentToken();
+
+  if (token) {
+    try {
+      await shareStore.unlockLink(props.slug, token);
+    } catch {
+      linkUnlockFailed.value = true;
+    } finally {
+      clearFragmentToken();
+    }
+  }
+
+  try {
+    await shareStore.loadAccess(props.slug);
+  } catch (error) {
+    shareStore.error = error instanceof Error ? error.message : t('share.errorDescription');
+    return;
+  }
+
+  if (shareStore.access?.granted) {
+    await shareStore.loadFolder(props.slug, true);
+  }
+}
+
+async function loadMore() {
+  if (shareStore.hasMore) {
+    await shareStore.loadFolder(props.slug, false);
+  }
+}
+
+async function unlockPassword() {
+  linkUnlockFailed.value = false;
+
+  try {
+    await shareStore.unlockPassword(props.slug, password.value);
+    password.value = '';
+
+    if (shareStore.access?.granted) {
+      await shareStore.loadFolder(props.slug, true);
+    }
+  } catch {
+    // The store-owned error is rendered under the password field.
+  }
+}
+
+onMounted(initializeShare);
+
+watch(
+  () => props.slug,
+  async () => {
+    password.value = '';
+    await initializeShare();
+  }
+);
+</script>

--- a/client/src/views/SharedPostView.vue
+++ b/client/src/views/SharedPostView.vue
@@ -1,0 +1,131 @@
+<template>
+  <main class="min-h-screen bg-bg px-5 py-6 text-text sm:px-8 sm:py-8">
+    <section class="mx-auto grid w-full max-w-[72rem] gap-5">
+      <RouterLink
+        class="inline-flex w-fit items-center gap-2 rounded-[0.8rem] border border-border bg-surface px-3 py-2 text-[0.86rem] font-semibold text-text no-underline hover:bg-surface-hover"
+        :to="{ name: 'shared-folder', params: { slug } }"
+      >
+        <span class="i-fluent-chevron-left-20-regular h-5 w-5" aria-hidden="true" />
+        {{ t('share.backToFolder') }}
+      </RouterLink>
+
+      <ErrorState v-if="shareStore.error" :title="t('share.postErrorTitle')" :message="shareStore.error" />
+
+      <section v-else-if="shareStore.image" class="relative">
+        <RouterLink
+          v-if="shareStore.image.previousImageId"
+          class="shared-post-nav shared-post-nav--previous"
+          :to="{ name: 'shared-image', params: { slug, id: String(shareStore.image.previousImageId) } }"
+          :aria-label="t('post.viewer.previous')"
+        >
+          <span class="i-fluent-chevron-left-20-regular h-5 w-5" aria-hidden="true" />
+        </RouterLink>
+        <RouterLink
+          v-if="shareStore.image.nextImageId"
+          class="shared-post-nav shared-post-nav--next"
+          :to="{ name: 'shared-image', params: { slug, id: String(shareStore.image.nextImageId) } }"
+          :aria-label="t('post.viewer.next')"
+        >
+          <span class="i-fluent-chevron-right-20-regular h-5 w-5" aria-hidden="true" />
+        </RouterLink>
+
+        <article class="grid overflow-hidden rounded-[1rem] border border-border bg-surface shadow-[var(--shadow)] lg:grid-cols-[minmax(0,1fr)_20rem]">
+          <div class="grid min-h-[24rem] place-items-center bg-black">
+            <video
+              v-if="shareStore.image.mediaType === 'video'"
+              class="max-h-[78vh] w-full bg-black"
+              :src="shareStore.image.previewUrl"
+              :poster="shareStore.image.thumbnailUrl"
+              controls
+              playsinline
+            />
+            <ResilientImage
+              v-else
+              class="max-h-[78vh] w-full object-contain"
+              :src="shareStore.image.previewUrl"
+              :alt="shareStore.image.filename"
+            />
+          </div>
+          <aside class="grid content-start gap-4 p-5">
+            <div class="grid gap-1">
+              <h1 class="m-0 text-[1.05rem] font-semibold tracking-[-0.02em]">{{ shareStore.image.folderName }}</h1>
+              <p class="m-0 break-words text-[0.9rem] text-muted">{{ shareStore.image.caption || shareStore.image.filename }}</p>
+            </div>
+            <dl class="grid gap-3 text-[0.88rem]">
+              <div class="grid gap-1">
+                <dt class="text-[0.72rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('post.viewer.stats.dimensions') }}</dt>
+                <dd class="m-0 font-semibold">{{ shareStore.image.width }} x {{ shareStore.image.height }}</dd>
+              </div>
+              <div v-if="shareStore.image.durationMs" class="grid gap-1">
+                <dt class="text-[0.72rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('post.viewer.stats.duration') }}</dt>
+                <dd class="m-0 font-semibold">{{ formatMediaDuration(shareStore.image.durationMs) }}</dd>
+              </div>
+              <div class="grid gap-1">
+                <dt class="text-[0.72rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('post.viewer.stats.type') }}</dt>
+                <dd class="m-0 font-semibold">{{ shareStore.image.mimeType }}</dd>
+              </div>
+            </dl>
+          </aside>
+        </article>
+      </section>
+
+      <section v-else class="mx-auto grid w-[min(100%,28rem)] gap-3 rounded-[1rem] border border-border bg-surface p-7 text-center">
+        <p class="m-0 text-muted">{{ t('common.loading') }}</p>
+      </section>
+    </section>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { RouterLink } from 'vue-router';
+
+import ErrorState from '../components/ErrorState.vue';
+import ResilientImage from '../components/ResilientImage.vue';
+import { useShareStore } from '../stores/share';
+import { formatMediaDuration } from '../utils/media';
+
+const props = defineProps<{
+  slug: string;
+  id: string;
+}>();
+
+const { t } = useI18n();
+const shareStore = useShareStore();
+const imageId = computed(() => Number(props.id));
+
+async function loadImage() {
+  if (Number.isFinite(imageId.value)) {
+    await shareStore.loadImage(imageId.value);
+  }
+}
+
+watch(() => [props.slug, imageId.value] as const, loadImage, { immediate: true });
+</script>
+
+<style scoped>
+.shared-post-nav {
+  position: fixed;
+  top: 50%;
+  z-index: 20;
+  display: inline-flex;
+  width: 2.4rem;
+  height: 2.4rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  color: #111;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.2);
+  transform: translateY(-50%);
+}
+
+.shared-post-nav--previous {
+  left: 0.75rem;
+}
+
+.shared-post-nav--next {
+  right: 0.75rem;
+}
+</style>

--- a/docs/api.md
+++ b/docs/api.md
@@ -23,6 +23,7 @@ When password protection is enabled:
 
 - most `/api` routes return `401` until the browser logs in, except for safe read routes in public viewer mode
 - `GET /api/health`, `GET /api/auth/status`, `POST /api/auth/login`, `POST /api/auth/unlock-admin`, and `POST /api/auth/logout` stay reachable without an authenticated session
+- scoped `/api/share/...` routes stay reachable so folder-share visitors can unlock and read one shared folder
 - `PUT /api/auth/password` is public only when password protection is currently disabled, so the first admin password can be set
 - `/thumbnails/...` and `/previews/...` also require the same authenticated session unless public viewer mode is enabled
 - authenticated sessions carry `admin` or `viewer` role data
@@ -337,6 +338,70 @@ Notes:
 
 - results follow the current app-wide default folder image order
 - that same order is reused by detail-view previous/next navigation within a folder
+
+## Folder share endpoints
+
+Folder share endpoints are scoped to one folder. They do not create admin or
+viewer sessions and do not unlock normal library routes.
+
+### `GET /api/share/folders/:slug/access`
+
+Returns whether a shared folder exists, whether the current request already has
+a valid grant, and whether a folder password is available.
+
+Response shape:
+
+```json
+{
+  "exists": true,
+  "granted": false,
+  "hasPassword": true,
+  "publicAccess": false
+}
+```
+
+### `GET /api/share/folders/:slug`
+
+Returns the shared folder summary after the request has access to that folder.
+
+Access can come from:
+
+- a valid admin or viewer session
+- public viewer mode
+- a valid folder-share link session
+- a valid folder-password share session
+
+Errors:
+
+- `401` when the share is locked, expired, or revoked
+- `404` when the folder does not exist
+
+### `GET /api/share/folders/:slug/images`
+
+Query parameters match `GET /api/folders/:slug/images`.
+
+The response shape contains the shared folder summary and a list of redacted item payloads where media URLs point to grant-checking API endpoints:
+
+- `thumbnailUrl`: `/api/share/images/:id/thumbnail`
+- `previewUrl`: `/api/share/images/:id/preview`
+
+Sensitive metadata including local folder paths, relative file paths, and EXIF metadata are omitted.
+
+### `GET /api/share/images/:id`
+
+Returns one shared post detail after checking access to that post's folder.
+
+Shared detail payloads do not expose original-file URLs (`originalUrl`) or local system paths. Only `thumbnailUrl` and `previewUrl` are provided, both pointing to guarded shared media endpoints.
+
+### `GET /api/share/images/:id/thumbnail`
+
+Serves or lazily generates the thumbnail for one shared post after checking the
+folder grant.
+
+### `GET /api/share/images/:id/preview`
+
+Serves or lazily generates the preview for one shared post after checking the
+folder grant.
 
 ### `GET /api/places`
 
@@ -1164,6 +1229,176 @@ Body:
 ```json
 {
   "imageId": 42
+}
+```
+
+Success:
+
+```json
+{
+  "ok": true
+}
+```
+
+### `GET /api/admin/folders/:slug/share-links`
+
+This route is read-only but `admin`-only.
+
+Returns share-link and folder-password status for one folder.
+
+Response shape:
+
+```json
+{
+  "links": [],
+  "password": {
+    "enabled": false,
+    "updatedAt": null
+  },
+  "publicFolderUrl": "/folders/oslo",
+  "publicAccess": false
+}
+```
+
+Each link item includes:
+
+- `id`
+- `folderId`
+- `tokenPrefix`
+- `expiresAt`
+- `revokedAt`
+- `createdAt`
+- `lastUsedAt`
+- `status` as `active`, `expired`, or `revoked`
+
+The token hash is never returned.
+
+### `POST /api/admin/folders/:slug/share-links`
+
+Creates a read-only share link for one folder.
+
+Body:
+
+```json
+{
+  "expiresIn": "24h",
+  "customExpiresAt": null,
+  "unlimited": false
+}
+```
+
+Allowed `expiresIn` values:
+
+- `1h`
+- `24h`
+- `7d`
+- `custom`
+- `unlimited`
+
+For `custom`, provide an ISO timestamp in `customExpiresAt`. `unlimited=true`
+or `expiresIn=unlimited` creates a no-expiry link that can still be revoked.
+
+Success:
+
+```json
+{
+  "ok": true,
+  "shareUrl": "/share/oslo#token=raw-token-shown-once",
+  "link": {
+    "id": 7,
+    "folderId": 1,
+    "tokenPrefix": "abcd1234",
+    "expiresAt": "2026-06-11T12:00:00.000Z",
+    "revokedAt": null,
+    "createdAt": "2026-06-10T12:00:00.000Z",
+    "lastUsedAt": null,
+    "status": "active"
+  }
+}
+```
+
+The raw token appears only inside `shareUrl` in this creation response.
+
+### `DELETE /api/admin/folders/:slug/share-links/:linkId`
+
+Revokes one share link.
+
+Success:
+
+```json
+{
+  "ok": true,
+  "link": {}
+}
+```
+
+### `PUT /api/admin/folders/:slug/share-password`
+
+Sets or changes a reusable folder password.
+
+Body:
+
+```json
+{
+  "password": "folder-password"
+}
+```
+
+Notes:
+
+- password minimum length is `8`
+- changing the password invalidates older password-based share sessions
+- the raw password is never returned or stored
+
+### `DELETE /api/admin/folders/:slug/share-password`
+
+Removes the reusable folder password and invalidates password-based share
+sessions.
+
+Success:
+
+```json
+{
+  "ok": true,
+  "password": {
+    "enabled": false,
+    "updatedAt": null
+  }
+}
+```
+
+### `POST /api/share/folders/:slug/unlock-link`
+
+Verifies a raw share-link token and sets the separate `foldergram_share_session`
+cookie.
+
+Body:
+
+```json
+{
+  "token": "raw-token-from-url-fragment"
+}
+```
+
+Success:
+
+```json
+{
+  "ok": true
+}
+```
+
+Expired, revoked, or otherwise invalid links return `403`.
+
+### `POST /api/share/folders/:slug/unlock-password`
+
+Verifies a reusable folder password and sets the same share-session cookie.
+
+Body:
+
+```json
+{
+  "password": "folder-password"
 }
 ```
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -111,6 +111,22 @@ The current implementation supports:
 
 It still does **not** have per-user accounts or per-user data isolation.
 
+## Can I share only one folder?
+
+Yes. Admins can open a folder page and use the Share button next to `Edit App
+Folder`.
+
+Folder sharing supports expiring links, unlimited revocable links, and reusable
+per-folder passwords. Shared visitors open `/share/:slug` and can browse only
+that folder.
+
+## Do folder shares unlock the whole library?
+
+No. A folder share is not an admin session, viewer session, or public-library
+mode. It does not grant Home, feed search, Reels, Places, Likes, Collections,
+Trash, Settings, scans, rebuild actions, captions, cover editing, delete
+actions, or original-file downloads.
+
 ## Why does the API call posts "images" in some fields?
 
 That naming is historical. The current app indexes both images and videos, and

--- a/docs/features.md
+++ b/docs/features.md
@@ -98,6 +98,7 @@ Folder pages include:
 
 - a folder header with avatar, posts counts, descriptions, and optional avatar-story opening
 - editable folder name and description via an admin "Edit App Folder" flow
+- an admin-only "Share folder" action for scoped read-only sharing
 - long descriptions that collapse to two lines by default and expose an expand/collapse caret only when the text actually overflows
 - a posts grid that follows the app-wide default folder order
 - highlight circles above the posts and reels tabs when the folder has story capsules
@@ -109,6 +110,35 @@ The reels tab is a filtered view backed by the same folder endpoint using
 
 The post viewer also uses the same default folder order when resolving previous
 and next navigation within a folder.
+
+## Folder sharing
+
+Admins can share one folder without creating user accounts or unlocking the
+whole library.
+
+The Share Folder dialog supports:
+
+- normal public folder URL copying when public viewer mode is enabled
+- read-only links for one folder
+- expiration presets for 1 hour, 24 hours, and 7 days
+- custom expiration timestamps
+- unlimited links that remain revocable
+- reusable per-folder passwords
+- revoking existing share links
+- removing or changing the folder password to invalidate password sessions
+
+Share links and password access are independent ways to open the folder. An
+active share link does not require the folder password, and revoking a link does
+not disable password access. The dialog shows every active access method and
+clarifies which methods remain available after an access setting changes.
+
+Shared visitors use `/share/:slug`, not the normal authenticated folder route.
+They can browse only that folder and its shared post view. They do not get Home,
+Explore, Reels, Places, Settings, Likes, Collections, Trash, scans, rebuild
+actions, captions, cover editing, delete actions, or original-file downloads.
+
+Shared thumbnails and previews are served through `/api/share/images/:id/...`
+after the server checks the folder grant for that image.
 
 ## Folder stories and highlights
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -141,6 +141,11 @@ If you plan to expose Foldergram on a homelab or LAN, open Settings after the
 first load and enable the admin password. From there, you can keep admin-only
 access, add a separate viewer password, or switch to public browse mode.
 
+Admins can also share one folder at a time from a folder page. Open a folder,
+choose the Share button next to `Edit App Folder`, then create an expiring link,
+an unlimited revocable link, or a reusable folder password. Shared visitors use
+`/share/:slug` and stay limited to that folder.
+
 Inside Settings:
 
 - `General Settings` contains stories mode, nested folder title format, excluded folders, Home/Reels defaults, and the default folder photo order
@@ -211,5 +216,6 @@ pnpm build:docs
 - Previews are generated under `data/previews`.
 - In the default unprotected state, Settings is available immediately.
 - After access protection is enabled, only admin sessions can open Settings or run scan and rebuild actions. Viewer and public sessions stay browse-only.
+- Folder share links and folder passwords are read-only and scoped to one folder; they do not grant Settings, Home feed, Reels, Places, Likes, Collections, Trash, or original-file downloads.
 
 If nothing appears, start with [Troubleshooting](/troubleshooting).

--- a/docs/security.md
+++ b/docs/security.md
@@ -28,7 +28,7 @@ When enabled:
 - Foldergram stores one-way password hashes, salts, and session metadata in SQLite `app_settings`
 - the browser unlocks access with a signed `HttpOnly` session cookie
 - the session payload carries the current role (`admin` or `viewer`)
-- `/api` routes require that session, except for `GET /api/health`, `GET /api/auth/status`, `POST /api/auth/login`, `POST /api/auth/unlock-admin`, and `POST /api/auth/logout`
+- `/api` routes require that session, except for `GET /api/health`, `GET /api/auth/status`, `POST /api/auth/login`, `POST /api/auth/unlock-admin`, `POST /api/auth/logout`, and the scoped `/api/share/...` routes
 - generated media under `/thumbnails` and `/previews` also require that session unless public viewer mode is enabled
 - in `viewer_access_mode=public`, safe read routes and generated media can be browsed anonymously
 - anonymous public favorites stay in the browser and never write into SQLite likes
@@ -39,6 +39,44 @@ When enabled:
 Changing either stored password or the viewer-access mode rotates the session
 version, which invalidates older sessions. Disabling password protection clears
 the stored auth settings.
+
+## Folder shares
+
+Folder shares are narrower than viewer sessions. They grant read-only access to
+one folder through `/share/:slug` and do not unlock Home, feed search, Reels,
+Places, Likes, Collections, Trash, Settings, scans, rebuilds, captions, cover
+editing, delete actions, or original-file downloads.
+
+Admins can create:
+
+- expiring folder links
+- unlimited folder links that can still be revoked
+- reusable per-folder passwords
+
+Share links and folder passwords are independent grants rather than layers of
+the same grant. Visitors with an active link do not also need the folder
+password. Revoking a link invalidates that link and its session, but visitors
+who know the reusable folder password can still create a password session. To
+remove both access paths, revoke the applicable links and change or remove the
+folder password.
+
+For share links:
+
+- the raw token is generated once and returned only in the creation response
+- the share URL places the raw token in the URL fragment as `#token=...`
+- SQLite stores only a SHA-256 token hash plus a short token prefix
+- expired and revoked links stop creating or validating share sessions
+
+After a visitor unlocks a share, Foldergram sets a separate signed `HttpOnly`
+cookie named `foldergram_share_session`. That cookie is not an admin or viewer
+session. The server re-checks the underlying link or folder-password version
+before granting folder access, so revoking a link, expiring a link, changing a
+folder password, or removing a folder password invalidates older share grants.
+
+Shared media does not use raw `/thumbnails/...` or `/previews/...` URLs in API
+payloads. Shared folder payloads point to `/api/share/images/:id/thumbnail` and
+`/api/share/images/:id/preview`, and those routes check that the request has a
+grant for the image's folder before serving or lazily generating the derivative.
 
 ## Mutation protection
 
@@ -127,6 +165,7 @@ This is a resilience measure, not a security feature.
 Foldergram includes small in-memory rate limiters for:
 
 - authentication attempts
+- folder share token and password unlock attempts
 - admin mutation routes such as rescan and rebuild operations
 
 These limiters are process-local and intentionally simple. They are useful for

--- a/server/db/migrations/000004_add_folder_shares.sql
+++ b/server/db/migrations/000004_add_folder_shares.sql
@@ -1,0 +1,36 @@
+-- migrate:up
+
+CREATE TABLE IF NOT EXISTS folder_share_links (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  folder_id INTEGER NOT NULL,
+  token_hash TEXT NOT NULL UNIQUE,
+  token_prefix TEXT NULL,
+  expires_at TEXT NULL,
+  revoked_at TEXT NULL,
+  allow_original_downloads INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_used_at TEXT NULL,
+  FOREIGN KEY (folder_id) REFERENCES folders(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_folder_share_links_folder_id
+  ON folder_share_links(folder_id);
+
+CREATE INDEX IF NOT EXISTS idx_folder_share_links_expires_at
+  ON folder_share_links(expires_at);
+
+ALTER TABLE folders
+ADD COLUMN share_password_version INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS folder_share_passwords (
+  folder_id INTEGER PRIMARY KEY,
+  password_hash TEXT NOT NULL,
+  password_salt TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 1,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (folder_id) REFERENCES folders(id) ON DELETE CASCADE
+);
+
+-- migrate:down
+
+-- Forward-only. Foldergram does not automatically roll back local user data migrations.

--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,7 @@
     "migrate:prod": "node dist/scripts/migrate.js",
     "start": "node dist/scripts/migrate.js && node dist/index.js",
     "rescan": "tsx src/scripts/rescan.ts",
-    "test": "vitest run"
+    "test": "vitest run --config vitest.config.ts test/"
   },
   "dependencies": {
     "chokidar": "^4.0.3",

--- a/server/src/constants/app-setting-keys.ts
+++ b/server/src/constants/app-setting-keys.ts
@@ -21,3 +21,4 @@ export const AUTH_SESSION_VERSION_SETTING_KEY = 'auth.session_version';
 export const AUTH_VIEWER_ACCESS_MODE_SETTING_KEY = 'auth.viewer_access_mode';
 export const AUTH_VIEWER_PASSWORD_HASH_SETTING_KEY = 'auth.viewer_password_hash';
 export const AUTH_VIEWER_PASSWORD_SALT_SETTING_KEY = 'auth.viewer_password_salt';
+export const SHARE_SESSION_SECRET_SETTING_KEY = 'share.session_secret';

--- a/server/src/db/database.ts
+++ b/server/src/db/database.ts
@@ -10,25 +10,42 @@ function initializeTransientDatabase(database: DatabaseSync): DatabaseSync {
   return database;
 }
 
-class DatabaseManager {
-  private database: DatabaseSync | null = null;
+const GLOBAL_DB_KEY = Symbol.for('foldergram.database.connection');
 
+class DatabaseManager {
   get connection(): DatabaseSync {
-    if (this.database) {
-      return this.database;
+    const globalObj = globalThis as unknown as Record<symbol, DatabaseSync | null>;
+    if (globalObj[GLOBAL_DB_KEY]) {
+      return globalObj[GLOBAL_DB_KEY]!;
     }
 
     const databasePath = storageService.getDatabasePath();
 
+    let db: DatabaseSync;
     if (databasePath === ':memory:') {
-      this.database = initializeTransientDatabase(new DatabaseSync(databasePath));
-      return this.database;
+      db = initializeTransientDatabase(new DatabaseSync(databasePath));
+    } else {
+      runStartupMigrations({ databasePath });
+      db = new DatabaseSync(databasePath);
+      assertNoLegacySchema(db);
     }
 
-    runStartupMigrations({ databasePath });
-    this.database = new DatabaseSync(databasePath);
-    assertNoLegacySchema(this.database);
-    return this.database;
+    globalObj[GLOBAL_DB_KEY] = db;
+    return db;
+  }
+
+  close(): void {
+    const globalObj = globalThis as unknown as Record<symbol, DatabaseSync | null>;
+    const db = globalObj[GLOBAL_DB_KEY];
+    if (db) {
+      try {
+        db.close();
+      } catch {
+        // Ignore errors if already closed
+      } finally {
+        globalObj[GLOBAL_DB_KEY] = null;
+      }
+    }
   }
 }
 

--- a/server/src/db/migration.ts
+++ b/server/src/db/migration.ts
@@ -27,7 +27,9 @@ const APP_SCHEMA_TABLES = [
   'folder_scan_state',
   'likes',
   'collections',
-  'collection_items'
+  'collection_items',
+  'folder_share_links',
+  'folder_share_passwords'
 ] as const;
 
 export interface BaselineResult {

--- a/server/src/db/repositories.ts
+++ b/server/src/db/repositories.ts
@@ -1,4 +1,5 @@
 import { databaseManager } from './database.js';
+import { SHARE_SESSION_SECRET_SETTING_KEY } from '../constants/app-setting-keys.js';
 import { normalizePath, safeJoin } from '../utils/path-utils.js';
 import { resolveUniqueSlug, slugifyFolderName } from '../utils/slug.js';
 import type {
@@ -11,6 +12,8 @@ import type {
   FolderImageOrder,
   FolderRole,
   FolderScanStateRecord,
+  FolderShareLinkRecord,
+  FolderSharePasswordRecord,
   ImageDetail,
   ImageRecord,
   LikeRecord,
@@ -26,7 +29,15 @@ import type {
   TakenAtSource
 } from '../types/models.js';
 
-const database = databaseManager.connection;
+import type { DatabaseSync } from 'node:sqlite';
+
+const database = new Proxy({} as DatabaseSync, {
+  get(_target, prop) {
+    const conn = databaseManager.connection as any;
+    const value = conn[prop];
+    return typeof value === 'function' ? value.bind(conn) : value;
+  }
+});
 const EFFECTIVE_FEED_TIME_SQL = 'COALESCE(images.taken_at, images.sort_timestamp)';
 const DEFAULT_COLLECTION_SLUG = 'saved';
 const DEFAULT_COLLECTION_NAME = 'Saved';
@@ -301,6 +312,19 @@ export interface UpsertFolderInput {
 export interface SaveFolderResult {
   folder: FolderRecord;
   wrote: boolean;
+}
+
+export interface CreateFolderShareLinkInput {
+  folderId: number;
+  tokenHash: string;
+  tokenPrefix: string;
+  expiresAt: string | null;
+}
+
+export interface UpsertFolderSharePasswordInput {
+  folderId: number;
+  passwordHash: string;
+  passwordSalt: string;
 }
 
 export interface UpsertImageInput {
@@ -2314,6 +2338,132 @@ export const collectionRepository = {
   }
 };
 
+export const folderShareLinkRepository = {
+  create(input: CreateFolderShareLinkInput): FolderShareLinkRecord {
+    database
+      .prepare(
+        `
+        INSERT INTO folder_share_links (
+          folder_id,
+          token_hash,
+          token_prefix,
+          expires_at,
+          allow_original_downloads,
+          created_at
+        )
+        VALUES (?, ?, ?, ?, 0, ?)
+        `
+      )
+      .run(
+        input.folderId,
+        input.tokenHash,
+        input.tokenPrefix,
+        input.expiresAt,
+        nowIso()
+      );
+
+    return this.getByTokenHash(input.tokenHash) as FolderShareLinkRecord;
+  },
+
+  getById(id: number): FolderShareLinkRecord | undefined {
+    return database.prepare('SELECT * FROM folder_share_links WHERE id = ?').get(id) as FolderShareLinkRecord | undefined;
+  },
+
+  getByTokenHash(tokenHash: string): FolderShareLinkRecord | undefined {
+    return database
+      .prepare('SELECT * FROM folder_share_links WHERE token_hash = ?')
+      .get(tokenHash) as FolderShareLinkRecord | undefined;
+  },
+
+  listByFolder(folderId: number): FolderShareLinkRecord[] {
+    return database
+      .prepare(
+        `
+        SELECT *
+        FROM folder_share_links
+        WHERE folder_id = ?
+        ORDER BY created_at DESC, id DESC
+        `
+      )
+      .all(folderId) as unknown as FolderShareLinkRecord[];
+  },
+
+  revoke(id: number, folderId: number): FolderShareLinkRecord | undefined {
+    const revokedAt = nowIso();
+    database
+      .prepare(
+        `
+        UPDATE folder_share_links
+        SET revoked_at = COALESCE(revoked_at, ?)
+        WHERE id = ? AND folder_id = ?
+        `
+      )
+      .run(revokedAt, id, folderId);
+
+    return this.getById(id);
+  },
+
+  touchLastUsed(id: number): void {
+    database.prepare('UPDATE folder_share_links SET last_used_at = ? WHERE id = ?').run(nowIso(), id);
+  }
+};
+
+export const folderSharePasswordRepository = {
+  get(folderId: number): FolderSharePasswordRecord | undefined {
+    return database
+      .prepare('SELECT * FROM folder_share_passwords WHERE folder_id = ?')
+      .get(folderId) as FolderSharePasswordRecord | undefined;
+  },
+
+  upsert(input: UpsertFolderSharePasswordInput): FolderSharePasswordRecord {
+    database.exec('BEGIN TRANSACTION;');
+    try {
+      database.prepare('UPDATE folders SET share_password_version = share_password_version + 1 WHERE id = ?').run(input.folderId);
+      const folder = database.prepare('SELECT share_password_version FROM folders WHERE id = ?').get(input.folderId) as { share_password_version: number } | undefined;
+      const version = folder ? folder.share_password_version : 1;
+
+      database
+        .prepare(
+          `
+          INSERT INTO folder_share_passwords (
+            folder_id,
+            password_hash,
+            password_salt,
+            version,
+            updated_at
+          )
+          VALUES (?, ?, ?, ?, ?)
+          ON CONFLICT(folder_id) DO UPDATE SET
+            password_hash = excluded.password_hash,
+            password_salt = excluded.password_salt,
+            version = excluded.version,
+            updated_at = excluded.updated_at
+          `
+        )
+        .run(input.folderId, input.passwordHash, input.passwordSalt, version, nowIso());
+
+      database.exec('COMMIT;');
+      return this.get(input.folderId) as FolderSharePasswordRecord;
+    } catch (error) {
+      database.exec('ROLLBACK;');
+      throw error;
+    }
+  },
+
+  remove(folderId: number): boolean {
+    database.exec('BEGIN TRANSACTION;');
+    try {
+      database.prepare('UPDATE folders SET share_password_version = share_password_version + 1 WHERE id = ?').run(folderId);
+      const result = database.prepare('DELETE FROM folder_share_passwords WHERE folder_id = ?').run(folderId);
+      database.exec('COMMIT;');
+      return Number(result.changes ?? 0) > 0;
+    } catch (error) {
+      database.exec('ROLLBACK;');
+      throw error;
+    }
+  }
+};
+
 export const collectionConstants = {
   defaultCollectionSlug: DEFAULT_COLLECTION_SLUG,
   defaultCollectionName: DEFAULT_COLLECTION_NAME
@@ -2348,10 +2498,13 @@ export const maintenanceRepository = {
       BEGIN;
       UPDATE folders SET avatar_image_id = NULL;
       DELETE FROM likes;
+      DELETE FROM folder_share_passwords;
+      DELETE FROM folder_share_links;
       DELETE FROM images;
       DELETE FROM folders;
       DELETE FROM folder_scan_state;
       DELETE FROM scan_runs;
+      DELETE FROM app_settings WHERE key = '${SHARE_SESSION_SECRET_SETTING_KEY}';
       DELETE FROM sqlite_sequence WHERE name IN ('folders', 'images', 'scan_runs');
       COMMIT;
     `);

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS folders (
   description TEXT NULL,
   avatar_image_id INTEGER NULL,
   avatar_source TEXT NOT NULL DEFAULT 'auto',
+  share_password_version INTEGER NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (avatar_image_id) REFERENCES images(id),
@@ -128,6 +129,28 @@ CREATE TABLE IF NOT EXISTS collection_items (
   FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS folder_share_links (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  folder_id INTEGER NOT NULL,
+  token_hash TEXT NOT NULL UNIQUE,
+  token_prefix TEXT NULL,
+  expires_at TEXT NULL,
+  revoked_at TEXT NULL,
+  allow_original_downloads INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_used_at TEXT NULL,
+  FOREIGN KEY (folder_id) REFERENCES folders(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS folder_share_passwords (
+  folder_id INTEGER PRIMARY KEY,
+  password_hash TEXT NOT NULL,
+  password_salt TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 1,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (folder_id) REFERENCES folders(id) ON DELETE CASCADE
+);
+
 CREATE INDEX IF NOT EXISTS idx_folders_slug ON folders(slug);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_folders_folder_path ON folders(folder_path);
 CREATE INDEX IF NOT EXISTS idx_folders_role ON folders(role);
@@ -159,4 +182,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_collections_single_default ON collections(
 CREATE INDEX IF NOT EXISTS idx_collections_updated_at ON collections(updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_collection_items_image ON collection_items(image_id);
 CREATE INDEX IF NOT EXISTS idx_collection_items_created ON collection_items(collection_id, created_at DESC, image_id DESC);
+CREATE INDEX IF NOT EXISTS idx_folder_share_links_folder_id ON folder_share_links(folder_id);
+CREATE INDEX IF NOT EXISTS idx_folder_share_links_expires_at ON folder_share_links(expires_at);
 `;

--- a/server/src/middleware/auth-protection.ts
+++ b/server/src/middleware/auth-protection.ts
@@ -9,10 +9,17 @@ export const AUTH_FORBIDDEN_MESSAGE = 'You do not have permission to perform thi
 function isPublicApiRoute(request: express.Request): boolean {
   const method = request.method.toUpperCase();
   const path = request.path;
+  const isShareReadRoute = path.startsWith('/share/') && isSafeReadMethod(method);
+  const isShareUnlockRoute =
+    method === 'POST' &&
+    path.startsWith('/share/folders/') &&
+    (path.endsWith('/unlock-link') || path.endsWith('/unlock-password'));
 
   return (
     (method === 'GET' && (path === '/health' || path === '/auth/status')) ||
-    (method === 'POST' && (path === '/auth/login' || path === '/auth/logout' || path === '/auth/unlock-admin'))
+    (method === 'POST' && (path === '/auth/login' || path === '/auth/logout' || path === '/auth/unlock-admin')) ||
+    isShareReadRoute ||
+    isShareUnlockRoute
   );
 }
 

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -2,12 +2,18 @@ import express from 'express';
 import { z } from 'zod';
 
 import { AUTH_PASSWORD_MAX_LENGTH, AUTH_PASSWORD_MIN_LENGTH, authService } from '../services/auth-service.js';
+import {
+  FOLDER_SHARE_PASSWORD_MAX_LENGTH,
+  FOLDER_SHARE_PASSWORD_MIN_LENGTH,
+  folderShareService
+} from '../services/folder-share-service.js';
 import { galleryService } from '../services/gallery-service.js';
 import { requireCapability } from '../middleware/auth-protection.js';
 import { createRateLimiter } from '../middleware/rate-limit.js';
 import { LIBRARY_REBUILD_REQUIRED_MESSAGE, scannerService } from '../services/scanner-service.js';
 import { storageService } from '../services/storage-service.js';
 import { watcherService } from '../services/watcher-service.js';
+import { serveDerivativeForImage } from './lazy-derivatives.js';
 
 const router = express.Router();
 
@@ -103,6 +109,9 @@ const storyIdSchema = z.object({
 const imageIdSchema = z.object({
   id: z.coerce.number().int().positive()
 });
+const shareLinkIdSchema = z.object({
+  linkId: z.coerce.number().int().positive()
+});
 
 export const patchFolderBodySchema = z.object({
   name: z.string().min(1).max(255),
@@ -164,6 +173,50 @@ const viewerAccessBodySchema = z
       });
     }
   });
+const createShareLinkBodySchema = z
+  .object({
+    expiresIn: z.enum(['1h', '24h', '7d', 'custom', 'unlimited']).default('24h'),
+    customExpiresAt: z.string().datetime().nullable().optional(),
+    unlimited: z.boolean().default(false)
+  })
+  .superRefine((body, context) => {
+    if (body.unlimited || body.expiresIn === 'unlimited') {
+      return;
+    }
+
+    if (body.expiresIn === 'custom' && !body.customExpiresAt) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Custom expiration date is required.',
+        path: ['customExpiresAt']
+      });
+      return;
+    }
+
+    if (body.customExpiresAt && Date.parse(body.customExpiresAt) <= Date.now()) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Share links must expire in the future.',
+        path: ['customExpiresAt']
+      });
+    }
+  });
+const shareTokenBodySchema = z.object({
+  token: z.string().trim().min(1).max(512)
+});
+const sharePasswordBodySchema = z.object({
+  password: z
+    .string()
+    .min(FOLDER_SHARE_PASSWORD_MIN_LENGTH, `Password must be at least ${FOLDER_SHARE_PASSWORD_MIN_LENGTH} characters.`)
+    .max(FOLDER_SHARE_PASSWORD_MAX_LENGTH, `Password must be at most ${FOLDER_SHARE_PASSWORD_MAX_LENGTH} characters.`)
+    .refine((value) => value.trim().length > 0, 'Password cannot be empty.')
+});
+const submittedSharePasswordBodySchema = z.object({
+  password: z
+    .string()
+    .min(1, 'Password is required.')
+    .max(FOLDER_SHARE_PASSWORD_MAX_LENGTH, `Password must be at most ${FOLDER_SHARE_PASSWORD_MAX_LENGTH} characters.`)
+});
 
 export const authRequestBodySchemas = {
   login: loginBodySchema,
@@ -195,6 +248,50 @@ const authRateLimiter = createRateLimiter({
   max: 10,
   message: 'Too many authentication attempts. Please try again in a minute.'
 });
+const shareUnlockRateLimiter = createRateLimiter({
+  windowMs: 60 * 1000,
+  max: 20,
+  message: 'Too many share unlock attempts. Please try again in a minute.'
+});
+
+function resolveShareLinkExpiration(body: z.infer<typeof createShareLinkBodySchema>): Date | null {
+  if (body.unlimited || body.expiresIn === 'unlimited') {
+    return null;
+  }
+
+  if (body.expiresIn === 'custom') {
+    return new Date(body.customExpiresAt as string);
+  }
+
+  const durationMs =
+    body.expiresIn === '1h'
+      ? 60 * 60 * 1000
+      : body.expiresIn === '7d'
+        ? 7 * 24 * 60 * 60 * 1000
+        : 24 * 60 * 60 * 1000;
+
+  return new Date(Date.now() + durationMs);
+}
+
+function setShareResponseHeaders(response: express.Response): void {
+  response.setHeader('Cache-Control', 'private, no-store');
+  response.vary('Cookie');
+}
+
+function sendShareAccessDenied(response: express.Response, status = 401): void {
+  setShareResponseHeaders(response);
+  response.status(status).json({ message: 'This folder share is expired, revoked, or locked.' });
+}
+
+function ensureShareFolderAccess(request: express.Request, response: express.Response, folderId: number): boolean {
+  if (!folderShareService.getFolderGrant(request, folderId)) {
+    sendShareAccessDenied(response);
+    return false;
+  }
+
+  setShareResponseHeaders(response);
+  return true;
+}
 
 router.get('/health', (_request, response) => {
   const storageState = storageService.getState();
@@ -511,6 +608,114 @@ router.post('/folders/:slug/cover', requireCapability('canManageLibrary', 'Admin
   response.json({ ok: true });
 });
 
+router.get(
+  '/admin/folders/:slug/share-links',
+  requireCapability('canManageLibrary', 'Admin access is required.'),
+  (request, response) => {
+    const params = slugSchema.parse(request.params);
+    const payload = folderShareService.listLinks(params.slug);
+
+    if (!payload) {
+      response.status(404).json({ message: 'Folder not found' });
+      return;
+    }
+
+    response.json({
+      links: payload.links,
+      password: payload.password,
+      publicFolderUrl: `/folders/${encodeURIComponent(payload.folder.slug)}`,
+      publicAccess: !authService.isEnabled() || authService.isPublicViewerAccessEnabled()
+    });
+  }
+);
+
+router.post(
+  '/admin/folders/:slug/share-links',
+  requireCapability('canManageLibrary', 'Admin access is required.'),
+  (request, response) => {
+    const params = slugSchema.parse(request.params);
+    const body = createShareLinkBodySchema.parse(request.body);
+    const created = folderShareService.createLink(params.slug, {
+      expiresAt: resolveShareLinkExpiration(body)
+    });
+
+    if (!created) {
+      response.status(404).json({ message: 'Folder not found' });
+      return;
+    }
+
+    response.status(201).json({
+      ok: true,
+      shareUrl: `/share/${encodeURIComponent(created.folder.slug)}#token=${encodeURIComponent(created.rawToken)}`,
+      link: created.link
+    });
+  }
+);
+
+router.delete(
+  '/admin/folders/:slug/share-links/:linkId',
+  requireCapability('canManageLibrary', 'Admin access is required.'),
+  (request, response) => {
+    const params = slugSchema.merge(shareLinkIdSchema).parse(request.params);
+    const link = folderShareService.revokeLink(params.slug, params.linkId);
+
+    if (!link) {
+      response.status(404).json({ message: 'Share link not found' });
+      return;
+    }
+
+    response.json({
+      ok: true,
+      link
+    });
+  }
+);
+
+router.put(
+  '/admin/folders/:slug/share-password',
+  requireCapability('canManageLibrary', 'Admin access is required.'),
+  (request, response) => {
+    const params = slugSchema.parse(request.params);
+    const body = sharePasswordBodySchema.parse(request.body);
+    const password = folderShareService.setPassword(params.slug, body.password);
+
+    if (!password) {
+      response.status(404).json({ message: 'Folder not found' });
+      return;
+    }
+
+    response.json({
+      ok: true,
+      password: {
+        enabled: password.enabled,
+        updatedAt: password.updatedAt
+      }
+    });
+  }
+);
+
+router.delete(
+  '/admin/folders/:slug/share-password',
+  requireCapability('canManageLibrary', 'Admin access is required.'),
+  (request, response) => {
+    const params = slugSchema.parse(request.params);
+    const password = folderShareService.removePassword(params.slug);
+
+    if (!password) {
+      response.status(404).json({ message: 'Folder not found' });
+      return;
+    }
+
+    response.json({
+      ok: true,
+      password: {
+        enabled: false,
+        updatedAt: null
+      }
+    });
+  }
+);
+
 router.delete('/folders/:slug', requireCapability('canDeleteMedia', 'Admin access is required.'), async (request, response) => {
   const params = slugSchema.parse(request.params);
   const query = deleteFolderQuerySchema.parse(request.query);
@@ -540,6 +745,133 @@ router.get('/folders/:slug/images', (request, response) => {
   }
 
   response.json(payload);
+});
+
+router.get('/share/folders/:slug/access', (request, response) => {
+  const params = slugSchema.parse(request.params);
+  const access = folderShareService.getAccessState(request, params.slug);
+
+  if (!access.exists) {
+    response.status(404).json({ message: 'Folder share not found' });
+    return;
+  }
+
+  setShareResponseHeaders(response);
+  response.json(access);
+});
+
+router.post('/share/folders/:slug/unlock-link', shareUnlockRateLimiter, (request, response) => {
+  const params = slugSchema.parse(request.params);
+  const body = shareTokenBodySchema.parse(request.body);
+  const grant = folderShareService.verifyLinkToken(params.slug, body.token);
+
+  if (!grant) {
+    folderShareService.clearShareSession(response, request);
+    sendShareAccessDenied(response, 403);
+    return;
+  }
+
+  folderShareService.setShareSession(response, request, grant);
+  setShareResponseHeaders(response);
+  response.json({ ok: true });
+});
+
+router.post('/share/folders/:slug/unlock-password', shareUnlockRateLimiter, (request, response) => {
+  const params = slugSchema.parse(request.params);
+  const body = submittedSharePasswordBodySchema.parse(request.body);
+  const grant = folderShareService.verifyPassword(params.slug, body.password);
+
+  if (!grant) {
+    folderShareService.clearShareSession(response, request);
+    sendShareAccessDenied(response);
+    return;
+  }
+
+  folderShareService.setShareSession(response, request, grant);
+  setShareResponseHeaders(response);
+  response.json({ ok: true });
+});
+
+router.get('/share/folders/:slug', (request, response) => {
+  const params = slugSchema.parse(request.params);
+  const folder = galleryService.getSharedFolderBySlug(params.slug);
+
+  if (!folder) {
+    response.status(404).json({ message: 'Folder share not found' });
+    return;
+  }
+
+  if (!ensureShareFolderAccess(request, response, folder.id)) {
+    return;
+  }
+
+  response.json(folder);
+});
+
+router.get('/share/folders/:slug/images', (request, response) => {
+  const params = slugSchema.parse(request.params);
+  const query = paginationQuerySchema.merge(mediaTypeQuerySchema).parse(request.query);
+  const payload = galleryService.getSharedFolderImages(params.slug, query.page, query.limit, query.mediaType);
+
+  if (!payload) {
+    response.status(404).json({ message: 'Folder share not found' });
+    return;
+  }
+
+  if (!ensureShareFolderAccess(request, response, payload.folder.id)) {
+    return;
+  }
+
+  response.json(payload);
+});
+
+router.get('/share/images/:id', (request, response) => {
+  const params = imageIdSchema.parse(request.params);
+  const query = mediaTypeQuerySchema.parse(request.query);
+  const image = galleryService.getSharedImageDetail(params.id, query.mediaType);
+
+  if (!image) {
+    response.status(404).json({ message: 'Post not found' });
+    return;
+  }
+
+  if (!ensureShareFolderAccess(request, response, image.folderId)) {
+    return;
+  }
+
+  response.json(image);
+});
+
+router.get('/share/images/:id/thumbnail', async (request, response) => {
+  const params = imageIdSchema.parse(request.params);
+  const image = galleryService.getShareDerivativeImage(params.id);
+
+  if (!image) {
+    response.status(404).json({ message: 'Thumbnail not found' });
+    return;
+  }
+
+  if (!ensureShareFolderAccess(request, response, image.folder_id)) {
+    return;
+  }
+
+  await serveDerivativeForImage(response, image, 'thumbnail', { noStore: true });
+});
+
+router.get('/share/images/:id/preview', async (request, response) => {
+  const params = imageIdSchema.parse(request.params);
+  const image = galleryService.getShareDerivativeImage(params.id);
+
+  if (!image) {
+    response.status(404).json({ message: 'Preview not found' });
+    return;
+  }
+
+  if (!ensureShareFolderAccess(request, response, image.folder_id)) {
+    return;
+  }
+
+  await serveDerivativeForImage(response, image, 'preview', { noStore: true });
 });
 
 router.get('/places', (_request, response) => {

--- a/server/src/routes/lazy-derivatives.ts
+++ b/server/src/routes/lazy-derivatives.ts
@@ -5,11 +5,12 @@ import pLimit from 'p-limit';
 
 import { appConfig } from '../config/env.js';
 import { imageRepository } from '../db/repositories.js';
+import type { ImageRecord } from '../types/models.js';
 import { log } from '../services/log-service.js';
 import { generatePreviewDerivative, generateThumbnailDerivative } from '../services/derivative-service.js';
 import { scannerService } from '../services/scanner-service.js';
 import { resolveOriginalPath } from '../utils/media-paths.js';
-import { applyDerivativeErrorHeaders, applyProtectedMediaHeaders } from '../utils/media-response.js';
+import { applyDerivativeErrorHeaders, applyNoStoreMediaHeaders, applyProtectedMediaHeaders } from '../utils/media-response.js';
 import { normalizePath, safeJoin } from '../utils/path-utils.js';
 
 // In-memory map to deduplicate concurrent generation requests for the same derivative path.
@@ -43,8 +44,16 @@ function isConnectionTerminationError(error: unknown): boolean {
   return code === 'ECONNABORTED' || code === 'ECONNRESET' || code === 'ERR_STREAM_PREMATURE_CLOSE';
 }
 
-function sendDerivativeFile(response: express.Response, absolutePath: string): Promise<SendDerivativeResult> {
-  applyProtectedMediaHeaders(response);
+function sendDerivativeFile(
+  response: express.Response,
+  absolutePath: string,
+  options?: { noStore?: boolean }
+): Promise<SendDerivativeResult> {
+  if (options?.noStore) {
+    applyNoStoreMediaHeaders(response);
+  } else {
+    applyProtectedMediaHeaders(response);
+  }
 
   return new Promise((resolve, reject) => {
     response.sendFile(absolutePath, (error) => {
@@ -174,6 +183,106 @@ async function serveOrGenerate(
 
   try {
     const result = await sendDerivativeFile(response, absoluteOutputPath);
+    if (result === 'aborted') {
+      return;
+    }
+  } catch {
+    if (response.headersSent) {
+      return;
+    }
+
+    applyDerivativeErrorHeaders(response);
+    response.status(500).json({ message: 'Failed to serve derivative.' });
+  }
+}
+
+export async function serveDerivativeForImage(
+  response: express.Response,
+  imageRecord: ImageRecord,
+  kind: 'thumbnail' | 'preview',
+  options?: { noStore?: boolean }
+): Promise<void> {
+  const requestedPath = kind === 'thumbnail' ? imageRecord.thumbnail_path : imageRecord.preview_path;
+  const rootDir = kind === 'thumbnail' ? appConfig.thumbnailsDir : appConfig.previewsDir;
+  const absoluteOutputPath = resolveDerivativePath(rootDir, requestedPath);
+  if (!absoluteOutputPath) {
+    applyDerivativeErrorHeaders(response);
+    response.status(400).json({ message: 'Invalid derivative path.' });
+    return;
+  }
+
+  try {
+    await fs.access(absoluteOutputPath);
+    try {
+      const result = await sendDerivativeFile(response, absoluteOutputPath, options);
+      if (result === 'aborted') {
+        return;
+      }
+    } catch {
+      if (response.headersSent) {
+        return;
+      }
+
+      applyDerivativeErrorHeaders(response);
+      response.status(500).json({ message: 'Failed to serve derivative.' });
+    }
+    return;
+  } catch {
+    // File does not exist — fall through to generation.
+  }
+
+  if (scannerService.isLibraryRebuildRequired()) {
+    applyDerivativeErrorHeaders(response);
+    response.status(409).json({ message: 'Library rebuild required before generating derivatives.' });
+    return;
+  }
+
+  let generationPromise = inflightGenerations.get(absoluteOutputPath);
+
+  if (!generationPromise) {
+    log.info('Lazy derivative generate', {
+      kind,
+      file: requestedPath,
+      source: imageRecord.relative_path
+    });
+
+    generationPromise = generationLimit(async () => {
+      try {
+        const sourcePath = resolveOriginalPath(imageRecord.relative_path);
+
+        if (kind === 'thumbnail') {
+          await generateThumbnailDerivative(sourcePath, imageRecord.relative_path, false, {
+            thumbnailPath: imageRecord.thumbnail_path
+          });
+          return;
+        }
+
+        await generatePreviewDerivative(sourcePath, imageRecord.relative_path, false, {
+          previewPath: imageRecord.preview_path
+        });
+      } finally {
+        inflightGenerations.delete(absoluteOutputPath);
+      }
+    });
+
+    inflightGenerations.set(absoluteOutputPath, generationPromise);
+  }
+
+  try {
+    await generationPromise;
+  } catch (error) {
+    if (response.headersSent) {
+      return;
+    }
+
+    const message = error instanceof Error ? error.message : 'Failed to generate derivative.';
+    applyDerivativeErrorHeaders(response);
+    response.status(500).json({ message });
+    return;
+  }
+
+  try {
+    const result = await sendDerivativeFile(response, absoluteOutputPath, options);
     if (result === 'aborted') {
       return;
     }

--- a/server/src/services/folder-share-service.ts
+++ b/server/src/services/folder-share-service.ts
@@ -1,0 +1,551 @@
+import { createHash, createHmac, randomBytes, scryptSync, timingSafeEqual } from 'node:crypto';
+
+import type express from 'express';
+
+import { SHARE_SESSION_SECRET_SETTING_KEY } from '../constants/app-setting-keys.js';
+import {
+  appSettingsRepository,
+  folderRepository,
+  folderShareLinkRepository,
+  folderSharePasswordRepository
+} from '../db/repositories.js';
+import type { FolderRecord, FolderShareLinkRecord, FolderSharePasswordRecord } from '../types/models.js';
+import { authService } from './auth-service.js';
+
+export const FOLDER_SHARE_SESSION_COOKIE_NAME = 'foldergram_share_session';
+export const FOLDER_SHARE_PASSWORD_MIN_LENGTH = 8;
+export const FOLDER_SHARE_PASSWORD_MAX_LENGTH = 256;
+
+const TOKEN_BYTE_LENGTH = 32;
+const TOKEN_PREFIX_LENGTH = 8;
+const PASSWORD_HASH_LENGTH = 64;
+const SHARE_SESSION_DURATION_MS = 24 * 60 * 60 * 1000;
+const SHARE_SESSION_VERSION = 1;
+
+interface LinkShareSessionPayload {
+  exp: number;
+  folderId: number;
+  kind: 'link';
+  linkId: number;
+  sv: number;
+}
+
+interface PasswordShareSessionPayload {
+  exp: number;
+  folderId: number;
+  kind: 'password';
+  sv: number;
+  version: number;
+}
+
+type ShareSessionPayload = LinkShareSessionPayload | PasswordShareSessionPayload;
+
+export interface PublicFolderShareLink {
+  id: number;
+  folderId: number;
+  tokenPrefix: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+  lastUsedAt: string | null;
+  status: 'active' | 'expired' | 'revoked';
+}
+
+export interface FolderShareGrant {
+  folderId: number;
+  kind: 'global' | 'link' | 'password';
+  linkId?: number;
+}
+
+interface LinkGrant {
+  expiresAt: string | null;
+  folderId: number;
+  kind: 'link';
+  linkId: number;
+}
+
+interface PasswordGrant {
+  folderId: number;
+  kind: 'password';
+  version: number;
+}
+
+function decodeBase64Url(value: string | null): Buffer | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const buffer = Buffer.from(value, 'base64url');
+    return buffer.length > 0 ? buffer : null;
+  } catch {
+    return null;
+  }
+}
+
+function getShareSessionSecret(): Buffer {
+  const existing = decodeBase64Url(appSettingsRepository.get(SHARE_SESSION_SECRET_SETTING_KEY));
+  if (existing) {
+    return existing;
+  }
+
+  const secret = randomBytes(32);
+  appSettingsRepository.set(SHARE_SESSION_SECRET_SETTING_KEY, secret.toString('base64url'));
+  return secret;
+}
+
+function signValue(value: string, secret: Buffer): string {
+  return createHmac('sha256', secret).update(value).digest('base64url');
+}
+
+function parseCookieValue(cookieHeader: string | undefined, cookieName: string): string | null {
+  if (!cookieHeader) {
+    return null;
+  }
+
+  const prefix = `${cookieName}=`;
+
+  for (const chunk of cookieHeader.split(';')) {
+    const trimmed = chunk.trim();
+    if (!trimmed.startsWith(prefix)) {
+      continue;
+    }
+
+    const rawValue = trimmed.slice(prefix.length);
+    if (rawValue.length === 0) {
+      return null;
+    }
+
+    try {
+      return decodeURIComponent(rawValue);
+    } catch {
+      return rawValue;
+    }
+  }
+
+  return null;
+}
+
+function parseSessionToken(token: string, secret: Buffer): ShareSessionPayload | null {
+  const separatorIndex = token.lastIndexOf('.');
+  if (separatorIndex <= 0 || separatorIndex === token.length - 1) {
+    return null;
+  }
+
+  const encodedPayload = token.slice(0, separatorIndex);
+  const signature = token.slice(separatorIndex + 1);
+  const expectedSignature = signValue(encodedPayload, secret);
+
+  if (
+    signature.length !== expectedSignature.length ||
+    !timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))
+  ) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) as Partial<ShareSessionPayload>;
+    if (
+      typeof payload.exp !== 'number' ||
+      !Number.isFinite(payload.exp) ||
+      typeof payload.folderId !== 'number' ||
+      !Number.isInteger(payload.folderId) ||
+      payload.folderId <= 0 ||
+      typeof payload.sv !== 'number' ||
+      payload.sv !== SHARE_SESSION_VERSION
+    ) {
+      return null;
+    }
+
+    if (payload.kind === 'link') {
+      if (typeof payload.linkId !== 'number' || !Number.isInteger(payload.linkId) || payload.linkId <= 0) {
+        return null;
+      }
+
+      return {
+        exp: payload.exp,
+        folderId: payload.folderId,
+        kind: 'link',
+        linkId: payload.linkId,
+        sv: payload.sv
+      };
+    }
+
+    if (payload.kind === 'password') {
+      if (typeof payload.version !== 'number' || !Number.isInteger(payload.version) || payload.version <= 0) {
+        return null;
+      }
+
+      return {
+        exp: payload.exp,
+        folderId: payload.folderId,
+        kind: 'password',
+        sv: payload.sv,
+        version: payload.version
+      };
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function isSecureRequest(request: express.Request): boolean {
+  if (request.secure) {
+    return true;
+  }
+
+  const forwardedProto = request.get('x-forwarded-proto');
+  if (!forwardedProto) {
+    return false;
+  }
+
+  const firstValue = forwardedProto
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .find((entry) => entry.length > 0);
+
+  return firstValue === 'https' || firstValue === 'https:';
+}
+
+function hashShareToken(token: string): string {
+  return createHash('sha256').update(token).digest('base64url');
+}
+
+function hashPassword(password: string, salt: Buffer): Buffer {
+  return scryptSync(password.normalize('NFKC'), salt, PASSWORD_HASH_LENGTH);
+}
+
+function isLinkExpired(link: Pick<FolderShareLinkRecord, 'expires_at'>, now = Date.now()): boolean {
+  if (!link.expires_at) {
+    return false;
+  }
+
+  const expiresAt = Date.parse(link.expires_at);
+  return !Number.isFinite(expiresAt) || expiresAt <= now;
+}
+
+function isLinkUsable(link: FolderShareLinkRecord, now = Date.now()): boolean {
+  return link.revoked_at === null && !isLinkExpired(link, now);
+}
+
+function mapShareLink(link: FolderShareLinkRecord, now = new Date()): PublicFolderShareLink {
+  return {
+    id: link.id,
+    folderId: link.folder_id,
+    tokenPrefix: link.token_prefix,
+    expiresAt: link.expires_at,
+    revokedAt: link.revoked_at,
+    createdAt: link.created_at,
+    lastUsedAt: link.last_used_at,
+    status: link.revoked_at ? 'revoked' : isLinkExpired(link, now.getTime()) ? 'expired' : 'active'
+  };
+}
+
+function getGlobalGrant(request: express.Request, folderId: number): FolderShareGrant | null {
+  if (!authService.isEnabled() || authService.isAuthenticatedRequest(request) || authService.isPublicViewerAccessEnabled()) {
+    return {
+      folderId,
+      kind: 'global'
+    };
+  }
+
+  return null;
+}
+
+function getSessionCookieMaxAge(grant: LinkGrant | PasswordGrant): number {
+  if (grant.kind === 'password' || !grant.expiresAt) {
+    return SHARE_SESSION_DURATION_MS;
+  }
+
+  return Math.max(0, Math.min(SHARE_SESSION_DURATION_MS, Date.parse(grant.expiresAt) - Date.now()));
+}
+
+function createSignedSessionToken(payload: ShareSessionPayload): string {
+  const secret = getShareSessionSecret();
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = signValue(encodedPayload, secret);
+  return `${encodedPayload}.${signature}`;
+}
+
+function validateSessionPayload(payload: ShareSessionPayload): LinkGrant | PasswordGrant | null {
+  if (payload.exp <= Date.now()) {
+    return null;
+  }
+
+  if (payload.kind === 'link') {
+    const link = folderShareLinkRepository.getById(payload.linkId);
+    if (!link || link.folder_id !== payload.folderId || !isLinkUsable(link)) {
+      return null;
+    }
+
+    return {
+      expiresAt: link.expires_at,
+      folderId: link.folder_id,
+      kind: 'link',
+      linkId: link.id
+    };
+  }
+
+  const password = folderSharePasswordRepository.get(payload.folderId);
+  if (!password || password.version !== payload.version) {
+    return null;
+  }
+
+  return {
+    folderId: payload.folderId,
+    kind: 'password',
+    version: payload.version
+  };
+}
+
+function getShareSessionGrant(request: express.Request): LinkGrant | PasswordGrant | null {
+  const token = parseCookieValue(request.get('cookie') ?? undefined, FOLDER_SHARE_SESSION_COOKIE_NAME);
+  if (!token) {
+    return null;
+  }
+
+  const payload = parseSessionToken(token, getShareSessionSecret());
+  return payload ? validateSessionPayload(payload) : null;
+}
+
+function getPasswordRecord(folderId: number): FolderSharePasswordRecord | undefined {
+  return folderSharePasswordRepository.get(folderId);
+}
+
+export const folderShareService = {
+  listLinks(slug: string): { folder: FolderRecord; links: PublicFolderShareLink[]; password: { enabled: boolean; updatedAt: string | null } } | null {
+    const folder = folderRepository.getNormalBySlug(slug);
+    if (!folder) {
+      return null;
+    }
+
+    const password = getPasswordRecord(folder.id);
+    return {
+      folder,
+      links: folderShareLinkRepository.listByFolder(folder.id).map((link) => mapShareLink(link)),
+      password: {
+        enabled: Boolean(password),
+        updatedAt: password?.updated_at ?? null
+      }
+    };
+  },
+
+  createLink(slug: string, options: { expiresAt: Date | null }): {
+    folder: FolderRecord;
+    link: PublicFolderShareLink;
+    rawToken: string;
+  } | null {
+    const folder = folderRepository.getNormalBySlug(slug);
+    if (!folder) {
+      return null;
+    }
+
+    const rawToken = randomBytes(TOKEN_BYTE_LENGTH).toString('base64url');
+    const link = folderShareLinkRepository.create({
+      folderId: folder.id,
+      tokenHash: hashShareToken(rawToken),
+      tokenPrefix: rawToken.slice(0, TOKEN_PREFIX_LENGTH),
+      expiresAt: options.expiresAt ? options.expiresAt.toISOString() : null
+    });
+
+    return {
+      folder,
+      link: mapShareLink(link),
+      rawToken
+    };
+  },
+
+  revokeLink(slug: string, linkId: number): PublicFolderShareLink | null {
+    const folder = folderRepository.getNormalBySlug(slug);
+    if (!folder) {
+      return null;
+    }
+
+    const link = folderShareLinkRepository.revoke(linkId, folder.id);
+    return link && link.folder_id === folder.id ? mapShareLink(link) : null;
+  },
+
+  verifyLinkToken(slug: string, token: string): LinkGrant | null {
+    const folder = folderRepository.getNormalBySlug(slug);
+    if (!folder) {
+      return null;
+    }
+
+    const normalizedToken = token.trim();
+    if (normalizedToken.length === 0 || normalizedToken.length > 512) {
+      return null;
+    }
+
+    const link = folderShareLinkRepository.getByTokenHash(hashShareToken(normalizedToken));
+    if (!link || link.folder_id !== folder.id || !isLinkUsable(link)) {
+      return null;
+    }
+
+    folderShareLinkRepository.touchLastUsed(link.id);
+
+    return {
+      expiresAt: link.expires_at,
+      folderId: folder.id,
+      kind: 'link',
+      linkId: link.id
+    };
+  },
+
+  setPassword(slug: string, password: string): { folder: FolderRecord; enabled: true; updatedAt: string } | null {
+    const folder = folderRepository.getNormalBySlug(slug);
+    if (!folder) {
+      return null;
+    }
+
+    const salt = randomBytes(16);
+    const passwordHash = hashPassword(password, salt);
+    const record = folderSharePasswordRepository.upsert({
+      folderId: folder.id,
+      passwordHash: passwordHash.toString('base64url'),
+      passwordSalt: salt.toString('base64url')
+    });
+
+    return {
+      folder,
+      enabled: true,
+      updatedAt: record.updated_at
+    };
+  },
+
+  removePassword(slug: string): { folder: FolderRecord; enabled: false } | null {
+    const folder = folderRepository.getNormalBySlug(slug);
+    if (!folder) {
+      return null;
+    }
+
+    folderSharePasswordRepository.remove(folder.id);
+    return {
+      folder,
+      enabled: false
+    };
+  },
+
+  verifyPassword(slug: string, password: string): PasswordGrant | null {
+    const folder = folderRepository.getNormalBySlug(slug);
+    if (!folder) {
+      return null;
+    }
+
+    const record = getPasswordRecord(folder.id);
+    const expectedHash = decodeBase64Url(record?.password_hash ?? null);
+    const salt = decodeBase64Url(record?.password_salt ?? null);
+    if (!record || !expectedHash || !salt) {
+      return null;
+    }
+
+    const submittedHash = hashPassword(password, salt);
+    if (
+      submittedHash.length !== expectedHash.length ||
+      !timingSafeEqual(submittedHash, expectedHash)
+    ) {
+      return null;
+    }
+
+    return {
+      folderId: folder.id,
+      kind: 'password',
+      version: record.version
+    };
+  },
+
+  getAccessState(request: express.Request, slug: string): {
+    exists: boolean;
+    granted: boolean;
+    hasPassword: boolean;
+    publicAccess: boolean;
+  } {
+    const folder = folderRepository.getNormalBySlug(slug);
+    if (!folder) {
+      return {
+        exists: false,
+        granted: false,
+        hasPassword: false,
+        publicAccess: false
+      };
+    }
+
+    const publicAccess = !authService.isEnabled() || authService.isPublicViewerAccessEnabled();
+
+    return {
+      exists: true,
+      granted: Boolean(this.getFolderGrant(request, folder.id)),
+      hasPassword: Boolean(getPasswordRecord(folder.id)),
+      publicAccess
+    };
+  },
+
+  setShareSession(response: express.Response, request: express.Request, grant: LinkGrant | PasswordGrant): void {
+    const maxAge = getSessionCookieMaxAge(grant);
+    if (maxAge <= 0) {
+      return;
+    }
+
+    const payload: ShareSessionPayload =
+      grant.kind === 'link'
+        ? {
+            exp: Date.now() + maxAge,
+            folderId: grant.folderId,
+            kind: 'link',
+            linkId: grant.linkId,
+            sv: SHARE_SESSION_VERSION
+          }
+        : {
+            exp: Date.now() + maxAge,
+            folderId: grant.folderId,
+            kind: 'password',
+            sv: SHARE_SESSION_VERSION,
+            version: grant.version
+          };
+
+    response.cookie(FOLDER_SHARE_SESSION_COOKIE_NAME, createSignedSessionToken(payload), {
+      encode: (value) => value,
+      httpOnly: true,
+      maxAge,
+      path: '/',
+      sameSite: 'lax',
+      secure: isSecureRequest(request)
+    });
+  },
+
+  clearShareSession(response: express.Response, request: express.Request): void {
+    response.cookie(FOLDER_SHARE_SESSION_COOKIE_NAME, '', {
+      encode: (value) => value,
+      expires: new Date(0),
+      httpOnly: true,
+      maxAge: 0,
+      path: '/',
+      sameSite: 'lax',
+      secure: isSecureRequest(request)
+    });
+  },
+
+  getFolderGrant(request: express.Request, folderId: number): FolderShareGrant | null {
+    const globalGrant = getGlobalGrant(request, folderId);
+    if (globalGrant) {
+      return globalGrant;
+    }
+
+    const shareGrant = getShareSessionGrant(request);
+    if (!shareGrant || shareGrant.folderId !== folderId) {
+      return null;
+    }
+
+    return shareGrant.kind === 'link'
+      ? {
+          folderId,
+          kind: 'link',
+          linkId: shareGrant.linkId
+        }
+      : {
+          folderId,
+          kind: 'password'
+        };
+  }
+};

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -36,9 +36,13 @@ import type {
   FolderRecord,
   FolderSummaryRecord,
   ImageDetail,
+  ImageRecord,
   MediaType,
   PlaceKind,
   PlaybackStrategy,
+  SharedFeedItem,
+  SharedFolderSummary,
+  SharedImageDetail,
   TrashImage
 } from '../types/models.js';
 import {
@@ -259,6 +263,22 @@ function toPublicMediaUrl(basePath: '/thumbnails' | '/previews', relativePath: s
 
 function buildOriginalUrl(id: number): string {
   return `/api/originals/${id}`;
+}
+
+function appendVersion(url: string, version?: string | null): string {
+  if (!version) {
+    return url;
+  }
+
+  return `${url}?v=${encodeURIComponent(version)}`;
+}
+
+function buildShareThumbnailUrl(id: number, version?: string | null): string {
+  return appendVersion(`/api/share/images/${id}/thumbnail`, version);
+}
+
+function buildSharePreviewUrl(id: number, version?: string | null): string {
+  return appendVersion(`/api/share/images/${id}/preview`, version);
 }
 
 function buildPreviewUrl(
@@ -482,6 +502,25 @@ function mapFeedImage(image: IndexedFeedImage, derivativeVersion = getDerivative
   };
 }
 
+function mapSharedFeedImage(image: IndexedFeedImage, derivativeVersion = getDerivativeAssetVersion()): SharedFeedItem {
+  return {
+    id: image.id,
+    folderId: image.folderId,
+    folderSlug: image.folderSlug,
+    folderName: image.folderName,
+    filename: image.filename,
+    caption: image.caption,
+    width: image.width,
+    height: image.height,
+    mediaType: image.mediaType,
+    durationMs: image.durationMs,
+    isAnimated: Boolean(image.isAnimated),
+    thumbnailUrl: buildShareThumbnailUrl(image.id, derivativeVersion),
+    previewUrl: buildSharePreviewUrl(image.id, derivativeVersion),
+    sortTimestamp: image.sortTimestamp
+  };
+}
+
 function mapImageDetail(image: IndexedImageDetail, derivativeVersion = getDerivativeAssetVersion()): ImageDetail {
   const { playbackStrategy, exifJson, placeId, placeSlug, placeName, placeKind, placeIsApproximate, isSaved, ...rest } = image;
   const useOriginalForImages = appConfig.imageDetailSource === 'original';
@@ -501,6 +540,28 @@ function mapImageDetail(image: IndexedImageDetail, derivativeVersion = getDeriva
     originalUrl: buildOriginalUrl(rest.id),
     playbackStrategy,
     place: mapPlaceSummaryFromRow({ placeId, placeSlug, placeName, placeKind, placeIsApproximate })
+  };
+}
+
+function mapSharedImageDetail(image: IndexedImageDetail, derivativeVersion = getDerivativeAssetVersion()): SharedImageDetail {
+  return {
+    id: image.id,
+    folderId: image.folderId,
+    folderSlug: image.folderSlug,
+    folderName: image.folderName,
+    filename: image.filename,
+    caption: image.caption,
+    mediaType: image.mediaType,
+    mimeType: image.mimeType,
+    width: image.width,
+    height: image.height,
+    durationMs: image.durationMs,
+    isAnimated: Boolean(image.isAnimated),
+    thumbnailUrl: buildShareThumbnailUrl(image.id, derivativeVersion),
+    previewUrl: buildSharePreviewUrl(image.id, derivativeVersion),
+    sortTimestamp: image.sortTimestamp,
+    nextImageId: image.nextImageId,
+    previousImageId: image.previousImageId
   };
 }
 
@@ -569,6 +630,22 @@ function buildFolderSummary(folder: FolderSummaryRecord) {
     hasAvatarStory: Boolean(folder.has_avatar_story),
     avatarImageId: avatar?.id ?? null,
     avatarUrl: avatar ? mapImageDetail(avatar, derivativeVersion).thumbnailUrl : null
+  };
+}
+
+function buildSharedFolderSummary(folder: FolderSummaryRecord): SharedFolderSummary {
+  const derivativeVersion = getDerivativeAssetVersion();
+  const summary = buildFolderSummary(folder);
+
+  return {
+    id: summary.id,
+    slug: summary.slug,
+    name: summary.name,
+    description: summary.description,
+    imageCount: summary.imageCount,
+    videoCount: summary.videoCount,
+    avatarThumbnailUrl: summary.avatarImageId ? buildShareThumbnailUrl(summary.avatarImageId, derivativeVersion) : null,
+    sortTimestamp: summary.latestImageMtimeMs ?? 0
   };
 }
 
@@ -1349,6 +1426,19 @@ export const galleryService = {
     return buildFolderSummary(folder);
   },
 
+  getSharedFolderBySlug(slug: string) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const folder = folderRepository.getSummaryBySlug(slug);
+    if (!folder) {
+      return null;
+    }
+
+    return buildSharedFolderSummary(folder);
+  },
+
   updateFolderMetadata(slug: string, name: string, description: string | null) {
     if (!storageService.getState().libraryAvailable) {
       return null;
@@ -1489,6 +1579,32 @@ export const galleryService = {
     };
   },
 
+  getSharedFolderImages(slug: string, page: number, limit: number, mediaType?: MediaType) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const folder = folderRepository.getSummaryBySlug(slug);
+    if (!folder) {
+      return null;
+    }
+
+    const total = mediaType ? imageRepository.countVisibleByFolder(folder.id, mediaType) : folder.image_count;
+    const derivativeVersion = getDerivativeAssetVersion();
+    const defaultFolderImageOrder = getDefaultFolderImageOrder();
+
+    return {
+      folder: buildSharedFolderSummary(folder),
+      items: imageRepository
+        .listFolderImages(folder.id, page, limit, mediaType, defaultFolderImageOrder)
+        .map((image) => mapSharedFeedImage(image, derivativeVersion)),
+      page,
+      limit,
+      total,
+      hasMore: page * limit < total
+    };
+  },
+
   getImageDetail(id: number, mediaType?: MediaType) {
     if (!storageService.getState().libraryAvailable) {
       return null;
@@ -1508,6 +1624,38 @@ export const galleryService = {
     }
 
     return mapImageDetail(detail, getDerivativeAssetVersion());
+  },
+
+  getSharedImageDetail(id: number, mediaType?: MediaType) {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const defaultFolderImageOrder = getDefaultFolderImageOrder();
+    const detail = imageRepository.getImageDetail(id, mediaType, false, defaultFolderImageOrder);
+    if (!detail) {
+      return null;
+    }
+
+    return mapSharedImageDetail(detail, getDerivativeAssetVersion());
+  },
+
+  getShareDerivativeImage(id: number): ImageRecord | null {
+    if (!storageService.getState().libraryAvailable) {
+      return null;
+    }
+
+    const image = imageRepository.getById(id);
+    if (!image || image.is_deleted || image.is_trashed) {
+      return null;
+    }
+
+    const folder = folderRepository.getById(image.folder_id);
+    if (!folder || folder.role !== 'normal') {
+      return null;
+    }
+
+    return image;
   },
 
   getPlacesStatus() {

--- a/server/src/types/models.ts
+++ b/server/src/types/models.ts
@@ -162,6 +162,26 @@ export interface CollectionMembershipRecord extends CollectionSummaryRecord {
   contains_image: number;
 }
 
+export interface FolderShareLinkRecord {
+  id: number;
+  folder_id: number;
+  token_hash: string;
+  token_prefix: string | null;
+  expires_at: string | null;
+  revoked_at: string | null;
+  allow_original_downloads: number;
+  created_at: string;
+  last_used_at: string | null;
+}
+
+export interface FolderSharePasswordRecord {
+  folder_id: number;
+  password_hash: string;
+  password_salt: string;
+  version: number;
+  updated_at: string;
+}
+
 export interface FeedImage {
   id: number;
   folderId: number;
@@ -214,4 +234,52 @@ export interface PlaceDetail extends PlaceSummary {
   countryCode: string | null;
   description: string | null;
   postCount: number;
+}
+
+export interface SharedFolderSummary {
+  id: number;
+  slug: string;
+  name: string;
+  description: string | null;
+  imageCount: number;
+  videoCount: number;
+  avatarThumbnailUrl: string | null;
+  sortTimestamp: number;
+}
+
+export interface SharedFeedItem {
+  id: number;
+  folderId: number;
+  folderSlug: string;
+  folderName: string;
+  filename: string;
+  caption: string | null;
+  width: number;
+  height: number;
+  mediaType: MediaType;
+  durationMs: number | null;
+  isAnimated?: boolean | null;
+  thumbnailUrl: string;
+  previewUrl: string;
+  sortTimestamp: number;
+}
+
+export interface SharedImageDetail {
+  id: number;
+  folderId: number;
+  folderSlug: string;
+  folderName: string;
+  filename: string;
+  caption: string | null;
+  mediaType: MediaType;
+  mimeType: string;
+  width: number;
+  height: number;
+  durationMs: number | null;
+  isAnimated?: boolean | null;
+  thumbnailUrl: string;
+  previewUrl: string;
+  sortTimestamp: number;
+  nextImageId: number | null;
+  previousImageId: number | null;
 }

--- a/server/src/utils/media-response.ts
+++ b/server/src/utils/media-response.ts
@@ -22,6 +22,15 @@ export function applyDerivativeErrorHeaders(response: HeaderResponse): void {
   }
 }
 
+export function applyNoStoreMediaHeaders(response: HeaderResponse & { vary?: (field: string) => void }): void {
+  response.setHeader('Cache-Control', 'private, no-store');
+  if (typeof response.vary === 'function') {
+    response.vary('Cookie');
+  } else {
+    response.setHeader('Vary', 'Cookie');
+  }
+}
+
 export function createProtectedStaticOptions() {
   return {
     fallthrough: false,

--- a/server/test/folder-share-routes.test.ts
+++ b/server/test/folder-share-routes.test.ts
@@ -1,0 +1,443 @@
+import http from 'node:http';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import type express from 'express';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import sharp from 'sharp';
+
+type DatabaseModule = typeof import('../src/db/database.js');
+type AuthServiceModule = typeof import('../src/services/auth-service.js');
+
+async function requestApp(
+  app: express.Application,
+  method: string,
+  urlPath: string,
+  headers: Record<string, string> = {},
+  body?: any
+) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+    server.on('error', reject);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string' || !address.port) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error('Failed to obtain a valid server port.');
+  }
+
+  const url = `http://127.0.0.1:${address.port}${urlPath}`;
+
+  try {
+    const res = await fetch(url, {
+      method,
+      headers: body ? { 'Content-Type': 'application/json', ...headers } : headers,
+      body: body ? JSON.stringify(body) : undefined,
+      redirect: 'manual'
+    });
+
+    let responseBody: any = null;
+    const contentType = res.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      responseBody = await res.json();
+    } else {
+      responseBody = await res.text();
+    }
+
+    return {
+      status: res.status,
+      headers: res.headers,
+      body: responseBody
+    };
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+describe.sequential('folder share API routes', () => {
+  let tempRoot = '';
+  let app: express.Application;
+  let authService: AuthServiceModule['authService'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'foldergram-share-routes-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    try {
+      const dbModule: DatabaseModule = await import('../src/db/database.js');
+      dbModule.databaseManager.close();
+    } catch {
+      // Ignore
+    }
+
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await Promise.all([
+      fs.mkdir(path.join(tempRoot, 'db'), { recursive: true }),
+      fs.mkdir(path.join(tempRoot, 'gallery'), { recursive: true }),
+      fs.mkdir(path.join(tempRoot, 'thumbnails'), { recursive: true }),
+      fs.mkdir(path.join(tempRoot, 'previews'), { recursive: true })
+    ]);
+
+    vi.resetModules();
+    const { createApp } = await import('../src/app.js');
+    ({ authService } = await import('../src/services/auth-service.js'));
+    const { folderRepository, imageRepository, maintenanceRepository } = await import('../src/db/repositories.js');
+
+    maintenanceRepository.resetLibraryIndex();
+    authService.setAdminPassword('admin12345');
+    authService.setViewerAccess('password', 'viewer12345');
+
+    const folderA = folderRepository.upsert({ slug: 'folder-a', name: 'Folder A', folderPath: 'folder-a' });
+    const folderB = folderRepository.upsert({ slug: 'folder-b', name: 'Folder B', folderPath: 'folder-b' });
+
+    imageRepository.upsert({
+      folderId: folderA.id,
+      filename: 'image-a.jpg',
+      extension: 'jpg',
+      relativePath: 'folder-a/image-a.jpg',
+      absolutePath: path.join(tempRoot, 'gallery', 'folder-a', 'image-a.jpg'),
+      fileSize: 1024,
+      width: 800,
+      height: 600,
+      mediaType: 'image',
+      mimeType: 'image/jpeg',
+      durationMs: null,
+      fingerprint: 'fp-a',
+      mtimeMs: Date.now(),
+      firstSeenAt: new Date().toISOString(),
+      sortTimestamp: Date.now(),
+      takenAt: Date.now(),
+      takenAtSource: 'mtime',
+      thumbnailPath: 'folder-a/image-a.webp',
+      previewPath: 'folder-a/image-a.webp',
+      exifJson: JSON.stringify({ latitude: 37.7749, longitude: -122.4194, cameraMake: 'Canon' })
+    });
+
+    imageRepository.upsert({
+      folderId: folderB.id,
+      filename: 'image-b.jpg',
+      extension: 'jpg',
+      relativePath: 'folder-b/image-b.jpg',
+      absolutePath: path.join(tempRoot, 'gallery', 'folder-b', 'image-b.jpg'),
+      fileSize: 2048,
+      width: 1200,
+      height: 900,
+      mediaType: 'image',
+      mimeType: 'image/jpeg',
+      durationMs: null,
+      fingerprint: 'fp-b',
+      mtimeMs: Date.now(),
+      firstSeenAt: new Date().toISOString(),
+      sortTimestamp: Date.now(),
+      takenAt: Date.now(),
+      takenAtSource: 'mtime',
+      thumbnailPath: 'folder-b/image-b.webp',
+      previewPath: 'folder-b/image-b.webp',
+      exifJson: null
+    });
+
+    await fs.mkdir(path.join(tempRoot, 'gallery', 'folder-a'), { recursive: true });
+    await fs.mkdir(path.join(tempRoot, 'gallery', 'folder-b'), { recursive: true });
+
+    const tinyJpeg = await sharp({
+      create: { width: 10, height: 10, channels: 3, background: { r: 255, g: 0, b: 0 } }
+    })
+      .jpeg()
+      .toBuffer();
+
+    await fs.writeFile(path.join(tempRoot, 'gallery', 'folder-a', 'image-a.jpg'), tinyJpeg);
+    await fs.writeFile(path.join(tempRoot, 'gallery', 'folder-b', 'image-b.jpg'), tinyJpeg);
+
+    // Create dummy derivative files on disk
+    await fs.mkdir(path.join(tempRoot, 'thumbnails', 'folder-a'), { recursive: true });
+    await fs.mkdir(path.join(tempRoot, 'thumbnails', 'folder-b'), { recursive: true });
+    await fs.writeFile(path.join(tempRoot, 'thumbnails', 'folder-a', 'image-a.webp'), 'dummy-thumb-a');
+    await fs.writeFile(path.join(tempRoot, 'thumbnails', 'folder-b', 'image-b.webp'), 'dummy-thumb-b');
+
+    await fs.mkdir(path.join(tempRoot, 'previews', 'folder-a'), { recursive: true });
+    await fs.mkdir(path.join(tempRoot, 'previews', 'folder-b'), { recursive: true });
+    await fs.writeFile(path.join(tempRoot, 'previews', 'folder-a', 'image-a.webp'), 'dummy-preview-a');
+    await fs.writeFile(path.join(tempRoot, 'previews', 'folder-b', 'image-b.webp'), 'dummy-preview-b');
+
+    app = createApp();
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    try {
+      const dbModule: DatabaseModule = await import('../src/db/database.js');
+      dbModule.databaseManager.close();
+    } catch {
+      // Ignore
+    }
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('rejects share session cookies on admin endpoints with 401 and viewer cookies with 403', async () => {
+    const { folderShareService } = await import('../src/services/folder-share-service.js');
+    const { folderRepository } = await import('../src/db/repositories.js');
+    const folder = folderRepository.getNormalBySlug('folder-a')!;
+    const link = folderShareService.createLink('folder-a', { expiresAt: null })!;
+    const grant = folderShareService.verifyLinkToken('folder-a', link.rawToken)!;
+
+    // Generate share cookie
+    const mockRes = { cookie: vi.fn().mockReturnThis(), setHeader: vi.fn() };
+    folderShareService.setShareSession(mockRes as any, { secure: false, get: () => undefined } as any, grant);
+    const shareCookie = mockRes.cookie.mock.calls.at(-1)?.[1];
+
+    // Anonymous request -> 401
+    const anonRes = await requestApp(app, 'GET', '/api/admin/stats');
+    expect(anonRes.status).toBe(401);
+
+    // Share cookie request -> 401
+    const shareRes = await requestApp(app, 'GET', '/api/admin/stats', {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(shareRes.status).toBe(401);
+
+    // Viewer auth cookie request -> 403
+    const viewerResMock = { cookie: vi.fn().mockReturnThis(), setHeader: vi.fn() };
+    authService.setAuthenticatedSession(viewerResMock as any, { secure: false, get: () => undefined } as any, 'viewer');
+    const viewerCookie = viewerResMock.cookie.mock.calls.at(-1)?.[1];
+
+    const viewerRes = await requestApp(app, 'GET', '/api/admin/stats', {
+      Cookie: `foldergram_session=${viewerCookie}`
+    });
+    expect(viewerRes.status).toBe(403);
+  });
+
+  it('rejects cross-folder derivative access', async () => {
+    const { folderShareService } = await import('../src/services/folder-share-service.js');
+    const link = folderShareService.createLink('folder-a', { expiresAt: null })!;
+    const grant = folderShareService.verifyLinkToken('folder-a', link.rawToken)!;
+
+    const mockRes = { cookie: vi.fn().mockReturnThis(), setHeader: vi.fn() };
+    folderShareService.setShareSession(mockRes as any, { secure: false, get: () => undefined } as any, grant);
+    const shareCookie = mockRes.cookie.mock.calls.at(-1)?.[1];
+
+    // Access image 1 (in folder-a) -> allowed (200)
+    const allowedRes = await requestApp(app, 'GET', '/api/share/images/1/thumbnail', {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(allowedRes.status).toBe(200);
+
+    // Access image 2 (in folder-b) -> rejected (401)
+    const rejectedRes = await requestApp(app, 'GET', '/api/share/images/2/thumbnail', {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(rejectedRes.status).toBe(401);
+  });
+
+  it('immediately revokes active share sessions when link is revoked', async () => {
+    const { folderShareService } = await import('../src/services/folder-share-service.js');
+    const link = folderShareService.createLink('folder-a', { expiresAt: null })!;
+    const grant = folderShareService.verifyLinkToken('folder-a', link.rawToken)!;
+
+    const mockRes = { cookie: vi.fn().mockReturnThis(), setHeader: vi.fn() };
+    folderShareService.setShareSession(mockRes as any, { secure: false, get: () => undefined } as any, grant);
+    const shareCookie = mockRes.cookie.mock.calls.at(-1)?.[1];
+
+    // Session works initially
+    const initialRes = await requestApp(app, 'GET', '/api/share/folders/folder-a', {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(initialRes.status).toBe(200);
+
+    // Revoke link
+    folderShareService.revokeLink('folder-a', link.link.id);
+
+    // Session is immediately rejected
+    const revokedRes = await requestApp(app, 'GET', '/api/share/folders/folder-a', {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(revokedRes.status).toBe(401);
+  });
+
+  it('redacts sensitive metadata from shared JSON endpoints', async () => {
+    const { folderShareService } = await import('../src/services/folder-share-service.js');
+    const link = folderShareService.createLink('folder-a', { expiresAt: null })!;
+    const grant = folderShareService.verifyLinkToken('folder-a', link.rawToken)!;
+
+    const mockRes = { cookie: vi.fn().mockReturnThis(), setHeader: vi.fn() };
+    folderShareService.setShareSession(mockRes as any, { secure: false, get: () => undefined } as any, grant);
+    const shareCookie = mockRes.cookie.mock.calls.at(-1)?.[1];
+
+    // Folder detail
+    const folderRes = await requestApp(app, 'GET', '/api/share/folders/folder-a', {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(folderRes.status).toBe(200);
+    expect(folderRes.body).not.toHaveProperty('folderPath');
+    expect(folderRes.body).not.toHaveProperty('absolutePath');
+
+    // Folder images
+    const imagesRes = await requestApp(app, 'GET', '/api/share/folders/folder-a/images', {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(imagesRes.status).toBe(200);
+    expect(imagesRes.body.items[0]).not.toHaveProperty('folderPath');
+    expect(imagesRes.body.items[0]).not.toHaveProperty('relativePath');
+    expect(imagesRes.body.items[0]).not.toHaveProperty('exif');
+
+    // Shared image detail
+    const imageDetailRes = await requestApp(app, 'GET', '/api/share/images/1', {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(imageDetailRes.status).toBe(200);
+    expect(imageDetailRes.body).not.toHaveProperty('folderPath');
+    expect(imageDetailRes.body).not.toHaveProperty('relativePath');
+    expect(imageDetailRes.body).not.toHaveProperty('absolutePath');
+    expect(imageDetailRes.body).not.toHaveProperty('exif');
+  });
+
+  it('serves shared derivatives (pre-existing and lazy-generated) with Cache-Control: private, no-store and Vary: Cookie', async () => {
+    const { folderShareService } = await import('../src/services/folder-share-service.js');
+    const link = folderShareService.createLink('folder-a', { expiresAt: null })!;
+    const grant = folderShareService.verifyLinkToken('folder-a', link.rawToken)!;
+
+    const mockRes = { cookie: vi.fn().mockReturnThis(), setHeader: vi.fn() };
+    folderShareService.setShareSession(mockRes as any, { secure: false, get: () => undefined } as any, grant);
+    const shareCookie = mockRes.cookie.mock.calls.at(-1)?.[1];
+
+    // Case 1: Pre-existing derivative file
+    const resPreExisting = await requestApp(app, 'GET', '/api/share/images/1/thumbnail', {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(resPreExisting.status).toBe(200);
+    expect(resPreExisting.headers.get('cache-control')).toBe('private, no-store');
+    expect(resPreExisting.headers.get('vary')).toContain('Cookie');
+
+    // Case 2: Lazy generation (file does not exist on disk, must be generated on-demand)
+    await fs.rm(path.join(tempRoot, 'thumbnails', 'folder-a', 'image-a.webp'), { force: true });
+    await fs.rm(path.join(tempRoot, 'previews', 'folder-a', 'image-a.webp'), { force: true });
+
+    const resLazyThumb = await requestApp(app, 'GET', '/api/share/images/1/thumbnail', {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(resLazyThumb.status).toBe(200);
+    expect(resLazyThumb.headers.get('cache-control')).toBe('private, no-store');
+    expect(resLazyThumb.headers.get('vary')).toContain('Cookie');
+
+    const resLazyPreview = await requestApp(app, 'GET', '/api/share/images/1/preview', {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(resLazyPreview.status).toBe(200);
+    expect(resLazyPreview.headers.get('cache-control')).toBe('private, no-store');
+    expect(resLazyPreview.headers.get('vary')).toContain('Cookie');
+  });
+
+  it('rejects unlocking expired share links via API endpoint', async () => {
+    const { folderShareService } = await import('../src/services/folder-share-service.js');
+    const link = folderShareService.createLink('folder-a', {
+      expiresAt: new Date(Date.now() - 3_600_000)
+    })!;
+
+    const unlockRes = await requestApp(
+      app,
+      'POST',
+      '/api/share/folders/folder-a/unlock-link',
+      { 'x-foldergram-intent': '1' },
+      { token: link.rawToken }
+    );
+    expect(unlockRes.status).toBe(403);
+    expect(unlockRes.body).toEqual({ message: 'This folder share is expired, revoked, or locked.' });
+  });
+
+  it('never stores raw reusable passwords in SQLite or returns them in API responses', async () => {
+    const { folderShareService } = await import('../src/services/folder-share-service.js');
+    const { folderSharePasswordRepository, folderRepository } = await import('../src/db/repositories.js');
+
+    folderShareService.setPassword('folder-a', 'super-secret-password-99');
+
+    const folderA = folderRepository.getNormalBySlug('folder-a')!;
+    const dbRecord = folderSharePasswordRepository.get(folderA.id)!;
+
+    expect(dbRecord.password_hash).not.toBe('super-secret-password-99');
+    expect(dbRecord.password_hash).not.toContain('super-secret-password-99');
+    expect(Object.keys(dbRecord)).not.toContain('password');
+
+    // Admin share links list endpoint
+    const adminResMock = { cookie: vi.fn().mockReturnThis(), setHeader: vi.fn() };
+    authService.setAuthenticatedSession(adminResMock as any, { secure: false, get: () => undefined } as any, 'admin');
+    const adminCookie = adminResMock.cookie.mock.calls.at(-1)?.[1];
+
+    const linksRes = await requestApp(app, 'GET', '/api/admin/folders/folder-a/share-links', {
+      Cookie: `foldergram_session=${adminCookie}`
+    });
+    expect(linksRes.status).toBe(200);
+
+    expect(JSON.stringify(linksRes.body)).not.toContain('super-secret-password-99');
+  });
+
+  it('rejects cross-folder preview access with 401', async () => {
+    const { folderShareService } = await import('../src/services/folder-share-service.js');
+    const link = folderShareService.createLink('folder-a', { expiresAt: null })!;
+    const grant = folderShareService.verifyLinkToken('folder-a', link.rawToken)!;
+
+    const mockRes = { cookie: vi.fn().mockReturnThis(), setHeader: vi.fn() };
+    folderShareService.setShareSession(mockRes as any, { secure: false, get: () => undefined } as any, grant);
+    const shareCookie = mockRes.cookie.mock.calls.at(-1)?.[1];
+
+    const allowedRes = await requestApp(app, 'GET', '/api/share/images/1/preview', {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(allowedRes.status).toBe(200);
+
+    const rejectedRes = await requestApp(app, 'GET', '/api/share/images/2/preview', {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(rejectedRes.status).toBe(401);
+  });
+
+  it('revokes share links through API endpoint with required intent header', async () => {
+    const { folderShareService } = await import('../src/services/folder-share-service.js');
+    const link = folderShareService.createLink('folder-a', { expiresAt: null })!;
+    const grant = folderShareService.verifyLinkToken('folder-a', link.rawToken)!;
+
+    const mockRes = { cookie: vi.fn().mockReturnThis(), setHeader: vi.fn() };
+    folderShareService.setShareSession(mockRes as any, { secure: false, get: () => undefined } as any, grant);
+    const shareCookie = mockRes.cookie.mock.calls.at(-1)?.[1];
+
+    // Session works initially
+    const initialRes = await requestApp(app, 'GET', '/api/share/images/1/thumbnail', {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(initialRes.status).toBe(200);
+
+    // Get admin cookie
+    const adminResMock = { cookie: vi.fn().mockReturnThis(), setHeader: vi.fn() };
+    authService.setAuthenticatedSession(adminResMock as any, { secure: false, get: () => undefined } as any, 'admin');
+    const adminCookie = adminResMock.cookie.mock.calls.at(-1)?.[1];
+
+    // Delete link via API
+    const deleteRes = await requestApp(
+      app,
+      'DELETE',
+      `/api/admin/folders/folder-a/share-links/${link.link.id}`,
+      {
+        Cookie: `foldergram_session=${adminCookie}`,
+        'x-foldergram-intent': '1'
+      }
+    );
+    expect(deleteRes.status).toBe(200);
+
+    // Share session should now be rejected
+    const rejectedRes = await requestApp(app, 'GET', '/api/share/images/1/thumbnail', {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(rejectedRes.status).toBe(401);
+  });
+});

--- a/server/test/folder-share-service.test.ts
+++ b/server/test/folder-share-service.test.ts
@@ -1,0 +1,231 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import type express from 'express';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type AuthServiceModule = typeof import('../src/services/auth-service.js');
+type FolderShareServiceModule = typeof import('../src/services/folder-share-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type DatabaseModule = typeof import('../src/db/database.js');
+
+interface MockResponse {
+  cookie: ReturnType<typeof vi.fn>;
+  setHeader: ReturnType<typeof vi.fn>;
+}
+
+function createRequest(headers: Record<string, string | undefined> = {}): express.Request {
+  const normalizedHeaders = new Map(Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]));
+
+  return {
+    secure: false,
+    get(name: string) {
+      return normalizedHeaders.get(name.toLowerCase());
+    }
+  } as unknown as express.Request;
+}
+
+function createResponse(): MockResponse {
+  return {
+    cookie: vi.fn().mockReturnThis(),
+    setHeader: vi.fn()
+  };
+}
+
+function extractCookieHeader(response: MockResponse): string {
+  const [name, value] = response.cookie.mock.calls.at(-1) ?? [];
+  if (typeof name !== 'string' || typeof value !== 'string') {
+    throw new Error('Expected a share session cookie to be set');
+  }
+
+  return `${name}=${value}`;
+}
+
+describe.sequential('folder share service', () => {
+  let tempRoot = '';
+  let authService: AuthServiceModule['authService'];
+  let folderShareService: FolderShareServiceModule['folderShareService'];
+  let folderRepository: RepositoriesModule['folderRepository'];
+  let folderShareLinkRepository: RepositoriesModule['folderShareLinkRepository'];
+  let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'foldergram-folder-share-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    try {
+      const dbModule: DatabaseModule = await import('../src/db/database.js');
+      dbModule.databaseManager.close();
+    } catch {
+      // Ignore if not loaded
+    }
+
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await Promise.all([
+      fs.mkdir(path.join(tempRoot, 'db'), { recursive: true }),
+      fs.mkdir(path.join(tempRoot, 'gallery'), { recursive: true }),
+      fs.mkdir(path.join(tempRoot, 'thumbnails'), { recursive: true }),
+      fs.mkdir(path.join(tempRoot, 'previews'), { recursive: true })
+    ]);
+
+    vi.resetModules();
+    ({ authService } = await import('../src/services/auth-service.js'));
+    ({ folderShareService } = await import('../src/services/folder-share-service.js'));
+    ({ folderRepository, folderShareLinkRepository, maintenanceRepository } = await import('../src/db/repositories.js'));
+    maintenanceRepository.resetLibraryIndex();
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    try {
+      const dbModule: DatabaseModule = await import('../src/db/database.js');
+      dbModule.databaseManager.close();
+    } catch {
+      // Ignore
+    }
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('stores only a token hash and returns the raw token only in the created URL payload', () => {
+    folderRepository.upsert({ slug: 'family', name: 'Family', folderPath: 'family' });
+
+    const created = folderShareService.createLink('family', {
+      expiresAt: new Date(Date.now() + 60_000)
+    });
+
+    expect(created).not.toBeNull();
+    expect(created!.rawToken).toHaveLength(43);
+    expect(created!.link.tokenPrefix).toBe(created!.rawToken.slice(0, 8));
+    expect(Object.keys(created!.link)).not.toContain('token_hash');
+
+    const stored = folderShareLinkRepository.listByFolder(created!.folder.id);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].token_hash).not.toBe(created!.rawToken);
+    expect(stored[0].token_hash).not.toContain(created!.rawToken);
+  });
+
+  it('creates a folder-scoped share session from a valid token', () => {
+    authService.setAdminPassword('admin-pass-123');
+    const folder = folderRepository.upsert({ slug: 'album', name: 'Album', folderPath: 'album' });
+    const otherFolder = folderRepository.upsert({ slug: 'other', name: 'Other', folderPath: 'other' });
+    const created = folderShareService.createLink('album', {
+      expiresAt: new Date(Date.now() + 60_000)
+    })!;
+    const grant = folderShareService.verifyLinkToken('album', created.rawToken);
+    const response = createResponse();
+
+    expect(grant).toMatchObject({
+      folderId: folder.id,
+      kind: 'link'
+    });
+
+    folderShareService.setShareSession(response as unknown as express.Response, createRequest(), grant!);
+    const request = createRequest({
+      cookie: extractCookieHeader(response)
+    });
+
+    expect(folderShareService.getFolderGrant(request, folder.id)).toMatchObject({
+      folderId: folder.id,
+      kind: 'link'
+    });
+    expect(folderShareService.getFolderGrant(request, otherFolder.id)).toBeNull();
+  });
+
+  it('rejects expired and revoked link tokens', () => {
+    folderRepository.upsert({ slug: 'album', name: 'Album', folderPath: 'album' });
+    const expired = folderShareService.createLink('album', {
+      expiresAt: new Date(Date.now() - 60_000)
+    })!;
+    const active = folderShareService.createLink('album', {
+      expiresAt: null
+    })!;
+
+    expect(folderShareService.verifyLinkToken('album', expired.rawToken)).toBeNull();
+    expect(folderShareService.verifyLinkToken('album', active.rawToken)).toMatchObject({
+      kind: 'link'
+    });
+
+    folderShareService.revokeLink('album', active.link.id);
+    expect(folderShareService.verifyLinkToken('album', active.rawToken)).toBeNull();
+  });
+
+  it('invalidates password sessions when the folder password changes or is removed', () => {
+    authService.setAdminPassword('admin-pass-123');
+    const folder = folderRepository.upsert({ slug: 'album', name: 'Album', folderPath: 'album' });
+
+    folderShareService.setPassword('album', 'share-pass-123');
+    const grant = folderShareService.verifyPassword('album', 'share-pass-123');
+    const response = createResponse();
+
+    expect(grant).toMatchObject({
+      folderId: folder.id,
+      kind: 'password'
+    });
+
+    folderShareService.setShareSession(response as unknown as express.Response, createRequest(), grant!);
+    const request = createRequest({
+      cookie: extractCookieHeader(response)
+    });
+
+    expect(folderShareService.getFolderGrant(request, folder.id)).toMatchObject({
+      folderId: folder.id,
+      kind: 'password'
+    });
+
+    folderShareService.setPassword('album', 'changed-pass-123');
+    expect(folderShareService.getFolderGrant(request, folder.id)).toBeNull();
+    expect(folderShareService.verifyPassword('album', 'share-pass-123')).toBeNull();
+    expect(folderShareService.verifyPassword('album', 'changed-pass-123')).toMatchObject({
+      kind: 'password'
+    });
+
+    const changedGrant = folderShareService.verifyPassword('album', 'changed-pass-123')!;
+    const changedResponse = createResponse();
+    folderShareService.setShareSession(changedResponse as unknown as express.Response, createRequest(), changedGrant);
+    const changedRequest = createRequest({
+      cookie: extractCookieHeader(changedResponse)
+    });
+
+    expect(folderShareService.getFolderGrant(changedRequest, folder.id)).toMatchObject({
+      kind: 'password'
+    });
+
+    folderShareService.removePassword('album');
+    expect(folderShareService.getFolderGrant(changedRequest, folder.id)).toBeNull();
+
+    // Recreate password and verify original version-1 session cookie remains rejected
+    folderShareService.setPassword('album', 'new-pass-456');
+    expect(folderShareService.getFolderGrant(request, folder.id)).toBeNull();
+    expect(folderShareService.getFolderGrant(changedRequest, folder.id)).toBeNull();
+  });
+
+  it('invalidates active share sessions when a full library reset occurs', () => {
+    authService.setAdminPassword('admin-pass-123');
+    const folder = folderRepository.upsert({ slug: 'album', name: 'Album', folderPath: 'album' });
+    const created = folderShareService.createLink('album', { expiresAt: new Date(Date.now() + 60_000) })!;
+    const grant = folderShareService.verifyLinkToken('album', created.rawToken)!;
+    const response = createResponse();
+
+    folderShareService.setShareSession(response as unknown as express.Response, createRequest(), grant);
+    const request = createRequest({ cookie: extractCookieHeader(response) });
+
+    expect(folderShareService.getFolderGrant(request, folder.id)).toMatchObject({
+      folderId: folder.id,
+      kind: 'link'
+    });
+
+    maintenanceRepository.resetLibraryIndex();
+
+    expect(folderShareService.getFolderGrant(request, folder.id)).toBeNull();
+  });
+});

--- a/server/test/migration-bootstrap.test.ts
+++ b/server/test/migration-bootstrap.test.ts
@@ -143,7 +143,7 @@ describe.sequential('dbmate startup migrations', () => {
       expect(tableExists(database, 'images')).toBe(true);
       expect(tableExists(database, 'collections')).toBe(true);
       expect(tableHasColumn(database, 'images', 'caption')).toBe(true);
-      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002']);
+      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002', '000004']);
     } finally {
       database.close();
     }
@@ -238,7 +238,7 @@ describe.sequential('dbmate startup migrations', () => {
     const database = new DatabaseSync(databasePath);
 
     try {
-      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002']);
+      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002', '000004']);
       expect(tableExists(database, 'collections')).toBe(true);
       expect(tableHasColumn(database, 'folders', 'avatar_image_id')).toBe(true);
       expect(tableHasColumn(database, 'folders', 'avatar_source')).toBe(true);
@@ -292,7 +292,7 @@ ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
 
     try {
       expect(tableHasColumn(database, 'images', 'migration_note')).toBe(true);
-      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002', '000003']);
+      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002', '000003', '000004']);
     } finally {
       database.close();
     }
@@ -400,7 +400,7 @@ ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
     const database = new DatabaseSync(databasePath);
 
     try {
-      expect(listAppliedVersions(database)).toEqual(['000001', '000002', '000003']);
+      expect(listAppliedVersions(database)).toEqual(['000001', '000002', '000003', '000004']);
       expect(tableHasColumn(database, 'images', 'migration_note')).toBe(true);
       expect(tableHasColumn(database, 'images', 'caption')).toBe(true);
       expect(database.prepare('SELECT playback_strategy AS playbackStrategy FROM images WHERE id = 1').get()).toEqual({
@@ -435,8 +435,8 @@ ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
     const database = new DatabaseSync(databasePath);
 
     try {
-      expect(listAppliedVersions(database)).toEqual(['000001', '000002', '000003']);
-      expect(database.prepare('SELECT COUNT(*) AS count FROM schema_migrations').get()).toEqual({ count: 3 });
+      expect(listAppliedVersions(database)).toEqual(['000001', '000002', '000003', '000004']);
+      expect(database.prepare('SELECT COUNT(*) AS count FROM schema_migrations').get()).toEqual({ count: 4 });
     } finally {
       database.close();
     }
@@ -521,5 +521,37 @@ THIS IS NOT VALID SQL;
 
     const { databaseManager } = await importDatabaseModule();
     expect(tableExists(databaseManager.connection, 'folders')).toBe(true);
+  });
+
+  it('adds share_password_version to folders and creates folder_share_passwords in consolidated 000004 migration', async () => {
+    const { runStartupMigrations } = await importMigrationModule();
+    const databasePath = path.join(tempRoot, 'db', 'gallery.sqlite');
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+
+    runStartupMigrations({ databasePath });
+
+    const database = new DatabaseSync(databasePath);
+
+    try {
+      expect(tableHasColumn(database, 'folders', 'share_password_version')).toBe(true);
+
+      const columnInfo = getColumnInfo(database, 'folders', 'share_password_version');
+      expect(columnInfo).not.toBeNull();
+      expect(columnInfo?.notnull).toBe(1);
+      expect(columnInfo?.dflt_value).toBe('0');
+
+      database
+        .prepare('INSERT INTO folders(slug, name, folder_path) VALUES (?, ?, ?)')
+        .run('test-folder', 'Test Folder', 'test-folder');
+
+      const inserted = database
+        .prepare('SELECT share_password_version FROM folders WHERE slug = ?')
+        .get('test-folder') as { share_password_version: number };
+
+      expect(inserted.share_password_version).toBe(0);
+      expect(tableExists(database, 'folder_share_passwords')).toBe(true);
+    } finally {
+      database.close();
+    }
   });
 });

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -1,0 +1,17 @@
+import sharp from 'sharp';
+import { afterAll, afterEach, beforeEach } from 'vitest';
+import { databaseManager } from '../src/db/database.js';
+
+sharp.cache(false);
+
+beforeEach(() => {
+  databaseManager.close();
+});
+
+afterEach(() => {
+  databaseManager.close();
+});
+
+afterAll(() => {
+  databaseManager.close();
+});

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,0 +1,16 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    include: ['test/**/*.test.ts'],
+    setupFiles: ['./test/setup.ts'],
+    fileParallelism: false,
+    maxWorkers: 1,
+    minWorkers: 1
+  }
+});


### PR DESCRIPTION
Adds expiring and revocable folder links, reusable folder passwords, and read-only shared views. Includes access hardening, privacy-safe media delivery, polished modal styling, tests, and documentation.

Closes #45 & #30 