### PR TITLE
Add folder-based Carousel posts and migration workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Generated derivatives are now stored under stable asset-key shards instead of mi
 - Image and video support with configurable eager or lazy derivative generation for fast browsing.
 - Original-media download controls on home feed cards, post detail, and stories, alongside open-original actions.
 - Optional role-based local access with admin, viewer, and public browse modes.
-- Settings split into `General Settings` for Home/Reels defaults, language selection, stories mode, and excluded folders, plus `Scan & Library` for scan and rebuild actions.
+- Settings split into `General Settings` for Home/Reels defaults, language selection, stories and carousel folder modes, and excluded folders, plus `Scan & Library` for scan and rebuild actions.
 - Phase-aware scan progress for first indexing, derivative migration, and rebuilds.
 - A web app manifest plus production service worker registration.
 - A debounced filesystem watcher in development mode only.
@@ -54,8 +54,8 @@ Generated derivatives are now stored under stable asset-key shards instead of mi
 
 Foldergram maps directly to your filesystem:
 
-1. **App Folders:** Any non-hidden folder under `GALLERY_ROOT` that directly contains supported media becomes one indexed App Folder.
-2. **Posts:** Each supported image or video directly inside that folder becomes one indexed post.
+1. **App Folders:** Any non-hidden folder under `GALLERY_ROOT` that directly contains supported media becomes one indexed App Folder. In reserved carousel mode, a folder also qualifies when its `carousels/` directory has an immediate child containing supported media directly.
+2. **Posts:** Each supported image or video directly inside an App Folder becomes one indexed post. Media in `AppFolder/carousels/Post name/` is grouped into a carousel post in reserved mode.
 3. **Nested folders stay separate:** Nested local folders are not merged into their parent App Folder. If a nested folder directly contains supported media, it becomes its own App Folder with parent folder name in the route (e.g. /folder/parent-nested).
 4. **Root files are ignored:** Files placed directly in `GALLERY_ROOT` are ignored.
 
@@ -278,9 +278,9 @@ not read directly by the container.
 - Use `GALLERY_EXCLUDED_FOLDERS` to skip unwanted source folders during discovery and rescans.
 - Rules without a slash match a folder name anywhere in the gallery tree, such as `@eaDir` or `thumbnails`.
 - Rules with a slash match one exact relative folder path beneath `GALLERY_ROOT`, such as `Archive/cache`.
-- The Settings sidebar now separates app-wide preferences into `General Settings`. That section includes the instant language selector plus saved app-language default, the stories-folders toggle, Home/Reels defaults, and the excluded-folder editor.
+- The Settings sidebar separates app-wide preferences into `General Settings`. That section includes the instant language selector plus saved app-language default, stories and carousel folder modes, Home/Reels defaults, and the excluded-folder editor.
 - `General Settings` can add or remove custom exclusion rules at runtime. Env-backed rules stay read-only there and still require a restart to change.
-- After changing excluded folders or stories mode in `General Settings`, run a full library scan from `Scan & Library` so previously indexed folders are soft-removed or reclassified correctly.
+- After changing excluded folders, stories mode, or carousel mode in `General Settings`, follow the action shown in `Scan & Library` so indexed folders and posts are classified correctly. Run a full scan normally; use the index rebuild when the gallery location requires one.
 
 ### Detail Media and Derivative Timing
 
@@ -380,3 +380,9 @@ Foldergram welcomes small, clearly aligned pull requests for bug fixes, document
 Before working on major features, architectural changes, or changes to core behavior such as scanning, indexing, routing, auth or access flow, and storage strategy, open an issue or discussion first. Pull requests for large changes that were not discussed in advance will not be accepted.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution policy, local setup notes, branch naming guidance, and pull request expectations.
+
+## Carousel posts
+
+Foldergram supports one post containing 2–20 ordered images, animated images, and videos. Put each post in `AppFolder/carousels/Post name/`; filename order controls its slides and the first item is its cover. A carousel counts as one post, has one caption, and its videos are excluded from Reels. The index stores visible posts separately from physical media through `posts` and `post_items`.
+
+See [Posts with Multiple Photos or Videos](docs/carousel-posts.md) for the complete source tree, edge cases, settings, and troubleshooting guide.

--- a/client/src/api/gallery.test.ts
+++ b/client/src/api/gallery.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { addImageToCollection, fetchSharedImage, fetchSharedPost } from './gallery';
+
+describe('post and image API namespaces', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the canonical shared-post endpoint for new shared links and preserves the legacy image endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ id: 42 })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchSharedPost(42);
+    await fetchSharedImage(17);
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/share/posts/42');
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('/api/share/images/17');
+  });
+
+  it('uses canonical post IDs for collection membership mutations', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ id: 42, isSaved: true })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await addImageToCollection('trip-picks', 42);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/collections/trip-picks/posts/42',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+});

--- a/client/src/api/gallery.ts
+++ b/client/src/api/gallery.ts
@@ -264,14 +264,22 @@ export function fetchSharedFolderImages(slug: string, page = 1, limit = 24, medi
   return requestJson<SharedFolderImagesPayload>(`/api/share/folders/${encodeURIComponent(slug)}/images?${params.toString()}`);
 }
 
-export function fetchSharedImage(id: number, mediaType?: 'image' | 'video') {
+function fetchSharedDetail(resource: 'posts' | 'images', id: number, mediaType?: 'image' | 'video') {
   const params = new URLSearchParams();
   if (mediaType) {
     params.set('mediaType', mediaType);
   }
 
   const suffix = params.size > 0 ? `?${params.toString()}` : '';
-  return requestJson<SharedImageDetail>(`/api/share/images/${id}${suffix}`);
+  return requestJson<SharedImageDetail>(`/api/share/${resource}/${id}${suffix}`);
+}
+
+export function fetchSharedPost(id: number, mediaType?: 'image' | 'video') {
+  return fetchSharedDetail('posts', id, mediaType);
+}
+
+export function fetchSharedImage(id: number, mediaType?: 'image' | 'video') {
+  return fetchSharedDetail('images', id, mediaType);
 }
 
 export function fetchImage(id: number, mediaType?: 'image' | 'video') {
@@ -281,11 +289,11 @@ export function fetchImage(id: number, mediaType?: 'image' | 'video') {
   }
 
   const suffix = params.size > 0 ? `?${params.toString()}` : '';
-  return requestJson<ImageDetail>(`/api/images/${id}${suffix}`);
+  return requestJson<ImageDetail>(`/api/posts/${id}${suffix}`);
 }
 
 export async function updateImageCaption(id: number, caption: string | null) {
-  const payload = await requestJson<ImageCaptionMutationResult>(`/api/images/${id}/caption`, {
+  const payload = await requestJson<ImageCaptionMutationResult>(`/api/posts/${id}/caption`, {
     method: 'PATCH',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ caption })
@@ -329,7 +337,7 @@ export function fetchCollectionImages(slug: string, page = 1, limit = 24) {
 }
 
 export function fetchImageCollections(id: number) {
-  return requestJson<ImageCollectionsPayload>(`/api/images/${id}/collections`);
+  return requestJson<ImageCollectionsPayload>(`/api/posts/${id}/collections`);
 }
 
 export function fetchTrashImages(page = 1, limit = 24) {
@@ -337,55 +345,55 @@ export function fetchTrashImages(page = 1, limit = 24) {
 }
 
 export function likeImage(id: number) {
-  return requestJson<LikeMutationResult>(`/api/images/${id}/like`, {
+  return requestJson<LikeMutationResult>(`/api/posts/${id}/like`, {
     method: 'POST'
   });
 }
 
 export function unlikeImage(id: number) {
-  return requestJson<LikeMutationResult>(`/api/images/${id}/like`, {
+  return requestJson<LikeMutationResult>(`/api/posts/${id}/like`, {
     method: 'DELETE'
   });
 }
 
 export function saveImage(id: number) {
-  return requestJson<CollectionMutationResult>(`/api/images/${id}/save`, {
+  return requestJson<CollectionMutationResult>(`/api/posts/${id}/save`, {
     method: 'POST'
   });
 }
 
 export function unsaveImage(id: number) {
-  return requestJson<CollectionMutationResult>(`/api/images/${id}/save`, {
+  return requestJson<CollectionMutationResult>(`/api/posts/${id}/save`, {
     method: 'DELETE'
   });
 }
 
 export function addImageToCollection(slug: string, id: number) {
-  return requestJson<CollectionMutationResult>(`/api/collections/${encodeURIComponent(slug)}/images/${id}`, {
+  return requestJson<CollectionMutationResult>(`/api/collections/${encodeURIComponent(slug)}/posts/${id}`, {
     method: 'POST'
   });
 }
 
 export function removeImageFromCollection(slug: string, id: number) {
-  return requestJson<CollectionMutationResult>(`/api/collections/${encodeURIComponent(slug)}/images/${id}`, {
+  return requestJson<CollectionMutationResult>(`/api/collections/${encodeURIComponent(slug)}/posts/${id}`, {
     method: 'DELETE'
   });
 }
 
 export function trashImage(id: number) {
-  return requestJson<TrashImageResult>(`/api/images/${id}/trash`, {
+  return requestJson<TrashImageResult>(`/api/posts/${id}/trash`, {
     method: 'POST'
   });
 }
 
 export function restoreImage(id: number) {
-  return requestJson<RestoreImageResult>(`/api/images/${id}/restore`, {
+  return requestJson<RestoreImageResult>(`/api/posts/${id}/restore`, {
     method: 'POST'
   });
 }
 
 export function deleteImage(id: number) {
-  return requestJson<DeleteImageResult>(`/api/images/${id}`, {
+  return requestJson<DeleteImageResult>(`/api/posts/${id}`, {
     method: 'DELETE'
   });
 }
@@ -578,5 +586,21 @@ export function updateExcludedFolders(rules: string[]) {
     method: 'PUT',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ rules })
+  });
+}
+
+export function updateCarouselsMode(treatCarouselsAsFolders: boolean) {
+  return requestJson<AppStats>('/api/admin/settings/carousels-as-folders', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ treatCarouselsAsFolders })
+  });
+}
+
+export function updateCarouselsMigrationDecision(decision: 'restore' | 'carousels') {
+  return requestJson<AppStats>('/api/admin/settings/carousels-migration-decision', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ decision })
   });
 }

--- a/client/src/components/CarouselMediaStage.test.ts
+++ b/client/src/components/CarouselMediaStage.test.ts
@@ -1,0 +1,93 @@
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+import { i18n } from '../locales';
+import type { PostMediaItem } from '../types/api';
+import CarouselMediaStage from './CarouselMediaStage.vue';
+
+describe('CarouselMediaStage', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  const mockItems: PostMediaItem[] = [
+    {
+      imageId: 1,
+      filename: 'slide1.mp4',
+      mediaType: 'video',
+      width: 1080,
+      height: 1080,
+      previewUrl: '/preview1.mp4',
+      thumbnailUrl: '/thumb1.webp',
+      originalUrl: '/original1.mp4',
+      position: 1
+    },
+    {
+      imageId: 2,
+      filename: 'slide2.jpg',
+      mediaType: 'image',
+      width: 1080,
+      height: 1080,
+      previewUrl: '/preview2.jpg',
+      thumbnailUrl: '/thumb2.webp',
+      originalUrl: '/original2.jpg',
+      position: 2
+    }
+  ];
+
+  it('renders video slides using VideoMediaPlayer and navigates between slides', async () => {
+    const wrapper = mount(CarouselMediaStage, {
+      props: {
+        items: mockItems,
+        modelValue: 0,
+        autoplay: true
+      },
+      global: {
+        plugins: [i18n]
+      }
+    });
+
+    const player = wrapper.findComponent({ name: 'VideoMediaPlayer' });
+    expect(player.exists()).toBe(true);
+    expect(player.props('autoplay')).toBe(true);
+
+    const nextBtn = wrapper.find('button[aria-label="Next carousel item"]');
+    expect(nextBtn.exists()).toBe(true);
+    await nextBtn.trigger('click');
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([1]);
+  });
+
+  it('ignores pointer swipes when initiated on controls with data-swipe-ignore', async () => {
+    const wrapper = mount(CarouselMediaStage, {
+      props: {
+        items: mockItems,
+        modelValue: 0
+      },
+      global: {
+        plugins: [i18n]
+      }
+    });
+
+    const root = wrapper.element as HTMLElement;
+    const progressFooter = wrapper.find('.video-progress-footer');
+    expect(progressFooter.exists()).toBe(true);
+
+    // Trigger pointerdown on progress footer (data-swipe-ignore="true")
+    await progressFooter.trigger('pointerdown', {
+      pointerId: 1,
+      clientX: 200,
+      button: 0
+    });
+
+    // Trigger pointerup with horizontal movement
+    await wrapper.trigger('pointerup', {
+      pointerId: 1,
+      clientX: 50
+    });
+
+    // Should NOT have navigated because pointerdown was on an ignored element
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+  });
+});

--- a/client/src/components/CarouselMediaStage.vue
+++ b/client/src/components/CarouselMediaStage.vue
@@ -1,0 +1,201 @@
+<template>
+  <div
+    class="relative h-full w-full overflow-hidden bg-surface-alt outline-none select-none"
+    :style="{ aspectRatio }"
+    role="group"
+    aria-roledescription="carousel"
+    :aria-label="t('post.carousel.label', { count: items.length })"
+    tabindex="0"
+    @keydown.left="handleKeyLeft"
+    @keydown.right="handleKeyRight"
+    @pointercancel.stop="cancelPointer"
+    @pointerdown.stop="startPointer"
+    @pointerup.stop="finishPointer"
+  >
+    <template v-for="(item, index) in items" :key="item.imageId">
+      <VideoMediaPlayer
+        v-if="item.mediaType === 'video' && index === activeIndex"
+        class="h-full w-full object-contain bg-black"
+        :src="item.previewUrl"
+        :original-url="item.originalUrl"
+        :playback-strategy="item.playbackStrategy"
+        :width="item.width"
+        :height="item.height"
+        :poster="item.thumbnailUrl"
+        :alt="item.filename"
+        :muted="appStore.videoMuted"
+        :autoplay="autoplay"
+        variant="viewer"
+        @autoplay-muted="appStore.setVideoMuted(true)"
+        @toggle-mute="appStore.setVideoMuted(!appStore.videoMuted)"
+      />
+      <ResilientImage
+        v-else-if="index === activeIndex"
+        class="h-full w-full object-contain"
+        :src="item.isAnimated ? item.previewUrl : (preferPreview ? item.previewUrl : item.thumbnailUrl)"
+        :fallback-src="item.originalUrl"
+        :alt="item.filename"
+        :width="item.width"
+        :height="item.height"
+        :loading="loading"
+        :retry-while="retryWhile"
+        draggable="false"
+      />
+    </template>
+
+    <button
+      v-if="activeIndex > 0"
+      class="absolute left-3 top-1/2 z-2 inline-flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border-0 bg-black/55 text-white shadow-lg cursor-pointer"
+      type="button"
+      :aria-label="t('post.carousel.previousItem')"
+      data-swipe-ignore="true"
+      @click.stop="previous"
+    >
+      <span class="i-fluent-chevron-left-20-filled h-5 w-5" aria-hidden="true" />
+    </button>
+    <button
+      v-if="activeIndex < items.length - 1"
+      class="absolute right-3 top-1/2 z-2 inline-flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border-0 bg-black/55 text-white shadow-lg cursor-pointer"
+      type="button"
+      :aria-label="t('post.carousel.nextItem')"
+      data-swipe-ignore="true"
+      @click.stop="next"
+    >
+      <span class="i-fluent-chevron-right-20-filled h-5 w-5" aria-hidden="true" />
+    </button>
+
+    <div
+      class="absolute right-3 top-3 z-2 rounded-full bg-black/60 px-2.5 py-1 text-xs font-semibold text-white"
+      aria-live="polite"
+      data-swipe-ignore="true"
+    >
+      {{ t('post.carousel.position', { current: activeIndex + 1, count: items.length }) }}
+    </div>
+    <div
+      v-if="items.length <= 10"
+      class="absolute inset-x-0 bottom-3 z-2 flex justify-center gap-1.5 pointer-events-none"
+      aria-hidden="true"
+    >
+      <span
+        v-for="(_, index) in items"
+        :key="index"
+        class="h-1.5 w-1.5 rounded-full shadow"
+        :class="index === activeIndex ? 'bg-white' : 'bg-white/45'"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import type { PostMediaItem } from '../types/api';
+import { useAppStore } from '../stores/app';
+import ResilientImage from './ResilientImage.vue';
+import VideoMediaPlayer from './VideoMediaPlayer.vue';
+
+const props = withDefaults(
+  defineProps<{
+    items: PostMediaItem[];
+    modelValue?: number;
+    preferPreview?: boolean;
+    retryWhile?: boolean;
+    loading?: 'eager' | 'lazy';
+    muted?: boolean;
+    autoplay?: boolean;
+  }>(),
+  {
+    modelValue: 0,
+    preferPreview: false,
+    retryWhile: false,
+    loading: 'lazy',
+    muted: true,
+    autoplay: false
+  }
+);
+
+const emit = defineEmits<{
+  'update:modelValue': [index: number];
+}>();
+
+const { t } = useI18n();
+const appStore = useAppStore();
+const pointerId = ref<number | null>(null);
+const pointerStartX = ref(0);
+
+const activeIndex = computed(() => Math.min(Math.max(props.modelValue, 0), Math.max(props.items.length - 1, 0)));
+const frameItem = computed(() => props.items[0]);
+const aspectRatio = computed(() =>
+  frameItem.value
+    ? `${Math.max(frameItem.value.width, 1)} / ${Math.max(frameItem.value.height, 1)}`
+    : '1 / 1'
+);
+
+function isGestureIgnored(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return Boolean(
+    target.closest('[data-swipe-ignore="true"]') ||
+    target.closest('button, input, select, textarea, a, media-play-button, media-mute-button, media-fullscreen-button, media-time-slider')
+  );
+}
+
+function setIndex(index: number) {
+  const nextIndex = Math.min(Math.max(index, 0), Math.max(props.items.length - 1, 0));
+  if (nextIndex !== activeIndex.value) emit('update:modelValue', nextIndex);
+}
+
+function previous() {
+  setIndex(activeIndex.value - 1);
+}
+
+function next() {
+  setIndex(activeIndex.value + 1);
+}
+
+function handleKeyLeft(event: KeyboardEvent) {
+  if (isGestureIgnored(event.target)) {
+    event.stopPropagation();
+    return;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+  previous();
+}
+
+function handleKeyRight(event: KeyboardEvent) {
+  if (isGestureIgnored(event.target)) {
+    event.stopPropagation();
+    return;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+  next();
+}
+
+function startPointer(event: PointerEvent) {
+  if (event.pointerType === 'mouse' && event.button !== 0) return;
+  if (isGestureIgnored(event.target)) return;
+  pointerId.value = event.pointerId;
+  pointerStartX.value = event.clientX;
+  (event.currentTarget as HTMLElement).setPointerCapture?.(event.pointerId);
+}
+
+function finishPointer(event: PointerEvent) {
+  if (pointerId.value !== event.pointerId) return;
+  const distance = event.clientX - pointerStartX.value;
+  if (Math.abs(distance) >= 48) distance > 0 ? previous() : next();
+  cancelPointer();
+}
+
+function cancelPointer() {
+  pointerId.value = null;
+}
+
+watch(
+  () => props.items.map((item) => item.imageId).join(','),
+  () => {
+    if (activeIndex.value >= props.items.length) emit('update:modelValue', 0);
+  }
+);
+</script>

--- a/client/src/components/FeedCard.vue
+++ b/client/src/components/FeedCard.vue
@@ -55,7 +55,18 @@
       </button>
     </div>
 
-    <RouterLink v-if="!isHomeContext" custom :to="imageRoute" v-slot="{ href, navigate }">
+    <CarouselMediaStage
+      v-if="isCarousel"
+      v-model="carouselIndex"
+      class="rounded-[0.5rem] border border-border"
+      :items="item.mediaItems!"
+      :prefer-preview="isHomeContext"
+      :retry-while="appStore.isScanning"
+      :loading="isHomeContext ? 'eager' : 'lazy'"
+      :muted="appStore.videoMuted"
+    />
+
+    <RouterLink v-else-if="!isHomeContext" custom :to="imageRoute" v-slot="{ href, navigate }">
       <a
         :href="href"
         class="relative block overflow-hidden rounded-[0.5rem] border border-border bg-surface-alt"
@@ -439,6 +450,7 @@ import { formatMediaDuration, formatVideoTimestamp } from '../utils/media';
 import { resolveFeedAspectRatio } from '../utils/media-layout';
 import { getOriginalMediaDownloadUrl, getOriginalMediaUrl } from '../utils/original-media';
 import Avatar from './Avatar.vue';
+import CarouselMediaStage from './CarouselMediaStage.vue';
 import CollectionBookmark from './CollectionBookmark.vue';
 import ConfirmDialog from './ConfirmDialog.vue';
 import PostCaptionModal from './PostCaptionModal.vue';
@@ -497,6 +509,7 @@ const homeVideoDurationMs = ref(props.item.durationMs ?? 0);
 const homeVideoCurrentTimeMs = ref(0);
 const lastHomeImageTapAt = ref(0);
 const heartBurstEl = ref<HTMLElement | null>(null);
+const carouselIndex = ref(0);
 
 let homeImageTapResetTimer: ReturnType<typeof setTimeout> | null = null;
 let homeVideoObserver: IntersectionObserver | null = null;
@@ -516,6 +529,7 @@ const imageRoute = computed(() => ({
   query: route.query
 }));
 const isHomeContext = computed(() => props.context === 'home');
+const isCarousel = computed(() => props.item.postType === 'carousel' && (props.item.mediaItems?.length ?? 0) > 1);
 const showHomeStoryAvatar = computed(() => isHomeContext.value && props.hasAvatarStory);
 const shouldOpenPostInModal = computed(() => props.context !== 'home');
 const displayFolderTitle = computed(() => formatFolderTitle(props.item, appStore.nestedFolderTitleFormat));
@@ -537,8 +551,11 @@ const formattedDuration = computed(() => formatMediaDuration(props.item.duration
 const mediaAspectRatio = computed(() => resolveFeedAspectRatio(props.item.width, props.item.height));
 const homeVideoAspectRatio = computed(() => loadedHomeVideoAspectRatio.value ?? mediaAspectRatio.value);
 const homeImageSrc = computed(() => (props.item.isAnimated ? props.item.previewUrl : props.item.thumbnailUrl));
-const originalMediaUrl = computed(() => getOriginalMediaUrl(props.item.id));
-const downloadOriginalMediaUrl = computed(() => getOriginalMediaDownloadUrl(props.item.id));
+const activeMediaImageId = computed(() =>
+  isCarousel.value ? props.item.mediaItems?.[carouselIndex.value]?.imageId ?? props.item.id : props.item.id
+);
+const originalMediaUrl = computed(() => getOriginalMediaUrl(activeMediaImageId.value));
+const downloadOriginalMediaUrl = computed(() => getOriginalMediaDownloadUrl(activeMediaImageId.value));
 const homeVideoSource = computed<PlayerSrc>(() => ({
   src: props.item.previewUrl,
   type: 'video/mp4'

--- a/client/src/components/FolderGrid.vue
+++ b/client/src/components/FolderGrid.vue
@@ -6,6 +6,7 @@
         class="group relative overflow-hidden bg-surface-alt"
         :class="variant === 'reels' ? 'aspect-[9/14]' : variant === 'posts' ? 'aspect-[3/4]' : 'aspect-square'"
         @click="handleImageNavigation($event, navigate)"
+        :aria-label="item.postType === 'carousel' ? t('post.carousel.open', { count: item.itemCount ?? item.mediaItems?.length ?? 0 }) : undefined"
       >
         <ResilientImage
           :src="item.thumbnailUrl"
@@ -21,6 +22,14 @@
             {{ formatMediaDuration(item.durationMs) }}
           </span>
         </div>
+        <div
+          v-if="'postType' in item && item.postType === 'carousel'"
+          class="absolute top-2 right-2 flex items-center justify-center gap-[0.22rem] rounded-[0.4rem] bg-black/45 px-[0.42rem] py-[0.2rem] text-white pointer-events-none shadow-[0_1px_4px_rgba(0,0,0,0.2)] backdrop-blur-[2px]"
+          aria-hidden="true"
+        >
+          <span class="i-fluent-square-multiple-24-filled w-[0.9rem] h-[0.9rem] text-white" />
+          <span class="text-[0.65rem] font-semibold leading-none tabular-nums">{{ item.itemCount ?? item.mediaItems?.length }}</span>
+        </div>
       </a>
     </RouterLink>
   </section>
@@ -28,6 +37,7 @@
 
 <script setup lang="ts">
 import { RouterLink, useRoute } from 'vue-router';
+import { useI18n } from 'vue-i18n';
 
 import { useAppStore } from '../stores/app';
 import type { FeedItem, SharedFeedItem } from '../types/api';
@@ -50,11 +60,12 @@ const props = withDefaults(
 
 const appStore = useAppStore();
 const route = useRoute();
+const { t } = useI18n();
 
 function buildImageRoute(id: number) {
   if (props.sharedSlug) {
     return {
-      name: 'shared-image',
+      name: 'shared-post',
       params: {
         slug: props.sharedSlug,
         id: String(id)

--- a/client/src/components/PostViewer.vue
+++ b/client/src/components/PostViewer.vue
@@ -132,7 +132,18 @@
         @pointermove="handleMediaPointermove"
         @pointerup="handleMediaPointerup"
       >
-        <template v-if="image.mediaType === 'video'">
+        <CarouselMediaStage
+          v-if="isCarousel"
+          v-model="carouselIndex"
+          class="viewer__media-shell"
+          :items="image.mediaItems!"
+          prefer-preview
+          :retry-while="appStore.isScanning"
+          loading="eager"
+          :muted="appStore.videoMuted"
+          autoplay
+        />
+        <template v-else-if="image.mediaType === 'video'">
           <div
             class="viewer__media-shell viewer__media-shell--video viewer__media-shell--video-interactive"
             :style="mediaShellStyle"
@@ -360,7 +371,7 @@
               {{ t('post.viewer.stats.dimensions') }}
             </dt>
             <dd class="viewer__sidebar-stat-value m-0 text-[0.96rem] font-semibold">
-              {{ image.width }} × {{ image.height }}
+              {{ activeMediaWidth }} × {{ activeMediaHeight }}
             </dd>
           </div>
           <div class="viewer__sidebar-stat">
@@ -372,7 +383,7 @@
             </dd>
           </div>
           <div
-            v-if="image.durationMs"
+            v-if="activeMediaDurationMs"
             class="viewer__sidebar-stat"
           >
             <dt class="viewer__sidebar-stat-label">
@@ -565,7 +576,7 @@
     <Teleport to="body">
       <PostCaptionModal
         v-if="isEditingCaption && image"
-        :filename="image.filename"
+        :filename="captionFallbackFilename"
         :caption="image.caption"
         :error="captionError"
         :loading="captionSaving"
@@ -596,6 +607,7 @@
   import { formatFolderTitle } from "../utils/folder-titles"
   import { getOriginalMediaDownloadUrl, getOriginalMediaUrl } from "../utils/original-media"
   import Avatar from "./Avatar.vue"
+  import CarouselMediaStage from "./CarouselMediaStage.vue"
   import CollectionBookmark from "./CollectionBookmark.vue"
   import PostCaptionModal from "./PostCaptionModal.vue"
   import ResilientImage from "./ResilientImage.vue"
@@ -637,6 +649,7 @@
   const sidebarSheetDragOffset = ref(0)
   const settingCover = ref(false)
   const isEditingCaption = ref(false)
+  const carouselIndex = ref(0)
   const {
     saving: captionSaving,
     error: captionError,
@@ -646,8 +659,23 @@
 
   const WHEEL_NAVIGATION_THRESHOLD = 72
   const NAVIGATION_COOLDOWN_MS = 320
-  const originalMediaUrl = computed(() => (props.image ? getOriginalMediaUrl(props.image.id) : ""))
-  const downloadOriginalMediaUrl = computed(() => (props.image ? getOriginalMediaDownloadUrl(props.image.id) : ""))
+  const isCarousel = computed(() => props.image?.postType === 'carousel' && (props.image.mediaItems?.length ?? 0) > 1)
+  const activeMediaItem = computed(() => isCarousel.value ? props.image?.mediaItems?.[carouselIndex.value] ?? null : null)
+  const activeMediaImageId = computed(() => activeMediaItem.value?.imageId ?? props.image?.id ?? null)
+  const activeMediaWidth = computed(() => activeMediaItem.value?.width ?? props.image?.width ?? 0)
+  const activeMediaHeight = computed(() => activeMediaItem.value?.height ?? props.image?.height ?? 0)
+  const activeMediaDurationMs = computed(() => activeMediaItem.value?.durationMs ?? props.image?.durationMs ?? null)
+  const captionFallbackFilename = computed(() => {
+    if (props.image?.postType === 'carousel' && props.image.carouselTitle) {
+      return props.image.carouselTitle
+    }
+    if (props.image?.postType === 'carousel' && props.image.sourcePath) {
+      return props.image.sourcePath.replaceAll('\\', '/').split('/').at(-1) ?? props.image.filename
+    }
+    return props.image?.filename ?? ''
+  })
+  const originalMediaUrl = computed(() => activeMediaItem.value?.originalUrl ?? (activeMediaImageId.value ? getOriginalMediaUrl(activeMediaImageId.value) : ""))
+  const downloadOriginalMediaUrl = computed(() => activeMediaImageId.value ? getOriginalMediaDownloadUrl(activeMediaImageId.value) : "")
   const MODAL_SIDEBAR_COLLAPSE_BREAKPOINT = 960
   const SHEET_SWIPE_MIN_DISTANCE = 56
   const SHEET_SWIPE_MAX_HORIZONTAL_DISTANCE = 96
@@ -678,7 +706,7 @@
       return ""
     }
 
-    const megabytes = props.image.fileSize / (1024 * 1024)
+    const megabytes = (activeMediaItem.value?.fileSize ?? props.image.fileSize) / (1024 * 1024)
     return `${megabytes.toFixed(2)} MB`
   })
 
@@ -730,6 +758,10 @@
     }
   })
 
+  watch(() => props.image?.id, () => {
+    carouselIndex.value = 0
+  })
+
   const locallySetCover = ref(false)
 
   const isCurrentCover = computed(() => {
@@ -737,11 +769,11 @@
     if (!props.image) return false;
 
     if ('folderAvatarImageId' in props.image && typeof props.image.folderAvatarImageId === 'number') {
-      return props.image.id === props.image.folderAvatarImageId;
+      return activeMediaImageId.value === props.image.folderAvatarImageId;
     }
 
     if (foldersStore.currentFolder?.avatarUrl) {
-      return foldersStore.currentFolder.avatarUrl.includes(`/api/images/${props.image.id}/`);
+      return Boolean(activeMediaImageId.value && foldersStore.currentFolder.avatarUrl.includes(`/api/images/${activeMediaImageId.value}/`));
     }
 
     return false;
@@ -760,9 +792,11 @@
       return ""
     }
 
-    return props.image.mediaType === "video"
-      ? t('post.viewer.videoType', { mimeType: props.image.mimeType })
-      : props.image.mimeType
+    const mediaType = activeMediaItem.value?.mediaType ?? props.image.mediaType
+    const mimeType = activeMediaItem.value?.mimeType ?? props.image.mimeType
+    return mediaType === "video"
+      ? t('post.viewer.videoType', { mimeType })
+      : mimeType
   })
   const formattedDate = computed(() =>
     props.image
@@ -776,10 +810,10 @@
       : "",
   )
   const formattedDuration = computed(() =>
-    formatMediaDuration(props.image?.durationMs),
+    formatMediaDuration(activeMediaDurationMs.value),
   )
   const exifDetails = computed<MetadataDetail[]>(() => {
-    const exif = props.image?.exif
+    const exif = activeMediaItem.value?.exif ?? props.image?.exif
     if (!exif) {
       return []
     }
@@ -1224,21 +1258,25 @@
   }
 
   function handleMediaPointerdown(event: PointerEvent) {
+    if (isCarousel.value) return
     swipeNavigation.onPointerdown(event)
     handleMediaSheetRevealPointerdown(event)
   }
 
   function handleMediaPointermove(event: PointerEvent) {
+    if (isCarousel.value) return
     swipeNavigation.onPointermove(event)
     handleMediaSheetRevealPointermove(event)
   }
 
   async function handleMediaPointerup(event: PointerEvent) {
+    if (isCarousel.value) return
     await swipeNavigation.onPointerup(event)
     await handleMediaSheetRevealPointerup(event)
   }
 
   function handleMediaPointercancel(event: PointerEvent) {
+    if (isCarousel.value) return
     swipeNavigation.onPointercancel()
     handleMediaSheetRevealPointercancel(event)
   }
@@ -1668,7 +1706,7 @@
       return
     }
 
-    if (isEditingCaption.value) {
+    if (isEditingCaption.value || isGestureIgnoredTarget(event.target)) {
       return
     }
 
@@ -1741,7 +1779,7 @@
     if (!props.image || settingCover.value) return;
     try {
       settingCover.value = true;
-      await foldersStore.setFolderCover(props.image.folderSlug, props.image.id);
+      await foldersStore.setFolderCover(props.image.folderSlug, activeMediaImageId.value ?? props.image.id);
       locallySetCover.value = true;
     } catch (error) {
       alert(error instanceof Error ? error.message : 'Failed to set cover');

--- a/client/src/components/ReelInfoSidebar.vue
+++ b/client/src/components/ReelInfoSidebar.vue
@@ -138,7 +138,10 @@ const hasExplicitItemCaption = computed(() => Object.hasOwn(props.item, 'caption
 const caption = computed(() =>
   resolveDisplayCaption({
     filename: props.item.filename,
-    caption: hasExplicitItemCaption.value ? props.item.caption ?? null : detail.value?.caption
+    caption: hasExplicitItemCaption.value ? props.item.caption ?? null : detail.value?.caption,
+    postType: props.item.postType,
+    sourcePath: props.item.sourcePath,
+    carouselTitle: props.item.carouselTitle
   })
 );
 const formattedDate = computed(() =>

--- a/client/src/components/VideoMediaPlayer.test.ts
+++ b/client/src/components/VideoMediaPlayer.test.ts
@@ -1,0 +1,205 @@
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+import { i18n } from '../locales';
+import VideoMediaPlayer from './VideoMediaPlayer.vue';
+
+describe('VideoMediaPlayer', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('renders media player with VideoProgressFooter and swipe-ignore tags', () => {
+    const wrapper = mount(VideoMediaPlayer, {
+      props: {
+        src: '/test-video.mp4',
+        poster: '/test-poster.webp',
+        alt: 'test video'
+      },
+      global: {
+        plugins: [i18n]
+      }
+    });
+
+    expect(wrapper.find('media-player').exists()).toBe(true);
+    expect(wrapper.find('media-provider').exists()).toBe(true);
+    expect(wrapper.find('media-poster').exists()).toBe(true);
+    expect(wrapper.find('.video-progress-footer').exists()).toBe(true);
+    expect(wrapper.find('.video-progress-footer').attributes('data-swipe-ignore')).toBe('true');
+  });
+
+  it('forwards autoplay to the media player', () => {
+    const wrapper = mount(VideoMediaPlayer, {
+      props: {
+        src: '/test-video.mp4',
+        autoplay: true,
+        muted: true
+      },
+      global: {
+        plugins: [i18n]
+      }
+    });
+
+    expect((wrapper.find('media-player').element as any).autoPlay).toBe(true);
+  });
+
+  it('retries blocked audible autoplay while muted', async () => {
+    const wrapper = mount(VideoMediaPlayer, {
+      props: {
+        src: '/test-video.mp4',
+        autoplay: true,
+        muted: false
+      },
+      global: {
+        plugins: [i18n]
+      }
+    });
+
+    const playerEl = wrapper.find('media-player').element as any;
+    playerEl.play = vi.fn().mockResolvedValue(undefined);
+    playerEl.dispatchEvent(new CustomEvent('auto-play-fail'));
+    await vi.waitFor(() => expect(playerEl.play).toHaveBeenCalled());
+
+    expect(playerEl.muted).toBe(true);
+    expect(wrapper.emitted('autoplay-muted')).toHaveLength(1);
+  });
+
+  it('evaluates HD eligibility based on playbackStrategy, dimensions, and originalUrl', async () => {
+    // Eligible: playbackStrategy: original, large resolution (downscaled preview), originalUrl present
+    const wrapperEligible = mount(VideoMediaPlayer, {
+      props: {
+        src: '/test-video-preview.mp4',
+        originalUrl: '/test-video-original.mp4',
+        playbackStrategy: 'original',
+        width: 1920,
+        height: 1080
+      },
+      global: {
+        plugins: [i18n]
+      }
+    });
+
+    const hdBtn = wrapperEligible.find('button[data-swipe-ignore="true"]');
+    expect(hdBtn.exists()).toBe(true);
+    expect(hdBtn.classes()).not.toContain('video-media-player__control--active');
+
+    // Ineligible: playbackStrategy is preview (not compatible for direct playback)
+    const wrapperIneligibleStrategy = mount(VideoMediaPlayer, {
+      props: {
+        src: '/test-video-preview.mp4',
+        originalUrl: '/test-video-original.mov',
+        playbackStrategy: 'preview',
+        width: 1920,
+        height: 1080
+      },
+      global: {
+        plugins: [i18n]
+      }
+    });
+    expect(wrapperIneligibleStrategy.find('button[data-swipe-ignore="true"]').exists()).toBe(false);
+
+    // Ineligible: small resolution that did not downscale
+    const wrapperIneligibleSize = mount(VideoMediaPlayer, {
+      props: {
+        src: '/test-video-preview.mp4',
+        originalUrl: '/test-video-original.mp4',
+        playbackStrategy: 'original',
+        width: 640,
+        height: 480
+      },
+      global: {
+        plugins: [i18n]
+      }
+    });
+    expect(wrapperIneligibleSize.find('button[data-swipe-ignore="true"]').exists()).toBe(false);
+  });
+
+  it('toggles HD state and resets when src changes', async () => {
+    const wrapper = mount(VideoMediaPlayer, {
+      props: {
+        src: '/test-video-preview.mp4',
+        originalUrl: '/test-video-original.mp4',
+        playbackStrategy: 'original',
+        width: 1920,
+        height: 1080
+      },
+      global: {
+        plugins: [i18n]
+      }
+    });
+
+    const hdBtn = wrapper.find('button[data-swipe-ignore="true"]');
+    await hdBtn.trigger('click');
+    expect(wrapper.emitted('toggle-hd')?.[0]).toEqual([true]);
+    expect(wrapper.vm.isHd).toBe(true);
+
+    // Change slide / preview src -> should reset isHd
+    await wrapper.setProps({ src: '/another-video.mp4', originalUrl: '/another-original.mp4' });
+    expect(wrapper.vm.isHd).toBe(false);
+  });
+
+  it('restores currentTime and playing state after HD toggle when loaded-metadata fires', async () => {
+    const wrapper = mount(VideoMediaPlayer, {
+      props: {
+        src: '/test-video-preview.mp4',
+        originalUrl: '/test-video-original.mp4',
+        playbackStrategy: 'original',
+        width: 1920,
+        height: 1080
+      },
+      global: {
+        plugins: [i18n]
+      }
+    });
+
+    const playerEl = wrapper.find('media-player').element as any;
+    playerEl.currentTime = 42.5;
+    playerEl.paused = false; // playing before toggle
+    playerEl.play = vi.fn().mockResolvedValue(undefined);
+
+    const hdBtn = wrapper.find('button[data-swipe-ignore="true"]');
+    await hdBtn.trigger('click');
+
+    // Simulate loaded-metadata event on media player after source changed
+    playerEl.dispatchEvent(new Event('loaded-metadata'));
+
+    expect(playerEl.currentTime).toBe(42.5);
+    expect(playerEl.play).toHaveBeenCalled();
+  });
+
+  it('stops keyboard event propagation for arrow keys on controls', async () => {
+    const wrapper = mount(VideoMediaPlayer, {
+      props: {
+        src: '/test-video.mp4'
+      },
+      global: {
+        plugins: [i18n]
+      }
+    });
+
+    const muteBtn = wrapper.find('media-mute-button');
+    const keyEvent = new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true });
+    const stopPropagationSpy = vi.spyOn(keyEvent, 'stopPropagation');
+
+    muteBtn.element.dispatchEvent(keyEvent);
+    expect(stopPropagationSpy).toHaveBeenCalled();
+  });
+
+  it('pauses player on unmount', () => {
+    const wrapper = mount(VideoMediaPlayer, {
+      props: {
+        src: '/test-video.mp4'
+      },
+      global: {
+        plugins: [i18n]
+      }
+    });
+
+    const mockPlayer = { pause: vi.fn(), removeEventListener: vi.fn() };
+    (wrapper.vm as any).playerElement = mockPlayer;
+
+    wrapper.unmount();
+    expect(mockPlayer.pause).toHaveBeenCalled();
+  });
+});

--- a/client/src/components/VideoMediaPlayer.vue
+++ b/client/src/components/VideoMediaPlayer.vue
@@ -1,0 +1,520 @@
+<template>
+  <div
+    class="video-media-player relative h-full w-full overflow-hidden bg-black select-none"
+    role="button"
+    tabindex="0"
+    @click="handleSurfaceClick"
+    @keydown="handleSurfaceKeydown"
+  >
+    <media-player
+      ref="playerElement"
+      class="video-media-player__player h-full w-full object-contain"
+      :class="`video-media-player__player--${variant}`"
+      :src.prop="computedSource"
+      :title.prop="title || alt || ''"
+      :fullscreenOrientation.prop="'none'"
+      :playsInline.prop="playsinline"
+      :muted.prop="muted"
+      :autoPlay.prop="autoplay"
+      :loop.prop="loop"
+      :load="load"
+      :preload="preload"
+      @fullscreen-change="handleFullscreenChange"
+      @auto-play-fail="handleAutoplayFail"
+    >
+      <media-provider />
+      <media-poster
+        v-if="poster"
+        class="video-media-player__poster"
+        :src.prop="poster"
+        :alt.prop="alt || title || ''"
+      />
+      <VideoProgressFooter
+        v-if="showControls"
+        :variant="variant"
+        :time-label="computedTimeLabel"
+        data-swipe-ignore="true"
+      >
+        <template #leading>
+          <div class="video-media-player__controls-group" data-swipe-ignore="true">
+            <media-play-button
+              class="video-media-player__control"
+              :aria-label="t('post.viewer.togglePlayback')"
+              data-swipe-ignore="true"
+            >
+              <span
+                class="video-media-player__control-icon video-media-player__play-icon video-media-player__play-icon--play i-fluent-play-16-filled"
+                aria-hidden="true"
+              />
+              <span
+                class="video-media-player__control-icon video-media-player__play-icon video-media-player__play-icon--pause i-fluent-pause-16-filled"
+                aria-hidden="true"
+              />
+            </media-play-button>
+          </div>
+        </template>
+        <template #trailing>
+          <div class="video-media-player__controls-group" data-swipe-ignore="true">
+            <media-mute-button
+              class="video-media-player__control"
+              :aria-label="t('post.viewer.toggleSound')"
+              data-swipe-ignore="true"
+              @click.stop="handleMuteClick"
+            >
+              <span
+                class="video-media-player__control-icon video-media-player__mute-icon video-media-player__mute-icon--on i-fluent-speaker-2-16-regular"
+                aria-hidden="true"
+              />
+              <span
+                class="video-media-player__control-icon video-media-player__mute-icon video-media-player__mute-icon--off i-fluent-speaker-mute-16-regular"
+                aria-hidden="true"
+              />
+            </media-mute-button>
+
+            <button
+              v-if="hasHdOption"
+              class="video-media-player__control"
+              :class="{ 'video-media-player__control--active': isHd }"
+              type="button"
+              :aria-label="isHd ? t('post.viewer.switchToPreviewQuality') : t('post.viewer.switchToHdOriginal')"
+              :aria-pressed="isHd"
+              :title="isHd ? t('post.viewer.previewQuality') : t('post.viewer.hdOriginal')"
+              data-swipe-ignore="true"
+              @click.stop="toggleHd"
+            >
+              <span
+                class="video-media-player__control-icon"
+                :class="isHd ? 'i-fluent-hd-16-filled' : 'i-fluent-hd-16-regular'"
+                aria-hidden="true"
+              />
+            </button>
+
+            <media-fullscreen-button
+              class="video-media-player__control"
+              :aria-label="t('post.viewer.toggleFullscreen')"
+              target="media"
+              data-swipe-ignore="true"
+            >
+              <span
+                class="video-media-player__control-icon video-media-player__fullscreen-icon video-media-player__fullscreen-icon--enter i-fluent-full-screen-maximize-16-regular"
+                aria-hidden="true"
+              />
+              <span
+                class="video-media-player__control-icon video-media-player__fullscreen-icon video-media-player__fullscreen-icon--exit i-fluent-full-screen-minimize-16-regular"
+                aria-hidden="true"
+              />
+            </media-fullscreen-button>
+          </div>
+        </template>
+      </VideoProgressFooter>
+    </media-player>
+
+    <div
+      v-if="showPausedIndicator"
+      class="video-media-player__pause-indicator absolute inset-0 m-auto flex h-14 w-14 items-center justify-center rounded-full bg-black/60 text-white pointer-events-none transition-opacity"
+      aria-hidden="true"
+    >
+      <span class="i-fluent-play-20-filled h-8 w-8" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { MediaPlayerElement } from 'vidstack/elements';
+import type { MediaFullscreenChangeEvent, MediaLoadingStrategy, PlayerSrc } from 'vidstack';
+
+import { videoPreviewWouldDownscale } from '../utils/media';
+import VideoProgressFooter from './VideoProgressFooter.vue';
+
+const props = withDefaults(
+  defineProps<{
+    src: string | PlayerSrc;
+    originalUrl?: string;
+    playbackStrategy?: 'preview' | 'original' | null;
+    width?: number | null;
+    height?: number | null;
+    poster?: string;
+    alt?: string;
+    title?: string;
+    muted?: boolean;
+    loop?: boolean;
+    autoplay?: boolean;
+    playsinline?: boolean;
+    load?: MediaLoadingStrategy;
+    preload?: 'none' | 'metadata' | 'auto';
+    variant?: 'feed' | 'viewer';
+    showControls?: boolean;
+    timeLabel?: string;
+  }>(),
+  {
+    originalUrl: '',
+    playbackStrategy: null,
+    width: null,
+    height: null,
+    poster: '',
+    alt: '',
+    title: '',
+    muted: true,
+    loop: true,
+    autoplay: false,
+    playsinline: true,
+    load: 'eager',
+    preload: 'metadata',
+    variant: 'viewer',
+    showControls: true,
+    timeLabel: ''
+  }
+);
+
+const emit = defineEmits<{
+  'toggle-mute': [];
+  'autoplay-muted': [];
+  'toggle-hd': [isHd: boolean];
+  'toggle-playback': [];
+  'fullscreen-change': [isFullscreen: boolean];
+  'loaded-metadata': [payload: { naturalWidth: number; naturalHeight: number; duration: number }];
+  'time-update': [payload: { currentTime: number; duration: number }];
+}>();
+
+const { t } = useI18n();
+const playerElement = ref<MediaPlayerElement | null>(null);
+const durationSec = ref(0);
+const currentTimeSec = ref(0);
+const isPaused = ref(false);
+const showPausedIndicator = ref(false);
+const isHd = ref(false);
+let pendingRestoreState: { currentTime: number; wasPaused: boolean } | null = null;
+let hidePausedTimer: NodeJS.Timeout | null = null;
+let removeEventListeners: (() => void) | null = null;
+
+const hasHdOption = computed(() => {
+  return (
+    props.playbackStrategy === 'original' &&
+    Boolean(props.originalUrl) &&
+    videoPreviewWouldDownscale(props.width, props.height)
+  );
+});
+
+const basePreviewUrl = computed<string>(() => {
+  if (typeof props.src === 'string') {
+    return props.src;
+  }
+  if (Array.isArray(props.src)) {
+    const first = props.src[0];
+    if (typeof first === 'string') return first;
+    return (first && typeof first === 'object' && 'src' in first && typeof (first as any).src === 'string') ? (first as any).src : '';
+  }
+  if (props.src && typeof props.src === 'object' && 'src' in props.src && typeof (props.src as any).src === 'string') {
+    return (props.src as any).src;
+  }
+  return '';
+});
+
+const activeVideoUrl = computed<string>(() => {
+  if (isHd.value && props.originalUrl) {
+    return props.originalUrl;
+  }
+  return basePreviewUrl.value;
+});
+
+const computedSource = computed<PlayerSrc>(() => {
+  return {
+    src: activeVideoUrl.value,
+    type: 'video/mp4'
+  };
+});
+
+function formatTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '0:00';
+  const total = Math.floor(seconds);
+  const mins = Math.floor(total / 60);
+  const secs = total % 60;
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+const computedTimeLabel = computed(() => {
+  if (props.timeLabel) return props.timeLabel;
+  return `${formatTime(currentTimeSec.value)} / ${formatTime(durationSec.value)}`;
+});
+
+function handleFullscreenChange(event: MediaFullscreenChangeEvent) {
+  emit('fullscreen-change', Boolean(event.detail));
+}
+
+function handleMuteClick() {
+  emit('toggle-mute');
+}
+
+async function handleAutoplayFail() {
+  const player = playerElement.value;
+  if (!player || !props.autoplay || props.muted) return;
+
+  // Browsers commonly reject audible autoplay. Keep carousel playback automatic
+  // by retrying muted and persist that state through the owning app store.
+  player.muted = true;
+  emit('autoplay-muted');
+  await nextTick();
+  await player.play().catch(() => {});
+}
+
+async function toggleHd() {
+  const player = playerElement.value;
+  const current = player?.currentTime ?? 0;
+  const wasPaused = player?.paused ?? true;
+
+  isHd.value = !isHd.value;
+  pendingRestoreState = { currentTime: current, wasPaused };
+  emit('toggle-hd', isHd.value);
+}
+
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return Boolean(
+    target.closest('[data-swipe-ignore="true"]') ||
+    target.closest('button, input, select, textarea, a, media-play-button, media-mute-button, media-fullscreen-button, media-time-slider')
+  );
+}
+
+function handleSurfaceClick(event: MouseEvent) {
+  if (isInteractiveTarget(event.target)) return;
+  togglePlayback();
+}
+
+function handleSurfaceKeydown(event: KeyboardEvent) {
+  if (isInteractiveTarget(event.target)) {
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+      event.stopPropagation();
+    }
+    return;
+  }
+
+  if (event.key === ' ' || event.key === 'k') {
+    event.preventDefault();
+    togglePlayback();
+  }
+}
+
+async function togglePlayback() {
+  const player = playerElement.value;
+  if (!player) return;
+
+  if (player.paused) {
+    await player.play().catch(() => {});
+    isPaused.value = false;
+    showPausedIndicator.value = false;
+    if (hidePausedTimer) clearTimeout(hidePausedTimer);
+  } else {
+    player.pause();
+    isPaused.value = true;
+    showPausedIndicator.value = true;
+    if (hidePausedTimer) clearTimeout(hidePausedTimer);
+    hidePausedTimer = setTimeout(() => {
+      showPausedIndicator.value = false;
+    }, 1500);
+  }
+  emit('toggle-playback');
+}
+
+function setupListeners() {
+  const player = playerElement.value;
+  if (!player) return;
+
+  const onLoadedMetadata = async () => {
+    durationSec.value = player.duration || 0;
+    const video = player.querySelector('video');
+    emit('loaded-metadata', {
+      naturalWidth: video?.videoWidth || 0,
+      naturalHeight: video?.videoHeight || 0,
+      duration: player.duration || 0
+    });
+
+    if (pendingRestoreState) {
+      const { currentTime, wasPaused } = pendingRestoreState;
+      pendingRestoreState = null;
+      try {
+        player.currentTime = currentTime;
+        if (!wasPaused) {
+          await player.play().catch(() => {});
+        }
+      } catch {}
+    }
+  };
+
+  const onTimeUpdate = () => {
+    currentTimeSec.value = player.currentTime || 0;
+    durationSec.value = player.duration || 0;
+    emit('time-update', {
+      currentTime: player.currentTime || 0,
+      duration: player.duration || 0
+    });
+  };
+
+  const onPlay = () => {
+    isPaused.value = false;
+    showPausedIndicator.value = false;
+  };
+
+  const onPause = () => {
+    isPaused.value = true;
+  };
+
+  player.addEventListener('loaded-metadata', onLoadedMetadata);
+  player.addEventListener('time-update', onTimeUpdate);
+  player.addEventListener('play', onPlay);
+  player.addEventListener('pause', onPause);
+
+  removeEventListeners = () => {
+    player.removeEventListener('loaded-metadata', onLoadedMetadata);
+    player.removeEventListener('time-update', onTimeUpdate);
+    player.removeEventListener('play', onPlay);
+    player.removeEventListener('pause', onPause);
+  };
+}
+
+onMounted(() => {
+  setupListeners();
+});
+
+onBeforeUnmount(() => {
+  if (playerElement.value) {
+    try {
+      playerElement.value.pause();
+    } catch {}
+  }
+  if (removeEventListeners) removeEventListeners();
+  if (hidePausedTimer) clearTimeout(hidePausedTimer);
+});
+
+watch(basePreviewUrl, () => {
+  isHd.value = false;
+  pendingRestoreState = null;
+});
+
+watch(playerElement, () => {
+  if (removeEventListeners) removeEventListeners();
+  setupListeners();
+});
+
+defineExpose({
+  playerElement,
+  togglePlayback,
+  toggleHd,
+  isHd,
+  hasHdOption,
+  play: () => playerElement.value?.play(),
+  pause: () => playerElement.value?.pause()
+});
+</script>
+
+<style scoped>
+.video-media-player__player {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  color: white;
+  background: black;
+}
+
+.video-media-player__player :deep(media-provider) {
+  position: absolute;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.video-media-player__player :deep(video) {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: black;
+}
+
+.video-media-player__poster {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  background: black;
+  transition: opacity 0.2s ease-out;
+}
+
+.video-media-player__poster[data-visible] {
+  opacity: 1;
+}
+
+.video-media-player__poster[data-hidden] {
+  display: none;
+}
+
+.video-media-player__poster :deep(img) {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border: 0;
+  pointer-events: none;
+  user-select: none;
+}
+
+.video-media-player__controls-group {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.video-media-player__control {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 0;
+  border-radius: 9999px;
+  background: transparent;
+  color: white;
+  cursor: pointer;
+  outline: none;
+  opacity: 0.85;
+  transition: opacity 0.15s ease, transform 0.1s ease;
+}
+
+.video-media-player__control:hover {
+  opacity: 1;
+}
+
+.video-media-player__control--active {
+  color: #38bdf8;
+  opacity: 1;
+}
+
+.video-media-player__control-icon {
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+media-player[data-paused] .video-media-player__play-icon--pause,
+media-player:not([data-paused]) .video-media-player__play-icon--play {
+  display: none;
+}
+
+media-player[data-muted] .video-media-player__mute-icon--on,
+media-player:not([data-muted]) .video-media-player__mute-icon--off {
+  display: none;
+}
+
+media-player[data-fullscreen] .video-media-player__fullscreen-icon--enter,
+media-player:not([data-fullscreen]) .video-media-player__fullscreen-icon--exit {
+  display: none;
+}
+</style>

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -149,6 +149,22 @@
         "helper": "Choose a mode here, then save it below. Run a library scan afterward so the indexed folder structure matches.",
         "helperSaving": "Wait for the current settings update to finish first."
       },
+      "carouselsMigration": {
+        "eyebrow": "Carousel Migration",
+        "title": "This library may already use folders named carousels",
+        "description": "Choose whether AppFolder/carousels should create multi-item posts or remain ordinary folders.",
+        "useFeature": "Use Carousel Posts",
+        "keepFolders": "Keep Normal Folders",
+        "helper": "Choose a mode here, then save it below. Run a library scan afterward so indexed folders and carousel posts match."
+      },
+      "carouselsAnnouncement": {
+        "title": "Carousel Posts",
+        "headline": "Reserved carousels/ folders can combine media into one post",
+        "description": "Create one direct child folder inside AppFolder/carousels for each carousel, then place 2–20 images, animated images, or videos directly inside it. Natural filename order controls the slides, and the first item becomes the cover. Numeric filename prefixes are optional.",
+        "dismissAria": "Dismiss carousel posts announcement",
+        "showStructure": "See carousel directory structure",
+        "hideStructure": "Hide carousel directory structure"
+      },
       "announcement": {
         "title": "Stories",
         "headline": "Reserved stories/ folders can power App Folder stories",
@@ -250,6 +266,12 @@
         "enabledDescription": "Legacy mode is enabled. stories folders remain ordinary app folders everywhere.",
         "disabledDescription": "Reserved stories mode is enabled. AppFolder/stories powers avatar stories and highlight circles."
       },
+      "carouselsMode": {
+        "label": "Treat carousels folders as normal app folders",
+        "toggleLabel": "Toggle carousel folders behavior",
+        "enabledDescription": "Legacy mode is enabled. carousels folders remain ordinary app folders.",
+        "disabledDescription": "Reserved carousel mode is enabled. Each direct child of AppFolder/carousels becomes one post."
+      },
       "excludedFolders": {
         "label": "Excluded source folders",
         "description": "Skip matching folders anywhere by name or by exact relative path under the gallery root. Hidden paths and app-managed storage stay excluded automatically.",
@@ -263,29 +285,37 @@
       },
       "actionNote": {
         "loading": "Loading the current app preferences...",
-        "excludedAndOther": "Save the folder exclusion rules with the other app-wide changes. Run a library scan afterward so stories and excluded folders reindex correctly.",
+        "excludedAndOther": "Save the folder exclusion rules with the other app-wide changes. Run a library scan afterward so reserved folder modes and excluded folders reindex correctly.",
         "excludedOnly": "This saves the custom excluded folders only. Run a library scan afterward so those folders disappear from the index.",
-        "storiesAndDefaults": "Save the new stories rule and the updated app defaults together.",
-        "storiesOnly": "This saves the stories folders rule only. Run a library scan afterward to reindex with the new behavior.",
+        "storiesAndDefaults": "Save the folder behavior and updated app defaults together. Run a library scan afterward to reindex the affected folders.",
+        "storiesOnly": "This saves the reserved folder behavior. Run a library scan afterward to reindex with the selected mode.",
         "multipleDefaults": "Save these app defaults together. Language applies immediately in this browser; Home visitors can still switch modes on the homepage; Reels, app folders, and nested folder titles use app defaults.",
         "languageOnly": "This changes the language immediately in this browser. Save it too if you want the selected language to become the app-wide default.",
         "homeOnly": "This updates the first feed mode shown on Home for this app. Visitors can still switch modes from the homepage.",
         "reelsOnly": "This updates the queue style used when Reels opens for this app. Visitors cannot switch modes from the reels page.",
         "folderOnly": "This updates the default photo order used by app folder grids.",
         "nestedFolderTitleOnly": "This updates how nested app folders are labeled throughout the app.",
-        "idle": "These are the current app-wide defaults for language, Home, Reels, app folders, nested folder titles, stories folders, and excluded folders."
+        "carouselReconciliation": "The Carousel folder mode is saved. Complete the library action above to apply it to the index.",
+        "idle": "These are the current app-wide defaults for language, Home, Reels, app folders, nested folder titles, stories folders, carousel folders, and excluded folders."
       },
       "rescanNotice": {
-        "excludedAndStories": "Save these changes, then run a library scan before expecting stories folders and excluded folders to update.",
+        "rebuildRequired": "Save these changes, then rebuild the library index so the selected folder behavior is applied to the current gallery location.",
+        "pendingRebuild": "Rebuild the library index to apply the saved Carousel folder mode to the current gallery location.",
+        "pendingCarousels": "Run a library scan to apply the saved Carousel folder mode to indexed folders and posts.",
+        "excludedAndStories": "Save these changes, then run a library scan to update reserved folder behavior and excluded folders.",
         "excludedOnly": "Save this change, then run a library scan before excluded folders disappear from the index.",
-        "storiesOnly": "Save this change, then run a library scan before expecting stories folders, avatar stories, or highlights to update."
+        "storiesOnly": "Save this change, then run a library scan before expecting stories folders, avatar stories, or highlights to update.",
+        "carouselsOnly": "Save this change, then run a library scan before expecting carousel posts or carousels folders to update.",
+        "storiesAndCarousels": "Save these changes, then run a library scan before expecting stories and carousel folder behavior to update."
       },
       "feedback": {
+        "folderRulesSavedRebuild": "Folder behavior was saved. Rebuild the library index to apply it to the current gallery location.",
         "settingsAndFolderRulesSaved": "Settings were saved. Run a library scan to apply the folder rule changes.",
-        "folderRulesAndStoriesSaved": "Folder exclusion rules and stories folder behavior were saved. Run a library scan to apply them.",
+        "folderRulesSaved": "Folder behavior was saved. Run a library scan to apply the changes.",
         "excludedFoldersSaved": "Excluded folders were saved. Run a library scan to apply them.",
         "settingsAndStoriesSaved": "Settings were saved. Run a library scan to apply the stories folder change.",
         "storiesSaved": "Stories folder behavior was saved. Run a library scan to apply it.",
+        "carouselsSaved": "Carousel folder behavior was saved. Run a library scan to apply it.",
         "defaultsSaved": "App-wide defaults were updated.",
         "languageSaved": "App language default saved as {label}.",
         "homeSaved": "The homepage now opens with {label}.",
@@ -296,6 +326,7 @@
           "appLanguage": "app language",
           "excludedFolders": "excluded folders",
           "storiesFolderHandling": "stories folder handling",
+          "carouselsFolderHandling": "carousel folder handling",
           "homeFeedDefault": "Home feed default",
           "reelsFeedDefault": "Reels feed default",
           "appFolderOrder": "app folder order",
@@ -313,6 +344,11 @@
         "title": "Legacy derivative migration pending",
         "messageOne": "{count} indexed media record still uses the old mirrored thumbnail and preview paths. Run Scan Library to move it into asset-key storage.",
         "messageOther": "{count} indexed media records still use the old mirrored thumbnail and preview paths. Run Scan Library to move them into asset-key storage."
+      },
+      "carouselReconciliation": {
+        "title": "Carousel folder update pending",
+        "scanDescription": "The saved Carousel folder mode has not been applied to the index. Run Scan Library to update folders and posts.",
+        "rebuildDescription": "The saved Carousel folder mode has not been applied to the index. Rebuild Library Index below to apply it to the current gallery location."
       },
       "scanCard": {
         "title": "Scan Library",
@@ -334,6 +370,7 @@
         "otherTaskActive": "Another library task is running. Live progress appears in the sticky status bar.",
         "progress": "Live progress appears in the sticky status bar.",
         "legacyMigration": "Run Scan Library to move legacy mirrored thumbnails and previews into the asset-key storage layout.",
+        "carouselReconciliation": "Run Scan Library to apply the saved Carousel folder mode to indexed folders and posts.",
         "idle": "Scans check for added, updated, or missing media."
       },
       "thumbnailCard": {
@@ -390,6 +427,11 @@
       }
     },
     "notices": {
+      "scanWarning": {
+        "eyebrow": "Scan Warning",
+        "title": "Scan completed with {count} structural warning",
+        "title_plural": "Scan completed with {count} structural warnings"
+      },
       "scanError": {
         "eyebrow": "Scan Needs Attention",
         "title": "The last scan completed with errors",
@@ -814,6 +856,13 @@
     }
   },
   "post": {
+    "carousel": {
+      "label": "Carousel with {count} items",
+      "position": "{current} / {count}",
+      "previousItem": "Previous carousel item",
+      "nextItem": "Next carousel item",
+      "open": "Open carousel with {count} items"
+    },
     "captionModal": {
       "title": "Edit caption",
       "captionLabel": "Caption",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -149,6 +149,22 @@
         "helper": "Elige aquí un modo y luego guárdalo abajo. Después ejecuta un escaneo de la biblioteca para que la estructura indexada coincida.",
         "helperSaving": "Espera a que termine la actualización actual de ajustes."
       },
+      "carouselsMigration": {
+        "eyebrow": "Migración de carruseles",
+        "title": "Esta biblioteca puede usar carpetas llamadas carousels",
+        "description": "Elige si AppFolder/carousels debe crear publicaciones con varios elementos o seguir como carpetas normales.",
+        "useFeature": "Usar publicaciones carrusel",
+        "keepFolders": "Mantener carpetas normales",
+        "helper": "Elige un modo y guárdalo abajo. Después, ejecuta un escaneo de la biblioteca para que las carpetas indexadas y las publicaciones carrusel coincidan."
+      },
+      "carouselsAnnouncement": {
+        "title": "Publicaciones carrusel",
+        "headline": "Las carpetas reservadas carousels/ pueden combinar varios archivos en una publicación",
+        "description": "Crea una carpeta hija directa dentro de AppFolder/carousels para cada carrusel y coloca directamente en ella entre 2 y 20 imágenes, imágenes animadas o vídeos. El orden natural de los nombres determina las diapositivas y el primer elemento se convierte en la portada. Los prefijos numéricos son opcionales.",
+        "dismissAria": "Descartar anuncio de publicaciones carrusel",
+        "showStructure": "Ver estructura de directorios de carruseles",
+        "hideStructure": "Ocultar estructura de directorios de carruseles"
+      },
       "announcement": {
         "title": "Stories",
         "headline": "Las carpetas reservadas stories/ pueden alimentar las stories de las carpetas de la app",
@@ -250,6 +266,12 @@
         "enabledDescription": "El modo heredado está activado. Las carpetas stories siguen siendo carpetas normales de la app en todas partes.",
         "disabledDescription": "El modo reservado de stories está activado. AppFolder/stories alimenta las stories del avatar y los círculos destacados."
       },
+      "carouselsMode": {
+        "label": "Tratar las carpetas carousels como carpetas normales",
+        "toggleLabel": "Cambiar el comportamiento de las carpetas carousels",
+        "enabledDescription": "El modo heredado está activo. Las carpetas carousels siguen siendo carpetas normales.",
+        "disabledDescription": "El modo carrusel está activo. Cada hijo directo de AppFolder/carousels se convierte en una publicación."
+      },
       "excludedFolders": {
         "label": "Carpetas de origen excluidas",
         "description": "Omite carpetas coincidentes en cualquier lugar por nombre o por ruta relativa exacta bajo la raíz de la galería. Las rutas ocultas y el almacenamiento administrado por la app siguen excluyéndose automáticamente.",
@@ -263,29 +285,37 @@
       },
       "actionNote": {
         "loading": "Cargando las preferencias actuales de la app...",
-        "excludedAndOther": "Guarda las reglas de exclusión de carpetas junto con los otros cambios de toda la app. Después ejecuta un escaneo de la biblioteca para que stories y carpetas excluidas se reindexen correctamente.",
+        "excludedAndOther": "Guarda las reglas de exclusión de carpetas junto con los otros cambios de toda la app. Después, ejecuta un escaneo de la biblioteca para reindexar correctamente los modos de carpetas reservadas y las carpetas excluidas.",
         "excludedOnly": "Esto solo guarda las carpetas excluidas personalizadas. Después ejecuta un escaneo de la biblioteca para que esas carpetas desaparezcan del índice.",
-        "storiesAndDefaults": "Guarda juntos la nueva regla de stories y los valores globales actualizados.",
-        "storiesOnly": "Esto solo guarda la regla de carpetas stories. Después ejecuta un escaneo de la biblioteca para reindexar con el nuevo comportamiento.",
+        "storiesAndDefaults": "Guarda juntos el comportamiento de las carpetas y los valores globales actualizados. Después, ejecuta un escaneo de la biblioteca para reindexar las carpetas afectadas.",
+        "storiesOnly": "Esto guarda el comportamiento de las carpetas reservadas. Después, ejecuta un escaneo de la biblioteca para reindexar con el modo seleccionado.",
         "multipleDefaults": "Guarda juntos estos valores globales. El idioma se aplica de inmediato en este navegador; los visitantes de Inicio aún pueden cambiar de modo en la página principal; Reels, las carpetas de la app y los títulos de carpetas anidadas usan los valores predeterminados de la app.",
         "languageOnly": "Esto cambia el idioma de inmediato en este navegador. Guárdalo también si quieres que el idioma seleccionado se convierta en el predeterminado de toda la app.",
         "homeOnly": "Esto actualiza el primer modo de feed que se muestra en Inicio para esta app. Los visitantes aún pueden cambiar de modo desde la página principal.",
         "reelsOnly": "Esto actualiza el estilo de cola usado cuando se abre Reels para esta app. Los visitantes no pueden cambiar de modo desde la página de Reels.",
         "folderOnly": "Esto actualiza el orden de fotos predeterminado usado por las cuadrículas de carpetas de la app.",
         "nestedFolderTitleOnly": "Esto actualiza cómo se etiquetan las carpetas anidadas de la app en toda la aplicación.",
-        "idle": "Estos son los valores actuales de toda la app para idioma, Inicio, Reels, carpetas de la app, títulos de carpetas anidadas, carpetas stories y carpetas excluidas."
+        "carouselReconciliation": "El modo de las carpetas de carrusel está guardado. Completa la acción de biblioteca indicada arriba para aplicarlo al índice.",
+        "idle": "Estos son los valores actuales de toda la app para idioma, Inicio, Reels, carpetas de la app, títulos de carpetas anidadas, carpetas stories, carpetas de carrusel y carpetas excluidas."
       },
       "rescanNotice": {
-        "excludedAndStories": "Guarda estos cambios y luego ejecuta un escaneo de la biblioteca antes de esperar que se actualicen las carpetas stories y las carpetas excluidas.",
+        "rebuildRequired": "Guarda estos cambios y luego reconstruye el índice de la biblioteca para aplicar el comportamiento de carpetas seleccionado a la ubicación actual de la galería.",
+        "pendingRebuild": "Reconstruye el índice de la biblioteca para aplicar el modo guardado de las carpetas de carrusel a la ubicación actual de la galería.",
+        "pendingCarousels": "Ejecuta un escaneo de la biblioteca para aplicar el modo guardado de las carpetas de carrusel a las carpetas y publicaciones indexadas.",
+        "excludedAndStories": "Guarda estos cambios y luego ejecuta un escaneo de la biblioteca para actualizar el comportamiento de las carpetas reservadas y las carpetas excluidas.",
         "excludedOnly": "Guarda este cambio y luego ejecuta un escaneo de la biblioteca antes de que las carpetas excluidas desaparezcan del índice.",
-        "storiesOnly": "Guarda este cambio y luego ejecuta un escaneo de la biblioteca antes de esperar que se actualicen las carpetas stories, las stories del avatar o los destacados."
+        "storiesOnly": "Guarda este cambio y luego ejecuta un escaneo de la biblioteca antes de esperar que se actualicen las carpetas stories, las stories del avatar o los destacados.",
+        "carouselsOnly": "Guarda este cambio y luego ejecuta un escaneo de la biblioteca antes de esperar que se actualicen las publicaciones carrusel o las carpetas carousels.",
+        "storiesAndCarousels": "Guarda estos cambios y luego ejecuta un escaneo de la biblioteca antes de esperar que se actualice el comportamiento de las carpetas stories y carousels."
       },
       "feedback": {
+        "folderRulesSavedRebuild": "Se guardó el comportamiento de las carpetas. Reconstruye el índice de la biblioteca para aplicarlo a la ubicación actual de la galería.",
         "settingsAndFolderRulesSaved": "Los ajustes se guardaron. Ejecuta un escaneo de la biblioteca para aplicar los cambios de reglas de carpetas.",
-        "folderRulesAndStoriesSaved": "Se guardaron las reglas de exclusión de carpetas y el comportamiento de las carpetas stories. Ejecuta un escaneo de la biblioteca para aplicarlos.",
+        "folderRulesSaved": "Se guardó el comportamiento de las carpetas. Ejecuta un escaneo de la biblioteca para aplicar los cambios.",
         "excludedFoldersSaved": "Se guardaron las carpetas excluidas. Ejecuta un escaneo de la biblioteca para aplicarlas.",
         "settingsAndStoriesSaved": "Los ajustes se guardaron. Ejecuta un escaneo de la biblioteca para aplicar el cambio de carpetas stories.",
         "storiesSaved": "Se guardó el comportamiento de las carpetas stories. Ejecuta un escaneo de la biblioteca para aplicarlo.",
+        "carouselsSaved": "Se guardó el comportamiento de las carpetas de carrusel. Ejecuta un escaneo de la biblioteca para aplicarlo.",
         "defaultsSaved": "Se actualizaron los valores predeterminados de toda la app.",
         "languageSaved": "El idioma predeterminado de la app se guardó como {label}.",
         "homeSaved": "La página de Inicio ahora se abre con {label}.",
@@ -296,6 +326,7 @@
           "appLanguage": "idioma de la app",
           "excludedFolders": "carpetas excluidas",
           "storiesFolderHandling": "comportamiento de las carpetas stories",
+          "carouselsFolderHandling": "comportamiento de las carpetas de carrusel",
           "homeFeedDefault": "predeterminado del feed de Inicio",
           "reelsFeedDefault": "predeterminado de Reels",
           "appFolderOrder": "orden de las carpetas de la app",
@@ -313,6 +344,11 @@
         "title": "Migración heredada de derivados pendiente",
         "messageOne": "{count} registro de medio indexado aún usa las antiguas rutas reflejadas de miniaturas y vistas previas. Ejecuta Escanear biblioteca para moverlo al almacenamiento por clave de recurso.",
         "messageOther": "{count} registros de medios indexados aún usan las antiguas rutas reflejadas de miniaturas y vistas previas. Ejecuta Escanear biblioteca para moverlos al almacenamiento por clave de recurso."
+      },
+      "carouselReconciliation": {
+        "title": "Actualización de carpetas de carrusel pendiente",
+        "scanDescription": "El modo guardado de las carpetas de carrusel aún no se ha aplicado al índice. Ejecuta Escanear biblioteca para actualizar las carpetas y publicaciones.",
+        "rebuildDescription": "El modo guardado de las carpetas de carrusel aún no se ha aplicado al índice. Usa Reconstruir índice de la biblioteca abajo para aplicarlo a la ubicación actual de la galería."
       },
       "scanCard": {
         "title": "Escanear biblioteca",
@@ -334,6 +370,7 @@
         "otherTaskActive": "Hay otra tarea de biblioteca en ejecución. El progreso en vivo aparece en la barra de estado fija.",
         "progress": "El progreso en vivo aparece en la barra de estado fija.",
         "legacyMigration": "Ejecuta Escanear biblioteca para mover miniaturas y vistas previas reflejadas heredadas al diseño de almacenamiento con claves de recursos.",
+        "carouselReconciliation": "Ejecuta Escanear biblioteca para aplicar el modo guardado de las carpetas de carrusel a las carpetas y publicaciones indexadas.",
         "idle": "Los escaneos comprueban medios añadidos, actualizados o faltantes."
       },
       "thumbnailCard": {
@@ -390,6 +427,11 @@
       }
     },
     "notices": {
+      "scanWarning": {
+        "eyebrow": "Aviso de escaneo",
+        "title": "El escaneo terminó con {count} aviso estructural",
+        "title_plural": "El escaneo terminó con {count} avisos estructurales"
+      },
       "scanError": {
         "eyebrow": "El escaneo necesita atención",
         "title": "El último escaneo terminó con errores",
@@ -814,6 +856,13 @@
     }
   },
   "post": {
+    "carousel": {
+      "label": "Carrusel con {count} elementos",
+      "position": "{current} / {count}",
+      "previousItem": "Elemento anterior del carrusel",
+      "nextItem": "Elemento siguiente del carrusel",
+      "open": "Abrir carrusel con {count} elementos"
+    },
     "captionModal": {
       "title": "Editar descripción",
       "captionLabel": "Descripción",

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -149,6 +149,22 @@
         "helper": "先在这里选择模式，再在下方保存。随后运行一次图库扫描，让索引后的文件夹结构与之匹配。",
         "helperSaving": "请先等待当前设置更新完成。"
       },
+      "carouselsMigration": {
+        "eyebrow": "轮播迁移",
+        "title": "此图库可能已使用名为 carousels 的文件夹",
+        "description": "请选择 AppFolder/carousels 用于创建多媒体帖子，还是继续作为普通文件夹。",
+        "useFeature": "使用轮播帖子",
+        "keepFolders": "保留普通文件夹",
+        "helper": "请在此选择模式并在下方保存。随后运行一次图库扫描，使已索引文件夹与轮播帖子保持一致。"
+      },
+      "carouselsAnnouncement": {
+        "title": "轮播帖子",
+        "headline": "保留的 carousels/ 文件夹可以将多个媒体文件组合成一个帖子",
+        "description": "在 AppFolder/carousels 中为每个轮播创建一个直接子文件夹，然后在其中直接放入 2–20 个图片、动图或视频。幻灯片按文件名的自然顺序排列，第一项将作为封面。数字文件名前缀并非必需。",
+        "dismissAria": "关闭轮播帖子公告",
+        "showStructure": "查看轮播目录结构",
+        "hideStructure": "隐藏轮播目录结构"
+      },
       "announcement": {
         "title": "Stories",
         "headline": "保留的 stories/ 文件夹可以驱动应用文件夹的 Stories",
@@ -250,6 +266,12 @@
         "enabledDescription": "旧版模式已启用。stories 文件夹会继续在所有位置作为普通应用文件夹。",
         "disabledDescription": "保留 stories 模式已启用。AppFolder/stories 会驱动头像 stories 和精选圆圈。"
       },
+      "carouselsMode": {
+        "label": "将 carousels 文件夹视为普通应用文件夹",
+        "toggleLabel": "切换 carousels 文件夹行为",
+        "enabledDescription": "旧版模式已启用。carousels 文件夹仍是普通应用文件夹。",
+        "disabledDescription": "轮播模式已启用。AppFolder/carousels 的每个直接子文件夹会成为一篇帖子。"
+      },
       "excludedFolders": {
         "label": "排除的源文件夹",
         "description": "按名称或图库根目录下的精确相对路径跳过匹配文件夹。隐藏路径和应用管理的存储仍会自动排除。",
@@ -263,29 +285,37 @@
       },
       "actionNote": {
         "loading": "正在加载当前应用偏好...",
-        "excludedAndOther": "将文件夹排除规则与其他全局更改一起保存。随后运行一次图库扫描，以便 stories 和排除文件夹正确重新索引。",
+        "excludedAndOther": "将文件夹排除规则与其他全局更改一起保存。随后运行一次图库扫描，以便保留文件夹模式和排除文件夹正确重新索引。",
         "excludedOnly": "这只会保存自定义排除文件夹。随后运行一次图库扫描，以便这些文件夹从索引中消失。",
-        "storiesAndDefaults": "将新的 stories 规则与更新后的全局默认项一起保存。",
-        "storiesOnly": "这只会保存 stories 文件夹规则。随后运行一次图库扫描，以新行为重新建立索引。",
+        "storiesAndDefaults": "将文件夹行为与更新后的全局默认项一起保存。随后运行一次图库扫描，以重新索引受影响的文件夹。",
+        "storiesOnly": "这会保存保留文件夹的处理方式。随后运行一次图库扫描，以所选模式重新建立索引。",
         "multipleDefaults": "一起保存这些全局默认项。语言会立即在当前浏览器中生效；首页访问者仍可在主页上切换模式；短片、应用文件夹和嵌套文件夹标题使用应用默认项。",
         "languageOnly": "这会立即更改当前浏览器中的语言。如需让所选语言也成为整个应用的默认语言，请再保存一次。",
         "homeOnly": "这会更新此应用首页打开时显示的首个动态流模式。访问者仍可从主页切换模式。",
         "reelsOnly": "这会更新此应用打开短片时使用的队列样式。访问者无法从短片页面切换模式。",
         "folderOnly": "这会更新应用文件夹网格使用的默认照片顺序。",
         "nestedFolderTitleOnly": "这会更新整个应用中嵌套应用文件夹的标签显示方式。",
-        "idle": "这些是当前适用于语言、首页、短片、应用文件夹、嵌套文件夹标题、stories 文件夹和排除文件夹的全局默认项。"
+        "carouselReconciliation": "轮播文件夹模式已保存。请完成上方提示的图库操作，将其应用到索引。",
+        "idle": "这些是当前适用于语言、首页、短片、应用文件夹、嵌套文件夹标题、stories 文件夹、轮播文件夹和排除文件夹的全局默认项。"
       },
       "rescanNotice": {
-        "excludedAndStories": "保存这些更改后，请先运行一次图库扫描，再期待 stories 文件夹和排除文件夹更新。",
+        "rebuildRequired": "保存这些更改后，请重建图库索引，以便将所选文件夹行为应用到当前图库位置。",
+        "pendingRebuild": "请重建图库索引，以将已保存的轮播文件夹模式应用到当前图库位置。",
+        "pendingCarousels": "请运行一次图库扫描，将已保存的轮播文件夹模式应用到已索引的文件夹和帖子。",
+        "excludedAndStories": "保存这些更改后，请运行一次图库扫描，以更新保留文件夹行为和排除文件夹。",
         "excludedOnly": "保存此更改后，请先运行一次图库扫描，再期待排除文件夹从索引中消失。",
-        "storiesOnly": "保存此更改后，请先运行一次图库扫描，再期待 stories 文件夹、头像 stories 或精选内容更新。"
+        "storiesOnly": "保存此更改后，请先运行一次图库扫描，再期待 stories 文件夹、头像 stories 或精选内容更新。",
+        "carouselsOnly": "保存此更改后，请先运行一次图库扫描，再期待轮播帖子或 carousels 文件夹更新。",
+        "storiesAndCarousels": "保存这些更改后，请先运行一次图库扫描，再期待 stories 和 carousels 文件夹行为更新。"
       },
       "feedback": {
+        "folderRulesSavedRebuild": "文件夹行为已保存。请重建图库索引，以将其应用到当前图库位置。",
         "settingsAndFolderRulesSaved": "设置已保存。请运行一次图库扫描以应用文件夹规则更改。",
-        "folderRulesAndStoriesSaved": "文件夹排除规则和 stories 文件夹行为已保存。请运行一次图库扫描以应用它们。",
+        "folderRulesSaved": "文件夹行为已保存。请运行一次图库扫描以应用这些更改。",
         "excludedFoldersSaved": "排除文件夹已保存。请运行一次图库扫描以应用它们。",
         "settingsAndStoriesSaved": "设置已保存。请运行一次图库扫描以应用 stories 文件夹更改。",
         "storiesSaved": "stories 文件夹行为已保存。请运行一次图库扫描以应用它。",
+        "carouselsSaved": "轮播文件夹处理方式已保存。请运行一次图库扫描以应用更改。",
         "defaultsSaved": "全局默认项已更新。",
         "languageSaved": "应用语言默认值已保存为{label}。",
         "homeSaved": "首页现在会以 {label} 打开。",
@@ -296,6 +326,7 @@
           "appLanguage": "应用语言",
           "excludedFolders": "排除文件夹",
           "storiesFolderHandling": "stories 文件夹行为",
+          "carouselsFolderHandling": "轮播文件夹处理",
           "homeFeedDefault": "首页动态默认项",
           "reelsFeedDefault": "短片默认项",
           "appFolderOrder": "应用文件夹顺序",
@@ -313,6 +344,11 @@
         "title": "旧版派生资源迁移待处理",
         "messageOne": "{count} 条已索引媒体记录仍在使用旧的镜像缩略图和预览路径。运行“扫描图库”即可将其迁移到资源键存储。",
         "messageOther": "{count} 条已索引媒体记录仍在使用旧的镜像缩略图和预览路径。运行“扫描图库”即可将它们迁移到资源键存储。"
+      },
+      "carouselReconciliation": {
+        "title": "轮播文件夹更新待处理",
+        "scanDescription": "已保存的轮播文件夹模式尚未应用到索引。请运行“扫描图库”以更新文件夹和帖子。",
+        "rebuildDescription": "已保存的轮播文件夹模式尚未应用到索引。请使用下方的“重建图库索引”，将其应用到当前图库位置。"
       },
       "scanCard": {
         "title": "扫描图库",
@@ -334,6 +370,7 @@
         "otherTaskActive": "当前还有其他图库任务正在运行。实时进度会显示在置顶状态栏中。",
         "progress": "实时进度会显示在置顶状态栏中。",
         "legacyMigration": "运行“扫描图库”可将旧的镜像缩略图和预览图迁移到资源键存储布局。",
+        "carouselReconciliation": "运行“扫描图库”，将已保存的轮播文件夹模式应用到已索引的文件夹和帖子。",
         "idle": "扫描会检查新增、更新或缺失的媒体。"
       },
       "thumbnailCard": {
@@ -390,6 +427,11 @@
       }
     },
     "notices": {
+      "scanWarning": {
+        "eyebrow": "扫描警告",
+        "title": "扫描完成，发现 {count} 个结构警告",
+        "title_plural": "扫描完成，发现 {count} 个结构警告"
+      },
       "scanError": {
         "eyebrow": "扫描需要注意",
         "title": "上一次扫描已完成，但包含错误",
@@ -814,6 +856,13 @@
     }
   },
   "post": {
+    "carousel": {
+      "label": "包含 {count} 项的轮播帖子",
+      "position": "{current} / {count}",
+      "previousItem": "上一个轮播项目",
+      "nextItem": "下一个轮播项目",
+      "open": "打开包含 {count} 项的轮播帖子"
+    },
     "captionModal": {
       "title": "编辑说明",
       "captionLabel": "说明",

--- a/client/src/router/index.test.ts
+++ b/client/src/router/index.test.ts
@@ -332,5 +332,6 @@ describe('router', () => {
 
     expect(canAccessRoute(router.resolve('/share/family'))).toBe(true);
     expect(canAccessRoute(router.resolve('/share/family/images/42'))).toBe(true);
+    expect(canAccessRoute(router.resolve('/share/family/posts/42'))).toBe(true);
   });
 });

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -149,6 +149,15 @@ export const router = createRouter({
       }
     },
     {
+      path: '/share/:slug/posts/:id',
+      name: 'shared-post',
+      component: SharedPostView,
+      props: true,
+      meta: {
+        publicShare: true
+      }
+    },
+    {
       path: '/share/:slug/images/:id',
       name: 'shared-image',
       component: SharedPostView,

--- a/client/src/stores/app.ts
+++ b/client/src/stores/app.ts
@@ -109,7 +109,9 @@ export const useAppStore = defineStore('app', {
     defaultReelsFeedMode: (state): ReelsFeedMode => state.stats?.preferences.defaultReelsFeedMode ?? 'random',
     defaultFolderImageOrder: (state): FolderImageOrder => state.stats?.preferences.defaultFolderImageOrder ?? 'newest',
     nestedFolderTitleFormat: (state) => state.stats?.preferences.nestedFolderTitleFormat ?? 'folder',
-    treatStoriesAsFolders: (state) => state.stats?.preferences.treatStoriesAsFolders === true
+    treatStoriesAsFolders: (state) => state.stats?.preferences.treatStoriesAsFolders === true,
+    treatCarouselsAsFolders: (state) => state.stats?.preferences.treatCarouselsAsFolders === true,
+    isCarouselsReconciliationPending: (state) => state.stats?.carouselsMigration?.reconciliationPending === true
   },
   actions: {
     persistOpenedFolderState() {

--- a/client/src/stores/share.ts
+++ b/client/src/stores/share.ts
@@ -4,6 +4,7 @@ import {
   fetchSharedFolderAccess,
   fetchSharedFolderImages,
   fetchSharedImage,
+  fetchSharedPost,
   unlockSharedFolderLink,
   unlockSharedFolderPassword
 } from '../api/gallery';
@@ -130,13 +131,15 @@ export const useShareStore = defineStore('share', {
       }
     },
 
-    async loadImage(id: number, mediaType?: 'image' | 'video') {
+    async loadImage(id: number, mediaType?: 'image' | 'video', options: { legacyImageAlias?: boolean } = {}) {
       const requestToken = ++shareLoadToken;
       this.loading = true;
       this.error = null;
 
       try {
-        const image = await fetchSharedImage(id, mediaType);
+        const image = options.legacyImageAlias
+          ? await fetchSharedImage(id, mediaType)
+          : await fetchSharedPost(id, mediaType);
         if (requestToken !== shareLoadToken) {
           return;
         }

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -55,6 +55,27 @@ export interface UpdateExcludedFoldersSettingResult extends ExcludedFoldersSetti
   requiresScan: boolean;
 }
 
+export type PostType = 'single' | 'carousel';
+
+export interface PostMediaItem {
+  imageId: number;
+  position: number;
+  filename: string;
+  mediaType: MediaType;
+  width: number;
+  height: number;
+  durationMs: number | null;
+  isAnimated: boolean | null;
+  thumbnailUrl: string;
+  previewUrl: string;
+  playbackStrategy?: 'preview' | 'original' | null;
+  originalUrl?: string;
+  mimeType?: string;
+  fileSize?: number;
+  relativePath?: string;
+  exif?: ImageExifData | null;
+}
+
 export interface FeedItem {
   id: number;
   folderId: number;
@@ -64,7 +85,10 @@ export interface FeedItem {
   folderPath: string;
   folderBreadcrumb: string | null;
   filename: string;
+  sourcePath?: string;
   caption?: string | null;
+  carouselTitle?: string | null;
+  postType?: PostType;
   width: number;
   height: number;
   mediaType: 'image' | 'video';
@@ -76,6 +100,8 @@ export interface FeedItem {
   takenAt: number | null;
   isSaved?: boolean;
   place?: PlaceSummary | null;
+  mediaItems?: PostMediaItem[];
+  itemCount?: number;
 }
 
 export type PlaceKind = 'city' | 'approximate_spot' | 'manual';
@@ -280,6 +306,7 @@ export interface SharedFolderSummary {
   name: string;
   description: string | null;
   imageCount: number;
+  postCount: number;
   videoCount: number;
   avatarThumbnailUrl: string | null;
   sortTimestamp: number;
@@ -292,6 +319,7 @@ export interface SharedFeedItem {
   folderName: string;
   filename: string;
   caption: string | null;
+  carouselTitle?: string | null;
   width: number;
   height: number;
   mediaType: MediaType;
@@ -300,6 +328,9 @@ export interface SharedFeedItem {
   thumbnailUrl: string;
   previewUrl: string;
   sortTimestamp: number;
+  postType?: PostType;
+  itemCount?: number;
+  mediaItems?: PostMediaItem[];
 }
 
 export interface SharedImageDetail {
@@ -309,6 +340,7 @@ export interface SharedImageDetail {
   folderName: string;
   filename: string;
   caption: string | null;
+  carouselTitle?: string | null;
   mediaType: MediaType;
   mimeType: string;
   width: number;
@@ -320,6 +352,9 @@ export interface SharedImageDetail {
   sortTimestamp: number;
   nextImageId: number | null;
   previousImageId: number | null;
+  postType?: PostType;
+  itemCount?: number;
+  mediaItems?: PostMediaItem[];
 }
 
 export interface SharedFolderImagesPayload {
@@ -479,6 +514,8 @@ export interface ScanRunSummary {
   updated_files: number;
   removed_files: number;
   error_text: string | null;
+  warning_count: number;
+  warning_text: string | null;
 }
 
 export interface ScanProgress {
@@ -526,6 +563,9 @@ export interface RebuildThumbnailsResult {
 export interface AppStatus {
   folders: number;
   indexedImages: number;
+  indexedPosts: number;
+  indexedMediaAssets: number;
+  indexedCarousels: number;
   indexedVideos: number;
   scan: ScanProgress;
   storage: {
@@ -544,10 +584,16 @@ export interface AppStatus {
     defaultFolderImageOrder?: FolderImageOrder;
     nestedFolderTitleFormat?: NestedFolderTitleFormat;
     treatStoriesAsFolders: boolean;
+    treatCarouselsAsFolders: boolean;
   };
   storiesMigration: {
     hasLegacyStoriesCandidates: boolean;
     decisionPending: boolean;
+  };
+  carouselsMigration: {
+    hasLegacyCarouselsCandidates: boolean;
+    decisionPending: boolean;
+    reconciliationPending?: boolean;
   };
 }
 

--- a/client/src/utils/caption.test.ts
+++ b/client/src/utils/caption.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveDisplayCaption } from './caption';
+
+describe('caption display fallback', () => {
+  it('uses the safe carousel title when sourcePath is redacted', () => {
+    expect(resolveDisplayCaption({
+      filename: 'cover.jpg',
+      caption: null,
+      postType: 'carousel',
+      carouselTitle: 'summer_trip'
+    })).toBe('summer trip');
+  });
+
+  it('keeps sourcePath as the authenticated carousel fallback', () => {
+    expect(resolveDisplayCaption({
+      filename: 'cover.jpg',
+      caption: null,
+      postType: 'carousel',
+      sourcePath: 'album/carousels/summer-trip'
+    })).toBe('summer trip');
+  });
+});

--- a/client/src/utils/caption.ts
+++ b/client/src/utils/caption.ts
@@ -6,9 +6,23 @@ export function readableFilename(filename: string): string {
     .trim();
 }
 
-export function resolveDisplayCaption(item: { filename: string; caption?: string | null }): string {
+export function resolveDisplayCaption(item: {
+  filename: string;
+  caption?: string | null;
+  postType?: string;
+  sourcePath?: string;
+  carouselTitle?: string | null;
+}): string {
   if (typeof item.caption === 'string' && item.caption.trim().length > 0) {
     return item.caption;
+  }
+
+  if (item.postType === 'carousel') {
+    const fallback = item.carouselTitle
+      ?? (item.sourcePath ? item.sourcePath.replaceAll('\\', '/').split('/').at(-1) : null);
+    if (fallback) {
+      return readableFilename(fallback);
+    }
   }
 
   return readableFilename(item.filename);

--- a/client/src/views/SettingsView.test.ts
+++ b/client/src/views/SettingsView.test.ts
@@ -24,6 +24,9 @@ function createAppStatus(
   return {
     folders: 3,
     indexedImages: 18,
+    indexedPosts: 18,
+    indexedMediaAssets: 21,
+    indexedCarousels: 3,
     indexedVideos: 6,
     scan: {
       isScanning: false,
@@ -61,11 +64,17 @@ function createAppStatus(
       defaultReelsFeedMode,
       defaultFolderImageOrder,
       nestedFolderTitleFormat: 'folder',
-      treatStoriesAsFolders: false
+      treatStoriesAsFolders: false,
+      treatCarouselsAsFolders: false
     },
     storiesMigration: {
       hasLegacyStoriesCandidates: false,
       decisionPending: false
+    },
+    carouselsMigration: {
+      hasLegacyCarouselsCandidates: false,
+      decisionPending: false,
+      reconciliationPending: false
     }
   };
 }
@@ -142,6 +151,7 @@ describe('SettingsView', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.restoreAllMocks();
+    window.localStorage.clear();
     scrollIntoViewSpy.mockReset();
     Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
       configurable: true,
@@ -332,6 +342,30 @@ describe('SettingsView', () => {
     expect(wrapper.text()).toContain('24 indexed media records still use the old mirrored thumbnail and preview paths.');
     expect(wrapper.text()).toContain('Run Scan Library to move legacy mirrored thumbnails and previews into the asset-key storage layout.');
     expect(wrapper.text()).toContain('This keeps the current thumbnail paths and does not migrate legacy mirrored derivatives.');
+  });
+
+  it('shows localized scan guidance while carousel folder reconciliation is pending', async () => {
+    const appStore = useAppStore();
+    const status = createAppStatus();
+    status.carouselsMigration = {
+      hasLegacyCarouselsCandidates: false,
+      decisionPending: false,
+      reconciliationPending: true
+    };
+    appStore.$patch({ stats: status });
+
+    const wrapper = mountSettingsView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Carousel folder update pending');
+    expect(wrapper.text()).toContain(
+      'The saved Carousel folder mode has not been applied to the index. Run Scan Library to update folders and posts.'
+    );
+    expect(wrapper.text()).toContain(
+      'Run Scan Library to apply the saved Carousel folder mode to indexed folders and posts.'
+    );
+    expect(wrapper.text()).not.toContain('settings.library.carouselReconciliation');
+    expect(wrapper.text()).not.toContain('settings.library.scanActionNote.carouselReconciliation');
   });
 
   it('shows the Places onboarding banner and opens the Places tab from its setup action', async () => {
@@ -679,5 +713,186 @@ describe('SettingsView', () => {
     expect(wrapper.text()).not.toContain('This library may already use folders named stories');
     expect(wrapper.get('button[role="switch"]').attributes('aria-checked')).toBe('true');
     expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows, expands, and permanently dismisses the carousel posts announcement', async () => {
+    const appStore = useAppStore();
+    const status = createAppStatus();
+    status.carouselsMigration = {
+      hasLegacyCarouselsCandidates: false,
+      decisionPending: true
+    };
+    appStore.$patch({ stats: status });
+
+    const wrapper = mountSettingsView();
+    await flushPromises();
+    await openGeneralSettingsSidebarTab(wrapper);
+
+    expect(wrapper.text()).toContain('Carousel Posts');
+    expect(wrapper.text()).toContain('Reserved carousels/ folders can combine media into one post');
+    expect(wrapper.text()).not.toContain('This library may already use folders named carousels');
+
+    const structureButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'See carousel directory structure');
+    expect(structureButton).toBeDefined();
+    await structureButton!.trigger('click');
+
+    expect(wrapper.text()).toContain('carousels/');
+    expect(wrapper.text()).toContain('02-lions.mp4');
+    expect(wrapper.text()).toContain('detail.jpg');
+    expect(wrapper.text()).not.toContain('02-detail.jpg');
+
+    const dismissButton = wrapper.get('button[aria-label="Dismiss carousel posts announcement"]');
+    await dismissButton.trigger('click');
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain('Reserved carousels/ folders can combine media into one post');
+    expect(window.localStorage.getItem('foldergram-carousels-announcement-dismissed:v1')).toBe('1');
+
+    wrapper.unmount();
+    const remountedWrapper = mountSettingsView();
+    await flushPromises();
+    await openGeneralSettingsSidebarTab(remountedWrapper);
+
+    expect(remountedWrapper.text()).not.toContain('Reserved carousels/ folders can combine media into one post');
+  });
+
+  it('shows the carousel migration decision instead of the announcement when indexed folders conflict', async () => {
+    const appStore = useAppStore();
+    const status = createAppStatus();
+    status.carouselsMigration = {
+      hasLegacyCarouselsCandidates: true,
+      decisionPending: true
+    };
+    appStore.$patch({ stats: status });
+
+    const wrapper = mountSettingsView();
+    await flushPromises();
+    await openGeneralSettingsSidebarTab(wrapper);
+
+    expect(wrapper.text()).toContain('This library may already use folders named carousels');
+    expect(wrapper.text()).not.toContain('Reserved carousels/ folders can combine media into one post');
+  });
+
+  it('keeps the Carousel reconciliation reminder visible after settings reload until a scan completes', async () => {
+    const appStore = useAppStore();
+    const status = createAppStatus();
+    status.carouselsMigration = {
+      hasLegacyCarouselsCandidates: true,
+      decisionPending: false,
+      reconciliationPending: true
+    };
+    appStore.$patch({ stats: status });
+
+    const wrapper = mountSettingsView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Carousel folder update pending');
+    expect(wrapper.text()).toContain('Run Scan Library to update folders and posts.');
+    const scanButton = wrapper.findAll('button').find((button) => button.text() === 'Run Scan Library');
+    expect(scanButton?.attributes('disabled')).toBeUndefined();
+
+    await openGeneralSettingsSidebarTab(wrapper);
+
+    expect(wrapper.text()).toContain(
+      'Run a library scan to apply the saved Carousel folder mode to indexed folders and posts.'
+    );
+    const saveButton = wrapper.findAll('button').find((button) => button.text() === 'Saved');
+    expect(saveButton?.attributes('disabled')).toBeDefined();
+  });
+
+  it('directs pending Carousel reconciliation to the enabled rebuild action when a rebuild is required', async () => {
+    const appStore = useAppStore();
+    const status = createAppStatus();
+    status.libraryIndex.rebuildRequired = true;
+    status.libraryIndex.reason = 'gallery_root_changed';
+    status.carouselsMigration = {
+      hasLegacyCarouselsCandidates: true,
+      decisionPending: false,
+      reconciliationPending: true
+    };
+    appStore.$patch({ stats: status });
+
+    const wrapper = mountSettingsView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Rebuild Library Index below to apply it to the current gallery location.');
+    const scanButton = wrapper.findAll('button').find((button) => button.text() === 'Run Scan Library');
+    const rebuildButton = wrapper.findAll('button').find((button) => button.text() === 'Rebuild Library Index');
+    expect(scanButton?.attributes('disabled')).toBeDefined();
+    expect(rebuildButton?.attributes('disabled')).toBeUndefined();
+
+    await openGeneralSettingsSidebarTab(wrapper);
+    expect(wrapper.text()).toContain(
+      'Rebuild the library index to apply the saved Carousel folder mode to the current gallery location.'
+    );
+  });
+
+  it('directs a saved Carousel mode to rebuild when the gallery location requires a new index', async () => {
+    const appStore = useAppStore();
+    const status = createAppStatus();
+    status.libraryIndex.rebuildRequired = true;
+    status.libraryIndex.reason = 'gallery_root_changed';
+    appStore.$patch({ stats: status });
+    vi.spyOn(appStore, 'fetchStats').mockResolvedValue();
+
+    const responseStatus = createAppStatus();
+    responseStatus.libraryIndex.rebuildRequired = true;
+    responseStatus.libraryIndex.reason = 'gallery_root_changed';
+    responseStatus.preferences.treatCarouselsAsFolders = true;
+    responseStatus.carouselsMigration.reconciliationPending = true;
+    vi.spyOn(galleryApi, 'updateCarouselsMode').mockResolvedValue(responseStatus);
+
+    const wrapper = mountSettingsView();
+    await flushPromises();
+    await openGeneralSettingsSidebarTab(wrapper);
+
+    const switches = wrapper.findAll('button[role="switch"]');
+    await switches[1]!.trigger('click');
+    const saveButton = wrapper.findAll('button').find((button) => button.text() === 'Save changes');
+    await saveButton!.trigger('click');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      'Folder behavior was saved. Rebuild the library index to apply it to the current gallery location.'
+    );
+  });
+
+  it('displays accurate localized success message when only carousel setting is changed', async () => {
+    const appStore = useAppStore();
+    appStore.$patch({
+      stats: createAppStatus()
+    });
+
+    vi.spyOn(appStore, 'fetchStats').mockResolvedValue();
+    const updateCarouselsSpy = vi.spyOn(galleryApi, 'updateCarouselsMode').mockResolvedValue(createAppStatus());
+
+    const wrapper = mountSettingsView();
+    await flushPromises();
+    await openGeneralSettingsSidebarTab(wrapper);
+
+    const switches = wrapper.findAll('button[role="switch"]');
+    const carouselSwitch = switches[1]; // Second switch is carousels
+    expect(carouselSwitch).toBeDefined();
+
+    await carouselSwitch!.trigger('click');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      'Save this change, then run a library scan before expecting carousel posts or carousels folders to update.'
+    );
+
+    const saveButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'Save changes');
+
+    expect(saveButton).toBeDefined();
+    await saveButton!.trigger('click');
+    await flushPromises();
+
+    expect(updateCarouselsSpy).toHaveBeenCalledWith(true);
+    expect(wrapper.text()).toContain('Carousel folder behavior was saved. Run a library scan to apply it.');
+    expect(wrapper.text()).not.toContain('Stories folder behavior was saved');
   });
 });

--- a/client/src/views/SettingsView.vue
+++ b/client/src/views/SettingsView.vue
@@ -44,6 +44,15 @@
     </section>
 
     <section
+      v-if="showScanWarningNotice"
+      class="card grid gap-[0.45rem] px-5 py-4 border-[color-mix(in_srgb,#d2a133_35%,var(--border)_65%)]"
+    >
+      <span class="eyebrow text-[#9f6a00]">{{ t('settings.notices.scanWarning.eyebrow') }}</span>
+      <h2 class="m-0 text-[1rem]">{{ t('settings.notices.scanWarning.title', { count: lastCompletedScan?.warning_count ?? 0 }) }}</h2>
+      <p class="m-0 whitespace-pre-line text-[0.84rem] leading-[1.5] text-muted">{{ lastCompletedScan?.warning_text }}</p>
+    </section>
+
+    <section
       v-if="showIgnoredRootMediaNotice"
       class="card flex items-center justify-between gap-3 px-4 py-3 border-[color-mix(in_srgb,var(--border)_82%,#d2a133_18%)]"
       style="background: linear-gradient(180deg, color-mix(in srgb, var(--surface) 97%, #fff9ea 3%) 0%, color-mix(in srgb, var(--surface) 94%, #fff3d8 6%) 100%);"
@@ -467,6 +476,75 @@
 
         <!-- CATEGORY: GENERAL -->
         <template v-if="currentCategory === 'general'">
+          <section
+            v-if="showCarouselsMigrationNotice"
+            class="card grid gap-[1rem] p-6 border-[color-mix(in_srgb,#d2a133_42%,var(--border)_58%)]"
+            style="background: radial-gradient(circle at top right, rgba(210,161,51,0.18), transparent 40%), linear-gradient(180deg, color-mix(in srgb, var(--surface) 94%, #fff3cf 6%) 0%, color-mix(in srgb, var(--surface) 88%, #ffe6a6 12%) 100%);"
+          >
+            <div class="grid gap-[0.3rem]">
+              <span class="eyebrow text-[#9f6a00]">{{ t('settings.general.carouselsMigration.eyebrow') }}</span>
+              <h2 class="m-0 text-[1.1rem]">{{ t('settings.general.carouselsMigration.title') }}</h2>
+              <p class="m-0 text-muted">{{ t('settings.general.carouselsMigration.description') }}</p>
+            </div>
+            <div class="flex flex-col md:flex-row items-center gap-3 max-sm:items-stretch">
+              <button class="btn-primary min-w-[13rem]" type="button" :disabled="savingGeneralSettings" @click="chooseCarouselsMigrationMode(false)">
+                {{ t('settings.general.carouselsMigration.useFeature') }}
+              </button>
+              <button class="inline-flex min-h-11 items-center justify-center rounded-[0.95rem] border border-border bg-transparent px-4 text-[0.92rem] font-semibold text-text" type="button" :disabled="savingGeneralSettings" @click="chooseCarouselsMigrationMode(true)">
+                {{ t('settings.general.carouselsMigration.keepFolders') }}
+              </button>
+            </div>
+            <p class="m-0 text-muted">{{ t('settings.general.carouselsMigration.helper') }}</p>
+          </section>
+
+          <section
+            v-else-if="showCarouselsAnnouncementCard"
+            class="card grid gap-[1rem] border-[color-mix(in_srgb,var(--border)_84%,#8cc8ff_16%)] p-6"
+            style="background: linear-gradient(135deg, color-mix(in srgb, var(--surface) 97%, #f7fbff 3%) 0%, color-mix(in srgb, var(--surface) 93%, #e6f3ff 7%) 100%);"
+          >
+            <div class="flex items-start justify-between gap-4">
+              <div class="grid gap-[0.3rem]">
+                <div class="flex items-center gap-2">
+                  <h2 class="m-0 text-xl">{{ t('settings.general.carouselsAnnouncement.title') }}</h2>
+                  <span class="eyebrow inline-flex w-fit self-start text-xs">{{ t('common.newFeature') }}</span>
+                </div>
+                <p class="m-0 text-[0.95rem] font-medium text-text">{{ t('settings.general.carouselsAnnouncement.headline') }}</p>
+                <p class="m-0 text-muted">
+                  {{ t('settings.general.carouselsAnnouncement.description') }}
+                  <button
+                    class="ml-1 inline-flex border-0 bg-transparent p-0 text-[0.92em] font-semibold text-accent-strong underline underline-offset-[0.18em] cursor-pointer transition-opacity duration-180 hover:opacity-80"
+                    type="button"
+                    :aria-expanded="showCarouselsAnnouncementStructure"
+                    @click="toggleCarouselsAnnouncementStructure"
+                  >
+                    {{ showCarouselsAnnouncementStructure ? t('settings.general.carouselsAnnouncement.hideStructure') : t('settings.general.carouselsAnnouncement.showStructure') }}
+                  </button>
+                </p>
+              </div>
+              <button
+                class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-0 bg-[rgba(24,119,242,0.08)] text-accent-strong cursor-pointer transition-colors duration-180 hover:bg-[rgba(24,119,242,0.14)]"
+                type="button"
+                :aria-label="t('settings.general.carouselsAnnouncement.dismissAria')"
+                @click="dismissCarouselsAnnouncement"
+              >
+                <span class="i-fluent-dismiss-20-filled h-5 w-5" aria-hidden="true" />
+              </button>
+            </div>
+
+            <pre v-if="showCarouselsAnnouncementStructure" class="m-0 overflow-x-auto rounded-[0.95rem] border border-border bg-[color-mix(in_srgb,var(--surface-alt)_82%,transparent_18%)] p-4 text-[0.78rem] leading-[1.55] text-muted"><code>gallery/
+└─ AnimalPlanet/
+   ├─ cover.jpg
+   ├─ post-1.jpg
+   └─ carousels/
+      ├─ Safari/
+      │  ├─ 01-arrival.jpg
+      │  ├─ 02-lions.mp4
+      │  └─ 03-sunset.jpg
+      └─ Portraits/
+         ├─ front.jpg
+         └─ detail.jpg</code></pre>
+          </section>
+
           <section
             v-if="showStoriesMigrationNotice"
             class="card grid gap-[1rem] p-6 border-[color-mix(in_srgb,#d2a133_42%,var(--border)_58%)]"
@@ -903,6 +981,31 @@
                 </button>
               </div>
 
+              <div class="grid gap-3 border-t border-border px-6 py-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+                <div class="min-w-0">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <p class="m-0 text-[0.96rem] font-semibold text-text">{{ t('settings.general.carouselsMode.label') }}</p>
+                    <span class="inline-flex items-center rounded-full bg-surface-alt px-2 py-[0.2rem] text-[0.72rem] font-semibold uppercase tracking-[0.08em] text-muted">
+                      {{ t('settings.general.storiesMode.scanRequired') }}
+                    </span>
+                  </div>
+                  <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">{{ carouselsModeLabelDescription }}</p>
+                </div>
+                <button
+                  class="inline-flex items-center justify-end border-0 bg-transparent p-0 cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
+                  type="button"
+                  role="switch"
+                  :aria-checked="carouselsMode"
+                  :disabled="savingGeneralSettings || waitingForInitialStatus"
+                  @click="toggleCarouselsModeSetting"
+                >
+                  <span class="sr-only">{{ t('settings.general.carouselsMode.toggleLabel') }}</span>
+                  <span class="inline-flex h-7 w-12 items-center rounded-full p-[0.15rem] transition-colors duration-180" :class="carouselsMode ? 'bg-accent' : 'bg-[color-mix(in_srgb,var(--border)_88%,var(--surface-alt)_12%)]'">
+                    <span class="h-[1.35rem] w-[1.35rem] rounded-full bg-white shadow-[0_2px_8px_rgba(0,0,0,0.18)] transition-transform duration-180" :class="carouselsMode ? 'translate-x-[1.2rem]' : 'translate-x-0'" />
+                  </span>
+                </button>
+              </div>
+
               <div class="grid gap-4 px-6 py-4">
                 <div class="min-w-0">
                   <div class="flex flex-wrap items-center gap-2">
@@ -1062,6 +1165,16 @@
                   'text-[#c0392b] bg-[rgba(214,48,49,0.12)]': statusTone === 'danger',
                 }"
               >{{ statusLabel }}</span>
+            </div>
+
+            <div
+              v-if="appStore.isCarouselsReconciliationPending"
+              class="rounded-[0.95rem] border border-[rgba(210,161,51,0.28)] bg-[rgba(210,161,51,0.08)] px-4 py-3 text-[#9f6a00]"
+            >
+              <p class="m-0 text-[0.76rem] font-bold tracking-[0.08em] uppercase">{{ t('settings.library.carouselReconciliation.title') }}</p>
+              <p class="m-0 mt-1 text-[0.9rem] leading-relaxed">
+                {{ appStore.isLibraryRebuildRequired ? t('settings.library.carouselReconciliation.rebuildDescription') : t('settings.library.carouselReconciliation.scanDescription') }}
+              </p>
             </div>
 
             <div
@@ -1252,7 +1365,8 @@ import {
   updateHomeFeedDefault,
   updateNestedFolderTitleFormat,
   updateReelsFeedDefault,
-  updateStoriesMode
+  updateStoriesMode,
+  updateCarouselsMode
 } from '../api/gallery';
 import { SUPPORTED_LOCALES, type SupportedLocale } from '../locales';
 import { useAppStore } from '../stores/app';
@@ -1304,10 +1418,13 @@ const nestedFolderTitleFormat = ref<NestedFolderTitleFormat>('folder');
 const savedLocaleSelection = ref<SupportedLocale | null>(appStore.savedDefaultLocale);
 const localeSelectionHydrated = ref(false);
 const storiesMode = ref(false);
+const carouselsMode = ref(false);
 const feedDefaultsHydrated = ref(false);
 const storiesModeHydrated = ref(false);
+const carouselsModeHydrated = ref(false);
 const activeGeneralSettingsMenu = ref<'home' | 'reels' | 'folder' | 'nestedTitle' | null>(null);
 const showStoriesAnnouncementStructure = ref(false);
+const showCarouselsAnnouncementStructure = ref(false);
 const generalSettingsSaveArea = ref<HTMLElement | null>(null);
 const localeSelectId = 'settings-language-select';
 const acknowledgedStoriesMigrationChoice = ref(false);
@@ -1321,6 +1438,7 @@ const NOTICE_DISMISS_MS = 7 * 24 * 60 * 60 * 1000;
 const MIN_PASSWORD_LENGTH = 8;
 const STORIES_MIGRATION_NOTICE_STORAGE_KEY = 'foldergram-stories-migration-dismissed';
 const STORIES_ANNOUNCEMENT_STORAGE_KEY = 'foldergram-stories-announcement-dismissed';
+const CAROUSELS_ANNOUNCEMENT_STORAGE_KEY = 'foldergram-carousels-announcement-dismissed:v1';
 const PLACES_ONBOARDING_STORAGE_KEY = 'foldergram:places-onboarding-dismissed:v1';
 const EXCLUDED_FOLDER_EDGE_SLASH_PATTERN = /^\/+|\/+$/g;
 const EXCLUDED_FOLDER_UNSUPPORTED_PATTERN = /[*?]/;
@@ -1405,6 +1523,7 @@ const dismissedScanErrorNotice = ref(loadDismissedScanErrorNotice());
 const dismissedIgnoredRootMediaNotice = ref(loadDismissedIgnoredRootMediaNotice());
 const dismissedStoriesMigrationNotice = ref(loadDismissedStoriesNotice(STORIES_MIGRATION_NOTICE_STORAGE_KEY));
 const dismissedStoriesAnnouncement = ref(loadDismissedStoriesNotice(STORIES_ANNOUNCEMENT_STORAGE_KEY));
+const dismissedCarouselsAnnouncement = ref(loadDismissedStoriesNotice(CAROUSELS_ANNOUNCEMENT_STORAGE_KEY));
 const dismissedPlacesOnboardingBanner = ref(loadDismissedStoriesNotice(PLACES_ONBOARDING_STORAGE_KEY));
 
 function wait(milliseconds: number) {
@@ -1548,13 +1667,18 @@ function syncStoriesModeFromSaved() {
   storiesModeHydrated.value = true;
 }
 
+function syncCarouselsModeFromSaved() {
+  carouselsMode.value = appStore.treatCarouselsAsFolders;
+  carouselsModeHydrated.value = true;
+}
+
 function syncExcludedFoldersFromSaved() {
   customExcludedFoldersDraft.value = formatExcludedFolderRules(adminStats.value?.excludedFolders.customExcludedFolders ?? []);
   excludedFoldersHydrated.value = true;
 }
 
 const scan = computed(() => appStore.stats?.scan ?? null);
-const lastCompletedScan = computed(() => scan.value?.lastCompletedScan ?? adminStats.value?.lastScan ?? null);
+const lastCompletedScan = computed(() => adminStats.value?.lastScan ?? scan.value?.lastCompletedScan ?? null);
 const activeScanReason = computed(() => scan.value?.scanReason ?? null);
 const supportedLocaleOptions = computed<Array<{ id: SupportedLocale; label: string }>>(() =>
   SUPPORTED_LOCALES.map((locale) => ({
@@ -1635,6 +1759,7 @@ const savedReelsFeedDefaultMode = computed(() => appStore.defaultReelsFeedMode);
 const savedFolderImageOrderDefault = computed(() => appStore.defaultFolderImageOrder);
 const savedNestedFolderTitleFormat = computed(() => appStore.nestedFolderTitleFormat);
 const savedStoriesMode = computed(() => appStore.treatStoriesAsFolders);
+const savedCarouselsMode = computed(() => appStore.treatCarouselsAsFolders);
 const savedCustomExcludedFolders = computed(() => adminStats.value?.excludedFolders.customExcludedFolders ?? []);
 const envExcludedFolders = computed(() => adminStats.value?.excludedFolders.envExcludedFolders ?? []);
 const effectiveExcludedFolders = computed(() => adminStats.value?.excludedFolders.effectiveExcludedFolders ?? []);
@@ -1643,6 +1768,7 @@ const legacyDerivativeMigrationPending = computed(
 );
 const legacyDerivativeMigrationCount = computed(() => adminStats.value?.libraryIndex.pendingDerivativeMigrationRows ?? 0);
 const storiesModeRequiresDecision = computed(() => appStore.stats?.storiesMigration.decisionPending === true);
+const carouselsModeRequiresDecision = computed(() => appStore.stats?.carouselsMigration?.decisionPending === true);
 const savedHomeFeedDefaultModeLabel = computed(
   () => homeFeedDefaultOptions.value.find((mode) => mode.id === savedHomeFeedDefaultMode.value)?.label ?? t('settings.general.homeFeed.options.random.label')
 );
@@ -1701,6 +1827,14 @@ const feedDefaultsDirty = computed(
   () => homeFeedDefaultDirty.value || reelsFeedDefaultDirty.value || folderImageOrderDirty.value || nestedFolderTitleDirty.value
 );
 const storiesModeDirty = computed(() => storiesModeHydrated.value && storiesMode.value !== savedStoriesMode.value);
+const carouselsModeDirty = computed(() => carouselsModeHydrated.value && carouselsMode.value !== savedCarouselsMode.value);
+const storiesScanRequired = computed(() => storiesModeDirty.value || storiesModeRequiresDecision.value);
+const carouselsScanRequired = computed(
+  () => carouselsModeDirty.value || carouselsModeRequiresDecision.value || appStore.isCarouselsReconciliationPending
+);
+const hasUnsavedReservedFolderRuleChanges = computed(
+  () => storiesModeDirty.value || storiesModeRequiresDecision.value || carouselsModeDirty.value || carouselsModeRequiresDecision.value
+);
 const excludedFoldersDirty = computed(() => {
   if (!excludedFoldersHydrated.value) {
     return false;
@@ -1713,14 +1847,17 @@ const excludedFoldersDirty = computed(() => {
     return true;
   }
 });
+const hasUnsavedFolderRuleChanges = computed(
+  () => excludedFoldersDirty.value || hasUnsavedReservedFolderRuleChanges.value
+);
 const generalSettingsDirty = computed(
-  () => localeDirty.value || feedDefaultsDirty.value || storiesModeDirty.value || excludedFoldersDirty.value || storiesModeRequiresDecision.value
+  () => localeDirty.value || feedDefaultsDirty.value || storiesModeDirty.value || carouselsModeDirty.value || excludedFoldersDirty.value || storiesModeRequiresDecision.value || carouselsModeRequiresDecision.value
 );
 const showSavedDefaultLocaleNotice = computed(
   () => savedLocaleSelection.value !== null && appStore.locale !== savedLocaleSelection.value
 );
 const showGeneralSettingsRescanNotice = computed(
-  () => storiesModeDirty.value || storiesModeRequiresDecision.value || excludedFoldersDirty.value
+  () => storiesScanRequired.value || carouselsScanRequired.value || excludedFoldersDirty.value
 );
 const generalSettingsSaveDisabled = computed(
   () => waitingForInitialStatus.value || savingGeneralSettings.value || !generalSettingsDirty.value
@@ -1740,7 +1877,7 @@ const generalSettingsActionNote = computed(() => {
     return t('settings.general.actionNote.loading');
   }
 
-  if (excludedFoldersDirty.value && (storiesModeDirty.value || storiesModeRequiresDecision.value || defaultSettingsDirtyCount.value > 0)) {
+  if (excludedFoldersDirty.value && (hasUnsavedReservedFolderRuleChanges.value || defaultSettingsDirtyCount.value > 0)) {
     return t('settings.general.actionNote.excludedAndOther');
   }
 
@@ -1748,11 +1885,11 @@ const generalSettingsActionNote = computed(() => {
     return t('settings.general.actionNote.excludedOnly');
   }
 
-  if (storiesModeDirty.value && defaultSettingsDirtyCount.value > 0) {
+  if (hasUnsavedReservedFolderRuleChanges.value && defaultSettingsDirtyCount.value > 0) {
     return t('settings.general.actionNote.storiesAndDefaults');
   }
 
-  if (storiesModeDirty.value || storiesModeRequiresDecision.value) {
+  if (hasUnsavedReservedFolderRuleChanges.value) {
     return t('settings.general.actionNote.storiesOnly');
   }
 
@@ -1780,15 +1917,37 @@ const generalSettingsActionNote = computed(() => {
     return t('settings.general.actionNote.nestedFolderTitleOnly');
   }
 
+  if (appStore.isCarouselsReconciliationPending) {
+    return t('settings.general.actionNote.carouselReconciliation');
+  }
+
   return t('settings.general.actionNote.idle');
 });
 const generalSettingsRescanNotice = computed(() => {
-  if (excludedFoldersDirty.value && (storiesModeDirty.value || storiesModeRequiresDecision.value)) {
+  if (appStore.isLibraryRebuildRequired) {
+    return hasUnsavedFolderRuleChanges.value
+      ? t('settings.general.rescanNotice.rebuildRequired')
+      : t('settings.general.rescanNotice.pendingRebuild');
+  }
+
+  if (appStore.isCarouselsReconciliationPending && !hasUnsavedFolderRuleChanges.value) {
+    return t('settings.general.rescanNotice.pendingCarousels');
+  }
+
+  if (excludedFoldersDirty.value && (storiesScanRequired.value || carouselsScanRequired.value)) {
     return t('settings.general.rescanNotice.excludedAndStories');
   }
 
   if (excludedFoldersDirty.value) {
     return t('settings.general.rescanNotice.excludedOnly');
+  }
+
+  if (storiesScanRequired.value && carouselsScanRequired.value) {
+    return t('settings.general.rescanNotice.storiesAndCarousels');
+  }
+
+  if (carouselsScanRequired.value) {
+    return t('settings.general.rescanNotice.carouselsOnly');
   }
 
   return t('settings.general.rescanNotice.storiesOnly');
@@ -1797,6 +1956,21 @@ const storiesModeLabelDescription = computed(() =>
   storiesMode.value
     ? t('settings.general.storiesMode.enabledDescription')
     : t('settings.general.storiesMode.disabledDescription')
+);
+const carouselsModeLabelDescription = computed(() =>
+  carouselsMode.value
+    ? t('settings.general.carouselsMode.enabledDescription')
+    : t('settings.general.carouselsMode.disabledDescription')
+);
+const showCarouselsMigrationNotice = computed(() =>
+  appStore.stats?.carouselsMigration?.hasLegacyCarouselsCandidates === true &&
+  carouselsModeRequiresDecision.value
+);
+const showCarouselsAnnouncementCard = computed(
+  () =>
+    appStore.stats?.carouselsMigration?.hasLegacyCarouselsCandidates === false &&
+    appStore.stats?.carouselsMigration?.decisionPending === true &&
+    !dismissedCarouselsAnnouncement.value
 );
 const storiesMigrationActionHelper = computed(() => {
   if (savingGeneralSettings.value) {
@@ -1918,6 +2092,10 @@ const scanActionNote = computed(() => {
 
   if (legacyDerivativeMigrationPending.value) {
     return t('settings.library.scanActionNote.legacyMigration');
+  }
+
+  if (appStore.isCarouselsReconciliationPending) {
+    return t('settings.library.scanActionNote.carouselReconciliation');
   }
 
   return t('settings.library.scanActionNote.idle');
@@ -2144,6 +2322,12 @@ const showScanErrorNotice = computed(() => {
 
   return Date.now() >= dismissed.dismissedUntil;
 });
+const showScanWarningNotice = computed(() =>
+  !appStore.isLibraryUnavailable &&
+  !appStore.isScanning &&
+  lastCompletedScan.value?.status === 'completed' &&
+  (lastCompletedScan.value.warning_count ?? 0) > 0
+);
 const ignoredRootMediaCount = computed(() => appStore.stats?.libraryIndex.ignoredRootMediaCount ?? 0);
 const showIgnoredRootMediaNotice = computed(() => {
   if (appStore.isLibraryUnavailable || (appStore.stats?.folders ?? 0) === 0 || ignoredRootMediaCount.value === 0) {
@@ -2311,6 +2495,14 @@ function dismissStoriesAnnouncement() {
   }
 }
 
+function dismissCarouselsAnnouncement() {
+  dismissedCarouselsAnnouncement.value = true;
+  showCarouselsAnnouncementStructure.value = false;
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(CAROUSELS_ANNOUNCEMENT_STORAGE_KEY, '1');
+  }
+}
+
 function dismissPlacesOnboardingBanner() {
   dismissedPlacesOnboardingBanner.value = true;
   if (typeof window !== 'undefined') {
@@ -2324,6 +2516,10 @@ function openPlacesTab() {
 
 function toggleStoriesAnnouncementStructure() {
   showStoriesAnnouncementStructure.value = !showStoriesAnnouncementStructure.value;
+}
+
+function toggleCarouselsAnnouncementStructure() {
+  showCarouselsAnnouncementStructure.value = !showCarouselsAnnouncementStructure.value;
 }
 
 async function enableAccessProtection() {
@@ -2495,6 +2691,20 @@ function chooseStoriesMigrationMode(value: boolean) {
   });
 }
 
+function selectCarouselsMode(value: boolean, scrollToSaveArea = false) {
+  clearGeneralSettingsFeedback();
+  carouselsMode.value = value;
+  if (scrollToSaveArea) void scrollToGeneralSettingsSaveArea();
+}
+
+function toggleCarouselsModeSetting() {
+  selectCarouselsMode(!carouselsMode.value, showCarouselsMigrationNotice.value);
+}
+
+function chooseCarouselsMigrationMode(value: boolean) {
+  selectCarouselsMode(value, true);
+}
+
 function selectHomeFeedDefault(mode: FeedMode) {
   clearGeneralSettingsFeedback();
   homeFeedDefaultMode.value = mode;
@@ -2527,6 +2737,7 @@ async function saveGeneralSettings() {
   const shouldSaveLocale = localeDirty.value;
   const shouldSaveExcludedFolders = excludedFoldersDirty.value;
   const shouldSaveStories = storiesModeDirty.value || storiesModeRequiresDecision.value;
+  const shouldSaveCarousels = carouselsModeDirty.value || carouselsModeRequiresDecision.value;
   const shouldSaveHome = homeFeedDefaultDirty.value;
   const shouldSaveReels = reelsFeedDefaultDirty.value;
   const shouldSaveFolderOrder = folderImageOrderDirty.value;
@@ -2541,6 +2752,7 @@ async function saveGeneralSettings() {
     shouldSaveNestedFolderTitle
   ].filter(Boolean).length;
   const savedParts: string[] = [];
+  const savedFolderRuleCount = [shouldSaveExcludedFolders, shouldSaveStories, shouldSaveCarousels].filter(Boolean).length;
   let nextExcludedFolders: string[] = [];
 
   if (shouldSaveExcludedFolders) {
@@ -2592,7 +2804,21 @@ async function saveGeneralSettings() {
 
       if (appStore.stats) {
         appStore.stats.preferences.treatStoriesAsFolders = payload.treatStoriesAsFolders;
-        appStore.stats.storiesMigration.decisionPending = false;
+        if (appStore.stats.storiesMigration) {
+          appStore.stats.storiesMigration.decisionPending = false;
+        }
+      }
+    }
+
+    if (shouldSaveCarousels) {
+      const payload = await updateCarouselsMode(carouselsMode.value);
+      savedParts.push(t('settings.general.feedback.parts.carouselsFolderHandling'));
+      carouselsMode.value = payload.preferences.treatCarouselsAsFolders;
+      if (appStore.stats) {
+        appStore.stats.preferences.treatCarouselsAsFolders = payload.preferences.treatCarouselsAsFolders;
+        if (appStore.stats.carouselsMigration) {
+          appStore.stats.carouselsMigration.decisionPending = false;
+        }
       }
     }
 
@@ -2634,20 +2860,24 @@ async function saveGeneralSettings() {
 
     await appStore.fetchStats({ background: true });
 
-    if (shouldSaveStories || shouldSaveExcludedFolders) {
+    if (shouldSaveStories || shouldSaveCarousels || shouldSaveExcludedFolders) {
       await loadAdminStats().catch(() => {});
     }
 
-    if ((shouldSaveStories || shouldSaveExcludedFolders) && shouldSaveAnyDefault) {
+    if (savedFolderRuleCount > 0 && appStore.isLibraryRebuildRequired) {
+      setGeneralSettingsFeedback('success', t('settings.general.feedback.folderRulesSavedRebuild'));
+    } else if (savedFolderRuleCount > 0 && shouldSaveAnyDefault) {
       setGeneralSettingsFeedback('success', t('settings.general.feedback.settingsAndFolderRulesSaved'));
-    } else if (shouldSaveExcludedFolders && shouldSaveStories) {
-      setGeneralSettingsFeedback('success', t('settings.general.feedback.folderRulesAndStoriesSaved'));
+    } else if (savedFolderRuleCount > 1) {
+      setGeneralSettingsFeedback('success', t('settings.general.feedback.folderRulesSaved'));
     } else if (shouldSaveExcludedFolders) {
       setGeneralSettingsFeedback('success', t('settings.general.feedback.excludedFoldersSaved'));
     } else if (shouldSaveStories && shouldSaveAnyDefault) {
       setGeneralSettingsFeedback('success', t('settings.general.feedback.settingsAndStoriesSaved'));
     } else if (shouldSaveStories) {
       setGeneralSettingsFeedback('success', t('settings.general.feedback.storiesSaved'));
+    } else if (shouldSaveCarousels) {
+      setGeneralSettingsFeedback('success', t('settings.general.feedback.carouselsSaved'));
     } else if (savedDefaultCount > 1) {
       setGeneralSettingsFeedback('success', t('settings.general.feedback.defaultsSaved'));
     } else if (shouldSaveLocale) {
@@ -2678,11 +2908,12 @@ async function saveGeneralSettings() {
     }
   } catch (error) {
     await appStore.fetchStats({ background: true }).catch(() => {});
-    if (shouldSaveStories || shouldSaveExcludedFolders) {
+    if (shouldSaveStories || shouldSaveCarousels || shouldSaveExcludedFolders) {
       await loadAdminStats().catch(() => {});
     }
 
     const message = error instanceof Error ? error.message : t('settings.general.errors.update');
+
     if (savedParts.length > 0) {
       setGeneralSettingsFeedback(
         'error',
@@ -2817,6 +3048,7 @@ onMounted(async () => {
     syncLocaleSelectionFromSaved();
     syncFeedDefaultsFromSaved();
     syncStoriesModeFromSaved();
+    syncCarouselsModeFromSaved();
   }
   await placesStore.fetchStatus();
   await loadAdminStats().catch(() => {});
@@ -2830,7 +3062,8 @@ watch(
       savedHomeFeedDefaultMode.value,
       savedReelsFeedDefaultMode.value,
       savedFolderImageOrderDefault.value,
-      savedStoriesMode.value
+      savedStoriesMode.value,
+      savedCarouselsMode.value
     ] as const,
   ([stats, loadingStats]) => {
     if (!stats || loadingStats) {
@@ -2847,6 +3080,10 @@ watch(
 
     if (!storiesModeHydrated.value || savingGeneralSettings.value || !storiesModeDirty.value) {
       syncStoriesModeFromSaved();
+    }
+
+    if (!carouselsModeHydrated.value || savingGeneralSettings.value || !carouselsModeDirty.value) {
+      syncCarouselsModeFromSaved();
     }
   },
   {

--- a/client/src/views/SharedPostView.vue
+++ b/client/src/views/SharedPostView.vue
@@ -15,7 +15,7 @@
         <RouterLink
           v-if="shareStore.image.previousImageId"
           class="shared-post-nav shared-post-nav--previous"
-          :to="{ name: 'shared-image', params: { slug, id: String(shareStore.image.previousImageId) } }"
+          :to="{ name: 'shared-post', params: { slug, id: String(shareStore.image.previousImageId) } }"
           :aria-label="t('post.viewer.previous')"
         >
           <span class="i-fluent-chevron-left-20-regular h-5 w-5" aria-hidden="true" />
@@ -23,7 +23,7 @@
         <RouterLink
           v-if="shareStore.image.nextImageId"
           class="shared-post-nav shared-post-nav--next"
-          :to="{ name: 'shared-image', params: { slug, id: String(shareStore.image.nextImageId) } }"
+          :to="{ name: 'shared-post', params: { slug, id: String(shareStore.image.nextImageId) } }"
           :aria-label="t('post.viewer.next')"
         >
           <span class="i-fluent-chevron-right-20-regular h-5 w-5" aria-hidden="true" />
@@ -31,8 +31,16 @@
 
         <article class="grid overflow-hidden rounded-[1rem] border border-border bg-surface shadow-[var(--shadow)] lg:grid-cols-[minmax(0,1fr)_20rem]">
           <div class="grid min-h-[24rem] place-items-center bg-black">
+            <CarouselMediaStage
+              v-if="isCarousel"
+              v-model="carouselIndex"
+              class="max-h-[78vh] w-full"
+              :items="shareStore.image.mediaItems!"
+              prefer-preview
+              loading="eager"
+            />
             <video
-              v-if="shareStore.image.mediaType === 'video'"
+              v-else-if="shareStore.image.mediaType === 'video'"
               class="max-h-[78vh] w-full bg-black"
               :src="shareStore.image.previewUrl"
               :poster="shareStore.image.thumbnailUrl"
@@ -49,20 +57,20 @@
           <aside class="grid content-start gap-4 p-5">
             <div class="grid gap-1">
               <h1 class="m-0 text-[1.05rem] font-semibold tracking-[-0.02em]">{{ shareStore.image.folderName }}</h1>
-              <p class="m-0 break-words text-[0.9rem] text-muted">{{ shareStore.image.caption || shareStore.image.filename }}</p>
+              <p class="m-0 break-words text-[0.9rem] text-muted">{{ resolveDisplayCaption(shareStore.image) }}</p>
             </div>
             <dl class="grid gap-3 text-[0.88rem]">
               <div class="grid gap-1">
                 <dt class="text-[0.72rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('post.viewer.stats.dimensions') }}</dt>
-                <dd class="m-0 font-semibold">{{ shareStore.image.width }} x {{ shareStore.image.height }}</dd>
+                <dd class="m-0 font-semibold">{{ activeMedia?.width ?? shareStore.image.width }} x {{ activeMedia?.height ?? shareStore.image.height }}</dd>
               </div>
-              <div v-if="shareStore.image.durationMs" class="grid gap-1">
+              <div v-if="activeMedia?.durationMs ?? shareStore.image.durationMs" class="grid gap-1">
                 <dt class="text-[0.72rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('post.viewer.stats.duration') }}</dt>
-                <dd class="m-0 font-semibold">{{ formatMediaDuration(shareStore.image.durationMs) }}</dd>
+                <dd class="m-0 font-semibold">{{ formatMediaDuration(activeMedia?.durationMs ?? shareStore.image.durationMs) }}</dd>
               </div>
               <div class="grid gap-1">
                 <dt class="text-[0.72rem] font-bold uppercase tracking-[0.08em] text-muted">{{ t('post.viewer.stats.type') }}</dt>
-                <dd class="m-0 font-semibold">{{ shareStore.image.mimeType }}</dd>
+                <dd class="m-0 font-semibold">{{ activeMedia?.mimeType ?? shareStore.image.mimeType }}</dd>
               </div>
             </dl>
           </aside>
@@ -77,13 +85,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { RouterLink } from 'vue-router';
+import { RouterLink, useRoute } from 'vue-router';
 
 import ErrorState from '../components/ErrorState.vue';
+import CarouselMediaStage from '../components/CarouselMediaStage.vue';
 import ResilientImage from '../components/ResilientImage.vue';
 import { useShareStore } from '../stores/share';
+import { resolveDisplayCaption } from '../utils/caption';
 import { formatMediaDuration } from '../utils/media';
 
 const props = defineProps<{
@@ -92,12 +102,17 @@ const props = defineProps<{
 }>();
 
 const { t } = useI18n();
+const route = useRoute();
 const shareStore = useShareStore();
 const imageId = computed(() => Number(props.id));
+const carouselIndex = ref(0);
+const isCarousel = computed(() => shareStore.image?.postType === 'carousel' && (shareStore.image.mediaItems?.length ?? 0) > 1);
+const activeMedia = computed(() => isCarousel.value ? shareStore.image?.mediaItems?.[carouselIndex.value] ?? null : null);
 
 async function loadImage() {
+  carouselIndex.value = 0;
   if (Number.isFinite(imageId.value)) {
-    await shareStore.loadImage(imageId.value);
+    await shareStore.loadImage(imageId.value, undefined, { legacyImageAlias: route.name === 'shared-image' });
   }
 }
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -15,6 +15,7 @@ const guideItems = [
 const productItems = [
   { text: 'How It Works', link: '/how-it-works' },
   { text: 'Features', link: '/features' },
+  { text: 'Carousel Posts', link: '/carousel-posts' },
   { text: 'Media Processing', link: '/media-processing' },
   { text: 'Security', link: '/security' }
 ];

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,6 +28,7 @@ When password protection is enabled:
 - `/thumbnails/...` and `/previews/...` also require the same authenticated session unless public viewer mode is enabled
 - authenticated sessions carry `admin` or `viewer` role data
 - anonymous public reads use `role: "anonymous"` and `likesMode: "local"`
+- anonymous public JSON responses omit local media paths, post source paths, and EXIF metadata at every carousel-item depth; `folderPath` remains available for folder display and `carouselTitle` provides the safe child-folder label used for carousel caption fallback
 - admin-only mutations return `403` for viewer sessions
 
 The frontend sends same-origin credentials automatically and uses a signed
@@ -147,6 +148,7 @@ Notes:
 - `thumbnailUrl` points to `/thumbnails/...`.
 - `previewUrl` points to `/previews/...`.
 - feed items can include a nullable `caption`.
+- feed items representing carousel posts include `carouselTitle`, a display-safe child-folder label that remains available when anonymous-public responses omit `sourcePath`.
 
 ### `GET /api/feed/search`
 
@@ -387,11 +389,20 @@ The response shape contains the shared folder summary and a list of redacted ite
 
 Sensitive metadata including local folder paths, relative file paths, and EXIF metadata are omitted.
 
-### `GET /api/share/images/:id`
+### `GET /api/share/posts/:postId`
 
-Returns one shared post detail after checking access to that post's folder.
+Returns one shared post detail using the canonical `posts.id` namespace after
+checking access to that post's folder. Shared folder grids and carousel links
+use this route.
 
 Shared detail payloads do not expose original-file URLs (`originalUrl`) or local system paths. Only `thumbnailUrl` and `previewUrl` are provided, both pointing to guarded shared media endpoints.
+
+### `GET /api/share/images/:imageId`
+
+Historical compatibility alias. The value is interpreted only as an
+`images.id` and resolves through `post_items` to its owning post. Existing
+single-image shared links continue to work. New shared links should use
+`/api/share/posts/:postId`.
 
 ### `GET /api/share/images/:id/thumbnail`
 
@@ -672,7 +683,7 @@ Each trash item uses the normal feed-item shape plus `trashedAt`.
 That shared shape also includes the nullable `caption` field used by feed and
 viewer surfaces.
 
-### `GET /api/images/:id`
+### `GET /api/posts/:id`
 
 Query parameters:
 
@@ -690,14 +701,18 @@ Returns one post detail payload with:
 - `fileSize`
 - `originalUrl`
 - `playbackStrategy` for videos when an original MP4 is browser-compatible
+- `nextPostId`
+- `previousPostId`
 - `nextImageId`
 - `previousImageId`
 
-`nextImageId` and `previousImageId` are resolved within the same folder, the
-same active `mediaType` filter when one is supplied, and the current default
-folder image order from Settings.
+`nextPostId` and `previousPostId` are the canonical post-navigation fields.
+They are resolved within the same folder, the same active `mediaType` filter
+when one is supplied, and the current default folder image order from Settings.
+`nextImageId` and `previousImageId` are compatibility aliases with the same
+values.
 
-### `GET /api/images/:id/collections`
+### `GET /api/posts/:id/collections`
 
 Returns shared collection membership for one post.
 
@@ -773,7 +788,9 @@ Notable fields:
 | `preferences.defaultReelsFeedMode` | Current app-wide default reels mode used when `/reels` opens. |
 | `preferences.defaultFolderImageOrder` | Current app-wide default order used for folder grids and folder detail navigation. |
 | `preferences.treatStoriesAsFolders` | Whether folders literally named `stories` are treated as ordinary app folders instead of reserved story sources. |
+| `preferences.treatCarouselsAsFolders` | Whether folders literally named `carousels` are treated as ordinary app folders instead of reserved carousel sources. |
 | `storiesMigration` | Migration hint with `hasLegacyStoriesCandidates` and `decisionPending`. |
+| `carouselsMigration` | Carousel migration state with `hasLegacyCarouselsCandidates`, `decisionPending`, and `reconciliationPending`. The last field remains true until a successful full scan applies the saved Carousel folder mode. |
 
 ### `GET /api/scan-progress`
 
@@ -1168,7 +1185,7 @@ Notes:
 
 - `false` enables the default reserved-stories mode
 - `true` keeps `stories/` folders behaving like ordinary app folders
-- the Settings UI immediately follows this write with `POST /api/admin/rescan`, but this endpoint itself only saves the setting
+- this endpoint only saves the setting; use `POST /api/admin/rescan` afterward, or `POST /api/admin/rebuild-index` when `libraryIndex.rebuildRequired` is true
 
 ### `PUT /api/admin/settings/excluded-folders`
 
@@ -1410,7 +1427,7 @@ Success:
 }
 ```
 
-### `PATCH /api/images/:id/caption`
+### `PATCH /api/posts/:id/caption`
 
 Updates the custom caption for one visible post.
 
@@ -1442,7 +1459,7 @@ Success:
 `image` contains the updated post payload so the client can refresh loaded
 surfaces immediately.
 
-### `POST /api/images/:id/like`
+### `POST /api/posts/:id/like`
 
 Marks a post as liked.
 
@@ -1461,7 +1478,7 @@ Errors:
 - `404` with `{"message":"Image not found"}` when the post does not exist or is deleted
 - `403` when trust requirements are missing
 
-### `DELETE /api/images/:id/like`
+### `DELETE /api/posts/:id/like`
 
 Removes a like.
 
@@ -1475,7 +1492,7 @@ Success:
 }
 ```
 
-### `POST /api/images/:id/save`
+### `POST /api/posts/:id/save`
 
 Adds a post to the default saved collection.
 
@@ -1489,7 +1506,7 @@ Success:
 }
 ```
 
-### `DELETE /api/images/:id/save`
+### `DELETE /api/posts/:id/save`
 
 Removes a post from the default saved collection and clears any custom shared
 collection memberships for that post.
@@ -1548,7 +1565,7 @@ Deletes one shared custom collection.
 Deleting a custom collection does not unsave the underlying posts if they are
 still present in the default saved collection.
 
-### `POST /api/collections/:slug/images/:id`
+### `POST /api/collections/:slug/posts/:id`
 
 Adds a post to one shared collection.
 
@@ -1562,14 +1579,14 @@ Success:
 }
 ```
 
-### `DELETE /api/collections/:slug/images/:id`
+### `DELETE /api/collections/:slug/posts/:id`
 
 Removes a post from one shared collection.
 
 If the target collection is the default saved collection, the server clears all
 shared collection membership for that post.
 
-### `POST /api/images/:id/trash`
+### `POST /api/posts/:id/trash`
 
 Moves a post into Trash without removing the original file from disk.
 
@@ -1583,7 +1600,7 @@ Success:
 }
 ```
 
-### `POST /api/images/:id/restore`
+### `POST /api/posts/:id/restore`
 
 Restores a post from Trash.
 
@@ -1597,15 +1614,16 @@ Success:
 }
 ```
 
-### `DELETE /api/images/:id`
+### `DELETE /api/posts/:id`
 
-Permanently deletes:
+Permanently deletes every physical member of the post:
 
-- the source file from disk
-- its thumbnail derivative
-- its preview derivative
+- each source file from disk
+- each thumbnail derivative
+- each preview derivative
 
-Then it updates the index and folder avatar state.
+A single-item post has one member; a carousel has all of its ordered members
+removed. The endpoint then updates the index and folder avatar state.
 
 Success:
 
@@ -1766,3 +1784,31 @@ Those helpers are the best reference for current client-side usage, including:
 - default page sizes
 - when `mediaType` is sent
 - which routes are expected to return `items` arrays versus single objects
+
+## Post-oriented carousel API
+
+Feed and detail objects include `postType`, `itemCount`, ordered `mediaItems`, and a display-safe `carouselTitle`. Each member identifies its physical asset with `imageId`; original and derivative delivery remains asset-oriented. Canonical post routes are:
+
+- `GET /api/posts/:id`
+- `PATCH /api/posts/:id/caption`
+- `GET /api/posts/:id/collections`
+- `POST|DELETE /api/posts/:id/like`
+- `POST|DELETE /api/posts/:id/save`
+- `POST /api/posts/:id/trash` and `/restore`
+- `DELETE /api/posts/:id`
+- `GET /api/share/posts/:id`
+- `POST|DELETE /api/collections/:slug/posts/:id`
+
+- `POST /api/admin/settings/carousels-as-folders` (`{ treatCarouselsAsFolders: boolean }`)
+- `POST /api/admin/settings/carousels-migration-decision` (`{ decision: 'restore' | 'carousels' }`)
+
+Admin settings mutations for carousel mode store the mode and migration decision atomically, then return `200 OK` with updated `AppStats`. They do not start a library scan. Use `POST /api/admin/rescan` afterward to reindex folders and posts with the selected mode. When `libraryIndex.rebuildRequired` is true, use `POST /api/admin/rebuild-index` instead. Status keeps `carouselsMigration.reconciliationPending` true until a successful full scan records the selected mode as applied.
+
+The matching `/api/images/:id` routes remain compatibility aliases and interpret
+the number only as a physical `images.id`. They never fall back to a colliding
+post ID. `/post/:id` is canonical in the browser, while `/image/:id` remains an
+alias. Derivative routes remain image-oriented because they identify physical
+media assets. Status responses distinguish `indexedPosts`, `indexedMediaAssets`,
+`indexedCarousels`, and single-video `indexedVideos`; scan summaries may include
+`warning_count` and `warning_text`. Carousel mode and migration state are
+available in `preferences.treatCarouselsAsFolders` and `carouselsMigration`.

--- a/docs/carousel-posts.md
+++ b/docs/carousel-posts.md
@@ -1,0 +1,135 @@
+---
+title: Posts with Multiple Photos or Videos
+description: Create, order, scan, view, and manage carousel posts in Foldergram.
+---
+
+# Posts with Multiple Photos or Videos
+
+A carousel is one swipeable post containing 2–20 supported images, animated images, videos, or a mixture of them. It has one caption and one set of like, save, collection, trash, delete, and sharing actions.
+
+## Folder structure
+
+Create a reserved `carousels` folder directly inside an App Folder. Each immediate child is one post, and its media must be directly inside that child.
+
+One carousel beside ordinary posts:
+
+```text
+gallery/
+  AnimalPlanet/
+    cover.jpg
+    ordinary-post.jpg
+    carousels/
+      Lions/
+        01-cover.jpg
+        02-clip.mp4
+        03-pride.jpg
+```
+
+Multiple and mixed-media carousels:
+
+```text
+gallery/
+  Trips/
+    carousels/
+      Coast/
+        01-arrival.jpg
+        02-waves.mp4
+      City Night/
+        sign.gif
+        street.jpg
+        train.webm
+```
+
+An App Folder may contain only carousel posts; no placeholder file is required directly inside it. `carousels` and its post children do not appear as separate App Folders in reserved mode.
+
+## Filename ordering
+
+Items use a case-insensitive natural filename sort, so `2-photo.jpg` sorts before `10-photo.jpg`. Numeric prefixes are optional; use zero-padded prefixes such as `01-`, `02-`, and `03-` only when you want to make the intended order explicit. The first item becomes the post cover in feeds and grids.
+
+Renaming files can reorder a post after the next scan without replacing its caption, likes, or saved state. If more than 20 supported files exist, Foldergram uses the first 20 after sorting and reports a warning.
+
+## Covers and avatars
+
+The carousel cover and App Folder cover are separate:
+
+- A carousel always uses its first item. A first-position video uses its generated poster.
+- A manually selected App Folder cover has first priority.
+- A direct `cover.*` file inside the App Folder is next.
+- Otherwise, the representative item from the newest visible post is used.
+
+Use **Set as folder cover** in the post viewer to select the currently active carousel item.
+
+## Captions and actions
+
+A carousel has one editable caption. Without a custom caption, the display-safe carousel child-folder name is shown, such as `Lions`, even when anonymous-public responses redact the underlying source path. Likes, saves, collection membership, trash, restore, and deletion apply to the whole post, never to one item.
+
+In the viewer, Download original, Open original, dimensions, file size, format, EXIF details, and Set as folder cover follow the active item. Deleting a carousel permanently removes all included originals and generated derivatives.
+
+## Item ordering
+
+Carousel slides are sorted deterministically using natural numeric filename comparison. Numbers embedded in filenames sort numerically (e.g. `slide1.jpg`, `slide2.jpg`, `slide10.jpg`). Case variants and Unicode accents use canonical Unicode NFKD normalization and deterministic code-point tie breaking, ensuring the identical slide sequence across discovery runs and platforms.
+
+## Search behavior and deduplication
+
+When searching for media in the feed, queries match against filenames, captions, and folder paths across all carousel slides.
+If multiple slides in a carousel match the search query, the carousel appears exactly once in search results, ranked by the highest-scoring matching slide. The first position (representative slide) is displayed as the cover card, and pagination remains stable without duplicate posts across page boundaries.
+
+## Reels and mixed videos
+
+Videos play inside the carousel using the integrated video player with interactive timeline scrubbing, play/pause controls, mute toggling, and optional HD source switching. In the post viewer, the active video starts automatically. When a browser blocks audible autoplay, Foldergram retries muted and updates the shared video mute preference so playback can begin without another click. The HD button appears only when the original video is larger than the generated preview and uses a browser-supported direct playback format (`playbackStrategy: 'original'`). Toggling HD switches resolution without resetting current playback time or playing state.
+
+Swiping or navigating through slides isolates video controls so that dragging the time slider or tapping player buttons does not trigger slide changes, and unmounting or switching slides pauses background playback cleanly.
+
+Videos inside multi-item carousels do not appear in Reels or contribute to Reels counts. A child folder with exactly one video becomes a normal single-video post, so that fallback post may appear in Reels.
+
+## Edge cases
+
+| Source state | Result |
+| --- | --- |
+| 2–20 supported direct items | One carousel post. |
+| Exactly one supported item | One normal single-item post plus a warning. |
+| More than 20 supported items | First 20 are used; skipped items produce a warning and no derivatives. |
+| Empty or unsupported-only child | Ignored without creating a post. |
+| Hidden file or hidden child | Ignored. |
+| Unsupported file beside supported media | Unsupported file is ignored. |
+| Supported media directly inside `carousels` | Ignored with a warning; put it in a child folder. |
+| Valid child posts plus invalid root media | Valid posts are indexed and root media is warned about. |
+| Supported media in a deeper nested folder | Nested media is ignored with a warning. |
+| `cover.jpg` inside a carousel child | Treated as an ordinary carousel item. |
+| Two-item post loses one item | Same post becomes a single post and keeps its metadata. |
+| One-item post gains another item | Same post becomes a carousel and keeps its metadata. |
+| Child loses all supported items | Post is soft-deleted and can reactivate later. |
+| Reserved folder has only invalid root media | No post or carousel-only App Folder is created. |
+
+## Settings and migration
+
+Reserved carousel mode is the default. In **Settings → General Settings**, turn on **Treat carousels folders as normal app folders** only when directories named `carousels` should use the legacy folder rules.
+
+When there is no indexed `carousels` path conflict and no mode decision has been saved yet, General Settings shows a **Carousel Posts** announcement with an expandable directory example. Dismissing this informational card hides it permanently for the current browser and Foldergram origin. Clearing browser site data, using another browser profile, or opening Foldergram from another origin can show it again while the server-side mode decision remains pending.
+
+When an existing index contains a `carousels` path segment, Settings presents a migration choice:
+
+- **Use Carousel Posts** enables the reserved structure.
+- **Keep Normal Folders** preserves legacy folder discovery.
+
+Saving either choice stores the selected folder mode and resolves the migration decision. Settings keeps an update reminder visible until a successful full scan applies that mode to the index. Run **Scan Library** from **Settings → Scan & Library** to update folders and posts. If the gallery location requires a new index, use **Rebuild Library Index** instead. The same follow-up applies whenever you change **Treat carousels folders as normal app folders**.
+
+## Scanning and media processing
+
+Scanning writes posts, ordered item membership, and asset metadata to SQLite. Pages read that index and do not scan the filesystem during requests. Each included item uses the normal thumbnail, preview, video-poster, and lazy-derivative behavior. No derivative work is scheduled for items skipped beyond the 20-item limit.
+
+Structural problems complete the scan with warnings instead of reporting a processing failure. Review them in **Settings → Scan & Library**.
+
+## Troubleshooting
+
+- **App Folder is missing:** ensure `carousels` has an immediate child containing at least one supported direct media file, then scan.
+- **Carousels appear as ordinary folders:** turn off **Treat carousels folders as normal app folders**, save, then run **Scan Library**.
+- **Direct media is ignored:** move it from `AppFolder/carousels` into `AppFolder/carousels/Post name`.
+- **Order is unexpected:** use filename prefixes and rescan; dates and discovery order do not control item order.
+- **Only 20 items appear:** this is the per-post limit; split the remaining files into another child folder.
+- **Nested items are missing:** move them directly into the carousel child; nested discovery is intentionally disabled.
+- **An emptied carousel disappears:** removing every supported item soft-deletes that post on the next scan; restoring items reactivates the same indexed post when its media identities can be reconciled.
+- **A video is absent from Reels:** videos in a multi-item carousel are intentionally excluded.
+- **Caption fallback is unexpected:** edit the shared caption or rename the carousel child and rescan.
+- **Cover is unexpected:** position 1 controls the post cover; manual or direct `cover.*` rules control the App Folder avatar.
+- **Folder mode has not taken effect:** follow the pending update message in **Settings → Scan & Library**. Run **Scan Library**, or use **Rebuild Library Index** when Settings reports that a rebuild is required.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,12 @@ Fresh installs create the database from the baseline migration. Existing
 supported installs are baselined once on upgrade, so later releases can apply
 ordered schema changes automatically.
 
+Startup also validates the schema behind recorded folder-sharing and posts
+migrations. If an earlier startup recorded one of those migrations before its
+schema work began, Foldergram safely clears that incomplete marker and resumes
+the ordered migration. If a schema is only partially transformed or contains
+new data that cannot be rolled back safely, startup stops instead of guessing.
+
 For source installs, use `pnpm migrate` if you want to apply pending
 migrations without starting the rest of the app.
 
@@ -138,7 +144,7 @@ Behavior:
 The Settings sidebar is split into:
 
 - `Scan & Library` for manual scans, thumbnail rebuilds, and library-index rebuilds
-- `General Settings` for Home/Reels defaults, default folder order, nested folder title format, stories-folders mode, excluded folders, and any save-and-rescan notices tied to those app-wide rules
+- `General Settings` for Home/Reels defaults, default folder order, nested folder title format, stories and carousel folder modes, excluded folders, and save-and-scan notices tied to those app-wide rules
 - `Places` for offline GeoNames preparation status and place-assignment rebuilds
 - `Security & Access` for admin, viewer, and public-mode controls
 - `System Status` for storage, index, and last-scan details
@@ -228,7 +234,7 @@ Behavior:
 - In `DERIVATIVE_MODE=lazy`, neither a normal scan nor `Rebuild Library Index` pre-generates missing thumbnails or previews.
 - `Regenerate Thumbnails` remains a manual thumbnail and video-poster rebuild only. It does not rebuild previews.
 - When `SCAN_MEDIA_ERROR_MODE=skip` records media failures, the admin Settings view shows the full report path for that scan.
-- Runtime-only app-wide controls such as stories mode and excluded folders live under `Settings -> General Settings`, while the scan and rebuild actions live under `Settings -> Scan & Library`.
+- Runtime-only app-wide controls such as stories mode, carousel mode, and excluded folders live under `Settings -> General Settings`, while scan and rebuild actions live under `Settings -> Scan & Library`.
 
 ## Derivative layout upgrade
 
@@ -308,7 +314,10 @@ Practical guidance:
 
 Foldergram ignores files placed directly in `GALLERY_ROOT`.
 
-It indexes only folders that directly contain supported media:
+It indexes ordinary folders that directly contain supported media. In the
+default reserved-carousel mode, an App Folder can also qualify when its
+`carousels/` directory has an immediate child containing supported media
+directly, so carousel-only App Folders do not need a placeholder file:
 
 ```text
 gallery/
@@ -368,3 +377,7 @@ The current and previous gallery roots remain exposed only in
 `GET /api/admin/stats`. Admin-only live scan file and folder detail is available
 from `GET /api/admin/scan-progress` and from the `scan` field in
 `GET /api/admin/stats`.
+
+## Carousel-folder mode
+
+The SQLite setting `library.treat_carousels_as_folders` controls folders named `carousels`. Its default `false` value reserves `AppFolder/carousels/<post>/` for multi-item posts. Enable **Treat carousels folders as normal app folders** from **Settings → General Settings** to index those paths as ordinary folders instead. When no indexed path conflicts with the reserved name, Settings can show a dismissible Carousel Posts introduction with an expandable folder example. Existing path collisions produce a migration decision card that remains available until a mode is saved. Settings shows a pending update until a successful full scan has applied the saved mode. Use **Scan Library** under normal conditions, or **Rebuild Library Index** when the gallery location requires a new index. There is no `.env` equivalent.

--- a/docs/development.md
+++ b/docs/development.md
@@ -154,3 +154,7 @@ The deploy workflow in `.github/workflows/deploy-docs.yml`:
 In production mode, the Express app serves `client/dist` and falls back to the
 SPA entry for non-API routes. Thumbnails and previews continue to be served as
 static files from their configured directories.
+
+## Carousel verification
+
+Focused coverage lives in `server/test/carousel-posts-feature.test.ts` and `server/test/migration-bootstrap.test.ts`. Fixtures should cover reserved and legacy discovery, natural ordering, mixed media, warnings, the 20-item cap, stable post identity, post-wide mutations, and migration metadata preservation. Run server/client tests plus app and documentation builds before shipping carousel changes.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -174,3 +174,7 @@ Yes, if an admin enables `viewer_access_mode=public` from Settings.
 In that mode, visitors can browse immediately and keep favorites only in the
 current browser, alongside browser-local saved collections. Admin-only controls
 still require unlocking with the admin password.
+
+## How do I create a post with several photos or videos?
+
+Put 2–20 supported files directly in `AppFolder/carousels/Post name/`, prefix their filenames to control order, and scan. The first item is the post cover, the child-folder name is the default caption, and the carousel counts as one post. Videos inside it play in the carousel rather than appearing in Reels. See [Carousel Posts](/carousel-posts).

--- a/docs/features.md
+++ b/docs/features.md
@@ -266,7 +266,7 @@ Its left sidebar is split into:
 | Section | What it contains |
 | --- | --- |
 | `Scan & Library` | Phase-aware live scan state, manual scan, thumbnail-only rebuild, and library-index rebuild actions. Admins also see the full report path when a scan finishes with skipped media errors. |
-| `General Settings` | App-language selection with instant local switching plus saved app-wide defaults, Home and Reels default feed modes, the default App Folder photo order, nested folder title format, stories-folders mode, excluded-folder rules, migration notices, and save-and-rescan prompts for those app-wide changes. |
+| `General Settings` | App-language selection with instant local switching plus saved app-wide defaults, Home and Reels default feed modes, the default App Folder photo order, nested folder title format, stories and carousel folder modes, excluded-folder rules, feature introductions, migration decisions, and save-and-scan prompts for folder-rule changes. |
 | `Places` | Offline GeoNames preparation status plus place-assignment rebuild actions for GPS-tagged photos. |
 | `Security & Access` | Admin password, viewer password, public mode, sign-out, and related auth controls. |
 | `System Status` | Storage and index state plus last completed scan details, including whether the last run completed with errors. |
@@ -277,9 +277,11 @@ changes` also stores the selected language as the app-wide default for browsers
 without their own override. That saved default also reaches the login gate and
 other pre-auth translated UI on devices that are using the app-wide language.
 Nested folder title format changes are presentation-only and update without a
-rescan. Env-backed excluded-folder rules are shown read-only and custom rules
-are saved at runtime. Changing stories mode or excluded folders still requires
-a follow-up scan from `Scan & Library`.
+scan. Env-backed excluded-folder rules are shown read-only and custom rules
+are saved at runtime. After changing stories mode, carousel mode, or excluded
+folders, follow the action shown in `Scan & Library` to update the index. Run a
+library scan normally, or rebuild the index when the gallery location requires
+one.
 
 On mobile, Settings uses a dedicated sticky top icon bar instead of the desktop
 sidebar.
@@ -347,3 +349,7 @@ The current repository does **not** implement:
 - remote multi-user permissions
 - cloud sync
 - hierarchical album navigation
+
+## Carousel posts
+
+Carousel posts combine 2–20 images, animated images, and videos in one feed card and viewer. Arrow buttons, keyboard controls, touch swipes, counters, and dots move between items. The post has one shared caption and one set of like, save, collection, trash, and delete actions; active-item download and file details remain asset-specific. See [Carousel Posts](/carousel-posts).

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -311,3 +311,9 @@ Once data is indexed:
 - moments, highlights, and folder stories read from SQLite
 - thumbnails and previews are served as static files
 - originals are served by image ID only
+
+## Posts and carousel discovery
+
+Visible items are represented by `posts`; ordered physical membership lives in `post_items`. Ordinary media has one member, while `AppFolder/carousels/Post name/` can have up to 20. Runtime pages query posts first and hydrate each page's members in one batch. Post IDs, captions, likes, saved state, trash state, and sort timestamps stay stable when carousel files reorder.
+
+In reserved mode, a folder can qualify as an App Folder solely through a valid immediate carousel child. Folder counts count posts, and Reels queries require a single-item video post, so videos inside real carousels are excluded.

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ features:
 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
 </div>
 <h3>How indexing works</h3>
-<p>Foldergram walks <code>GALLERY_ROOT</code> recursively, skipping hidden paths. Any folder that directly contains supported media becomes an indexed album. Files at the gallery root and nested folders each become their own album.</p>
+<p>Foldergram walks <code>GALLERY_ROOT</code> recursively, skipping hidden paths. Files directly at the gallery root are ignored, while ordinary nested folders that directly contain supported media become separate albums. In the default reserved modes, <code>stories/</code> descendants provide stories and highlights, and media in <code>carousels/Post name/</code> becomes a post in its owning App Folder instead of making those reserved descendants separate albums; a valid carousel child can also qualify a carousel-only owner as an App Folder.</p>
 </div>
 
 <div class="cs-feature">
@@ -91,7 +91,7 @@ features:
 <div class="cs-feature">
 <div class="cs-feature-step">1</div>
 <h3>Discover folders</h3>
-<p>Walk the gallery tree, skip hidden paths, and collect every non-hidden folder that directly contains supported media files.</p>
+<p>Walk the gallery tree, skip hidden paths, and collect every non-hidden folder that directly contains supported media files. In reserved carousel mode, a folder also qualifies when its <code>carousels/</code> directory has an immediate child containing supported media directly.</p>
 </div>
 
 <div class="cs-feature">
@@ -121,7 +121,7 @@ features:
 <div class="cs-feature">
 <div class="cs-feature-step">6</div>
 <h3>Maintain locally</h3>
-<p>Admins manage Home, Reels, and folder-order defaults, stories mode, excluded folders, and Places preparation from Settings, then run scans or rebuilds locally. All controls stay on disk and on-device.</p>
+<p>Admins manage Home, Reels, and folder-order defaults, stories and carousel folder modes, excluded folders, and Places preparation from Settings, then run scans or rebuilds locally. All controls stay on disk and on-device.</p>
 </div>
 
 </div>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -121,7 +121,7 @@ mode with admin unlock.
 
 The Settings sidebar separates app-wide preferences from maintenance actions:
 
-- `General Settings` contains app language, stories mode, nested folder title format, excluded folders, Home/Reels defaults, and the default folder photo order
+- `General Settings` contains app language, stories and carousel folder modes, nested folder title format, excluded folders, Home/Reels defaults, and the default folder photo order
 - `Places` contains offline place-data preparation and place-assignment rebuilds for GPS-tagged photos
 - `Scan & Library` contains manual scan plus rebuild actions
 

--- a/docs/media-processing.md
+++ b/docs/media-processing.md
@@ -226,3 +226,7 @@ gallery tree. That lets Foldergram:
 - preserve the same thumbnail and preview paths when a media item is moved
 - migrate existing derivatives in place instead of regenerating everything
 - garbage-collect stale derivatives by indexed asset reference instead of by mirrored folder tree
+
+## Carousel items
+
+Every included carousel item uses the normal thumbnail, preview, poster, and lazy-generation pipeline. Position 1 supplies the feed/grid cover; later items are fitted inside the shared stage without modifying originals. Only the first 20 naturally sorted supported files are indexed, and skipped extras do not enter derivative queues.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -41,7 +41,8 @@ data/
 
 The important rule is simple:
 
-- A non-hidden folder becomes an indexed album only when it directly contains supported media.
+- A non-hidden folder becomes an indexed album when it directly contains supported media.
+- In reserved carousel mode, it can instead qualify when `carousels/` has an immediate child containing supported media directly; carousel-only albums do not need a placeholder file.
 - Nested folders become separate albums if they directly contain media.
 
 Optional: add folder stories and highlights with a reserved `stories/` folder:
@@ -148,7 +149,7 @@ an unlimited revocable link, or a reusable folder password. Shared visitors use
 
 Inside Settings:
 
-- `General Settings` contains stories mode, nested folder title format, excluded folders, Home/Reels defaults, and the default folder photo order
+- `General Settings` contains stories and carousel folder modes, nested folder title format, excluded folders, Home/Reels defaults, and the default folder photo order
 - `Places` contains offline place-data preparation and place-assignment rebuilds for GPS-tagged photos
 - `Scan & Library` contains manual scan plus rebuild actions
 
@@ -219,3 +220,7 @@ pnpm build:docs
 - Folder share links and folder passwords are read-only and scoped to one folder; they do not grant Settings, Home feed, Reels, Places, Likes, Collections, Trash, or original-file downloads.
 
 If nothing appears, start with [Troubleshooting](/troubleshooting).
+
+## Create a carousel post
+
+Create `AppFolder/carousels/Trip/`, add `01-arrival.jpg`, `02-clip.mp4`, and `03-sunset.jpg`, then run a scan. The child becomes one swipeable post in filename order. See [Carousel Posts](/carousel-posts) for limits and edge cases.

--- a/docs/security.md
+++ b/docs/security.md
@@ -31,6 +31,7 @@ When enabled:
 - `/api` routes require that session, except for `GET /api/health`, `GET /api/auth/status`, `POST /api/auth/login`, `POST /api/auth/unlock-admin`, `POST /api/auth/logout`, and the scoped `/api/share/...` routes
 - generated media under `/thumbnails` and `/previews` also require that session unless public viewer mode is enabled
 - in `viewer_access_mode=public`, safe read routes and generated media can be browsed anonymously
+- anonymous public JSON payloads omit local media paths, post source paths, and EXIF metadata, including nested carousel items
 - anonymous public favorites stay in the browser and never write into SQLite likes
 - authenticated API and media responses are marked `Cache-Control: no-store` and `Vary: Cookie`
 - the production service worker skips caching protected thumbnail and preview responses

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,13 +50,19 @@ For source installs, you can rerun the migration step directly with:
 pnpm migrate
 ```
 
+Foldergram can automatically resume known migrations that were recorded before
+their schema work began. If the log instead reports a partially present schema,
+do not delete the database; restore a known-good `gallery.sqlite` backup and
+retry the upgrade.
+
 ## Nothing is being indexed
 
 Start with the gallery structure rules:
 
 - files directly inside `GALLERY_ROOT` are ignored
 - hidden folders are ignored
-- a folder is indexed only when it directly contains supported media
+- a folder is indexed when it directly contains supported media
+- in reserved carousel mode, a folder is also indexed when `carousels/` has an immediate child containing supported media directly
 
 This will not be indexed:
 
@@ -241,3 +247,9 @@ If it fails, check for:
 The client actively unregisters previously installed service workers in
 development. Reload once after startup if you previously visited a production
 build from the same origin and the browser still has stale cached assets.
+
+## Carousel scan warnings and reconciliation recovery
+
+Structural carousel warnings appear in **Settings → Scan & Library** without turning a successful scan into a processing failure. Move media placed directly in `carousels/` into a child folder; move nested media directly into that post child; split posts above 20 items; and expect a one-item child to become a normal post with a warning. If carousel children appear as ordinary folders, disable **Treat carousels folders as normal app folders**, save, then run **Scan Library**.
+
+After changing the carousel folder setting, follow the pending update message in **Settings → Scan & Library**. Run **Scan Library** to apply the saved mode, or use **Rebuild Library Index** when Settings reports that a rebuild is required. The reminder remains visible until the index reflects the selected mode.

--- a/server/db/migrations/000005_add_posts_and_carousels.sql
+++ b/server/db/migrations/000005_add_posts_and_carousels.sql
@@ -1,0 +1,186 @@
+-- migrate:up
+ALTER TABLE folders ADD COLUMN carousel_owner_folder_id INTEGER NULL REFERENCES folders(id) ON DELETE SET NULL;
+ALTER TABLE scan_runs ADD COLUMN warning_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE scan_runs ADD COLUMN warning_text TEXT NULL;
+
+CREATE TEMP TABLE foldergram_000005_expected_counts (
+  normal_posts INTEGER NOT NULL,
+  likes INTEGER NOT NULL,
+  collection_items INTEGER NOT NULL
+);
+
+INSERT INTO foldergram_000005_expected_counts (normal_posts, likes, collection_items)
+SELECT
+  (
+    SELECT COUNT(*)
+    FROM images AS img
+    JOIN folders AS f ON f.id = img.folder_id
+    WHERE f.role = 'normal'
+      AND LOWER(img.filename) NOT IN ('cover.jpg', 'cover.jpeg', 'cover.png', 'cover.webp', 'cover.avif', 'cover.gif')
+  ),
+  (
+    SELECT COUNT(DISTINCT l.image_id)
+    FROM likes AS l
+    JOIN images AS img ON img.id = l.image_id
+    JOIN folders AS f ON f.id = img.folder_id
+    WHERE f.role = 'normal'
+      AND LOWER(img.filename) NOT IN ('cover.jpg', 'cover.jpeg', 'cover.png', 'cover.webp', 'cover.avif', 'cover.gif')
+  ),
+  (
+    SELECT COUNT(*)
+    FROM collection_items AS ci
+    JOIN images AS img ON img.id = ci.image_id
+    JOIN folders AS f ON f.id = img.folder_id
+    WHERE f.role = 'normal'
+      AND LOWER(img.filename) NOT IN ('cover.jpg', 'cover.jpeg', 'cover.png', 'cover.webp', 'cover.avif', 'cover.gif')
+  );
+
+CREATE TABLE IF NOT EXISTS posts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  folder_id INTEGER NOT NULL,
+  place_id INTEGER NULL,
+  source_path TEXT NOT NULL UNIQUE,
+  post_type TEXT NOT NULL DEFAULT 'single',
+  caption TEXT NULL,
+  sort_timestamp INTEGER NOT NULL,
+  taken_at INTEGER NULL,
+  taken_at_source TEXT NULL,
+  is_deleted INTEGER NOT NULL DEFAULT 0,
+  deleted_at TEXT NULL,
+  is_trashed INTEGER NOT NULL DEFAULT 0,
+  trashed_at TEXT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (folder_id) REFERENCES folders(id) ON DELETE CASCADE,
+  FOREIGN KEY (place_id) REFERENCES places(id) ON DELETE SET NULL,
+  CHECK (post_type IN ('single', 'carousel'))
+);
+
+CREATE TABLE IF NOT EXISTS post_items (
+  post_id INTEGER NOT NULL,
+  image_id INTEGER NOT NULL UNIQUE,
+  position INTEGER NOT NULL,
+  PRIMARY KEY (post_id, position),
+  FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE,
+  FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE,
+  CHECK (position >= 1 AND position <= 20)
+);
+
+-- Backfill posts for existing normal images (excluding cover images)
+INSERT INTO posts (
+  id,
+  folder_id,
+  place_id,
+  source_path,
+  post_type,
+  caption,
+  sort_timestamp,
+  taken_at,
+  taken_at_source,
+  is_deleted,
+  deleted_at,
+  is_trashed,
+  trashed_at,
+  created_at,
+  updated_at
+)
+SELECT
+  img.id,
+  img.folder_id,
+  img.place_id,
+  img.relative_path,
+  'single',
+  img.caption,
+  img.sort_timestamp,
+  img.taken_at,
+  img.taken_at_source,
+  img.is_deleted,
+  img.deleted_at,
+  img.is_trashed,
+  img.trashed_at,
+  img.created_at,
+  img.updated_at
+FROM images AS img
+JOIN folders AS f ON img.folder_id = f.id
+WHERE f.role = 'normal'
+  AND LOWER(img.filename) NOT IN ('cover.jpg', 'cover.jpeg', 'cover.png', 'cover.webp', 'cover.avif', 'cover.gif');
+
+-- Backfill post_items for migrated single posts
+INSERT INTO post_items (post_id, image_id, position)
+SELECT id, id, 1
+FROM posts;
+
+-- Rebuild likes table keyed by post_id
+CREATE TABLE new_likes (
+  post_id INTEGER PRIMARY KEY,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE
+);
+
+INSERT INTO new_likes (post_id, created_at)
+SELECT DISTINCT pi.post_id, l.created_at
+FROM likes l
+JOIN post_items pi ON l.image_id = pi.image_id;
+
+DROP TABLE likes;
+ALTER TABLE new_likes RENAME TO likes;
+
+-- Rebuild collection_items table keyed by post_id
+CREATE TABLE new_collection_items (
+  collection_id INTEGER NOT NULL,
+  post_id INTEGER NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (collection_id, post_id),
+  FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE CASCADE,
+  FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE
+);
+
+INSERT INTO new_collection_items (collection_id, post_id, created_at)
+SELECT DISTINCT ci.collection_id, pi.post_id, ci.created_at
+FROM collection_items ci
+JOIN post_items pi ON ci.image_id = pi.image_id;
+
+DROP TABLE collection_items;
+ALTER TABLE new_collection_items RENAME TO collection_items;
+
+CREATE TEMP TABLE foldergram_000005_assertions (
+  valid INTEGER NOT NULL CHECK (valid = 1)
+);
+
+INSERT INTO foldergram_000005_assertions (valid)
+SELECT CASE WHEN
+  (SELECT COUNT(*) FROM posts) = expected.normal_posts
+  AND (SELECT COUNT(*) FROM post_items) = expected.normal_posts
+  AND NOT EXISTS (
+    SELECT 1
+    FROM posts
+    LEFT JOIN post_items ON post_items.post_id = posts.id
+    WHERE post_items.post_id IS NULL OR posts.id <> post_items.image_id OR post_items.position <> 1
+  )
+  AND (SELECT COUNT(*) FROM likes) = expected.likes
+  AND (SELECT COUNT(*) FROM collection_items) = expected.collection_items
+THEN 1 ELSE 0 END
+FROM foldergram_000005_expected_counts AS expected;
+
+DROP TABLE foldergram_000005_assertions;
+DROP TABLE foldergram_000005_expected_counts;
+
+-- Create indexes
+CREATE INDEX IF NOT EXISTS idx_posts_folder_visible_sort ON posts(folder_id, is_deleted, is_trashed, sort_timestamp DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_posts_visible_sort ON posts(is_deleted, is_trashed, sort_timestamp DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_posts_type_visibility ON posts(post_type, is_deleted, is_trashed);
+CREATE INDEX IF NOT EXISTS idx_posts_place_visibility ON posts(place_id, is_deleted, is_trashed, sort_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_posts_source_path ON posts(source_path);
+CREATE INDEX IF NOT EXISTS idx_posts_trashed_listing ON posts(is_trashed, is_deleted, trashed_at DESC, id DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_post_items_image_id ON post_items(image_id);
+CREATE INDEX IF NOT EXISTS idx_post_items_post_id ON post_items(post_id, position);
+
+CREATE INDEX IF NOT EXISTS idx_likes_created_at ON likes(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_collection_items_post ON collection_items(post_id);
+CREATE INDEX IF NOT EXISTS idx_collection_items_created ON collection_items(collection_id, created_at DESC, post_id DESC);
+CREATE INDEX IF NOT EXISTS idx_folders_carousel_owner ON folders(carousel_owner_folder_id);
+
+-- migrate:down
+DROP TABLE IF EXISTS post_items;
+DROP TABLE IF EXISTS posts;

--- a/server/src/constants/app-setting-keys.ts
+++ b/server/src/constants/app-setting-keys.ts
@@ -22,3 +22,6 @@ export const AUTH_VIEWER_ACCESS_MODE_SETTING_KEY = 'auth.viewer_access_mode';
 export const AUTH_VIEWER_PASSWORD_HASH_SETTING_KEY = 'auth.viewer_password_hash';
 export const AUTH_VIEWER_PASSWORD_SALT_SETTING_KEY = 'auth.viewer_password_salt';
 export const SHARE_SESSION_SECRET_SETTING_KEY = 'share.session_secret';
+export const TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY = 'library.treat_carousels_as_folders';
+export const CAROUSELS_MIGRATION_DECISION_SETTING_KEY = 'library.carousels_migration_decision';
+export const CAROUSELS_APPLIED_MODE_SETTING_KEY = 'library.carousels_applied_mode';

--- a/server/src/db/migration.ts
+++ b/server/src/db/migration.ts
@@ -11,16 +11,22 @@ import {
   applyBaselineCompatMigrations,
   assertNoLegacySchema,
   rebuildBaselineForeignKeys,
+  tableHasColumn,
   tableExists
 } from './schema-compat.js';
 import { log } from '../services/log-service.js';
 import { storageService } from '../services/storage-service.js';
 
 export const BASELINE_MIGRATION_VERSION = '000001';
+const CAPTION_MIGRATION_VERSION = '000002';
+const FOLDER_SHARES_MIGRATION_VERSION = '000004';
+const POSTS_MIGRATION_VERSION = '000005';
 const SCHEMA_MIGRATIONS_TABLE_SQL = 'CREATE TABLE IF NOT EXISTS schema_migrations (version TEXT PRIMARY KEY)';
 const APP_SCHEMA_TABLES = [
   'folders',
   'images',
+  'posts',
+  'post_items',
   'places',
   'scan_runs',
   'app_settings',
@@ -109,6 +115,145 @@ function migrationVersionExists(database: DatabaseSync, version: string): boolea
   return row?.version === version;
 }
 
+function removeMigrationVersion(database: DatabaseSync, version: string): void {
+  database.prepare('DELETE FROM schema_migrations WHERE version = ?').run(version);
+}
+
+function countRowsMatching(database: DatabaseSync, sql: string): number {
+  const row = database.prepare(sql).get() as { count: number };
+  return row.count;
+}
+
+function hasCompleteFolderSharesSchema(database: DatabaseSync): boolean {
+  return (
+    tableExists(database, 'folder_share_links') &&
+    tableExists(database, 'folder_share_passwords') &&
+    tableHasColumn(database, 'folders', 'share_password_version')
+  );
+}
+
+function repairIncorrectFolderSharesMigrationMarker(database: DatabaseSync): void {
+  if (!migrationVersionExists(database, FOLDER_SHARES_MIGRATION_VERSION)) {
+    return;
+  }
+
+  if (hasCompleteFolderSharesSchema(database)) {
+    return;
+  }
+
+  const hasShareLinks = tableExists(database, 'folder_share_links');
+  const hasSharePasswords = tableExists(database, 'folder_share_passwords');
+  const hasSharePasswordVersion = tableHasColumn(database, 'folders', 'share_password_version');
+
+  if (!hasShareLinks && !hasSharePasswords && !hasSharePasswordVersion) {
+    removeMigrationVersion(database, FOLDER_SHARES_MIGRATION_VERSION);
+    log.info('Removed an incomplete migration 000004 marker so folder-sharing tables can be created');
+    return;
+  }
+
+  throw new Error(
+    'Migration 000004 is recorded as applied, but its folder-sharing schema is only partially present. Restore the database from backup before retrying the upgrade.'
+  );
+}
+
+function repairInterruptedPostsMigrationMarker(database: DatabaseSync): void {
+  if (!migrationVersionExists(database, POSTS_MIGRATION_VERSION)) {
+    return;
+  }
+
+  const hasCarouselOwner = tableHasColumn(database, 'folders', 'carousel_owner_folder_id');
+  const hasWarningCount = tableHasColumn(database, 'scan_runs', 'warning_count');
+  const hasWarningText = tableHasColumn(database, 'scan_runs', 'warning_text');
+  const hasPosts = tableExists(database, 'posts');
+  const hasPostItems = tableExists(database, 'post_items');
+  const likesUsePostId = tableHasColumn(database, 'likes', 'post_id');
+  const collectionItemsUsePostId = tableHasColumn(database, 'collection_items', 'post_id');
+
+  const migrationComplete =
+    hasCarouselOwner &&
+    hasWarningCount &&
+    hasWarningText &&
+    hasPosts &&
+    hasPostItems &&
+    likesUsePostId &&
+    collectionItemsUsePostId;
+
+  if (migrationComplete) {
+    validatePostsMigrationCompleteness(database);
+    return;
+  }
+
+  const stillUsesPreMigrationPostSchema =
+    !hasPosts &&
+    !hasPostItems &&
+    tableHasColumn(database, 'likes', 'image_id') &&
+    !likesUsePostId &&
+    tableHasColumn(database, 'collection_items', 'image_id') &&
+    !collectionItemsUsePostId;
+
+  if (!stillUsesPreMigrationPostSchema) {
+    throw new Error(
+      'Migration 000005 is recorded as applied, but its posts schema is only partially present. Restore the database from backup before retrying the upgrade.'
+    );
+  }
+
+  if (
+    hasCarouselOwner &&
+    countRowsMatching(database, 'SELECT COUNT(*) AS count FROM folders WHERE carousel_owner_folder_id IS NOT NULL') > 0
+  ) {
+    throw new Error('Cannot safely resume migration 000005 because carousel ownership data already exists.');
+  }
+
+  if (
+    hasWarningCount &&
+    countRowsMatching(database, 'SELECT COUNT(*) AS count FROM scan_runs WHERE warning_count <> 0') > 0
+  ) {
+    throw new Error('Cannot safely resume migration 000005 because scan warning counts already exist.');
+  }
+
+  if (
+    hasWarningText &&
+    countRowsMatching(database, 'SELECT COUNT(*) AS count FROM scan_runs WHERE warning_text IS NOT NULL') > 0
+  ) {
+    throw new Error('Cannot safely resume migration 000005 because scan warning details already exist.');
+  }
+
+  database.exec('BEGIN IMMEDIATE');
+  try {
+    if (hasCarouselOwner) {
+      database.exec('ALTER TABLE folders DROP COLUMN carousel_owner_folder_id');
+    }
+    if (hasWarningCount) {
+      database.exec('ALTER TABLE scan_runs DROP COLUMN warning_count');
+    }
+    if (hasWarningText) {
+      database.exec('ALTER TABLE scan_runs DROP COLUMN warning_text');
+    }
+    removeMigrationVersion(database, POSTS_MIGRATION_VERSION);
+    database.exec('COMMIT');
+  } catch (error) {
+    database.exec('ROLLBACK');
+    throw error;
+  }
+
+  log.info('Reset an interrupted migration 000005 marker so the posts migration can resume');
+}
+
+function repairKnownIncompleteMigrationMarkers(databasePath: string): void {
+  const database = new DatabaseSync(databasePath);
+
+  try {
+    if (!tableExists(database, 'schema_migrations')) {
+      return;
+    }
+
+    repairIncorrectFolderSharesMigrationMarker(database);
+    repairInterruptedPostsMigrationMarker(database);
+  } finally {
+    database.close();
+  }
+}
+
 export function baselineExistingDatabaseIfNeeded(databasePath: string, options: StartupMigrationOptions = {}): BaselineResult {
   const database = new DatabaseSync(databasePath);
   const migrationsDirectory = options.migrationsDirectory ?? defaultMigrationsDirectory();
@@ -131,7 +276,16 @@ export function baselineExistingDatabaseIfNeeded(databasePath: string, options: 
       applyBaselineSchema(database, migrationsDirectory);
     }
     database.exec(SCHEMA_MIGRATIONS_TABLE_SQL);
-    database.prepare('INSERT OR IGNORE INTO schema_migrations(version) VALUES (?)').run(BASELINE_MIGRATION_VERSION);
+    // Compatibility work materializes the original baseline and the caption
+    // column. Folder-sharing and later feature migrations must still run
+    // through Dbmate so their complete schema transformations are applied.
+    const baselineVersions = [BASELINE_MIGRATION_VERSION, CAPTION_MIGRATION_VERSION];
+    if (hasCompleteFolderSharesSchema(database)) {
+      baselineVersions.push(FOLDER_SHARES_MIGRATION_VERSION);
+    }
+    for (const version of baselineVersions) {
+      database.prepare('INSERT OR IGNORE INTO schema_migrations(version) VALUES (?)').run(version);
+    }
 
     return {
       baselineInserted: true,
@@ -170,6 +324,309 @@ function runDbmateUp(databasePath: string, options: StartupMigrationOptions = {}
   }
 }
 
+interface TableColumnInfo {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+}
+
+interface RequiredColumn {
+  name: string;
+  type: string;
+  notNull: boolean;
+  primaryKeyPosition?: number;
+  defaultValue?: string | null;
+}
+
+interface ForeignKeyInfo {
+  table: string;
+  from: string;
+  to: string;
+  on_delete: string;
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function normalizeDefaultValue(value: string | null): string | null {
+  if (value === null) return null;
+  let normalized = value.trim();
+  while (normalized.startsWith('(') && normalized.endsWith(')')) {
+    normalized = normalized.slice(1, -1).trim();
+  }
+  return normalized.toUpperCase();
+}
+
+function validateRequiredColumns(database: DatabaseSync, tableName: string, requiredColumns: RequiredColumn[]): void {
+  if (!tableExists(database, tableName)) {
+    throw new Error(`Migration 000005 integrity check failed: missing required table ${tableName}.`);
+  }
+
+  const columns = database
+    .prepare(`PRAGMA table_info(${quoteIdentifier(tableName)})`)
+    .all() as unknown as TableColumnInfo[];
+  const byName = new Map(columns.map((column) => [column.name, column]));
+
+  for (const required of requiredColumns) {
+    const actual = byName.get(required.name);
+    if (!actual) {
+      throw new Error(`Migration 000005 integrity check failed: ${tableName}.${required.name} is missing.`);
+    }
+    if (actual.type.trim().toUpperCase() !== required.type) {
+      throw new Error(
+        `Migration 000005 integrity check failed: ${tableName}.${required.name} must be declared as ${required.type}.`
+      );
+    }
+    const isNotNull = actual.notnull === 1 || actual.pk > 0;
+    if (isNotNull !== required.notNull) {
+      throw new Error(
+        `Migration 000005 integrity check failed: ${tableName}.${required.name} has incorrect nullability.`
+      );
+    }
+    if (required.primaryKeyPosition !== undefined && actual.pk !== required.primaryKeyPosition) {
+      throw new Error(
+        `Migration 000005 integrity check failed: ${tableName}.${required.name} has incorrect primary-key position.`
+      );
+    }
+    if (
+      required.defaultValue !== undefined &&
+      normalizeDefaultValue(actual.dflt_value) !== normalizeDefaultValue(required.defaultValue)
+    ) {
+      throw new Error(`Migration 000005 integrity check failed: ${tableName}.${required.name} has an incorrect default.`);
+    }
+  }
+}
+
+function getIndexColumns(database: DatabaseSync, indexName: string): string[] {
+  return (
+    database.prepare(`PRAGMA index_info(${quoteIdentifier(indexName)})`).all() as Array<{ seqno: number; name: string }>
+  )
+    .sort((left, right) => left.seqno - right.seqno)
+    .map((row) => row.name);
+}
+
+function validateRequiredIndex(
+  database: DatabaseSync,
+  tableName: string,
+  indexName: string,
+  columns: string[],
+  unique: boolean
+): void {
+  const indexes = database
+    .prepare(`PRAGMA index_list(${quoteIdentifier(tableName)})`)
+    .all() as Array<{ name: string; unique: number }>;
+  const index = indexes.find((candidate) => candidate.name === indexName);
+  if (!index) {
+    throw new Error(
+      `Migration 000005 integrity check failed: missing required index ${indexName} on table ${tableName}. Restore the database from backup before retrying.`
+    );
+  }
+  if ((index.unique === 1) !== unique || getIndexColumns(database, indexName).join('\0') !== columns.join('\0')) {
+    throw new Error(
+      `Migration 000005 integrity check failed: index ${indexName} has an incorrect uniqueness or column order.`
+    );
+  }
+}
+
+function validateUniqueColumns(database: DatabaseSync, tableName: string, columns: string[]): void {
+  const indexes = database
+    .prepare(`PRAGMA index_list(${quoteIdentifier(tableName)})`)
+    .all() as Array<{ name: string; unique: number }>;
+  const found = indexes.some(
+    (index) => index.unique === 1 && getIndexColumns(database, index.name).join('\0') === columns.join('\0')
+  );
+  if (!found) {
+    throw new Error(
+      `Migration 000005 integrity check failed: ${tableName} is missing a unique constraint on (${columns.join(', ')}).`
+    );
+  }
+}
+
+function validateForeignKey(
+  database: DatabaseSync,
+  tableName: string,
+  sourceColumn: string,
+  referencedTable: string,
+  referencedColumn: string,
+  onDelete: string
+): void {
+  const foreignKeys = database
+    .prepare(`PRAGMA foreign_key_list(${quoteIdentifier(tableName)})`)
+    .all() as unknown as ForeignKeyInfo[];
+  const found = foreignKeys.some(
+    (foreignKey) =>
+      foreignKey.from === sourceColumn &&
+      foreignKey.table === referencedTable &&
+      foreignKey.to === referencedColumn &&
+      foreignKey.on_delete.toUpperCase() === onDelete
+  );
+  if (!found) {
+    throw new Error(
+      `Migration 000005 integrity check failed: ${tableName}.${sourceColumn} must reference ${referencedTable}.${referencedColumn} ON DELETE ${onDelete}.`
+    );
+  }
+}
+
+function validateCheckConstraint(database: DatabaseSync, tableName: string, pattern: RegExp, description: string): void {
+  const row = database
+    .prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(tableName) as { sql: string | null } | undefined;
+  if (!row?.sql || !pattern.test(row.sql)) {
+    throw new Error(`Migration 000005 integrity check failed: ${tableName} is missing ${description}.`);
+  }
+}
+
+function assertNoRows(database: DatabaseSync, sql: string, message: string): void {
+  const count = countRowsMatching(database, sql);
+  if (count > 0) {
+    throw new Error(`Migration 000005 integrity check failed: ${count} ${message}.`);
+  }
+}
+
+export function validatePostsMigrationCompleteness(database: DatabaseSync): void {
+  if (!migrationVersionExists(database, POSTS_MIGRATION_VERSION)) {
+    return;
+  }
+
+  validateRequiredColumns(database, 'folders', [
+    { name: 'carousel_owner_folder_id', type: 'INTEGER', notNull: false, defaultValue: null }
+  ]);
+  validateRequiredColumns(database, 'scan_runs', [
+    { name: 'warning_count', type: 'INTEGER', notNull: true, defaultValue: '0' },
+    { name: 'warning_text', type: 'TEXT', notNull: false, defaultValue: null }
+  ]);
+  validateRequiredColumns(database, 'posts', [
+    { name: 'id', type: 'INTEGER', notNull: true, primaryKeyPosition: 1 },
+    { name: 'folder_id', type: 'INTEGER', notNull: true },
+    { name: 'place_id', type: 'INTEGER', notNull: false },
+    { name: 'source_path', type: 'TEXT', notNull: true },
+    { name: 'post_type', type: 'TEXT', notNull: true, defaultValue: "'single'" },
+    { name: 'caption', type: 'TEXT', notNull: false },
+    { name: 'sort_timestamp', type: 'INTEGER', notNull: true },
+    { name: 'taken_at', type: 'INTEGER', notNull: false },
+    { name: 'taken_at_source', type: 'TEXT', notNull: false },
+    { name: 'is_deleted', type: 'INTEGER', notNull: true, defaultValue: '0' },
+    { name: 'deleted_at', type: 'TEXT', notNull: false },
+    { name: 'is_trashed', type: 'INTEGER', notNull: true, defaultValue: '0' },
+    { name: 'trashed_at', type: 'TEXT', notNull: false },
+    { name: 'created_at', type: 'TEXT', notNull: true, defaultValue: 'CURRENT_TIMESTAMP' },
+    { name: 'updated_at', type: 'TEXT', notNull: true, defaultValue: 'CURRENT_TIMESTAMP' }
+  ]);
+  validateRequiredColumns(database, 'post_items', [
+    { name: 'post_id', type: 'INTEGER', notNull: true, primaryKeyPosition: 1 },
+    { name: 'image_id', type: 'INTEGER', notNull: true, primaryKeyPosition: 0 },
+    { name: 'position', type: 'INTEGER', notNull: true, primaryKeyPosition: 2 }
+  ]);
+  validateRequiredColumns(database, 'likes', [
+    { name: 'post_id', type: 'INTEGER', notNull: true, primaryKeyPosition: 1 },
+    { name: 'created_at', type: 'TEXT', notNull: true, defaultValue: 'CURRENT_TIMESTAMP' }
+  ]);
+  validateRequiredColumns(database, 'collection_items', [
+    { name: 'collection_id', type: 'INTEGER', notNull: true, primaryKeyPosition: 1 },
+    { name: 'post_id', type: 'INTEGER', notNull: true, primaryKeyPosition: 2 },
+    { name: 'created_at', type: 'TEXT', notNull: true, defaultValue: 'CURRENT_TIMESTAMP' }
+  ]);
+
+  const requiredIndexes = [
+    ['posts', 'idx_posts_folder_visible_sort', ['folder_id', 'is_deleted', 'is_trashed', 'sort_timestamp', 'id'], false],
+    ['posts', 'idx_posts_visible_sort', ['is_deleted', 'is_trashed', 'sort_timestamp', 'id'], false],
+    ['posts', 'idx_posts_type_visibility', ['post_type', 'is_deleted', 'is_trashed'], false],
+    ['posts', 'idx_posts_place_visibility', ['place_id', 'is_deleted', 'is_trashed', 'sort_timestamp'], false],
+    ['posts', 'idx_posts_source_path', ['source_path'], false],
+    ['posts', 'idx_posts_trashed_listing', ['is_trashed', 'is_deleted', 'trashed_at', 'id'], false],
+    ['post_items', 'idx_post_items_image_id', ['image_id'], true],
+    ['post_items', 'idx_post_items_post_id', ['post_id', 'position'], false],
+    ['likes', 'idx_likes_created_at', ['created_at'], false],
+    ['collection_items', 'idx_collection_items_post', ['post_id'], false],
+    ['collection_items', 'idx_collection_items_created', ['collection_id', 'created_at', 'post_id'], false],
+    ['folders', 'idx_folders_carousel_owner', ['carousel_owner_folder_id'], false]
+  ] as const;
+  for (const [tableName, indexName, columns, unique] of requiredIndexes) {
+    validateRequiredIndex(database, tableName, indexName, [...columns], unique);
+  }
+  validateUniqueColumns(database, 'posts', ['source_path']);
+  validateUniqueColumns(database, 'post_items', ['image_id']);
+
+  validateForeignKey(database, 'folders', 'carousel_owner_folder_id', 'folders', 'id', 'SET NULL');
+  validateForeignKey(database, 'posts', 'folder_id', 'folders', 'id', 'CASCADE');
+  validateForeignKey(database, 'posts', 'place_id', 'places', 'id', 'SET NULL');
+  validateForeignKey(database, 'post_items', 'post_id', 'posts', 'id', 'CASCADE');
+  validateForeignKey(database, 'post_items', 'image_id', 'images', 'id', 'CASCADE');
+  validateForeignKey(database, 'likes', 'post_id', 'posts', 'id', 'CASCADE');
+  validateForeignKey(database, 'collection_items', 'collection_id', 'collections', 'id', 'CASCADE');
+  validateForeignKey(database, 'collection_items', 'post_id', 'posts', 'id', 'CASCADE');
+
+  validateCheckConstraint(
+    database,
+    'posts',
+    /CHECK\s*\(\s*post_type\s+IN\s*\(\s*'single'\s*,\s*'carousel'\s*\)\s*\)/i,
+    'the post_type single/carousel check constraint'
+  );
+  validateCheckConstraint(
+    database,
+    'post_items',
+    /CHECK\s*\(\s*position\s*>=\s*1\s+AND\s+position\s*<=\s*20\s*\)/i,
+    'the position range check constraint'
+  );
+
+  assertNoRows(
+    database,
+    'SELECT COUNT(*) AS count FROM posts WHERE NOT EXISTS (SELECT 1 FROM post_items WHERE post_items.post_id = posts.id AND post_items.position = 1)',
+    'post(s) lack a representative position 1 item'
+  );
+  assertNoRows(
+    database,
+    `SELECT COUNT(*) AS count FROM (
+       SELECT posts.id
+       FROM posts
+       JOIN post_items ON post_items.post_id = posts.id
+       GROUP BY posts.id
+       HAVING MIN(post_items.position) <> 1 OR MAX(post_items.position) <> COUNT(*)
+     )`,
+    'post(s) have non-contiguous item positions'
+  );
+  assertNoRows(
+    database,
+    `SELECT COUNT(*) AS count FROM (
+       SELECT posts.id
+       FROM posts
+       JOIN post_items ON post_items.post_id = posts.id
+       GROUP BY posts.id, posts.post_type
+       HAVING (posts.post_type = 'single' AND COUNT(*) <> 1)
+          OR (posts.post_type = 'carousel' AND (COUNT(*) < 2 OR COUNT(*) > 20))
+     )`,
+    'post(s) have an item count inconsistent with post_type'
+  );
+  assertNoRows(
+    database,
+    `SELECT COUNT(*) AS count
+     FROM images
+     JOIN folders ON folders.id = images.folder_id
+     WHERE images.is_deleted = 0
+       AND folders.role = 'normal'
+       AND LOWER(images.filename) NOT IN ('cover.jpg', 'cover.jpeg', 'cover.png', 'cover.webp', 'cover.avif', 'cover.gif')
+       AND NOT EXISTS (SELECT 1 FROM post_items WHERE post_items.image_id = images.id)`,
+    'active normal media item(s) lack post membership'
+  );
+
+  const foreignKeyErrors = database.prepare('PRAGMA foreign_key_check').all();
+  if (foreignKeyErrors.length > 0) {
+    throw new Error(
+      `Migration 000005 integrity check failed: foreign_key_check found ${foreignKeyErrors.length} violation(s).`
+    );
+  }
+  const integrityRows = database.prepare('PRAGMA integrity_check').all() as Array<Record<string, unknown>>;
+  const integrityMessages = integrityRows.flatMap((row) => Object.values(row).map(String));
+  if (integrityMessages.length !== 1 || integrityMessages[0].toLowerCase() !== 'ok') {
+    throw new Error(
+      `Migration 000005 integrity check failed: integrity_check returned ${integrityMessages.join('; ') || 'no result'}.`
+    );
+  }
+}
+
 export function runStartupMigrations(options: StartupMigrationOptions = {}): StartupMigrationResult {
   const databasePath = options.databasePath ?? storageService.getDatabasePath();
   if (databasePath === ':memory:') {
@@ -182,7 +639,15 @@ export function runStartupMigrations(options: StartupMigrationOptions = {}): Sta
   }
 
   const baselineResult = baselineExistingDatabaseIfNeeded(databasePath, options);
+  repairKnownIncompleteMigrationMarkers(databasePath);
   runDbmateUp(databasePath, options);
+
+  const database = new DatabaseSync(databasePath);
+  try {
+    validatePostsMigrationCompleteness(database);
+  } finally {
+    database.close();
+  }
 
   return {
     baselineInserted: baselineResult.baselineInserted,

--- a/server/src/db/repositories.ts
+++ b/server/src/db/repositories.ts
@@ -8,6 +8,7 @@ import type {
   CollectionRecord,
   CollectionSummaryRecord,
   FeedImage,
+  FeedPost,
   FolderAvatarSource,
   FolderImageOrder,
   FolderRole,
@@ -21,11 +22,17 @@ import type {
   PlaceKind,
   PlaceRecord,
   PlaybackStrategy,
+  PostDetail,
+  PostItemRecord,
+  PostMediaItem,
+  PostRecord,
+  PostType,
   ReelCandidate,
   FolderRecord,
   FolderSummaryRecord,
   ScanRunRecord,
   TrashImage,
+  TrashPost,
   TakenAtSource
 } from '../types/models.js';
 
@@ -38,19 +45,39 @@ const database = new Proxy({} as DatabaseSync, {
     return typeof value === 'function' ? value.bind(conn) : value;
   }
 });
-const EFFECTIVE_FEED_TIME_SQL = 'COALESCE(images.taken_at, images.sort_timestamp)';
+
+const EFFECTIVE_FEED_TIME_SQL = 'COALESCE(posts.taken_at, posts.sort_timestamp)';
+const EFFECTIVE_IMAGE_FEED_TIME_SQL = 'COALESCE(images.taken_at, images.sort_timestamp)';
 const DEFAULT_COLLECTION_SLUG = 'saved';
 const DEFAULT_COLLECTION_NAME = 'Saved';
 const COVER_FILENAMES = ['cover.jpg', 'cover.jpeg', 'cover.png', 'cover.webp', 'cover.avif', 'cover.gif'] as const;
 const COVER_FILENAME_SQL = COVER_FILENAMES.map((name) => `'${name}'`).join(', ');
 const NORMAL_FOLDER_ROLE_SQL = "folders.role = 'normal'";
 const NORMAL_FOLDER_ID_SUBQUERY_SQL = "SELECT id FROM folders WHERE role = 'normal'";
+
 const VISIBLE_IMAGE_WHERE_SQL =
   `images.is_deleted = 0 AND images.is_trashed = 0 AND LOWER(images.filename) NOT IN (${COVER_FILENAME_SQL}) AND ${NORMAL_FOLDER_ROLE_SQL}`;
 const VISIBLE_IMAGE_WHERE_UNSCOPED_SQL =
   `is_deleted = 0 AND is_trashed = 0 AND LOWER(filename) NOT IN (${COVER_FILENAME_SQL}) AND folder_id IN (${NORMAL_FOLDER_ID_SUBQUERY_SQL})`;
+
+const NOT_EXPLICIT_FOLDER_COVER_SQL =
+  `NOT EXISTS (` +
+  `SELECT 1 FROM post_items AS cover_items ` +
+  `INNER JOIN images AS cover_images ON cover_images.id = cover_items.image_id ` +
+  `WHERE cover_items.post_id = posts.id ` +
+  `AND cover_items.position = 1 ` +
+  `AND cover_images.folder_id = posts.folder_id ` +
+  `AND LOWER(cover_images.filename) IN (${COVER_FILENAME_SQL})` +
+  `)`;
+
+const VISIBLE_POST_WHERE_SQL =
+  `posts.is_deleted = 0 AND posts.is_trashed = 0 AND ${NORMAL_FOLDER_ROLE_SQL} AND ${NOT_EXPLICIT_FOLDER_COVER_SQL}`;
+const VISIBLE_POST_WHERE_UNSCOPED_SQL =
+  `is_deleted = 0 AND is_trashed = 0 AND folder_id IN (${NORMAL_FOLDER_ID_SUBQUERY_SQL}) AND ${NOT_EXPLICIT_FOLDER_COVER_SQL}`;
+
 const STORY_IMAGE_WHERE_SQL = 'images.is_deleted = 0 AND images.is_trashed = 0';
 const STORY_IMAGE_WHERE_UNSCOPED_SQL = 'is_deleted = 0 AND is_trashed = 0';
+
 const HAS_AVATAR_STORY_SQL = `
   EXISTS (
     SELECT 1
@@ -63,103 +90,134 @@ const HAS_AVATAR_STORY_SQL = `
     LIMIT 1
   )
 `;
+
 const ACTIVE_FOLDER_AVATAR_IMAGE_ID_SQL = `
   SELECT avatar_images.id
   FROM images AS avatar_images
   WHERE avatar_images.id = folders.avatar_image_id
-    AND avatar_images.folder_id = folders.id
+    AND (
+      avatar_images.folder_id = folders.id
+      OR EXISTS (
+        SELECT 1
+        FROM folders AS avatar_source_folders
+        WHERE avatar_source_folders.id = avatar_images.folder_id
+          AND avatar_source_folders.role = 'carousel_source'
+          AND avatar_source_folders.carousel_owner_folder_id = folders.id
+      )
+    )
     AND avatar_images.is_deleted = 0
     AND avatar_images.is_trashed = 0
   LIMIT 1
 `;
-const FALLBACK_FOLDER_AVATAR_IMAGE_ID_SQL = `
-  SELECT fallback_images.id
-  FROM images AS fallback_images
-  WHERE fallback_images.folder_id = folders.id
-    AND fallback_images.is_deleted = 0
-    AND fallback_images.is_trashed = 0
-    AND LOWER(fallback_images.filename) NOT IN (${COVER_FILENAME_SQL})
-  ORDER BY fallback_images.sort_timestamp DESC, fallback_images.id DESC
+
+const EXPLICIT_FOLDER_COVER_IMAGE_ID_SQL = `
+  SELECT cover_images.id
+  FROM images AS cover_images
+  WHERE cover_images.folder_id = folders.id
+    AND cover_images.is_deleted = 0
+    AND cover_images.is_trashed = 0
+    AND LOWER(cover_images.filename) IN (${COVER_FILENAME_SQL})
+  ORDER BY
+    CASE LOWER(cover_images.filename)
+      WHEN 'cover.jpg' THEN 1
+      WHEN 'cover.jpeg' THEN 2
+      WHEN 'cover.png' THEN 3
+      WHEN 'cover.webp' THEN 4
+      WHEN 'cover.avif' THEN 5
+      WHEN 'cover.gif' THEN 6
+      ELSE 7
+    END,
+    cover_images.id ASC
   LIMIT 1
 `;
+
+const NEWEST_POST_AVATAR_IMAGE_ID_SQL = `
+  SELECT pi.image_id
+  FROM posts AS p
+  JOIN post_items AS pi ON pi.post_id = p.id AND pi.position = 1
+  JOIN images AS fallback_images ON fallback_images.id = pi.image_id
+  WHERE p.folder_id = folders.id
+    AND p.is_deleted = 0
+    AND p.is_trashed = 0
+  ORDER BY p.sort_timestamp DESC, p.id DESC
+  LIMIT 1
+`;
+
 const FOLDER_SUMMARY_AVATAR_IMAGE_ID_SQL = `
   COALESCE(
     (${ACTIVE_FOLDER_AVATAR_IMAGE_ID_SQL}),
-    (${FALLBACK_FOLDER_AVATAR_IMAGE_ID_SQL})
-  )
-`;
-const FOLDER_SUMMARY_AVATAR_THUMBNAIL_PATH_SQL = `
-  COALESCE(
-    (
-      SELECT avatar_images.thumbnail_path
-      FROM images AS avatar_images
-      WHERE avatar_images.id = folders.avatar_image_id
-        AND avatar_images.folder_id = folders.id
-        AND avatar_images.is_deleted = 0
-        AND avatar_images.is_trashed = 0
-      LIMIT 1
-    ),
-    (
-      SELECT fallback_images.thumbnail_path
-      FROM images AS fallback_images
-      WHERE fallback_images.folder_id = folders.id
-        AND fallback_images.is_deleted = 0
-        AND fallback_images.is_trashed = 0
-        AND LOWER(fallback_images.filename) NOT IN (${COVER_FILENAME_SQL})
-      ORDER BY fallback_images.sort_timestamp DESC, fallback_images.id DESC
-      LIMIT 1
-    )
+    (${EXPLICIT_FOLDER_COVER_IMAGE_ID_SQL}),
+    (${NEWEST_POST_AVATAR_IMAGE_ID_SQL})
   )
 `;
 
-function getQualifiedFolderImageOrderSql(order: FolderImageOrder): string {
+const FOLDER_SUMMARY_AVATAR_THUMBNAIL_PATH_SQL = `
+  (
+    SELECT thumbnail_path
+    FROM images
+    WHERE id = (${FOLDER_SUMMARY_AVATAR_IMAGE_ID_SQL})
+    LIMIT 1
+  )
+`;
+
+function getQualifiedFolderPostOrderSql(order: FolderImageOrder): string {
   return order === 'oldest'
-    ? 'images.sort_timestamp ASC, images.id ASC'
-    : 'images.sort_timestamp DESC, images.id DESC';
+    ? 'posts.sort_timestamp ASC, posts.id ASC'
+    : 'posts.sort_timestamp DESC, posts.id DESC';
 }
 
-function getUnscopedFolderImageOrderSql(order: FolderImageOrder): string {
+function getUnscopedFolderPostOrderSql(order: FolderImageOrder): string {
   return order === 'oldest'
     ? 'sort_timestamp ASC, id ASC'
     : 'sort_timestamp DESC, id DESC';
 }
+
+const POST_CAPTION_SEARCH_SQL = 'LOWER(COALESCE(posts.caption, \'\'))';
 const IMAGE_FILENAME_SEARCH_SQL = 'LOWER(images.filename)';
 const FOLDER_NAME_SEARCH_SQL = 'LOWER(folders.name)';
 const FOLDER_SLUG_SEARCH_SQL = 'LOWER(folders.slug)';
 const FOLDER_PATH_SEARCH_SQL = 'LOWER(folders.folder_path)';
+const POST_SOURCE_PATH_SEARCH_SQL = 'LOWER(posts.source_path)';
 const EXIF_CAMERA_MAKE_SEARCH_SQL =
   "LOWER(COALESCE(CASE WHEN json_valid(images.exif_json) THEN json_extract(images.exif_json, '$.cameraMake') END, ''))";
 const EXIF_CAMERA_MODEL_SEARCH_SQL =
   "LOWER(COALESCE(CASE WHEN json_valid(images.exif_json) THEN json_extract(images.exif_json, '$.cameraModel') END, ''))";
 const EXIF_LENS_MODEL_SEARCH_SQL =
   "LOWER(COALESCE(CASE WHEN json_valid(images.exif_json) THEN json_extract(images.exif_json, '$.lensModel') END, ''))";
+
 const MEDIA_SEARCH_FIELD_SQL = [
+  POST_CAPTION_SEARCH_SQL,
   IMAGE_FILENAME_SEARCH_SQL,
   FOLDER_NAME_SEARCH_SQL,
   FOLDER_SLUG_SEARCH_SQL,
   FOLDER_PATH_SEARCH_SQL,
+  POST_SOURCE_PATH_SEARCH_SQL,
   EXIF_CAMERA_MAKE_SEARCH_SQL,
   EXIF_CAMERA_MODEL_SEARCH_SQL,
   EXIF_LENS_MODEL_SEARCH_SQL
 ] as const;
-const IMAGE_SAVED_SELECT_SQL = `
-    CASE WHEN EXISTS (
-      SELECT 1
-      FROM collections
-      INNER JOIN collection_items ON collection_items.collection_id = collections.id
-      WHERE collections.is_default = 1
-        AND collection_items.image_id = images.id
-    ) THEN 1 ELSE 0 END AS isSaved
+
+const POST_SAVED_SELECT_SQL = `
+  CASE WHEN EXISTS (
+    SELECT 1
+    FROM collections
+    INNER JOIN collection_items ON collection_items.collection_id = collections.id
+    WHERE collections.is_default = 1
+      AND collection_items.post_id = posts.id
+  ) THEN 1 ELSE 0 END AS isSaved
 `;
-const FEED_IMAGE_SELECT_SQL = `
+
+const BASE_POST_SELECT_SQL = `
   SELECT
-    images.id,
-    images.folder_id AS folderId,
+    posts.id,
+    posts.folder_id AS folderId,
     folders.slug AS folderSlug,
     folders.name AS folderName,
     folders.folder_path AS folderPath,
     images.filename,
-    images.caption AS caption,
+    posts.caption AS caption,
+    posts.post_type AS postType,
+    posts.source_path AS sourcePath,
     images.width,
     images.height,
     images.media_type AS mediaType,
@@ -168,29 +226,82 @@ const FEED_IMAGE_SELECT_SQL = `
     images.thumbnail_path AS thumbnailUrl,
     images.preview_path AS previewUrl,
     images.playback_strategy AS playbackStrategy,
-    images.sort_timestamp AS sortTimestamp,
-    images.taken_at AS takenAt,
-    ${IMAGE_SAVED_SELECT_SQL},
+    posts.sort_timestamp AS sortTimestamp,
+    posts.taken_at AS takenAt,
+    ${POST_SAVED_SELECT_SQL},
     places.id AS placeId,
     places.slug AS placeSlug,
     places.display_name AS placeName,
     places.kind AS placeKind,
     places.is_approximate AS placeIsApproximate
-  FROM images
-  INNER JOIN folders ON folders.id = images.folder_id
-  LEFT JOIN places ON places.id = images.place_id
+  FROM posts
+  INNER JOIN folders ON folders.id = posts.folder_id
+  JOIN post_items ON post_items.post_id = posts.id AND post_items.position = 1
+  JOIN images ON images.id = post_items.image_id
+  LEFT JOIN places ON places.id = posts.place_id
 `;
+
 const FOLDER_SUMMARY_SELECT_SQL = `
   SELECT
     folders.*,
-    COUNT(images.id) AS image_count,
-    SUM(CASE WHEN images.media_type = 'video' THEN 1 ELSE 0 END) AS video_count,
-    MAX(images.mtime_ms) AS latest_image_mtime_ms,
+    (
+      SELECT COUNT(*)
+      FROM posts
+      WHERE posts.folder_id = folders.id
+        AND posts.is_deleted = 0
+        AND posts.is_trashed = 0
+    ) AS post_count,
+    (
+      SELECT COUNT(*)
+      FROM posts p
+      JOIN post_items pi ON pi.post_id = p.id AND pi.position = 1
+      JOIN images img ON img.id = pi.image_id
+      WHERE p.folder_id = folders.id
+        AND p.is_deleted = 0
+        AND p.is_trashed = 0
+        AND NOT (
+          img.folder_id = p.folder_id
+          AND LOWER(img.filename) IN (${COVER_FILENAME_SQL})
+        )
+    ) AS image_count,
+    (
+      SELECT COUNT(*)
+      FROM posts p
+      JOIN post_items pi ON pi.post_id = p.id AND pi.position = 1
+      JOIN images img ON img.id = pi.image_id
+      WHERE p.folder_id = folders.id
+        AND p.is_deleted = 0
+        AND p.is_trashed = 0
+        AND p.post_type = 'carousel'
+        AND NOT (
+          img.folder_id = p.folder_id
+          AND LOWER(img.filename) IN (${COVER_FILENAME_SQL})
+        )
+    ) AS carousel_count,
+    (
+      SELECT COUNT(*)
+      FROM posts p
+      JOIN post_items pi ON pi.post_id = p.id AND pi.position = 1
+      JOIN images img ON img.id = pi.image_id
+      WHERE p.folder_id = folders.id
+        AND p.is_deleted = 0
+        AND p.is_trashed = 0
+        AND p.post_type = 'single'
+        AND img.media_type = 'video'
+    ) AS video_count,
+    (
+      SELECT MAX(img.mtime_ms)
+      FROM posts p
+      JOIN post_items pi ON pi.post_id = p.id
+      JOIN images img ON img.id = pi.image_id
+      WHERE p.folder_id = folders.id
+        AND p.is_deleted = 0
+        AND p.is_trashed = 0
+    ) AS latest_image_mtime_ms,
     CASE WHEN ${HAS_AVATAR_STORY_SQL} THEN 1 ELSE 0 END AS has_avatar_story,
     ${FOLDER_SUMMARY_AVATAR_IMAGE_ID_SQL} AS summary_avatar_image_id,
     ${FOLDER_SUMMARY_AVATAR_THUMBNAIL_PATH_SQL} AS summary_avatar_thumbnail_path
   FROM folders
-  INNER JOIN images ON images.folder_id = folders.id AND ${VISIBLE_IMAGE_WHERE_SQL}
 `;
 
 interface MediaSearchSql {
@@ -216,6 +327,32 @@ function escapeLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, '\\$&');
 }
 
+function isValidJson(str: string): boolean {
+  try {
+    JSON.parse(str);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function resolvePostIdByImageId(imageId: number): number | undefined {
+  const itemRow = database.prepare('SELECT post_id FROM post_items WHERE image_id = ?').get(imageId) as { post_id: number } | undefined;
+  return itemRow?.post_id;
+}
+
+export function resolveImageId(id: number): number {
+  const imgRow = database.prepare('SELECT id FROM images WHERE id = ?').get(id) as { id: number } | undefined;
+  if (imgRow) {
+    return imgRow.id;
+  }
+  const itemRow = database.prepare('SELECT image_id FROM post_items WHERE post_id = ? ORDER BY position ASC LIMIT 1').get(id) as { image_id: number } | undefined;
+  if (itemRow) {
+    return itemRow.image_id;
+  }
+  return id;
+}
+
 function buildMediaSearchSql(query: string): MediaSearchSql | null {
   const normalizedQuery = normalizeSearchQuery(query);
   if (normalizedQuery.length === 0) {
@@ -232,6 +369,12 @@ function buildMediaSearchSql(query: string): MediaSearchSql | null {
   const queryPrefixPattern = `${escapeLikePattern(normalizedQuery)}%`;
 
   const rankSqlParts = [
+    `CASE
+      WHEN ${POST_CAPTION_SEARCH_SQL} = ? THEN 250
+      WHEN ${POST_CAPTION_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 190
+      WHEN ${POST_CAPTION_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 150
+      ELSE 0
+    END`,
     `CASE
       WHEN ${IMAGE_FILENAME_SEARCH_SQL} = ? THEN 240
       WHEN ${IMAGE_FILENAME_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 180
@@ -251,6 +394,7 @@ function buildMediaSearchSql(query: string): MediaSearchSql | null {
       ELSE 0
     END`,
     `CASE WHEN ${FOLDER_PATH_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 32 ELSE 0 END`,
+    `CASE WHEN ${POST_SOURCE_PATH_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 32 ELSE 0 END`,
     `CASE WHEN ${EXIF_CAMERA_MAKE_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 20 ELSE 0 END`,
     `CASE WHEN ${EXIF_CAMERA_MODEL_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 20 ELSE 0 END`,
     `CASE WHEN ${EXIF_LENS_MODEL_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 18 ELSE 0 END`
@@ -265,6 +409,10 @@ function buildMediaSearchSql(query: string): MediaSearchSql | null {
     normalizedQuery,
     queryPrefixPattern,
     queryContainsPattern,
+    normalizedQuery,
+    queryPrefixPattern,
+    queryContainsPattern,
+    queryContainsPattern,
     queryContainsPattern,
     queryContainsPattern,
     queryContainsPattern,
@@ -274,15 +422,19 @@ function buildMediaSearchSql(query: string): MediaSearchSql | null {
   for (const token of normalizedTokens) {
     const tokenPattern = `%${escapeLikePattern(token)}%`;
     rankSqlParts.push(
+      `CASE WHEN ${POST_CAPTION_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 20 ELSE 0 END`,
       `CASE WHEN ${IMAGE_FILENAME_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 18 ELSE 0 END`,
       `CASE WHEN ${FOLDER_NAME_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 12 ELSE 0 END`,
       `CASE WHEN ${FOLDER_SLUG_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 8 ELSE 0 END`,
       `CASE WHEN ${FOLDER_PATH_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 8 ELSE 0 END`,
+      `CASE WHEN ${POST_SOURCE_PATH_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 8 ELSE 0 END`,
       `CASE WHEN ${EXIF_CAMERA_MAKE_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 6 ELSE 0 END`,
       `CASE WHEN ${EXIF_CAMERA_MODEL_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 6 ELSE 0 END`,
       `CASE WHEN ${EXIF_LENS_MODEL_SEARCH_SQL} LIKE ? ESCAPE '\\' THEN 6 ELSE 0 END`
     );
     rankParams.push(
+      tokenPattern,
+      tokenPattern,
       tokenPattern,
       tokenPattern,
       tokenPattern,
@@ -307,6 +459,7 @@ export interface UpsertFolderInput {
   folderPath: string;
   role?: FolderRole;
   storyOwnerFolderId?: number | null;
+  carouselOwnerFolderId?: number | null;
 }
 
 export interface SaveFolderResult {
@@ -325,6 +478,21 @@ export interface UpsertFolderSharePasswordInput {
   folderId: number;
   passwordHash: string;
   passwordSalt: string;
+}
+
+export interface UpsertPostInput {
+  existingPostId?: number;
+  id?: number;
+  folderId: number;
+  placeId?: number | null;
+  sourcePath: string;
+  postType: PostType;
+  caption?: string | null;
+  sortTimestamp: number;
+  takenAt?: number | null;
+  takenAtSource?: TakenAtSource | null;
+  isDeleted?: number;
+  isTrashed?: number;
 }
 
 export interface UpsertImageInput {
@@ -439,10 +607,12 @@ export const folderRepository = {
     return database
       .prepare(
         `
-        ${FOLDER_SUMMARY_SELECT_SQL}
-        WHERE folders.role = 'normal'
-        GROUP BY folders.id
-        ORDER BY latest_image_mtime_ms DESC, folders.name COLLATE NOCASE ASC, folders.folder_path COLLATE NOCASE ASC
+        SELECT * FROM (
+          ${FOLDER_SUMMARY_SELECT_SQL}
+          WHERE folders.role = 'normal'
+        ) AS summaries
+        WHERE post_count > 0 OR summary_avatar_image_id IS NOT NULL
+        ORDER BY latest_image_mtime_ms DESC, name COLLATE NOCASE ASC, folder_path COLLATE NOCASE ASC
         `
       )
       .all() as unknown as FolderSummaryRecord[];
@@ -468,7 +638,6 @@ export const folderRepository = {
         `
         ${FOLDER_SUMMARY_SELECT_SQL}
         WHERE folders.slug = ? AND folders.role = 'normal'
-        GROUP BY folders.id
         `
       )
       .get(slug) as FolderSummaryRecord | undefined;
@@ -478,18 +647,20 @@ export const folderRepository = {
     const normalizedFolderPath = normalizePath(input.folderPath);
     const role = input.role ?? 'normal';
     const storyOwnerFolderId = input.storyOwnerFolderId ?? null;
+    const carouselOwnerFolderId = input.carouselOwnerFolderId ?? null;
     database.prepare(
       `
-      INSERT INTO folders (slug, name, folder_path, role, story_owner_folder_id, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT INTO folders (slug, name, folder_path, role, story_owner_folder_id, carousel_owner_folder_id, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(folder_path) DO UPDATE SET
         slug = excluded.slug,
         name = excluded.name,
         role = excluded.role,
         story_owner_folder_id = excluded.story_owner_folder_id,
+        carousel_owner_folder_id = excluded.carousel_owner_folder_id,
         updated_at = excluded.updated_at
       `
-    ).run(input.slug, input.name, normalizedFolderPath, role, storyOwnerFolderId, nowIso());
+    ).run(input.slug, input.name, normalizedFolderPath, role, storyOwnerFolderId, carouselOwnerFolderId, nowIso());
 
     return this.getByFolderPath(normalizedFolderPath) as FolderRecord;
   },
@@ -499,12 +670,14 @@ export const folderRepository = {
     const existing = this.getByFolderPath(normalizedFolderPath);
     const role = input.role ?? 'normal';
     const storyOwnerFolderId = input.storyOwnerFolderId ?? null;
+    const carouselOwnerFolderId = input.carouselOwnerFolderId ?? null;
 
     if (
       existing &&
       existing.slug === input.slug &&
       existing.role === role &&
-      existing.story_owner_folder_id === storyOwnerFolderId
+      existing.story_owner_folder_id === storyOwnerFolderId &&
+      existing.carousel_owner_folder_id === carouselOwnerFolderId
     ) {
       return {
         folder: existing,
@@ -514,8 +687,8 @@ export const folderRepository = {
 
     if (existing) {
       database
-        .prepare('UPDATE folders SET slug = ?, role = ?, story_owner_folder_id = ?, updated_at = ? WHERE id = ?')
-        .run(input.slug, role, storyOwnerFolderId, nowIso(), existing.id);
+        .prepare('UPDATE folders SET slug = ?, role = ?, story_owner_folder_id = ?, carousel_owner_folder_id = ?, updated_at = ? WHERE id = ?')
+        .run(input.slug, role, storyOwnerFolderId, carouselOwnerFolderId, nowIso(), existing.id);
 
       return {
         folder: this.getById(existing.id) as FolderRecord,
@@ -541,10 +714,17 @@ export const folderRepository = {
             SELECT COUNT(*) AS count
             FROM folders
             WHERE folders.role = 'normal'
-              AND EXISTS (
-                SELECT 1
-                FROM images
-                WHERE images.folder_id = folders.id AND ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL}
+              AND (
+                EXISTS (
+                  SELECT 1
+                  FROM posts
+                  WHERE posts.folder_id = folders.id AND posts.is_deleted = 0 AND posts.is_trashed = 0
+                )
+                OR EXISTS (
+                  SELECT 1
+                  FROM images
+                  WHERE images.folder_id = folders.id AND ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL}
+                )
               )
             `
           )
@@ -586,19 +766,16 @@ export const folderRepository = {
       return null;
     }
 
-    const explicitCoverImageId = imageRepository.getExplicitCoverImageId(folderId);
-    if (explicitCoverImageId !== null) {
-      return {
-        imageId: explicitCoverImageId,
-        source: 'cover'
-      };
-    }
-
     if (folder.avatar_source === 'manual' && folder.avatar_image_id !== null) {
       const manualImage = imageRepository.getById(folder.avatar_image_id);
+      const manualImageFolder = manualImage ? this.getById(manualImage.folder_id) : undefined;
+      const belongsToFolder = manualImage?.folder_id === folderId || (
+        manualImageFolder?.role === 'carousel_source' &&
+        manualImageFolder.carousel_owner_folder_id === folderId
+      );
       if (
         manualImage &&
-        manualImage.folder_id === folderId &&
+        belongsToFolder &&
         manualImage.is_deleted === 0 &&
         manualImage.is_trashed === 0
       ) {
@@ -607,6 +784,14 @@ export const folderRepository = {
           source: 'manual'
         };
       }
+    }
+
+    const explicitCoverImageId = imageRepository.getExplicitCoverImageId(folderId);
+    if (explicitCoverImageId !== null) {
+      return {
+        imageId: explicitCoverImageId,
+        source: 'cover'
+      };
     }
 
     return {
@@ -675,6 +860,25 @@ export const folderRepository = {
       .get() as { found: number } | undefined;
 
     return row?.found === 1;
+  },
+
+  hasLegacyCarouselsCandidates(): boolean {
+    const row = database
+      .prepare(
+        `
+        SELECT 1 AS found
+        FROM folders
+        WHERE
+          LOWER(folder_path) = 'carousels'
+          OR LOWER(folder_path) LIKE '%/carousels'
+          OR LOWER(folder_path) LIKE 'carousels/%'
+          OR LOWER(folder_path) LIKE '%/carousels/%'
+        LIMIT 1
+        `
+      )
+      .get() as { found: number } | undefined;
+
+    return row?.found === 1;
   }
 };
 
@@ -683,11 +887,11 @@ export const placeRepository = {
     return database
       .prepare(
         `
-        SELECT places.*, COUNT(images.id) AS post_count
+        SELECT places.*, COUNT(posts.id) AS post_count
         FROM places
-        INNER JOIN images ON images.place_id = places.id
-        INNER JOIN folders ON folders.id = images.folder_id
-        WHERE ${VISIBLE_IMAGE_WHERE_SQL}
+        INNER JOIN posts ON posts.place_id = places.id
+        INNER JOIN folders ON folders.id = posts.folder_id
+        WHERE ${VISIBLE_POST_WHERE_SQL}
         GROUP BY places.id
         ORDER BY post_count DESC, places.display_name COLLATE NOCASE ASC
         `
@@ -777,6 +981,479 @@ export const placeRepository = {
   },
 
   countVisibleImages(placeId: number, mediaType?: MediaType): number {
+    if (mediaType) {
+      return Number(
+        (
+          database
+            .prepare(
+              `
+              SELECT COUNT(DISTINCT posts.id) AS count
+              FROM posts
+              INNER JOIN folders ON folders.id = posts.folder_id
+              INNER JOIN post_items pi ON pi.post_id = posts.id
+              INNER JOIN images ON images.id = pi.image_id
+              WHERE posts.place_id = ? AND ${VISIBLE_POST_WHERE_SQL} AND images.media_type = ?
+              `
+            )
+            .get(placeId, mediaType) as { count: number }
+        ).count
+      );
+    }
+    return Number(
+      (
+        database
+          .prepare(
+            `
+            SELECT COUNT(*) AS count
+            FROM posts
+            INNER JOIN folders ON folders.id = posts.folder_id
+            WHERE posts.place_id = ? AND ${VISIBLE_POST_WHERE_SQL}
+            `
+          )
+          .get(placeId) as { count: number }
+      ).count
+    );
+  }
+};
+
+export const postRepository = {
+  upsertPost(input: UpsertPostInput): PostRecord {
+    const isDeleted = input.isDeleted ?? 0;
+    const isTrashed = input.isTrashed ?? 0;
+    const updatedAt = nowIso();
+
+    const existingByMembership = input.existingPostId !== undefined ? this.findById(input.existingPostId) : undefined;
+    const existingBySource = this.findBySourcePath(input.sourcePath);
+    const targetPost = existingByMembership ?? existingBySource;
+
+    if (targetPost) {
+      database.prepare(
+        `
+        UPDATE posts
+        SET folder_id = ?,
+            place_id = ?,
+            source_path = ?,
+            post_type = ?,
+            caption = COALESCE(caption, ?),
+            sort_timestamp = ?,
+            taken_at = ?,
+            taken_at_source = ?,
+            is_deleted = ?,
+            deleted_at = CASE WHEN ? = 1 THEN ? ELSE NULL END,
+            updated_at = ?
+        WHERE id = ?
+        `
+      ).run(
+        input.folderId,
+        input.placeId ?? null,
+        input.sourcePath,
+        input.postType,
+        input.caption ?? null,
+        input.sortTimestamp,
+        input.takenAt ?? null,
+        input.takenAtSource ?? null,
+        isDeleted,
+        isDeleted,
+        updatedAt,
+        updatedAt,
+        targetPost.id
+      );
+      return this.findById(targetPost.id)!;
+    }
+
+    const preferredIdAvailable = input.id !== undefined && !this.findById(input.id);
+    if (preferredIdAvailable) {
+      database.prepare(
+        `
+        INSERT INTO posts (
+          id, folder_id, place_id, source_path, post_type, caption, sort_timestamp, taken_at, taken_at_source,
+          is_deleted, deleted_at, is_trashed, trashed_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CASE WHEN ? = 1 THEN ? ELSE NULL END, ?, CASE WHEN ? = 1 THEN ? ELSE NULL END, ?)
+        ON CONFLICT(source_path) DO UPDATE SET
+          folder_id = excluded.folder_id,
+          place_id = excluded.place_id,
+          post_type = excluded.post_type,
+          caption = COALESCE(posts.caption, excluded.caption),
+          sort_timestamp = excluded.sort_timestamp,
+          taken_at = excluded.taken_at,
+          taken_at_source = excluded.taken_at_source,
+          is_deleted = excluded.is_deleted,
+          deleted_at = excluded.deleted_at,
+          updated_at = excluded.updated_at
+        `
+      ).run(
+        input.id!,
+        input.folderId,
+        input.placeId ?? null,
+        input.sourcePath,
+        input.postType,
+        input.caption ?? null,
+        input.sortTimestamp,
+        input.takenAt ?? null,
+        input.takenAtSource ?? null,
+        isDeleted,
+        isDeleted,
+        updatedAt,
+        isTrashed,
+        isTrashed,
+        updatedAt,
+        updatedAt
+      );
+    } else {
+      database.prepare(
+        `
+        INSERT INTO posts (
+          folder_id, place_id, source_path, post_type, caption, sort_timestamp, taken_at, taken_at_source,
+          is_deleted, deleted_at, is_trashed, trashed_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CASE WHEN ? = 1 THEN ? ELSE NULL END, ?, CASE WHEN ? = 1 THEN ? ELSE NULL END, ?)
+        ON CONFLICT(source_path) DO UPDATE SET
+          folder_id = excluded.folder_id,
+          place_id = excluded.place_id,
+          post_type = excluded.post_type,
+          caption = COALESCE(posts.caption, excluded.caption),
+          sort_timestamp = excluded.sort_timestamp,
+          taken_at = excluded.taken_at,
+          taken_at_source = excluded.taken_at_source,
+          is_deleted = excluded.is_deleted,
+          deleted_at = excluded.deleted_at,
+          updated_at = excluded.updated_at
+        `
+      ).run(
+        input.folderId,
+        input.placeId ?? null,
+        input.sourcePath,
+        input.postType,
+        input.caption ?? null,
+        input.sortTimestamp,
+        input.takenAt ?? null,
+        input.takenAtSource ?? null,
+        isDeleted,
+        isDeleted,
+        updatedAt,
+        isTrashed,
+        isTrashed,
+        updatedAt,
+        updatedAt
+      );
+    }
+
+    return this.findBySourcePath(input.sourcePath) as PostRecord;
+  },
+
+  setPostItems(postId: number, items: Array<{ imageId: number; position: number }>): void {
+    database.exec('BEGIN IMMEDIATE');
+    try {
+      this.replacePostItems(postId, items);
+      database.exec('COMMIT');
+    } catch (error) {
+      database.exec('ROLLBACK');
+      throw error;
+    }
+  },
+
+  upsertPostWithItems(input: UpsertPostInput, items: Array<{ imageId: number; position: number }>): PostRecord {
+    database.exec('BEGIN IMMEDIATE');
+    try {
+      const post = this.upsertPost(input);
+      this.replacePostItems(post.id, items);
+      database.exec('COMMIT');
+      return post;
+    } catch (error) {
+      database.exec('ROLLBACK');
+      throw error;
+    }
+  },
+
+  replacePostItems(postId: number, items: Array<{ imageId: number; position: number }>): void {
+    database.prepare('DELETE FROM post_items WHERE post_id = ?').run(postId);
+    const statement = database.prepare('INSERT INTO post_items (post_id, image_id, position) VALUES (?, ?, ?)');
+    for (const item of items) {
+      statement.run(postId, item.imageId, item.position);
+    }
+  },
+
+  syncRepresentativePlaces(): number {
+    const updatedAt = nowIso();
+    const result = database.prepare(
+      `
+      UPDATE posts
+      SET
+        place_id = (
+          SELECT images.place_id
+          FROM post_items
+          INNER JOIN images ON images.id = post_items.image_id
+          WHERE post_items.post_id = posts.id AND post_items.position = 1
+        ),
+        updated_at = ?
+      WHERE EXISTS (
+        SELECT 1
+        FROM post_items
+        WHERE post_items.post_id = posts.id AND post_items.position = 1
+      )
+        AND place_id IS NOT (
+          SELECT images.place_id
+          FROM post_items
+          INNER JOIN images ON images.id = post_items.image_id
+          WHERE post_items.post_id = posts.id AND post_items.position = 1
+        )
+      `
+    ).run(updatedAt);
+    return Number(result.changes ?? 0);
+  },
+
+  findById(id: number): PostRecord | undefined {
+    return database.prepare('SELECT * FROM posts WHERE id = ?').get(id) as PostRecord | undefined;
+  },
+
+  findBySourcePath(sourcePath: string): PostRecord | undefined {
+    return database.prepare('SELECT * FROM posts WHERE source_path = ?').get(sourcePath) as PostRecord | undefined;
+  },
+
+  findByImageId(imageId: number): PostRecord | undefined {
+    const row = database.prepare('SELECT post_id FROM post_items WHERE image_id = ? LIMIT 1').get(imageId) as { post_id: number } | undefined;
+    return row ? this.findById(row.post_id) : undefined;
+  },
+
+  findByExactImageIds(imageIds: number[]): PostRecord | undefined {
+    if (imageIds.length === 0) return undefined;
+    const uniqueImageIds = [...new Set(imageIds)];
+    if (uniqueImageIds.length !== imageIds.length) return undefined;
+    const placeholders = uniqueImageIds.map(() => '?').join(',');
+    const matchingPosts = database
+      .prepare(
+        `
+        SELECT post_id
+        FROM post_items
+        GROUP BY post_id
+        HAVING COUNT(*) = ?
+          AND SUM(CASE WHEN image_id IN (${placeholders}) THEN 1 ELSE 0 END) = ?
+        LIMIT 2
+        `
+      )
+      .all(uniqueImageIds.length, ...uniqueImageIds, uniqueImageIds.length) as Array<{ post_id: number }>;
+
+    if (matchingPosts.length === 1) {
+      return this.findById(matchingPosts[0].post_id);
+    }
+    return undefined;
+  },
+
+  isExplicitFolderCover(postId: number): boolean {
+    const row = database
+      .prepare(
+        `
+        SELECT 1 AS found
+        FROM posts
+        INNER JOIN folders ON folders.id = posts.folder_id
+        INNER JOIN post_items ON post_items.post_id = posts.id AND post_items.position = 1
+        INNER JOIN images ON images.id = post_items.image_id
+        WHERE posts.id = ?
+          AND folders.role = 'normal'
+          AND images.folder_id = posts.folder_id
+          AND LOWER(images.filename) IN (${COVER_FILENAME_SQL})
+        LIMIT 1
+        `
+      )
+      .get(postId) as { found: number } | undefined;
+    return row?.found === 1;
+  },
+
+  listImageRecords(postId: number): ImageRecord[] {
+    return database.prepare(
+      `SELECT images.*
+       FROM post_items
+       INNER JOIN images ON images.id = post_items.image_id
+       WHERE post_items.post_id = ?
+       ORDER BY post_items.position ASC`
+    ).all(postId) as unknown as ImageRecord[];
+  },
+
+  deletePostAndImages(postId: number): { id: number; folderSlug: string } | undefined {
+    const post = this.findById(postId);
+    if (!post) return undefined;
+    const folder = folderRepository.getById(post.folder_id);
+    const imageIds = this.listImageRecords(post.id).map((image) => image.id);
+    database.prepare('DELETE FROM posts WHERE id = ?').run(post.id);
+    const deleteImage = database.prepare('DELETE FROM images WHERE id = ?');
+    for (const imageId of imageIds) deleteImage.run(imageId);
+    return { id: post.id, folderSlug: folder?.slug ?? '' };
+  },
+
+  hydratePostItems(posts: FeedPost[]): FeedPost[] {
+    if (posts.length === 0) {
+      return posts;
+    }
+
+    const postIds = posts.map((p) => p.id);
+    const placeholders = postIds.map(() => '?').join(', ');
+    const rows = database
+      .prepare(
+        `
+        SELECT
+          pi.post_id AS postId,
+          pi.position,
+          img.id AS imageId,
+          img.filename,
+          img.width,
+          img.height,
+          img.media_type AS mediaType,
+          img.duration_ms AS durationMs,
+          img.is_animated AS isAnimated,
+          img.thumbnail_path AS thumbnailUrl,
+          img.preview_path AS previewUrl,
+          img.relative_path AS relativePath,
+          img.mime_type AS mimeType,
+          img.file_size AS fileSize,
+          img.playback_strategy AS playbackStrategy,
+          img.exif_json AS exifJson
+        FROM post_items pi
+        JOIN images img ON pi.image_id = img.id
+        WHERE pi.post_id IN (${placeholders})
+        ORDER BY pi.post_id, pi.position ASC
+        `
+      )
+      .all(...postIds) as Array<{
+        postId: number;
+        position: number;
+        imageId: number;
+        filename: string;
+        width: number;
+        height: number;
+        mediaType: MediaType;
+        durationMs: number | null;
+        isAnimated: number | null;
+        thumbnailUrl: string;
+        previewUrl: string;
+        relativePath: string;
+        mimeType: string;
+        fileSize: number;
+        playbackStrategy: PlaybackStrategy | null;
+        exifJson: string | null;
+      }>;
+
+    const itemsByPostId = new Map<number, PostMediaItem[]>();
+    for (const row of rows) {
+      if (!itemsByPostId.has(row.postId)) {
+        itemsByPostId.set(row.postId, []);
+      }
+      itemsByPostId.get(row.postId)!.push({
+        imageId: row.imageId,
+        position: row.position,
+        filename: row.filename,
+        width: row.width,
+        height: row.height,
+        mediaType: row.mediaType,
+        durationMs: row.durationMs,
+        isAnimated: row.isAnimated === 1,
+        thumbnailUrl: row.thumbnailUrl,
+        previewUrl: row.previewUrl,
+        originalUrl: `/api/originals/${row.imageId}`,
+        playbackStrategy: row.playbackStrategy,
+        mimeType: row.mimeType,
+        fileSize: row.fileSize,
+        relativePath: row.relativePath,
+        exif: row.exifJson && isValidJson(row.exifJson) ? JSON.parse(row.exifJson) : null
+      });
+    }
+
+    for (const post of posts) {
+      const items = itemsByPostId.get(post.id) ?? [];
+      post.mediaItems = items;
+      post.itemCount = items.length;
+      post.postType = items.length > 1 ? 'carousel' : (post.postType || 'single');
+
+      if (items.length > 0) {
+        const first = items[0];
+        post.filename = first.filename;
+        post.width = first.width;
+        post.height = first.height;
+        post.mediaType = first.mediaType;
+        post.durationMs = first.durationMs;
+        post.isAnimated = first.isAnimated;
+        post.thumbnailUrl = first.thumbnailUrl;
+        post.previewUrl = first.previewUrl;
+      }
+    }
+
+    return posts;
+  },
+
+  listFeed(page: number, limit: number): FeedPost[] {
+    const offset = (page - 1) * limit;
+    const posts = database.prepare(
+      `
+      ${BASE_POST_SELECT_SQL}
+      WHERE ${VISIBLE_POST_WHERE_SQL}
+      ORDER BY posts.sort_timestamp DESC, posts.id DESC
+      LIMIT ? OFFSET ?
+      `
+    ).all(limit, offset) as unknown as FeedPost[];
+
+    return this.hydratePostItems(posts);
+  },
+
+  countFeed(): number {
+    return Number(
+      (database.prepare(`SELECT COUNT(*) AS count FROM posts WHERE ${VISIBLE_POST_WHERE_UNSCOPED_SQL}`).get() as { count: number }).count
+    );
+  },
+
+  countVisibleMediaAssets(): number {
+    return Number((database.prepare(
+      `SELECT COUNT(*) AS count
+       FROM post_items
+       INNER JOIN posts ON posts.id = post_items.post_id
+       WHERE posts.is_deleted = 0
+         AND posts.is_trashed = 0
+         AND posts.folder_id IN (${NORMAL_FOLDER_ID_SUBQUERY_SQL})`
+    ).get() as { count: number }).count);
+  },
+
+  countVisibleCarousels(): number {
+    return Number((database.prepare(
+      `SELECT COUNT(*) AS count FROM posts WHERE ${VISIBLE_POST_WHERE_UNSCOPED_SQL} AND post_type = 'carousel'`
+    ).get() as { count: number }).count);
+  },
+
+  countVisibleSingleVideos(): number {
+    return Number((database.prepare(
+      `SELECT COUNT(*) AS count
+       FROM posts
+       INNER JOIN post_items ON post_items.post_id = posts.id AND post_items.position = 1
+       INNER JOIN images ON images.id = post_items.image_id
+       WHERE posts.is_deleted = 0
+         AND posts.is_trashed = 0
+         AND posts.folder_id IN (${NORMAL_FOLDER_ID_SUBQUERY_SQL})
+         AND posts.post_type = 'single'
+         AND images.media_type = 'video'`
+    ).get() as { count: number }).count);
+  },
+
+  listVisibleByFolder(
+    folderId: number,
+    page: number,
+    limit: number,
+    order: FolderImageOrder = 'newest',
+    mediaType?: MediaType
+  ): FeedPost[] {
+    const offset = (page - 1) * limit;
+    const orderBySql = getQualifiedFolderPostOrderSql(order);
+    const mediaTypeClause = mediaType ? ' AND images.media_type = ?' : '';
+    const posts = database.prepare(
+      `
+      ${BASE_POST_SELECT_SQL}
+      WHERE posts.folder_id = ? AND ${VISIBLE_POST_WHERE_SQL}${mediaTypeClause}
+      ORDER BY ${orderBySql}
+      LIMIT ? OFFSET ?
+      `
+    ).all(...(mediaType ? [folderId, mediaType, limit, offset] : [folderId, limit, offset])) as unknown as FeedPost[];
+
+    return this.hydratePostItems(posts);
+  },
+
+  countVisibleByFolder(folderId: number, mediaType?: MediaType): number {
     const mediaTypeClause = mediaType ? ' AND images.media_type = ?' : '';
     return Number(
       (
@@ -784,14 +1461,571 @@ export const placeRepository = {
           .prepare(
             `
             SELECT COUNT(*) AS count
-            FROM images
-            INNER JOIN folders ON folders.id = images.folder_id
-            WHERE images.place_id = ? AND ${VISIBLE_IMAGE_WHERE_SQL}${mediaTypeClause}
+            FROM posts
+            INNER JOIN folders ON folders.id = posts.folder_id
+            JOIN post_items ON post_items.post_id = posts.id AND post_items.position = 1
+            JOIN images ON images.id = post_items.image_id
+            WHERE posts.folder_id = ? AND ${VISIBLE_POST_WHERE_SQL}${mediaTypeClause}
             `
           )
-          .get(...(mediaType ? [placeId, mediaType] : [placeId])) as { count: number }
+          .get(...(mediaType ? [folderId, mediaType] : [folderId])) as { count: number }
       ).count
     );
+  },
+
+  listRecentCandidates(offset: number, limit: number): FeedPost[] {
+    const posts = database.prepare(
+      `
+      ${BASE_POST_SELECT_SQL}
+      WHERE ${VISIBLE_POST_WHERE_SQL}
+      ORDER BY ${EFFECTIVE_FEED_TIME_SQL} DESC, posts.sort_timestamp DESC, posts.id DESC
+      LIMIT ? OFFSET ?
+      `
+    ).all(limit, offset) as unknown as FeedPost[];
+
+    return this.hydratePostItems(posts);
+  },
+
+  countRediscover(cutoffTimestamp: number): number {
+    return Number(
+      (
+        database
+          .prepare(`SELECT COUNT(*) AS count FROM posts WHERE ${VISIBLE_POST_WHERE_UNSCOPED_SQL} AND ${EFFECTIVE_FEED_TIME_SQL} <= ?`)
+          .get(cutoffTimestamp) as { count: number }
+      ).count
+    );
+  },
+
+  listRediscoverCandidates(offset: number, limit: number, cutoffTimestamp: number): FeedPost[] {
+    const posts = database.prepare(
+      `
+      ${BASE_POST_SELECT_SQL}
+      LEFT JOIN likes ON likes.post_id = posts.id
+      WHERE ${VISIBLE_POST_WHERE_SQL} AND ${EFFECTIVE_FEED_TIME_SQL} <= ?
+      ORDER BY
+        CASE WHEN likes.post_id IS NULL THEN 0 ELSE 1 END DESC,
+        ${EFFECTIVE_FEED_TIME_SQL} DESC,
+        posts.sort_timestamp DESC,
+        posts.id DESC
+      LIMIT ? OFFSET ?
+      `
+    ).all(cutoffTimestamp, limit, offset) as unknown as FeedPost[];
+
+    return this.hydratePostItems(posts);
+  },
+
+  listRandom(page: number, limit: number, seed: number): FeedPost[] {
+    const offset = (page - 1) * limit;
+    const posts = database.prepare(
+      `
+      ${BASE_POST_SELECT_SQL}
+      WHERE ${VISIBLE_POST_WHERE_SQL}
+      ORDER BY ABS(((posts.id * 1103515245) + (? * 1013904223)) % 2147483647), posts.id DESC
+      LIMIT ? OFFSET ?
+      `
+    ).all(seed, limit, offset) as unknown as FeedPost[];
+
+    return this.hydratePostItems(posts);
+  },
+
+  listVisibleVideoCandidates(): ReelCandidate[] {
+    const posts = database.prepare(
+      `
+      SELECT
+        posts.id,
+        posts.folder_id AS folderId,
+        folders.slug AS folderSlug,
+        folders.name AS folderName,
+        folders.folder_path AS folderPath,
+        images.filename,
+        posts.caption AS caption,
+        posts.post_type AS postType,
+        posts.source_path AS sourcePath,
+        images.width,
+        images.height,
+        images.media_type AS mediaType,
+        images.duration_ms AS durationMs,
+        images.is_animated AS isAnimated,
+        images.thumbnail_path AS thumbnailUrl,
+        images.preview_path AS previewUrl,
+        images.playback_strategy AS playbackStrategy,
+        posts.sort_timestamp AS sortTimestamp,
+        posts.taken_at AS takenAt,
+        ${POST_SAVED_SELECT_SQL},
+        places.id AS placeId,
+        places.slug AS placeSlug,
+        places.display_name AS placeName,
+        places.kind AS placeKind,
+        places.is_approximate AS placeIsApproximate,
+        likes.created_at AS likedAt
+      FROM posts
+      INNER JOIN folders ON folders.id = posts.folder_id
+      JOIN post_items ON post_items.post_id = posts.id AND post_items.position = 1
+      JOIN images ON images.id = post_items.image_id
+      LEFT JOIN places ON places.id = posts.place_id
+      LEFT JOIN likes ON likes.post_id = posts.id
+      WHERE ${VISIBLE_POST_WHERE_SQL}
+        AND posts.post_type = 'single'
+        AND images.media_type = 'video'
+        AND LOWER(images.filename) NOT IN (${COVER_FILENAME_SQL})
+      ORDER BY posts.sort_timestamp DESC, posts.id DESC
+      `
+    ).all() as unknown as ReelCandidate[];
+
+    return this.hydratePostItems(posts) as ReelCandidate[];
+  },
+
+  listVisibleSearch(query: string, page: number, limit: number): FeedPost[] {
+    const mediaSearch = buildMediaSearchSql(query);
+    if (!mediaSearch) {
+      return [];
+    }
+
+    const offset = (page - 1) * limit;
+    const posts = database.prepare(
+      `
+      SELECT
+        base_posts.*
+      FROM (
+        SELECT
+          posts.id AS postId,
+          MAX(${mediaSearch.rankSql}) AS searchRank
+        FROM posts
+        INNER JOIN folders ON folders.id = posts.folder_id
+        JOIN post_items ON post_items.post_id = posts.id
+        JOIN images ON images.id = post_items.image_id
+        WHERE ${VISIBLE_POST_WHERE_SQL} AND ${mediaSearch.whereSql}
+        GROUP BY posts.id
+      ) AS search_matches
+      JOIN (
+        ${BASE_POST_SELECT_SQL}
+      ) AS base_posts ON base_posts.id = search_matches.postId
+      ORDER BY search_matches.searchRank DESC, base_posts.sortTimestamp DESC, base_posts.id DESC
+      LIMIT ? OFFSET ?
+      `
+    ).all(...mediaSearch.rankParams, ...mediaSearch.whereParams, limit, offset) as unknown as FeedPost[];
+
+    return this.hydratePostItems(posts);
+  },
+
+  countVisibleSearch(query: string): number {
+    const mediaSearch = buildMediaSearchSql(query);
+    if (!mediaSearch) {
+      return 0;
+    }
+
+    return Number(
+      (
+        database
+          .prepare(
+            `
+            SELECT COUNT(DISTINCT posts.id) AS count
+            FROM posts
+            INNER JOIN folders ON folders.id = posts.folder_id
+            JOIN post_items ON post_items.post_id = posts.id
+            JOIN images ON images.id = post_items.image_id
+            WHERE ${VISIBLE_POST_WHERE_SQL} AND ${mediaSearch.whereSql}
+            `
+          )
+          .get(...mediaSearch.whereParams) as { count: number }
+      ).count
+    );
+  },
+
+  countByMonthDayKeys(monthDayKeys: string[], maxYearExclusive: number): number {
+    if (monthDayKeys.length === 0) {
+      return 0;
+    }
+
+    const placeholders = monthDayKeys.map(() => '?').join(', ');
+    return Number(
+      (
+        database
+          .prepare(
+            `
+            SELECT COUNT(*) AS count
+            FROM posts
+            WHERE ${VISIBLE_POST_WHERE_UNSCOPED_SQL}
+              AND strftime('%m-%d', ${EFFECTIVE_FEED_TIME_SQL} / 1000, 'unixepoch', 'localtime') IN (${placeholders})
+              AND CAST(strftime('%Y', ${EFFECTIVE_FEED_TIME_SQL} / 1000, 'unixepoch', 'localtime') AS INTEGER) < ?
+            `
+          )
+          .get(...monthDayKeys, maxYearExclusive) as { count: number }
+      ).count
+    );
+  },
+
+  listByMonthDayKeys(monthDayKeys: string[], maxYearExclusive: number, page: number, limit: number): FeedPost[] {
+    if (monthDayKeys.length === 0) {
+      return [];
+    }
+
+    const offset = (page - 1) * limit;
+    const placeholders = monthDayKeys.map(() => '?').join(', ');
+
+    const posts = database.prepare(
+      `
+      ${BASE_POST_SELECT_SQL}
+      WHERE ${VISIBLE_POST_WHERE_SQL}
+        AND strftime('%m-%d', ${EFFECTIVE_FEED_TIME_SQL} / 1000, 'unixepoch', 'localtime') IN (${placeholders})
+        AND CAST(strftime('%Y', ${EFFECTIVE_FEED_TIME_SQL} / 1000, 'unixepoch', 'localtime') AS INTEGER) < ?
+      ORDER BY ${EFFECTIVE_FEED_TIME_SQL} DESC, posts.sort_timestamp DESC, posts.id DESC
+      LIMIT ? OFFSET ?
+      `
+    ).all(...monthDayKeys, maxYearExclusive, limit, offset) as unknown as FeedPost[];
+
+    return this.hydratePostItems(posts);
+  },
+
+  countByEffectiveTimeRange(startTimestamp: number, endTimestamp: number): number {
+    return Number(
+      (
+        database
+          .prepare(
+            `
+            SELECT COUNT(*) AS count
+            FROM posts
+            WHERE ${VISIBLE_POST_WHERE_UNSCOPED_SQL}
+              AND ${EFFECTIVE_FEED_TIME_SQL} BETWEEN ? AND ?
+            `
+          )
+          .get(startTimestamp, endTimestamp) as { count: number }
+      ).count
+    );
+  },
+
+  listByEffectiveTimeRange(startTimestamp: number, endTimestamp: number, page: number, limit: number): FeedPost[] {
+    const offset = (page - 1) * limit;
+
+    const posts = database.prepare(
+      `
+      ${BASE_POST_SELECT_SQL}
+      WHERE ${VISIBLE_POST_WHERE_SQL}
+        AND ${EFFECTIVE_FEED_TIME_SQL} BETWEEN ? AND ?
+      ORDER BY ${EFFECTIVE_FEED_TIME_SQL} DESC, posts.sort_timestamp DESC, posts.id DESC
+      LIMIT ? OFFSET ?
+      `
+    ).all(startTimestamp, endTimestamp, limit, offset) as unknown as FeedPost[];
+
+    return this.hydratePostItems(posts);
+  },
+
+  listPlacePosts(placeId: number, page: number, limit: number): FeedPost[] {
+    const offset = (page - 1) * limit;
+    const posts = database.prepare(
+      `
+      ${BASE_POST_SELECT_SQL}
+      WHERE posts.place_id = ? AND ${VISIBLE_POST_WHERE_SQL}
+      ORDER BY posts.sort_timestamp DESC, posts.id DESC
+      LIMIT ? OFFSET ?
+      `
+    ).all(placeId, limit, offset) as unknown as FeedPost[];
+
+    return this.hydratePostItems(posts);
+  },
+
+  listTrashed(page: number, limit: number): TrashPost[] {
+    const offset = (page - 1) * limit;
+    const posts = database.prepare(
+      `
+      SELECT
+        posts.id,
+        posts.folder_id AS folderId,
+        folders.slug AS folderSlug,
+        folders.name AS folderName,
+        folders.folder_path AS folderPath,
+        images.filename,
+        posts.caption AS caption,
+        posts.post_type AS postType,
+        posts.source_path AS sourcePath,
+        images.width,
+        images.height,
+        images.media_type AS mediaType,
+        images.duration_ms AS durationMs,
+        images.is_animated AS isAnimated,
+        images.thumbnail_path AS thumbnailUrl,
+        images.preview_path AS previewUrl,
+        images.playback_strategy AS playbackStrategy,
+        posts.sort_timestamp AS sortTimestamp,
+        posts.taken_at AS takenAt,
+        ${POST_SAVED_SELECT_SQL},
+        posts.trashed_at AS trashedAt,
+        places.id AS placeId,
+        places.slug AS placeSlug,
+        places.display_name AS placeName,
+        places.kind AS placeKind,
+        places.is_approximate AS placeIsApproximate
+      FROM posts
+      INNER JOIN folders ON folders.id = posts.folder_id
+      JOIN post_items ON post_items.post_id = posts.id AND post_items.position = 1
+      JOIN images ON images.id = post_items.image_id
+      LEFT JOIN places ON places.id = posts.place_id
+      WHERE posts.is_deleted = 0 AND posts.is_trashed = 1
+      ORDER BY posts.trashed_at DESC, posts.id DESC
+      LIMIT ? OFFSET ?
+      `
+    ).all(limit, offset) as unknown as TrashPost[];
+
+    return this.hydratePostItems(posts) as TrashPost[];
+  },
+
+  countTrashed(): number {
+    return Number(
+      (database.prepare('SELECT COUNT(*) AS count FROM posts WHERE is_deleted = 0 AND is_trashed = 1').get() as { count: number }).count
+    );
+  },
+
+  getPostDetail(
+    id: number,
+    folderImageOrder: FolderImageOrder = 'newest'
+  ): PostDetail | undefined {
+    const resolvedId = id;
+    const nextComparisonSql = folderImageOrder === 'oldest'
+      ? '(sort_timestamp > ? OR (sort_timestamp = ? AND id > ?))'
+      : '(sort_timestamp < ? OR (sort_timestamp = ? AND id < ?))';
+    const previousComparisonSql = folderImageOrder === 'oldest'
+      ? '(sort_timestamp < ? OR (sort_timestamp = ? AND id < ?))'
+      : '(sort_timestamp > ? OR (sort_timestamp = ? AND id > ?))';
+    const nextOrderSql = getUnscopedFolderPostOrderSql(folderImageOrder);
+    const previousOrderSql = getUnscopedFolderPostOrderSql(folderImageOrder === 'oldest' ? 'newest' : 'oldest');
+
+    const detailRow = database.prepare(
+      `
+      SELECT
+        posts.id,
+        posts.folder_id AS folderId,
+        folders.slug AS folderSlug,
+        folders.name AS folderName,
+        folders.folder_path AS folderPath,
+        folders.avatar_image_id AS folderAvatarImageId,
+        images.filename,
+        posts.caption AS caption,
+        posts.post_type AS postType,
+        posts.source_path AS sourcePath,
+        images.width,
+        images.height,
+        images.media_type AS mediaType,
+        images.duration_ms AS durationMs,
+        images.is_animated AS isAnimated,
+        images.relative_path AS relativePath,
+        images.mime_type AS mimeType,
+        images.file_size AS fileSize,
+        images.thumbnail_path AS thumbnailUrl,
+        images.preview_path AS previewUrl,
+        images.playback_strategy AS playbackStrategy,
+        images.exif_json AS exifJson,
+        images.absolute_path AS originalUrl,
+        posts.sort_timestamp AS sortTimestamp,
+        posts.taken_at AS takenAt,
+        ${POST_SAVED_SELECT_SQL},
+        places.id AS placeId,
+        places.slug AS placeSlug,
+        places.display_name AS placeName,
+        places.kind AS placeKind,
+        places.is_approximate AS placeIsApproximate
+      FROM posts
+      INNER JOIN folders ON folders.id = posts.folder_id
+      JOIN post_items ON post_items.post_id = posts.id AND post_items.position = 1
+      JOIN images ON images.id = post_items.image_id
+      LEFT JOIN places ON places.id = posts.place_id
+      WHERE posts.id = ? AND posts.is_deleted = 0 AND posts.is_trashed = 0 AND ${NORMAL_FOLDER_ROLE_SQL}
+      `
+    ).get(resolvedId) as (Omit<PostDetail, 'nextPostId' | 'previousPostId' | 'nextImageId' | 'previousImageId' | 'exif' | 'mediaItems' | 'itemCount'> & { originalUrl: string; exifJson: string | null }) | undefined;
+
+    if (!detailRow) {
+      return undefined;
+    }
+
+    const hydratedPosts = this.hydratePostItems([detailRow as unknown as FeedPost]);
+    const hydratedPost = hydratedPosts[0];
+
+    const next = database.prepare(
+      `
+      SELECT id
+      FROM posts
+      WHERE folder_id = ? AND ${VISIBLE_POST_WHERE_UNSCOPED_SQL}
+        AND ${nextComparisonSql}
+      ORDER BY ${nextOrderSql}
+      LIMIT 1
+      `
+    ).get(hydratedPost.folderId, hydratedPost.sortTimestamp, hydratedPost.sortTimestamp, hydratedPost.id) as { id: number } | undefined;
+
+    const previous = database.prepare(
+      `
+      SELECT id
+      FROM posts
+      WHERE folder_id = ? AND ${VISIBLE_POST_WHERE_UNSCOPED_SQL}
+        AND ${previousComparisonSql}
+      ORDER BY ${previousOrderSql}
+      LIMIT 1
+      `
+    ).get(hydratedPost.folderId, hydratedPost.sortTimestamp, hydratedPost.sortTimestamp, hydratedPost.id) as { id: number } | undefined;
+
+    const nextPostId = next?.id ?? null;
+    const previousPostId = previous?.id ?? null;
+
+    return {
+      ...hydratedPost,
+      folderAvatarImageId: detailRow.folderAvatarImageId,
+      relativePath: detailRow.relativePath,
+      mimeType: detailRow.mimeType,
+      fileSize: detailRow.fileSize,
+      exif: detailRow.exifJson && isValidJson(detailRow.exifJson) ? JSON.parse(detailRow.exifJson) : null,
+      originalUrl: detailRow.originalUrl,
+      playbackStrategy: detailRow.playbackStrategy,
+      nextPostId,
+      previousPostId,
+      nextImageId: nextPostId,
+      previousImageId: previousPostId
+    } as PostDetail;
+  },
+
+  updateCaption(id: number, caption: string | null): PostDetail | undefined {
+    const resolvedId = id;
+    database.prepare('UPDATE posts SET caption = ?, updated_at = ? WHERE id = ?').run(caption, nowIso(), resolvedId);
+    return this.getPostDetail(resolvedId);
+  },
+
+  softDeletePost(id: number): void {
+    const deletedAt = nowIso();
+    database.prepare('UPDATE posts SET is_deleted = 1, deleted_at = COALESCE(deleted_at, ?), updated_at = ? WHERE id = ?').run(deletedAt, deletedAt, id);
+  },
+
+  softDeleteMissingByFolder(folderId: number, activeSourcePaths: string[], postType?: PostType): number {
+    const rows = postType
+      ? (database.prepare('SELECT source_path FROM posts WHERE folder_id = ? AND post_type = ? AND is_deleted = 0').all(folderId, postType) as Array<{ source_path: string }>)
+      : (database.prepare('SELECT source_path FROM posts WHERE folder_id = ? AND is_deleted = 0').all(folderId) as Array<{ source_path: string }>);
+    const active = new Set(activeSourcePaths);
+    let removedCount = 0;
+
+    for (const row of rows) {
+      if (!active.has(row.source_path)) {
+        this.softDeletePostBySourcePath(row.source_path);
+        removedCount += 1;
+      }
+    }
+
+    return removedCount;
+  },
+
+  softDeleteMissingReservedCarousels(folderId: number, carouselsRootPath: string, activeSourcePaths: string[]): number {
+    const normalizedPrefix = `${normalizePath(carouselsRootPath)}/`;
+    const rows = database
+      .prepare('SELECT source_path FROM posts WHERE folder_id = ? AND is_deleted = 0 AND source_path LIKE ?')
+      .all(folderId, `${normalizedPrefix}%`) as Array<{ source_path: string }>;
+    const active = new Set(activeSourcePaths.map((sourcePath) => normalizePath(sourcePath)));
+    let removedCount = 0;
+
+    for (const row of rows) {
+      if (!active.has(normalizePath(row.source_path))) {
+        this.softDeletePostBySourcePath(row.source_path);
+        removedCount += 1;
+      }
+    }
+
+    return removedCount;
+  },
+
+  softDeleteReservedCarouselsForLegacyMode(): number {
+    const deletedAt = nowIso();
+    const result = database.prepare(`
+      UPDATE posts
+      SET is_deleted = 1,
+          deleted_at = COALESCE(deleted_at, ?),
+          updated_at = ?
+      WHERE is_deleted = 0
+        AND EXISTS (
+          SELECT 1
+          FROM folders
+          WHERE folders.id = posts.folder_id
+            AND LOWER(posts.source_path) LIKE LOWER(folders.folder_path || '/carousels/%')
+        )
+    `).run(deletedAt, deletedAt);
+
+    return Number(result.changes ?? 0);
+  },
+
+  softDeletePostBySourcePath(sourcePath: string): void {
+    const deletedAt = nowIso();
+    database.prepare('UPDATE posts SET is_deleted = 1, deleted_at = COALESCE(deleted_at, ?), updated_at = ? WHERE source_path = ?').run(deletedAt, deletedAt, sourcePath);
+  },
+
+  restorePost(id: number): void {
+    database.prepare('UPDATE posts SET is_deleted = 0, deleted_at = NULL, updated_at = ? WHERE id = ?').run(nowIso(), id);
+  },
+
+  trashPost(id: number, trashedAt = nowIso()): boolean {
+    const resolvedId = id;
+    const now = nowIso();
+    const result = database
+      .prepare(
+        `
+        UPDATE posts
+        SET is_trashed = 1, trashed_at = ?, updated_at = ?
+        WHERE id = ? AND is_deleted = 0 AND is_trashed = 0
+        `
+      )
+      .run(trashedAt, now, resolvedId);
+
+    if (Number(result.changes ?? 0) > 0) {
+      database.prepare(
+        `
+        UPDATE images
+        SET is_trashed = 1, trashed_at = ?, updated_at = ?
+        WHERE id IN (SELECT image_id FROM post_items WHERE post_id = ?)
+        `
+      ).run(trashedAt, now, resolvedId);
+      return true;
+    }
+    return false;
+  },
+
+  restoreTrashedPost(id: number): boolean {
+    const resolvedId = id;
+    const now = nowIso();
+    const result = database
+      .prepare(
+        `
+        UPDATE posts
+        SET is_trashed = 0, trashed_at = NULL, updated_at = ?
+        WHERE id = ? AND is_deleted = 0 AND is_trashed = 1
+        `
+      )
+      .run(now, resolvedId);
+
+    if (Number(result.changes ?? 0) > 0) {
+      database.prepare(
+        `
+        UPDATE images
+        SET is_trashed = 0, trashed_at = NULL, updated_at = ?
+        WHERE id IN (SELECT image_id FROM post_items WHERE post_id = ?)
+        `
+      ).run(now, resolvedId);
+      return true;
+    }
+    return false;
+  },
+
+  deletePost(id: number): { id: number; folderSlug: string } | undefined {
+    const post = this.findById(id);
+    if (!post) {
+      return undefined;
+    }
+
+    const folder = folderRepository.getById(post.folder_id);
+    database.prepare('DELETE FROM posts WHERE id = ?').run(post.id);
+    return {
+      id: post.id,
+      folderSlug: folder?.slug ?? ''
+    };
+  },
+
+  countAll(): number {
+    return Number((database.prepare('SELECT COUNT(*) AS count FROM posts').get() as { count: number }).count);
+  },
+
+  countCarousels(): number {
+    return Number((database.prepare("SELECT COUNT(*) AS count FROM posts WHERE post_type = 'carousel' AND is_deleted = 0 AND is_trashed = 0").get() as { count: number }).count);
   }
 };
 
@@ -802,6 +2036,20 @@ export const imageRepository = {
 
   getById(id: number): ImageRecord | undefined {
     return database.prepare('SELECT * FROM images WHERE id = ?').get(id) as ImageRecord | undefined;
+  },
+
+  getByThumbnailPath(thumbnailPath: string): ImageRecord | undefined {
+    return database.prepare('SELECT * FROM images WHERE thumbnail_path = ?').get(thumbnailPath) as ImageRecord | undefined;
+  },
+
+  getByPreviewPath(previewPath: string): ImageRecord | undefined {
+    return database.prepare('SELECT * FROM images WHERE preview_path = ?').get(previewPath) as ImageRecord | undefined;
+  },
+
+  listDerivativeReferences(): Array<Pick<ImageRecord, 'thumbnail_path' | 'preview_path' | 'is_deleted' | 'deleted_at'>> {
+    return database
+      .prepare('SELECT thumbnail_path, preview_path, is_deleted, deleted_at FROM images')
+      .all() as Array<Pick<ImageRecord, 'thumbnail_path' | 'preview_path' | 'is_deleted' | 'deleted_at'>>;
   },
 
   upsert(input: UpsertImageInput): ImageRecord {
@@ -867,7 +2115,28 @@ export const imageRepository = {
       nowIso()
     );
 
-    return this.getByRelativePath(input.relativePath) as ImageRecord;
+    const folder = folderRepository.getById(input.folderId);
+    const isNormalPostAsset = folder?.role === 'normal' && !COVER_FILENAMES.includes(input.filename.toLocaleLowerCase() as typeof COVER_FILENAMES[number]);
+
+    const record = this.getByRelativePath(input.relativePath) as ImageRecord;
+    if (record && isNormalPostAsset) {
+      const existingPost = postRepository.findByImageId(record.id) ?? postRepository.findBySourcePath(input.relativePath);
+      postRepository.upsertPostWithItems({
+        existingPostId: existingPost?.id,
+        id: existingPost ? undefined : record.id,
+        folderId: input.folderId,
+        placeId: record.place_id,
+        postType: 'single',
+        sourcePath: input.relativePath,
+        caption: null,
+        takenAt: input.takenAt ?? null,
+        sortTimestamp: input.sortTimestamp,
+        isDeleted: 0,
+        isTrashed: 0
+      }, [{ imageId: record.id, position: 1 }]);
+    }
+
+    return record;
   },
 
   refreshIndexed(input: RefreshIndexedImageInput): ImageRecord {
@@ -927,13 +2196,37 @@ export const imageRepository = {
       input.relativePath
     );
 
-    return this.getByRelativePath(input.relativePath) as ImageRecord;
+    const folder = folderRepository.getById(input.folderId);
+    const isNormalPostAsset = folder?.role === 'normal' && !COVER_FILENAMES.includes(input.filename.toLocaleLowerCase() as typeof COVER_FILENAMES[number]);
+
+    const record = this.getByRelativePath(input.relativePath) as ImageRecord;
+    if (record && isNormalPostAsset) {
+      const existingPost = postRepository.findByImageId(record.id) ?? postRepository.findBySourcePath(input.relativePath);
+      postRepository.upsertPostWithItems({
+        existingPostId: existingPost?.id,
+        id: existingPost ? undefined : record.id,
+        folderId: input.folderId,
+        placeId: record.place_id,
+        postType: 'single',
+        sourcePath: input.relativePath,
+        caption: null,
+        takenAt: input.takenAt ?? null,
+        sortTimestamp: record.sort_timestamp,
+        isDeleted: 0,
+        isTrashed: 0
+      }, [{ imageId: record.id, position: 1 }]);
+    }
+
+    return record;
   },
 
   markDeleted(relativePath: string): void {
     const deletedAt = nowIso();
     database
       .prepare('UPDATE images SET is_deleted = 1, deleted_at = COALESCE(deleted_at, ?), updated_at = ? WHERE relative_path = ?')
+      .run(deletedAt, deletedAt, relativePath);
+    database
+      .prepare('UPDATE posts SET is_deleted = 1, deleted_at = COALESCE(deleted_at, ?), updated_at = ? WHERE source_path = ?')
       .run(deletedAt, deletedAt, relativePath);
   },
 
@@ -952,16 +2245,46 @@ export const imageRepository = {
     return removedCount;
   },
 
-  markAllDeletedByFolder(folderId: number): number {
+  markAllDeletedByFolder(folderId: number, postType?: PostType): number {
     const deletedAt = nowIso();
     const result = database
       .prepare('UPDATE images SET is_deleted = 1, deleted_at = COALESCE(deleted_at, ?), updated_at = ? WHERE folder_id = ? AND is_deleted = 0')
       .run(deletedAt, deletedAt, folderId);
+    if (postType) {
+      database
+        .prepare('UPDATE posts SET is_deleted = 1, deleted_at = COALESCE(deleted_at, ?), updated_at = ? WHERE folder_id = ? AND post_type = ? AND is_deleted = 0')
+        .run(deletedAt, deletedAt, folderId, postType);
+    } else {
+      database
+        .prepare('UPDATE posts SET is_deleted = 1, deleted_at = COALESCE(deleted_at, ?), updated_at = ? WHERE folder_id = ? AND is_deleted = 0')
+        .run(deletedAt, deletedAt, folderId);
+    }
     return Number(result.changes ?? 0);
   },
 
   reactivate(relativePath: string): void {
-    database.prepare('UPDATE images SET is_deleted = 0, deleted_at = NULL, updated_at = ? WHERE relative_path = ?').run(nowIso(), relativePath);
+    const timestamp = nowIso();
+    database.prepare('UPDATE images SET is_deleted = 0, deleted_at = NULL, updated_at = ? WHERE relative_path = ?').run(timestamp, relativePath);
+    database.prepare('UPDATE posts SET is_deleted = 0, deleted_at = NULL, updated_at = ? WHERE source_path = ?').run(timestamp, relativePath);
+  },
+
+  countByMediaType(mediaType?: MediaType): number {
+    if (mediaType) {
+      return Number(
+        (
+          database
+            .prepare(`SELECT COUNT(*) AS count FROM images WHERE ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL} AND media_type = ?`)
+            .get(mediaType) as { count: number }
+        ).count
+      );
+    }
+    return Number(
+      (
+        database
+          .prepare(`SELECT COUNT(*) AS count FROM images WHERE ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL}`)
+          .get() as { count: number }
+      ).count
+    );
   },
 
   updateAssetKey(id: number, assetKey: string): void {
@@ -976,10 +2299,33 @@ export const imageRepository = {
 
   updateCaption(id: number, caption: string | null): void {
     database.prepare('UPDATE images SET caption = ?, updated_at = ? WHERE id = ?').run(caption, nowIso(), id);
+    const post = postRepository.findByImageId(id);
+    if (post) {
+      postRepository.updateCaption(post.id, caption);
+    }
   },
 
   assignPlace(id: number, placeId: number | null): void {
-    database.prepare('UPDATE images SET place_id = ?, updated_at = ? WHERE id = ?').run(placeId, nowIso(), id);
+    const updatedAt = nowIso();
+    database.exec('BEGIN IMMEDIATE');
+    try {
+      database.prepare('UPDATE images SET place_id = ?, updated_at = ? WHERE id = ?').run(placeId, updatedAt, id);
+      database.prepare(
+        `
+        UPDATE posts
+        SET place_id = ?, updated_at = ?
+        WHERE id IN (
+          SELECT post_id
+          FROM post_items
+          WHERE image_id = ? AND position = 1
+        )
+        `
+      ).run(placeId, updatedAt, id);
+      database.exec('COMMIT');
+    } catch (error) {
+      database.exec('ROLLBACK');
+      throw error;
+    }
   },
 
   reconcileMove(input: ReconcileImageMoveInput): ImageRecord {
@@ -1035,130 +2381,131 @@ export const imageRepository = {
       input.id
     );
 
-    return this.getById(input.id) as ImageRecord;
+    const record = this.getById(input.id) as ImageRecord;
+    const folder = folderRepository.getById(input.folderId);
+    const isNormalPostAsset =
+      folder?.role === 'normal' &&
+      !COVER_FILENAMES.includes(input.filename.toLocaleLowerCase() as typeof COVER_FILENAMES[number]);
+    if (isNormalPostAsset) {
+      const existingPost = postRepository.findByImageId(record.id) ?? postRepository.findBySourcePath(input.relativePath);
+      postRepository.upsertPostWithItems({
+        existingPostId: existingPost?.id,
+        id: existingPost ? undefined : record.id,
+        folderId: input.folderId,
+        placeId: record.place_id,
+        postType: 'single',
+        sourcePath: input.relativePath,
+        caption: existingPost?.caption ?? null,
+        takenAt: input.takenAt,
+        takenAtSource: input.takenAtSource,
+        sortTimestamp: existingPost?.sort_timestamp ?? record.sort_timestamp,
+        isDeleted: 0,
+        isTrashed: existingPost?.is_trashed ?? 0
+      }, [{ imageId: record.id, position: 1 }]);
+    }
+
+    return record;
   },
 
   moveToTrash(id: number, trashedAt = nowIso()): boolean {
-    const result = database
-      .prepare(
-        `
-        UPDATE images
-        SET is_trashed = 1, trashed_at = ?, updated_at = ?
-        WHERE id = ? AND is_deleted = 0 AND is_trashed = 0
-        `
-      )
-      .run(trashedAt, nowIso(), id);
-    return Number(result.changes ?? 0) > 0;
+    return postRepository.trashPost(id, trashedAt);
   },
 
   restoreFromTrash(id: number): boolean {
-    const result = database
-      .prepare(
-        `
-        UPDATE images
-        SET is_trashed = 0, trashed_at = NULL, updated_at = ?
-        WHERE id = ? AND is_deleted = 0 AND is_trashed = 1
-        `
-      )
-      .run(nowIso(), id);
-    return Number(result.changes ?? 0) > 0;
+    return postRepository.restoreTrashedPost(id);
   },
 
   deleteById(id: number): boolean {
+    const postRes = postRepository.deletePost(id);
     const result = database.prepare('DELETE FROM images WHERE id = ?').run(id);
-    return Number(result.changes ?? 0) > 0;
+    return Number(result.changes ?? 0) > 0 || postRes !== undefined;
   },
 
   listFeed(page: number, limit: number): FeedImage[] {
-    const offset = (page - 1) * limit;
-    return database.prepare(
-      `
-      ${FEED_IMAGE_SELECT_SQL}
-      WHERE ${VISIBLE_IMAGE_WHERE_SQL}
-      ORDER BY images.sort_timestamp DESC, images.id DESC
-      LIMIT ? OFFSET ?
-      `
-    ).all(limit, offset) as unknown as FeedImage[];
+    return postRepository.listFeed(page, limit);
   },
 
   countFeed(): number {
-    return Number(
-      (database.prepare(`SELECT COUNT(*) AS count FROM images WHERE ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL}`).get() as { count: number }).count
-    );
+    return postRepository.countFeed();
+  },
+
+  countVisibleMediaAssets(): number {
+    return postRepository.countVisibleMediaAssets();
+  },
+
+  countVisibleCarousels(): number {
+    return postRepository.countVisibleCarousels();
+  },
+
+  countVisibleSingleVideos(): number {
+    return postRepository.countVisibleSingleVideos();
   },
 
   countVisibleSearch(query: string): number {
-    const mediaSearch = buildMediaSearchSql(query);
-    if (!mediaSearch) {
-      return 0;
-    }
-
-    return Number(
-      (
-        database
-          .prepare(
-            `
-            SELECT COUNT(*) AS count
-            FROM images
-            INNER JOIN folders ON folders.id = images.folder_id
-            WHERE ${VISIBLE_IMAGE_WHERE_SQL} AND ${mediaSearch.whereSql}
-            `
-          )
-          .get(...mediaSearch.whereParams) as { count: number }
-      ).count
-    );
+    return postRepository.countVisibleSearch(query);
   },
 
   listRecentCandidates(offset: number, limit: number): FeedImage[] {
-    return database.prepare(
-      `
-      ${FEED_IMAGE_SELECT_SQL}
-      WHERE ${VISIBLE_IMAGE_WHERE_SQL}
-      ORDER BY ${EFFECTIVE_FEED_TIME_SQL} DESC, images.sort_timestamp DESC, images.id DESC
-      LIMIT ? OFFSET ?
-      `
-    ).all(limit, offset) as unknown as FeedImage[];
+    return postRepository.listRecentCandidates(offset, limit);
   },
 
   countRediscover(cutoffTimestamp: number): number {
-    return Number(
-      (
-        database
-          .prepare(`SELECT COUNT(*) AS count FROM images WHERE ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL} AND ${EFFECTIVE_FEED_TIME_SQL} <= ?`)
-          .get(cutoffTimestamp) as { count: number }
-      ).count
-    );
+    return postRepository.countRediscover(cutoffTimestamp);
   },
 
   listRediscoverCandidates(offset: number, limit: number, cutoffTimestamp: number): FeedImage[] {
-    return database.prepare(
-      `
-      ${FEED_IMAGE_SELECT_SQL}
-      LEFT JOIN likes ON likes.image_id = images.id
-      WHERE ${VISIBLE_IMAGE_WHERE_SQL} AND ${EFFECTIVE_FEED_TIME_SQL} <= ?
-      ORDER BY
-        CASE WHEN likes.image_id IS NULL THEN 0 ELSE 1 END DESC,
-        ${EFFECTIVE_FEED_TIME_SQL} DESC,
-        images.sort_timestamp DESC,
-        images.id DESC
-      LIMIT ? OFFSET ?
-      `
-    ).all(cutoffTimestamp, limit, offset) as unknown as FeedImage[];
+    return postRepository.listRediscoverCandidates(offset, limit, cutoffTimestamp);
   },
 
   listRandom(page: number, limit: number, seed: number): FeedImage[] {
-    const offset = (page - 1) * limit;
-    return database.prepare(
-      `
-      ${FEED_IMAGE_SELECT_SQL}
-      WHERE ${VISIBLE_IMAGE_WHERE_SQL}
-      ORDER BY ABS(((images.id * 1103515245) + (? * 1013904223)) % 2147483647), images.id DESC
-      LIMIT ? OFFSET ?
-      `
-    ).all(seed, limit, offset) as unknown as FeedImage[];
+    return postRepository.listRandom(page, limit, seed);
   },
 
   listVisibleVideoCandidates(): ReelCandidate[] {
+    return postRepository.listVisibleVideoCandidates();
+  },
+
+  listVisibleSearch(query: string, page: number, limit: number): FeedImage[] {
+    return postRepository.listVisibleSearch(query, page, limit);
+  },
+
+  countByMonthDayKeys(monthDayKeys: string[], maxYearExclusive: number): number {
+    return postRepository.countByMonthDayKeys(monthDayKeys, maxYearExclusive);
+  },
+
+  listByMonthDayKeys(monthDayKeys: string[], maxYearExclusive: number, page: number, limit: number): FeedImage[] {
+    return postRepository.listByMonthDayKeys(monthDayKeys, maxYearExclusive, page, limit);
+  },
+
+  countByEffectiveTimeRange(startTimestamp: number, endTimestamp: number): number {
+    return postRepository.countByEffectiveTimeRange(startTimestamp, endTimestamp);
+  },
+
+  listByEffectiveTimeRange(startTimestamp: number, endTimestamp: number, page: number, limit: number): FeedImage[] {
+    return postRepository.listByEffectiveTimeRange(startTimestamp, endTimestamp, page, limit);
+  },
+
+  listFolderImages(
+    folderId: number,
+    page: number,
+    limit: number,
+    mediaType?: MediaType,
+    order: FolderImageOrder = 'newest'
+  ): FeedImage[] {
+    return postRepository.listVisibleByFolder(folderId, page, limit, order, mediaType);
+  },
+
+  listPlaceImages(placeId: number, page: number, limit: number, mediaType?: MediaType): FeedImage[] {
+    const posts = postRepository.listPlacePosts(placeId, page, limit);
+    if (mediaType) {
+      return posts.filter((p) => p.mediaType === mediaType);
+    }
+    return posts;
+  },
+
+  listStoryFolderImages(folderId: number, page: number, limit: number, mediaType?: MediaType): FeedImage[] {
+    const offset = (page - 1) * limit;
+    const mediaTypeClause = mediaType ? ' AND images.media_type = ?' : '';
     return database.prepare(
       `
       SELECT
@@ -1179,206 +2526,15 @@ export const imageRepository = {
         images.playback_strategy AS playbackStrategy,
         images.sort_timestamp AS sortTimestamp,
         images.taken_at AS takenAt,
-        ${IMAGE_SAVED_SELECT_SQL},
+        0 AS isSaved,
         places.id AS placeId,
         places.slug AS placeSlug,
         places.display_name AS placeName,
         places.kind AS placeKind,
-        places.is_approximate AS placeIsApproximate,
-        likes.created_at AS likedAt
+        places.is_approximate AS placeIsApproximate
       FROM images
       INNER JOIN folders ON folders.id = images.folder_id
       LEFT JOIN places ON places.id = images.place_id
-      LEFT JOIN likes ON likes.image_id = images.id
-      WHERE ${VISIBLE_IMAGE_WHERE_SQL} AND images.media_type = 'video'
-      ORDER BY images.sort_timestamp DESC, images.id DESC
-      `
-    ).all() as unknown as ReelCandidate[];
-  },
-
-  listVisibleSearch(query: string, page: number, limit: number): FeedImage[] {
-    const mediaSearch = buildMediaSearchSql(query);
-    if (!mediaSearch) {
-      return [];
-    }
-
-    const offset = (page - 1) * limit;
-    return database.prepare(
-      `
-      SELECT
-        search_results.id,
-        search_results.folderId,
-        search_results.folderSlug,
-        search_results.folderName,
-        search_results.folderPath,
-        search_results.filename,
-        search_results.caption,
-        search_results.width,
-        search_results.height,
-        search_results.mediaType,
-        search_results.durationMs,
-        search_results.isAnimated,
-        search_results.thumbnailUrl,
-        search_results.previewUrl,
-        search_results.playbackStrategy,
-        search_results.sortTimestamp,
-        search_results.takenAt,
-        search_results.isSaved,
-        search_results.placeId,
-        search_results.placeSlug,
-        search_results.placeName,
-        search_results.placeKind,
-        search_results.placeIsApproximate
-      FROM (
-        SELECT
-          images.id,
-          images.folder_id AS folderId,
-          folders.slug AS folderSlug,
-          folders.name AS folderName,
-          folders.folder_path AS folderPath,
-          images.filename,
-          images.caption AS caption,
-          images.width,
-          images.height,
-          images.media_type AS mediaType,
-          images.duration_ms AS durationMs,
-          images.is_animated AS isAnimated,
-          images.thumbnail_path AS thumbnailUrl,
-          images.preview_path AS previewUrl,
-          images.playback_strategy AS playbackStrategy,
-          images.sort_timestamp AS sortTimestamp,
-          images.taken_at AS takenAt,
-          ${IMAGE_SAVED_SELECT_SQL},
-          places.id AS placeId,
-          places.slug AS placeSlug,
-          places.display_name AS placeName,
-          places.kind AS placeKind,
-          places.is_approximate AS placeIsApproximate,
-          (${mediaSearch.rankSql}) AS searchRank
-        FROM images
-        INNER JOIN folders ON folders.id = images.folder_id
-        LEFT JOIN places ON places.id = images.place_id
-        WHERE ${VISIBLE_IMAGE_WHERE_SQL} AND ${mediaSearch.whereSql}
-      ) AS search_results
-      ORDER BY search_results.searchRank DESC, search_results.sortTimestamp DESC, search_results.id DESC
-      LIMIT ? OFFSET ?
-      `
-    ).all(...mediaSearch.rankParams, ...mediaSearch.whereParams, limit, offset) as unknown as FeedImage[];
-  },
-
-  countByMonthDayKeys(monthDayKeys: string[], maxYearExclusive: number): number {
-    if (monthDayKeys.length === 0) {
-      return 0;
-    }
-
-    const placeholders = monthDayKeys.map(() => '?').join(', ');
-    return Number(
-      (
-        database
-          .prepare(
-            `
-            SELECT COUNT(*) AS count
-            FROM images
-            WHERE ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL}
-              AND strftime('%m-%d', ${EFFECTIVE_FEED_TIME_SQL} / 1000, 'unixepoch', 'localtime') IN (${placeholders})
-              AND CAST(strftime('%Y', ${EFFECTIVE_FEED_TIME_SQL} / 1000, 'unixepoch', 'localtime') AS INTEGER) < ?
-            `
-          )
-          .get(...monthDayKeys, maxYearExclusive) as { count: number }
-      ).count
-    );
-  },
-
-  listByMonthDayKeys(monthDayKeys: string[], maxYearExclusive: number, page: number, limit: number): FeedImage[] {
-    if (monthDayKeys.length === 0) {
-      return [];
-    }
-
-    const offset = (page - 1) * limit;
-    const placeholders = monthDayKeys.map(() => '?').join(', ');
-
-    return database.prepare(
-      `
-      ${FEED_IMAGE_SELECT_SQL}
-      WHERE ${VISIBLE_IMAGE_WHERE_SQL}
-        AND strftime('%m-%d', ${EFFECTIVE_FEED_TIME_SQL} / 1000, 'unixepoch', 'localtime') IN (${placeholders})
-        AND CAST(strftime('%Y', ${EFFECTIVE_FEED_TIME_SQL} / 1000, 'unixepoch', 'localtime') AS INTEGER) < ?
-      ORDER BY ${EFFECTIVE_FEED_TIME_SQL} DESC, images.sort_timestamp DESC, images.id DESC
-      LIMIT ? OFFSET ?
-      `
-    ).all(...monthDayKeys, maxYearExclusive, limit, offset) as unknown as FeedImage[];
-  },
-
-  countByEffectiveTimeRange(startTimestamp: number, endTimestamp: number): number {
-    return Number(
-      (
-        database
-          .prepare(
-            `
-            SELECT COUNT(*) AS count
-            FROM images
-            WHERE ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL}
-              AND ${EFFECTIVE_FEED_TIME_SQL} BETWEEN ? AND ?
-            `
-          )
-          .get(startTimestamp, endTimestamp) as { count: number }
-      ).count
-    );
-  },
-
-  listByEffectiveTimeRange(startTimestamp: number, endTimestamp: number, page: number, limit: number): FeedImage[] {
-    const offset = (page - 1) * limit;
-
-    return database.prepare(
-      `
-      ${FEED_IMAGE_SELECT_SQL}
-      WHERE ${VISIBLE_IMAGE_WHERE_SQL}
-        AND ${EFFECTIVE_FEED_TIME_SQL} BETWEEN ? AND ?
-      ORDER BY ${EFFECTIVE_FEED_TIME_SQL} DESC, images.sort_timestamp DESC, images.id DESC
-      LIMIT ? OFFSET ?
-      `
-    ).all(startTimestamp, endTimestamp, limit, offset) as unknown as FeedImage[];
-  },
-
-  listFolderImages(
-    folderId: number,
-    page: number,
-    limit: number,
-    mediaType?: MediaType,
-    order: FolderImageOrder = 'newest'
-  ): FeedImage[] {
-    const offset = (page - 1) * limit;
-    const mediaTypeClause = mediaType ? ' AND images.media_type = ?' : '';
-    const orderBySql = getQualifiedFolderImageOrderSql(order);
-    return database.prepare(
-      `
-      ${FEED_IMAGE_SELECT_SQL}
-      WHERE images.folder_id = ? AND ${VISIBLE_IMAGE_WHERE_SQL}${mediaTypeClause}
-      ORDER BY ${orderBySql}
-      LIMIT ? OFFSET ?
-      `
-    ).all(...(mediaType ? [folderId, mediaType, limit, offset] : [folderId, limit, offset])) as unknown as FeedImage[];
-  },
-
-  listPlaceImages(placeId: number, page: number, limit: number, mediaType?: MediaType): FeedImage[] {
-    const offset = (page - 1) * limit;
-    const mediaTypeClause = mediaType ? ' AND images.media_type = ?' : '';
-    return database.prepare(
-      `
-      ${FEED_IMAGE_SELECT_SQL}
-      WHERE images.place_id = ? AND ${VISIBLE_IMAGE_WHERE_SQL}${mediaTypeClause}
-      ORDER BY images.sort_timestamp DESC, images.id DESC
-      LIMIT ? OFFSET ?
-      `
-    ).all(...(mediaType ? [placeId, mediaType, limit, offset] : [placeId, limit, offset])) as unknown as FeedImage[];
-  },
-
-  listStoryFolderImages(folderId: number, page: number, limit: number, mediaType?: MediaType): FeedImage[] {
-    const offset = (page - 1) * limit;
-    const mediaTypeClause = mediaType ? ' AND images.media_type = ?' : '';
-    return database.prepare(
-      `
-      ${FEED_IMAGE_SELECT_SQL}
       WHERE images.folder_id = ? AND ${STORY_IMAGE_WHERE_SQL}${mediaTypeClause}
       ORDER BY images.sort_timestamp DESC, images.id DESC
       LIMIT ? OFFSET ?
@@ -1391,20 +2547,6 @@ export const imageRepository = {
     const mediaTypeClause = mediaType ? ' AND images.media_type = ?' : '';
     return database.prepare(
       `
-      ${FEED_IMAGE_SELECT_SQL}
-      WHERE folders.story_owner_folder_id = ?
-        AND folders.role = 'story_capsule'
-        AND ${STORY_IMAGE_WHERE_SQL}${mediaTypeClause}
-      ORDER BY ${EFFECTIVE_FEED_TIME_SQL} DESC, images.sort_timestamp DESC, images.id DESC
-      LIMIT ? OFFSET ?
-      `
-    ).all(...(mediaType ? [ownerFolderId, mediaType, limit, offset] : [ownerFolderId, limit, offset])) as unknown as FeedImage[];
-  },
-
-  listTrashed(page: number, limit: number): TrashImage[] {
-    const offset = (page - 1) * limit;
-    return database.prepare(
-      `
       SELECT
         images.id,
         images.folder_id AS folderId,
@@ -1423,8 +2565,7 @@ export const imageRepository = {
         images.playback_strategy AS playbackStrategy,
         images.sort_timestamp AS sortTimestamp,
         images.taken_at AS takenAt,
-        ${IMAGE_SAVED_SELECT_SQL},
-        images.trashed_at AS trashedAt,
+        0 AS isSaved,
         places.id AS placeId,
         places.slug AS placeSlug,
         places.display_name AS placeName,
@@ -1433,17 +2574,21 @@ export const imageRepository = {
       FROM images
       INNER JOIN folders ON folders.id = images.folder_id
       LEFT JOIN places ON places.id = images.place_id
-      WHERE images.is_deleted = 0 AND images.is_trashed = 1
-      ORDER BY images.trashed_at DESC, images.id DESC
+      WHERE folders.story_owner_folder_id = ?
+        AND folders.role = 'story_capsule'
+        AND ${STORY_IMAGE_WHERE_SQL}${mediaTypeClause}
+      ORDER BY ${EFFECTIVE_IMAGE_FEED_TIME_SQL} DESC, images.sort_timestamp DESC, images.id DESC
       LIMIT ? OFFSET ?
       `
-    ).all(limit, offset) as unknown as TrashImage[];
+    ).all(...(mediaType ? [ownerFolderId, mediaType, limit, offset] : [ownerFolderId, limit, offset])) as unknown as FeedImage[];
+  },
+
+  listTrashed(page: number, limit: number): TrashImage[] {
+    return postRepository.listTrashed(page, limit);
   },
 
   countTrashed(): number {
-    return Number(
-      (database.prepare('SELECT COUNT(*) AS count FROM images WHERE is_deleted = 0 AND is_trashed = 1').get() as { count: number }).count
-    );
+    return postRepository.countTrashed();
   },
 
   countByFolder(folderId: number, mediaType?: MediaType): number {
@@ -1458,14 +2603,7 @@ export const imageRepository = {
   },
 
   countVisibleByFolder(folderId: number, mediaType?: MediaType): number {
-    const mediaTypeClause = mediaType ? ' AND media_type = ?' : '';
-    return Number(
-      (
-        database
-          .prepare(`SELECT COUNT(*) AS count FROM images WHERE folder_id = ? AND ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL}${mediaTypeClause}`)
-          .get(...(mediaType ? [folderId, mediaType] : [folderId])) as { count: number }
-      ).count
-    );
+    return postRepository.countVisibleByFolder(folderId, mediaType);
   },
 
   countStoryMediaByFolder(folderId: number, mediaType?: MediaType): number {
@@ -1502,6 +2640,12 @@ export const imageRepository = {
   listActiveByFolder(folderId: number): ImageRecord[] {
     return database
       .prepare('SELECT * FROM images WHERE folder_id = ? AND is_deleted = 0 ORDER BY id ASC')
+      .all(folderId) as unknown as ImageRecord[];
+  },
+
+  listForFolderDeletion(folderId: number): ImageRecord[] {
+    return database
+      .prepare('SELECT * FROM images WHERE folder_id = ? ORDER BY id ASC')
       .all(folderId) as unknown as ImageRecord[];
   },
 
@@ -1627,9 +2771,18 @@ export const imageRepository = {
 
   getLatestFolderImageId(folderId: number): number | null {
     const row = database.prepare(
+      `SELECT pi.image_id
+       FROM posts p
+       JOIN post_items pi ON pi.post_id = p.id AND pi.position = 1
+       WHERE p.folder_id = ? AND p.is_deleted = 0 AND p.is_trashed = 0
+       ORDER BY p.sort_timestamp DESC, p.id DESC LIMIT 1`
+    ).get(folderId) as { image_id: number } | undefined;
+    if (row) return row.image_id;
+
+    const imgRow = database.prepare(
       `SELECT id FROM images WHERE folder_id = ? AND ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL} ORDER BY sort_timestamp DESC, id DESC LIMIT 1`
     ).get(folderId) as { id: number } | undefined;
-    return row?.id ?? null;
+    return imgRow?.id ?? null;
   },
 
   getLatestStoryImageId(folderId: number): number | null {
@@ -1679,93 +2832,7 @@ export const imageRepository = {
     allowHiddenCover = false,
     folderImageOrder: FolderImageOrder = 'newest'
   ): ImageDetail | undefined {
-    const whereClause = allowHiddenCover ? 'images.is_deleted = 0 AND images.is_trashed = 0' : VISIBLE_IMAGE_WHERE_SQL;
-    const nextComparisonSql = folderImageOrder === 'oldest'
-      ? '(sort_timestamp > ? OR (sort_timestamp = ? AND id > ?))'
-      : '(sort_timestamp < ? OR (sort_timestamp = ? AND id < ?))';
-    const previousComparisonSql = folderImageOrder === 'oldest'
-      ? '(sort_timestamp < ? OR (sort_timestamp = ? AND id < ?))'
-      : '(sort_timestamp > ? OR (sort_timestamp = ? AND id > ?))';
-    const nextOrderSql = getUnscopedFolderImageOrderSql(folderImageOrder);
-    const previousOrderSql = getUnscopedFolderImageOrderSql(folderImageOrder === 'oldest' ? 'newest' : 'oldest');
-    const detail = database.prepare(
-      `
-      SELECT
-        images.id,
-        images.folder_id AS folderId,
-        folders.slug AS folderSlug,
-        folders.name AS folderName,
-        folders.folder_path AS folderPath,
-        folders.avatar_image_id AS folderAvatarImageId,
-        images.filename,
-        images.caption AS caption,
-        images.width,
-        images.height,
-        images.media_type AS mediaType,
-        images.duration_ms AS durationMs,
-        images.is_animated AS isAnimated,
-        images.relative_path AS relativePath,
-        images.mime_type AS mimeType,
-        images.file_size AS fileSize,
-        images.thumbnail_path AS thumbnailUrl,
-        images.preview_path AS previewUrl,
-        images.playback_strategy AS playbackStrategy,
-        images.exif_json AS exifJson,
-        images.absolute_path AS originalUrl,
-        images.sort_timestamp AS sortTimestamp,
-        images.taken_at AS takenAt,
-        ${IMAGE_SAVED_SELECT_SQL},
-        places.id AS placeId,
-        places.slug AS placeSlug,
-        places.display_name AS placeName,
-        places.kind AS placeKind,
-        places.is_approximate AS placeIsApproximate
-      FROM images
-      INNER JOIN folders ON folders.id = images.folder_id
-      LEFT JOIN places ON places.id = images.place_id
-      WHERE images.id = ? AND ${whereClause}
-      `
-    ).get(id) as (Omit<ImageDetail, 'nextImageId' | 'previousImageId' | 'exif'> & { originalUrl: string; exifJson: string | null }) | undefined;
-
-    if (!detail || (mediaType && detail.mediaType !== mediaType)) {
-      return undefined;
-    }
-
-    const mediaTypeClause = mediaType ? ' AND media_type = ?' : '';
-    const next = database.prepare(
-      `
-      SELECT id
-      FROM images
-      WHERE folder_id = ? AND ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL}
-        ${mediaTypeClause}
-        AND ${nextComparisonSql}
-      ORDER BY ${nextOrderSql}
-      LIMIT 1
-      `
-    ).get(...(mediaType
-      ? [detail.folderId, mediaType, detail.sortTimestamp, detail.sortTimestamp, detail.id]
-      : [detail.folderId, detail.sortTimestamp, detail.sortTimestamp, detail.id])) as { id: number } | undefined;
-
-    const previous = database.prepare(
-      `
-      SELECT id
-      FROM images
-      WHERE folder_id = ? AND ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL}
-        ${mediaTypeClause}
-        AND ${previousComparisonSql}
-      ORDER BY ${previousOrderSql}
-      LIMIT 1
-      `
-    ).get(...(mediaType
-      ? [detail.folderId, mediaType, detail.sortTimestamp, detail.sortTimestamp, detail.id]
-      : [detail.folderId, detail.sortTimestamp, detail.sortTimestamp, detail.id])) as { id: number } | undefined;
-
-    return {
-      ...detail,
-      exif: null,
-      nextImageId: next?.id ?? null,
-      previousImageId: previous?.id ?? null
-    };
+    return postRepository.getPostDetail(id, folderImageOrder) as ImageDetail | undefined;
   },
 
   countDeleted(): number {
@@ -1798,94 +2865,29 @@ export const imageRepository = {
       ORDER BY id ASC
       `
     ).all(cutoffIso) as Array<Pick<ImageRecord, 'id' | 'thumbnail_path' | 'preview_path'>>;
-  },
-
-  listAllDerivativePaths(): Array<Pick<ImageRecord, 'thumbnail_path' | 'preview_path'>> {
-    return database.prepare('SELECT thumbnail_path, preview_path FROM images').all() as Array<Pick<ImageRecord, 'thumbnail_path' | 'preview_path'>>;
-  },
-
-  listDerivativeReferences(): Array<Pick<ImageRecord, 'thumbnail_path' | 'preview_path' | 'is_deleted' | 'deleted_at'>> {
-    return database
-      .prepare('SELECT thumbnail_path, preview_path, is_deleted, deleted_at FROM images')
-      .all() as Array<Pick<ImageRecord, 'thumbnail_path' | 'preview_path' | 'is_deleted' | 'deleted_at'>>;
-  },
-
-  countByMediaType(mediaType: MediaType): number {
-    return Number(
-      (
-        database
-          .prepare(`SELECT COUNT(*) AS count FROM images WHERE ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL} AND media_type = ?`)
-          .get(mediaType) as { count: number }
-      ).count
-    );
-  },
-
-  countWithThumbnail(): number {
-    return Number(
-      (
-        database
-          .prepare(`SELECT COUNT(*) AS count FROM images WHERE ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL} AND thumbnail_path IS NOT NULL`)
-          .get() as { count: number }
-      ).count
-    );
-  },
-
-  countWithPreview(): number {
-    return Number(
-      (
-        database
-          .prepare(`SELECT COUNT(*) AS count FROM images WHERE ${VISIBLE_IMAGE_WHERE_UNSCOPED_SQL} AND preview_path IS NOT NULL`)
-          .get() as { count: number }
-      ).count
-    );
-  },
-
-  getByThumbnailPath(thumbnailPath: string): ImageRecord | undefined {
-    return database.prepare('SELECT * FROM images WHERE thumbnail_path = ? AND is_deleted = 0 LIMIT 1').get(thumbnailPath) as ImageRecord | undefined;
-  },
-
-  getByPreviewPath(previewPath: string): ImageRecord | undefined {
-    return database.prepare('SELECT * FROM images WHERE preview_path = ? AND is_deleted = 0 LIMIT 1').get(previewPath) as ImageRecord | undefined;
   }
 };
 
 export const likeRepository = {
+  listAll(): LikeRecord[] {
+    return database.prepare('SELECT post_id, post_id AS image_id, created_at FROM likes ORDER BY created_at DESC, post_id DESC').all() as unknown as LikeRecord[];
+  },
+
+  listAllLikes(): LikeRecord[] {
+    return this.listAll();
+  },
+
   getByImageId(imageId: number): LikeRecord | undefined {
-    return database.prepare('SELECT * FROM likes WHERE image_id = ?').get(imageId) as LikeRecord | undefined;
+    const postId = resolvePostIdByImageId(imageId);
+    if (!postId) return undefined;
+    return database.prepare('SELECT post_id, post_id AS image_id, created_at FROM likes WHERE post_id = ?').get(postId) as LikeRecord | undefined;
   },
 
-  listLikedImages(): FeedImage[] {
-    return database.prepare(
-      `
-      SELECT
-        images.id,
-        images.folder_id AS folderId,
-        folders.slug AS folderSlug,
-        folders.name AS folderName,
-        folders.folder_path AS folderPath,
-        images.filename,
-        images.caption AS caption,
-        images.width,
-        images.height,
-        images.media_type AS mediaType,
-        images.duration_ms AS durationMs,
-        images.is_animated AS isAnimated,
-        images.thumbnail_path AS thumbnailUrl,
-        images.preview_path AS previewUrl,
-        images.playback_strategy AS playbackStrategy,
-        images.sort_timestamp AS sortTimestamp,
-        images.taken_at AS takenAt,
-        ${IMAGE_SAVED_SELECT_SQL}
-      FROM likes
-      INNER JOIN images ON images.id = likes.image_id
-      INNER JOIN folders ON folders.id = images.folder_id
-      WHERE ${VISIBLE_IMAGE_WHERE_SQL}
-      ORDER BY likes.created_at DESC, likes.image_id DESC
-      `
-    ).all() as unknown as FeedImage[];
+  getByPostId(postId: number): LikeRecord | undefined {
+    return database.prepare('SELECT post_id, post_id AS image_id, created_at FROM likes WHERE post_id = ?').get(postId) as LikeRecord | undefined;
   },
 
-  countLikedOlderThan(cutoffTimestamp: number): number {
+  count(): number {
     return Number(
       (
         database
@@ -1893,29 +2895,30 @@ export const likeRepository = {
             `
             SELECT COUNT(*) AS count
             FROM likes
-            INNER JOIN images ON images.id = likes.image_id
-            INNER JOIN folders ON folders.id = images.folder_id
-            WHERE ${VISIBLE_IMAGE_WHERE_SQL} AND ${EFFECTIVE_FEED_TIME_SQL} <= ?
+            INNER JOIN posts ON posts.id = likes.post_id
+            INNER JOIN folders ON folders.id = posts.folder_id
+            WHERE ${VISIBLE_POST_WHERE_SQL}
             `
           )
-          .get(cutoffTimestamp) as { count: number }
+          .get() as { count: number }
       ).count
     );
   },
 
-  listLikedOlderThan(page: number, limit: number, cutoffTimestamp: number): FeedImage[] {
+  listLikedImages(page: number = 1, limit: number = 1000): FeedImage[] {
     const offset = (page - 1) * limit;
-
-    return database.prepare(
+    const posts = database.prepare(
       `
       SELECT
-        images.id,
-        images.folder_id AS folderId,
+        posts.id,
+        posts.folder_id AS folderId,
         folders.slug AS folderSlug,
         folders.name AS folderName,
         folders.folder_path AS folderPath,
         images.filename,
-        images.caption AS caption,
+        posts.caption AS caption,
+        posts.post_type AS postType,
+        posts.source_path AS sourcePath,
         images.width,
         images.height,
         images.media_type AS mediaType,
@@ -1924,40 +2927,140 @@ export const likeRepository = {
         images.thumbnail_path AS thumbnailUrl,
         images.preview_path AS previewUrl,
         images.playback_strategy AS playbackStrategy,
-        images.sort_timestamp AS sortTimestamp,
-        images.taken_at AS takenAt,
-        ${IMAGE_SAVED_SELECT_SQL}
+        posts.sort_timestamp AS sortTimestamp,
+        posts.taken_at AS takenAt,
+        1 AS isSaved,
+        places.id AS placeId,
+        places.slug AS placeSlug,
+        places.display_name AS placeName,
+        places.kind AS placeKind,
+        places.is_approximate AS placeIsApproximate
       FROM likes
-      INNER JOIN images ON images.id = likes.image_id
-      INNER JOIN folders ON folders.id = images.folder_id
-      WHERE ${VISIBLE_IMAGE_WHERE_SQL} AND ${EFFECTIVE_FEED_TIME_SQL} <= ?
-      ORDER BY likes.created_at DESC, likes.image_id DESC
+      INNER JOIN posts ON posts.id = likes.post_id
+      INNER JOIN folders ON folders.id = posts.folder_id
+      JOIN post_items ON post_items.post_id = posts.id AND post_items.position = 1
+      JOIN images ON images.id = post_items.image_id
+      LEFT JOIN places ON places.id = posts.place_id
+      WHERE ${VISIBLE_POST_WHERE_SQL}
+      ORDER BY likes.created_at DESC, likes.post_id DESC
       LIMIT ? OFFSET ?
       `
-    ).all(cutoffTimestamp, limit, offset) as unknown as FeedImage[];
+    ).all(limit, offset) as unknown as FeedPost[];
+
+    return postRepository.hydratePostItems(posts);
   },
 
-  upsert(imageId: number): LikeRecord {
+  listLikedOlderThan(page: number, limit: number, cutoffTimestamp: number): FeedImage[] {
+    const offset = (page - 1) * limit;
+    const posts = database.prepare(
+      `
+      SELECT
+        posts.id,
+        posts.folder_id AS folderId,
+        folders.slug AS folderSlug,
+        folders.name AS folderName,
+        folders.folder_path AS folderPath,
+        images.filename,
+        posts.caption AS caption,
+        posts.post_type AS postType,
+        posts.source_path AS sourcePath,
+        images.width,
+        images.height,
+        images.media_type AS mediaType,
+        images.duration_ms AS durationMs,
+        images.is_animated AS isAnimated,
+        images.thumbnail_path AS thumbnailUrl,
+        images.preview_path AS previewUrl,
+        images.playback_strategy AS playbackStrategy,
+        posts.sort_timestamp AS sortTimestamp,
+        posts.taken_at AS takenAt,
+        1 AS isSaved,
+        places.id AS placeId,
+        places.slug AS placeSlug,
+        places.display_name AS placeName,
+        places.kind AS placeKind,
+        places.is_approximate AS placeIsApproximate
+      FROM likes
+      INNER JOIN posts ON posts.id = likes.post_id
+      INNER JOIN folders ON folders.id = posts.folder_id
+      JOIN post_items ON post_items.post_id = posts.id AND post_items.position = 1
+      JOIN images ON images.id = post_items.image_id
+      LEFT JOIN places ON places.id = posts.place_id
+      WHERE ${VISIBLE_POST_WHERE_SQL} AND ${EFFECTIVE_FEED_TIME_SQL} <= ?
+      ORDER BY likes.created_at DESC, likes.post_id DESC
+      LIMIT ? OFFSET ?
+      `
+    ).all(cutoffTimestamp, limit, offset) as unknown as FeedPost[];
+
+    return postRepository.hydratePostItems(posts);
+  },
+
+  listRecentCandidates(offset: number, limit: number, cutoffTimestamp: number): FeedImage[] {
+    const posts = database.prepare(
+      `
+      SELECT
+        posts.id,
+        posts.folder_id AS folderId,
+        folders.slug AS folderSlug,
+        folders.name AS folderName,
+        folders.folder_path AS folderPath,
+        images.filename,
+        posts.caption AS caption,
+        posts.post_type AS postType,
+        posts.source_path AS sourcePath,
+        images.width,
+        images.height,
+        images.media_type AS mediaType,
+        images.duration_ms AS durationMs,
+        images.is_animated AS isAnimated,
+        images.thumbnail_path AS thumbnailUrl,
+        images.preview_path AS previewUrl,
+        images.playback_strategy AS playbackStrategy,
+        posts.sort_timestamp AS sortTimestamp,
+        posts.taken_at AS takenAt,
+        1 AS isSaved,
+        places.id AS placeId,
+        places.slug AS placeSlug,
+        places.display_name AS placeName,
+        places.kind AS placeKind,
+        places.is_approximate AS placeIsApproximate
+      FROM likes
+      INNER JOIN posts ON posts.id = likes.post_id
+      INNER JOIN folders ON folders.id = posts.folder_id
+      JOIN post_items ON post_items.post_id = posts.id AND post_items.position = 1
+      JOIN images ON images.id = post_items.image_id
+      LEFT JOIN places ON places.id = posts.place_id
+      WHERE ${VISIBLE_POST_WHERE_SQL} AND ${EFFECTIVE_FEED_TIME_SQL} <= ?
+      ORDER BY likes.created_at DESC, likes.post_id DESC
+      LIMIT ? OFFSET ?
+      `
+    ).all(cutoffTimestamp, limit, offset) as unknown as FeedPost[];
+
+    return postRepository.hydratePostItems(posts);
+  },
+
+  upsert(postId: number): LikeRecord {
+    const createdAt = nowIso();
     database.prepare(
       `
-      INSERT INTO likes (image_id, created_at)
+      INSERT INTO likes (post_id, created_at)
       VALUES (?, ?)
-      ON CONFLICT(image_id) DO UPDATE SET
+      ON CONFLICT(post_id) DO UPDATE SET
         created_at = excluded.created_at
       `
-    ).run(imageId, nowIso());
+    ).run(postId, createdAt);
 
-    return this.getByImageId(imageId) as LikeRecord;
+    return (this.getByPostId(postId) ?? { post_id: postId, image_id: postId, created_at: createdAt }) as LikeRecord;
   },
 
-  remove(imageId: number): boolean {
-    const result = database.prepare('DELETE FROM likes WHERE image_id = ?').run(imageId);
+  remove(postId: number): boolean {
+    const result = database.prepare('DELETE FROM likes WHERE post_id = ?').run(postId);
     return Number(result.changes ?? 0) > 0;
   },
 
   removeByFolder(folderId: number): number {
     const result = database.prepare(
-      'DELETE FROM likes WHERE image_id IN (SELECT id FROM images WHERE folder_id = ?)'
+      'DELETE FROM likes WHERE post_id IN (SELECT id FROM posts WHERE folder_id = ?)'
     ).run(folderId);
     return Number(result.changes ?? 0);
   }
@@ -2003,14 +3106,14 @@ export const collectionRepository = {
     const result = database
       .prepare(
         `
-        INSERT OR IGNORE INTO collection_items (collection_id, image_id, created_at)
-        SELECT ?, custom_items.image_id, ?
+        INSERT OR IGNORE INTO collection_items (collection_id, post_id, created_at)
+        SELECT ?, custom_items.post_id, ?
         FROM collection_items AS custom_items
         INNER JOIN collections AS custom_collections ON custom_collections.id = custom_items.collection_id
         LEFT JOIN collection_items AS default_items
-          ON default_items.collection_id = ? AND default_items.image_id = custom_items.image_id
+          ON default_items.collection_id = ? AND default_items.post_id = custom_items.post_id
         WHERE custom_collections.is_default = 0
-          AND default_items.image_id IS NULL
+          AND default_items.post_id IS NULL
         `
       )
       .run(defaultCollection.id, timestamp, defaultCollection.id);
@@ -2091,40 +3194,59 @@ export const collectionRepository = {
           (
             SELECT COUNT(*)
             FROM collection_items
-            INNER JOIN images ON images.id = collection_items.image_id
-            INNER JOIN folders ON folders.id = images.folder_id
-            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
+            INNER JOIN posts ON posts.id = collection_items.post_id
+            JOIN post_items pi ON pi.post_id = posts.id AND pi.position = 1
+            JOIN images ON images.id = pi.image_id
+            INNER JOIN folders ON folders.id = posts.folder_id
+            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_POST_WHERE_SQL}
           ) AS item_count,
           (
-            SELECT images.id
+            SELECT pi.image_id
             FROM collection_items
-            INNER JOIN images ON images.id = collection_items.image_id
-            INNER JOIN folders ON folders.id = images.folder_id
-            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
-            ORDER BY collection_items.created_at DESC, collection_items.image_id DESC
+            INNER JOIN posts ON posts.id = collection_items.post_id
+            JOIN post_items pi ON pi.post_id = posts.id AND pi.position = 1
+            JOIN images ON images.id = pi.image_id
+            INNER JOIN folders ON folders.id = posts.folder_id
+            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_POST_WHERE_SQL}
+            ORDER BY collection_items.created_at DESC, collection_items.post_id DESC
             LIMIT 1
           ) AS cover_image_id,
           (
             SELECT images.thumbnail_path
             FROM collection_items
-            INNER JOIN images ON images.id = collection_items.image_id
-            INNER JOIN folders ON folders.id = images.folder_id
-            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
-            ORDER BY collection_items.created_at DESC, collection_items.image_id DESC
+            INNER JOIN posts ON posts.id = collection_items.post_id
+            JOIN post_items pi ON pi.post_id = posts.id AND pi.position = 1
+            JOIN images ON images.id = pi.image_id
+            INNER JOIN folders ON folders.id = posts.folder_id
+            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_POST_WHERE_SQL}
+            ORDER BY collection_items.created_at DESC, collection_items.post_id DESC
             LIMIT 1
           ) AS cover_thumbnail_path,
           (
             SELECT GROUP_CONCAT(preview_images.image_id)
             FROM (
-              SELECT collection_items.image_id
+              SELECT pi.image_id
               FROM collection_items
-              INNER JOIN images ON images.id = collection_items.image_id
-              INNER JOIN folders ON folders.id = images.folder_id
-              WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
-              ORDER BY collection_items.created_at DESC, collection_items.image_id DESC
+              INNER JOIN posts ON posts.id = collection_items.post_id
+              JOIN post_items pi ON pi.post_id = posts.id AND pi.position = 1
+              JOIN images ON images.id = pi.image_id
+              INNER JOIN folders ON folders.id = posts.folder_id
+              WHERE collection_items.collection_id = collections.id AND ${VISIBLE_POST_WHERE_SQL}
+              ORDER BY collection_items.created_at DESC, collection_items.post_id DESC
               LIMIT 4
             ) AS preview_images
-          ) AS preview_image_ids
+          ) AS preview_image_ids,
+          (
+            SELECT collection_items.post_id
+            FROM collection_items
+            INNER JOIN posts ON posts.id = collection_items.post_id
+            JOIN post_items pi ON pi.post_id = posts.id AND pi.position = 1
+            JOIN images ON images.id = pi.image_id
+            INNER JOIN folders ON folders.id = posts.folder_id
+            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_POST_WHERE_SQL}
+            ORDER BY collection_items.created_at DESC, collection_items.post_id DESC
+            LIMIT 1
+          ) AS cover_post_id
         FROM collections
         ORDER BY collections.is_default DESC, collections.updated_at DESC, collections.id DESC
         `
@@ -2132,7 +3254,7 @@ export const collectionRepository = {
       .all() as unknown as CollectionSummaryRecord[];
   },
 
-  listMembershipsForImage(imageId: number): CollectionMembershipRecord[] {
+  listMembershipsForImage(postId: number): CollectionMembershipRecord[] {
     this.ensureDefaultCollection();
     return database
       .prepare(
@@ -2142,72 +3264,80 @@ export const collectionRepository = {
           (
             SELECT COUNT(*)
             FROM collection_items
-            INNER JOIN images ON images.id = collection_items.image_id
-            INNER JOIN folders ON folders.id = images.folder_id
-            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
+            INNER JOIN posts ON posts.id = collection_items.post_id
+            JOIN post_items pi ON pi.post_id = posts.id AND pi.position = 1
+            JOIN images ON images.id = pi.image_id
+            INNER JOIN folders ON folders.id = posts.folder_id
+            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_POST_WHERE_SQL}
           ) AS item_count,
           (
-            SELECT images.id
+            SELECT pi.image_id
             FROM collection_items
-            INNER JOIN images ON images.id = collection_items.image_id
-            INNER JOIN folders ON folders.id = images.folder_id
-            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
-            ORDER BY collection_items.created_at DESC, collection_items.image_id DESC
+            INNER JOIN posts ON posts.id = collection_items.post_id
+            JOIN post_items pi ON pi.post_id = posts.id AND pi.position = 1
+            JOIN images ON images.id = pi.image_id
+            INNER JOIN folders ON folders.id = posts.folder_id
+            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_POST_WHERE_SQL}
+            ORDER BY collection_items.created_at DESC, collection_items.post_id DESC
             LIMIT 1
           ) AS cover_image_id,
           (
             SELECT images.thumbnail_path
             FROM collection_items
-            INNER JOIN images ON images.id = collection_items.image_id
-            INNER JOIN folders ON folders.id = images.folder_id
-            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
-            ORDER BY collection_items.created_at DESC, collection_items.image_id DESC
+            INNER JOIN posts ON posts.id = collection_items.post_id
+            JOIN post_items pi ON pi.post_id = posts.id AND pi.position = 1
+            JOIN images ON images.id = pi.image_id
+            INNER JOIN folders ON folders.id = posts.folder_id
+            WHERE collection_items.collection_id = collections.id AND ${VISIBLE_POST_WHERE_SQL}
+            ORDER BY collection_items.created_at DESC, collection_items.post_id DESC
             LIMIT 1
           ) AS cover_thumbnail_path,
           (
             SELECT GROUP_CONCAT(preview_images.image_id)
             FROM (
-              SELECT collection_items.image_id
+              SELECT pi.image_id
               FROM collection_items
-              INNER JOIN images ON images.id = collection_items.image_id
-              INNER JOIN folders ON folders.id = images.folder_id
-              WHERE collection_items.collection_id = collections.id AND ${VISIBLE_IMAGE_WHERE_SQL}
-              ORDER BY collection_items.created_at DESC, collection_items.image_id DESC
+              INNER JOIN posts ON posts.id = collection_items.post_id
+              JOIN post_items pi ON pi.post_id = posts.id AND pi.position = 1
+              JOIN images ON images.id = pi.image_id
+              INNER JOIN folders ON folders.id = posts.folder_id
+              WHERE collection_items.collection_id = collections.id AND ${VISIBLE_POST_WHERE_SQL}
+              ORDER BY collection_items.created_at DESC, collection_items.post_id DESC
               LIMIT 4
             ) AS preview_images
           ) AS preview_image_ids,
-          CASE WHEN EXISTS (
-            SELECT 1
-            FROM collection_items
-            WHERE collection_items.collection_id = collections.id
-              AND collection_items.image_id = ?
-          ) THEN 1 ELSE 0 END AS contains_image
+          (
+            CASE WHEN EXISTS (
+              SELECT 1
+              FROM collection_items
+              WHERE collection_items.collection_id = collections.id
+                AND collection_items.post_id = ?
+            ) THEN 1 ELSE 0 END
+          ) AS contains_image,
+          (
+            CASE WHEN EXISTS (
+              SELECT 1
+              FROM collection_items
+              WHERE collection_items.collection_id = collections.id
+                AND collection_items.post_id = ?
+            ) THEN 1 ELSE 0 END
+          ) AS contains_post
         FROM collections
         ORDER BY collections.is_default DESC, collections.updated_at DESC, collections.id DESC
         `
       )
-      .all(imageId) as unknown as CollectionMembershipRecord[];
+      .all(postId, postId) as unknown as CollectionMembershipRecord[];
   },
 
-  listImages(slug: string, page: number, limit: number): FeedImage[] {
-    this.ensureDefaultCollection();
-    const offset = (page - 1) * limit;
-    return database
-      .prepare(
-        `
-        ${FEED_IMAGE_SELECT_SQL}
-        INNER JOIN collection_items ON collection_items.image_id = images.id
-        INNER JOIN collections ON collections.id = collection_items.collection_id
-        WHERE collections.slug = ? AND ${VISIBLE_IMAGE_WHERE_SQL}
-        ORDER BY collection_items.created_at DESC, collection_items.image_id DESC
-        LIMIT ? OFFSET ?
-        `
-      )
-      .all(slug, limit, offset) as unknown as FeedImage[];
+  getSummaryBySlug(slug: string): CollectionSummaryRecord | undefined {
+    return this.listSummaries().find((item) => item.slug === slug);
   },
 
   countImages(slug: string): number {
-    this.ensureDefaultCollection();
+    const collection = this.getBySlug(slug);
+    if (!collection) {
+      return 0;
+    }
     return Number(
       (
         database
@@ -2215,154 +3345,185 @@ export const collectionRepository = {
             `
             SELECT COUNT(*) AS count
             FROM collection_items
-            INNER JOIN collections ON collections.id = collection_items.collection_id
-            INNER JOIN images ON images.id = collection_items.image_id
-            INNER JOIN folders ON folders.id = images.folder_id
-            WHERE collections.slug = ? AND ${VISIBLE_IMAGE_WHERE_SQL}
+            INNER JOIN posts ON posts.id = collection_items.post_id
+            JOIN post_items pi ON pi.post_id = posts.id AND pi.position = 1
+            JOIN images ON images.id = pi.image_id
+            INNER JOIN folders ON folders.id = posts.folder_id
+            WHERE collection_items.collection_id = ? AND ${VISIBLE_POST_WHERE_SQL}
             `
           )
-          .get(slug) as { count: number }
+          .get(collection.id) as { count: number }
       ).count
     );
   },
 
-  isImageSaved(imageId: number): boolean {
-    this.ensureDefaultCollection();
-    const row = database
-      .prepare(
-        `
-        SELECT 1 AS found
-        FROM collection_items
-        INNER JOIN collections ON collections.id = collection_items.collection_id
-        WHERE collections.is_default = 1 AND collection_items.image_id = ?
-        LIMIT 1
-        `
-      )
-      .get(imageId) as { found: number } | undefined;
-    return row?.found === 1;
+  listCollectionImages(slug: string, page: number, limit: number): FeedPost[] {
+    const collection = this.getBySlug(slug);
+    if (!collection) {
+      return [];
+    }
+
+    const offset = (page - 1) * limit;
+    const posts = database.prepare(
+      `
+      SELECT
+        posts.id,
+        posts.folder_id AS folderId,
+        folders.slug AS folderSlug,
+        folders.name AS folderName,
+        folders.folder_path AS folderPath,
+        images.filename,
+        posts.caption AS caption,
+        posts.post_type AS postType,
+        posts.source_path AS sourcePath,
+        images.width,
+        images.height,
+        images.media_type AS mediaType,
+        images.duration_ms AS durationMs,
+        images.is_animated AS isAnimated,
+        images.thumbnail_path AS thumbnailUrl,
+        images.preview_path AS previewUrl,
+        images.playback_strategy AS playbackStrategy,
+        posts.sort_timestamp AS sortTimestamp,
+        posts.taken_at AS takenAt,
+        1 AS isSaved,
+        places.id AS placeId,
+        places.slug AS placeSlug,
+        places.display_name AS placeName,
+        places.kind AS placeKind,
+        places.is_approximate AS placeIsApproximate
+      FROM collection_items
+      INNER JOIN posts ON posts.id = collection_items.post_id
+      INNER JOIN folders ON folders.id = posts.folder_id
+      JOIN post_items ON post_items.post_id = posts.id AND post_items.position = 1
+      JOIN images ON images.id = post_items.image_id
+      LEFT JOIN places ON places.id = posts.place_id
+      WHERE collection_items.collection_id = ? AND ${VISIBLE_POST_WHERE_SQL}
+      ORDER BY collection_items.created_at DESC, collection_items.post_id DESC
+      LIMIT ? OFFSET ?
+      `
+    ).all(collection.id, limit, offset) as unknown as FeedPost[];
+
+    return postRepository.hydratePostItems(posts);
   },
 
-  saveToDefault(imageId: number): CollectionRecord {
+  listImages(slug: string, page: number, limit: number): FeedPost[] {
+    return this.listCollectionImages(slug, page, limit);
+  },
+
+  isImageSaved(postId: number): boolean {
     const defaultCollection = this.ensureDefaultCollection();
-    const timestamp = nowIso();
-
-    database
-      .prepare(
-        `
-        INSERT INTO collection_items (collection_id, image_id, created_at)
-        VALUES (?, ?, ?)
-        ON CONFLICT(collection_id, image_id) DO UPDATE SET
-          created_at = excluded.created_at
-        `
-      )
-      .run(defaultCollection.id, imageId, timestamp);
-    database.prepare('UPDATE collections SET updated_at = ? WHERE id = ?').run(timestamp, defaultCollection.id);
-
-    return this.getById(defaultCollection.id) as CollectionRecord;
+    return Number(
+      (
+        database
+          .prepare('SELECT COUNT(*) AS count FROM collection_items WHERE collection_id = ? AND post_id = ?')
+          .get(defaultCollection.id, postId) as { count: number }
+      ).count
+    ) > 0;
   },
 
-  unsaveEverywhere(imageId: number): void {
-    const timestamp = nowIso();
-    database
-      .prepare(
-        `
-        UPDATE collections
-        SET updated_at = ?
-        WHERE id IN (
-          SELECT collection_id
-          FROM collection_items
-          WHERE image_id = ?
-        )
-        `
-      )
-      .run(timestamp, imageId);
-    database.prepare('DELETE FROM collection_items WHERE image_id = ?').run(imageId);
-  },
-
-  addImage(collectionSlug: string, imageId: number): CollectionRecord | undefined {
+  saveToDefault(postId: number): CollectionRecord {
     const defaultCollection = this.ensureDefaultCollection();
-    const collection = this.getBySlug(collectionSlug);
+    this.addItem(defaultCollection.id, postId);
+    return defaultCollection;
+  },
+
+  unsaveEverywhere(postId: number): void {
+    database.prepare('DELETE FROM collection_items WHERE post_id = ?').run(postId);
+  },
+
+  addImage(slug: string, postId: number): CollectionRecord | undefined {
+    const collection = this.getBySlug(slug);
     if (!collection) {
       return undefined;
     }
+    this.addItem(collection.id, postId);
+    return collection;
+  },
+
+  removeImage(slug: string, postId: number): CollectionRecord {
+    const collection = this.getBySlug(slug);
+    if (!collection) {
+      throw new Error(`Collection not found: ${slug}`);
+    }
+    this.removeItem(collection.id, postId);
+    return collection;
+  },
+
+  addItem(collectionId: number, postId: number): boolean {
+    const collection = this.getById(collectionId);
+    if (!collection) {
+      return false;
+    }
 
     const timestamp = nowIso();
-    if (collection.id !== defaultCollection.id) {
-      const defaultInsertResult = database
-        .prepare(
-          `
-          INSERT OR IGNORE INTO collection_items (collection_id, image_id, created_at)
-          VALUES (?, ?, ?)
-          `
-        )
-        .run(defaultCollection.id, imageId, timestamp);
+    database.prepare('INSERT OR IGNORE INTO collection_items (collection_id, post_id, created_at) VALUES (?, ?, ?)').run(
+      collectionId,
+      postId,
+      timestamp
+    );
 
-      if (Number(defaultInsertResult.changes ?? 0) > 0) {
-        database.prepare('UPDATE collections SET updated_at = ? WHERE id = ?').run(timestamp, defaultCollection.id);
-      }
+    if (collection.is_default === 0) {
+      this.repairDefaultMemberships();
     }
 
-    database
-      .prepare(
-        `
-        INSERT INTO collection_items (collection_id, image_id, created_at)
-        VALUES (?, ?, ?)
-        ON CONFLICT(collection_id, image_id) DO UPDATE SET
-          created_at = excluded.created_at
-        `
-      )
-      .run(collection.id, imageId, timestamp);
-    database.prepare('UPDATE collections SET updated_at = ? WHERE id = ?').run(timestamp, collection.id);
-
-    return this.getById(collection.id);
+    database.prepare('UPDATE collections SET updated_at = ? WHERE id = ?').run(timestamp, collectionId);
+    return true;
   },
 
-  removeImage(collectionSlug: string, imageId: number): CollectionRecord | undefined {
-    this.ensureDefaultCollection();
-    const collection = this.getBySlug(collectionSlug);
+  removeItem(collectionId: number, postId: number): boolean {
+    const collection = this.getById(collectionId);
     if (!collection) {
-      return undefined;
+      return false;
     }
 
-    database.prepare('DELETE FROM collection_items WHERE collection_id = ? AND image_id = ?').run(collection.id, imageId);
-    database.prepare('UPDATE collections SET updated_at = ? WHERE id = ?').run(nowIso(), collection.id);
+    const timestamp = nowIso();
+    database.prepare('DELETE FROM collection_items WHERE collection_id = ? AND post_id = ?').run(collectionId, postId);
 
-    return this.getById(collection.id);
+    database.prepare('UPDATE collections SET updated_at = ? WHERE id = ?').run(timestamp, collectionId);
+    return true;
   },
 
-  removeByFolder(folderId: number): number {
-    const result = database.prepare(
-      'DELETE FROM collection_items WHERE image_id IN (SELECT id FROM images WHERE folder_id = ?)'
-    ).run(folderId);
-    return Number(result.changes ?? 0);
+  toggleDefaultMembership(postId: number): boolean {
+    const defaultCollection = this.ensureDefaultCollection();
+    const isCurrentlySaved = Number(
+      (
+        database
+          .prepare('SELECT COUNT(*) AS count FROM collection_items WHERE collection_id = ? AND post_id = ?')
+          .get(defaultCollection.id, postId) as { count: number }
+      ).count
+    ) > 0;
+
+    if (isCurrentlySaved) {
+      this.removeItem(defaultCollection.id, postId);
+      return false;
+    }
+
+    this.addItem(defaultCollection.id, postId);
+    return true;
   }
 };
 
 export const folderShareLinkRepository = {
   create(input: CreateFolderShareLinkInput): FolderShareLinkRecord {
+    return this.createLink(input);
+  },
+
+  createLink(input: CreateFolderShareLinkInput): FolderShareLinkRecord {
     database
       .prepare(
         `
         INSERT INTO folder_share_links (
-          folder_id,
-          token_hash,
-          token_prefix,
-          expires_at,
-          allow_original_downloads,
-          created_at
+          folder_id, token_hash, token_prefix, expires_at, revoked_at, allow_original_downloads, created_at
         )
-        VALUES (?, ?, ?, ?, 0, ?)
+        VALUES (?, ?, ?, ?, NULL, 0, ?)
         `
       )
-      .run(
-        input.folderId,
-        input.tokenHash,
-        input.tokenPrefix,
-        input.expiresAt,
-        nowIso()
-      );
+      .run(input.folderId, input.tokenHash, input.tokenPrefix, input.expiresAt, nowIso());
 
-    return this.getByTokenHash(input.tokenHash) as FolderShareLinkRecord;
+    return database
+      .prepare('SELECT * FROM folder_share_links WHERE token_hash = ?')
+      .get(input.tokenHash) as unknown as FolderShareLinkRecord;
   },
 
   getById(id: number): FolderShareLinkRecord | undefined {
@@ -2370,32 +3531,27 @@ export const folderShareLinkRepository = {
   },
 
   getByTokenHash(tokenHash: string): FolderShareLinkRecord | undefined {
-    return database
-      .prepare('SELECT * FROM folder_share_links WHERE token_hash = ?')
-      .get(tokenHash) as FolderShareLinkRecord | undefined;
+    return database.prepare('SELECT * FROM folder_share_links WHERE token_hash = ?').get(tokenHash) as FolderShareLinkRecord | undefined;
   },
 
   listByFolder(folderId: number): FolderShareLinkRecord[] {
     return database
-      .prepare(
-        `
-        SELECT *
-        FROM folder_share_links
-        WHERE folder_id = ?
-        ORDER BY created_at DESC, id DESC
-        `
-      )
+      .prepare('SELECT * FROM folder_share_links WHERE folder_id = ? ORDER BY created_at DESC, id DESC')
       .all(folderId) as unknown as FolderShareLinkRecord[];
   },
 
   revoke(id: number, folderId: number): FolderShareLinkRecord | undefined {
+    return this.revokeLink(folderId, id);
+  },
+
+  revokeLink(folderId: number, id: number): FolderShareLinkRecord | undefined {
     const revokedAt = nowIso();
     database
       .prepare(
         `
         UPDATE folder_share_links
-        SET revoked_at = COALESCE(revoked_at, ?)
-        WHERE id = ? AND folder_id = ?
+        SET revoked_at = ?
+        WHERE id = ? AND folder_id = ? AND revoked_at IS NULL
         `
       )
       .run(revokedAt, id, folderId);
@@ -2407,6 +3563,8 @@ export const folderShareLinkRepository = {
     database.prepare('UPDATE folder_share_links SET last_used_at = ? WHERE id = ?').run(nowIso(), id);
   }
 };
+
+export const folderShareRepository = folderShareLinkRepository;
 
 export const folderSharePasswordRepository = {
   get(folderId: number): FolderSharePasswordRecord | undefined {
@@ -2487,6 +3645,27 @@ export const appSettingsRepository = {
       .run(key, value);
   },
 
+  setMany(entries: { key: string; value: string }[]): void {
+    if (entries.length === 0) return;
+    const stmt = database.prepare(
+      `
+      INSERT INTO app_settings (key, value)
+      VALUES (?, ?)
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value
+      `
+    );
+    database.exec('BEGIN');
+    try {
+      for (const entry of entries) {
+        stmt.run(entry.key, entry.value);
+      }
+      database.exec('COMMIT');
+    } catch (error) {
+      database.exec('ROLLBACK');
+      throw error;
+    }
+  },
+
   remove(key: string): void {
     database.prepare('DELETE FROM app_settings WHERE key = ?').run(key);
   }
@@ -2498,14 +3677,18 @@ export const maintenanceRepository = {
       BEGIN;
       UPDATE folders SET avatar_image_id = NULL;
       DELETE FROM likes;
+      DELETE FROM collection_items;
+      DELETE FROM collections WHERE is_default = 0;
       DELETE FROM folder_share_passwords;
       DELETE FROM folder_share_links;
+      DELETE FROM post_items;
+      DELETE FROM posts;
       DELETE FROM images;
       DELETE FROM folders;
       DELETE FROM folder_scan_state;
       DELETE FROM scan_runs;
       DELETE FROM app_settings WHERE key = '${SHARE_SESSION_SECRET_SETTING_KEY}';
-      DELETE FROM sqlite_sequence WHERE name IN ('folders', 'images', 'scan_runs');
+      DELETE FROM sqlite_sequence WHERE name IN ('folders', 'images', 'posts', 'scan_runs');
       COMMIT;
     `);
   }
@@ -2575,10 +3758,21 @@ export const scanRunRepository = {
     database.prepare(
       `
       UPDATE scan_runs
-      SET finished_at = ?, status = ?, scanned_files = ?, new_files = ?, updated_files = ?, removed_files = ?, error_text = ?
+      SET finished_at = ?, status = ?, scanned_files = ?, new_files = ?, updated_files = ?, removed_files = ?, error_text = ?, warning_count = ?, warning_text = ?
       WHERE id = ?
       `
-    ).run(input.finished_at, input.status, input.scanned_files, input.new_files, input.updated_files, input.removed_files, input.error_text, runId);
+    ).run(
+      input.finished_at,
+      input.status,
+      input.scanned_files,
+      input.new_files,
+      input.updated_files,
+      input.removed_files,
+      input.error_text,
+      input.warning_count ?? 0,
+      input.warning_text ?? null,
+      runId
+    );
   },
 
   latest(): ScanRunRecord | undefined {

--- a/server/src/db/schema-compat.ts
+++ b/server/src/db/schema-compat.ts
@@ -107,6 +107,10 @@ export function applyBaselineCompatMigrations(database: DatabaseSync): void {
     database.exec("ALTER TABLE images ADD COLUMN playback_strategy TEXT NOT NULL DEFAULT 'preview'");
   }
 
+  if (tableExists(database, 'images') && !tableHasColumn(database, 'images', 'caption')) {
+    database.exec('ALTER TABLE images ADD COLUMN caption TEXT NULL');
+  }
+
   if (tableExists(database, 'images') && tableHasColumn(database, 'images', 'playback_strategy')) {
     database.exec("UPDATE images SET playback_strategy = 'preview' WHERE playback_strategy IS NULL OR playback_strategy = ''");
   }
@@ -185,12 +189,27 @@ function cleanOptionalBaselineForeignKeys(database: DatabaseSync): void {
     SET avatar_image_id = NULL
     WHERE avatar_image_id IS NOT NULL
       AND NOT EXISTS (SELECT 1 FROM images WHERE images.id = folders.avatar_image_id);
+  `);
 
-    UPDATE folders
-    SET story_owner_folder_id = NULL
-    WHERE story_owner_folder_id IS NOT NULL
-      AND NOT EXISTS (SELECT 1 FROM folders AS owner_folders WHERE owner_folders.id = folders.story_owner_folder_id);
+  if (tableHasColumn(database, 'folders', 'story_owner_folder_id')) {
+    database.exec(`
+      UPDATE folders
+      SET story_owner_folder_id = NULL
+      WHERE story_owner_folder_id IS NOT NULL
+        AND NOT EXISTS (SELECT 1 FROM folders AS owner_folders WHERE owner_folders.id = folders.story_owner_folder_id);
+    `);
+  }
 
+  if (tableHasColumn(database, 'folders', 'carousel_owner_folder_id')) {
+    database.exec(`
+      UPDATE folders
+      SET carousel_owner_folder_id = NULL
+      WHERE carousel_owner_folder_id IS NOT NULL
+        AND NOT EXISTS (SELECT 1 FROM folders AS owner_folders WHERE owner_folders.id = folders.carousel_owner_folder_id);
+    `);
+  }
+
+  database.exec(`
     UPDATE images
     SET place_id = NULL
     WHERE place_id IS NOT NULL
@@ -199,6 +218,14 @@ function cleanOptionalBaselineForeignKeys(database: DatabaseSync): void {
 }
 
 function rebuildFoldersWithBaselineForeignKeys(database: DatabaseSync): void {
+  const hasCarouselOwner = tableHasColumn(database, 'folders', 'carousel_owner_folder_id');
+  const carouselColumnSql = hasCarouselOwner ? 'carousel_owner_folder_id INTEGER NULL,' : '';
+  const carouselInsertColumnSql = hasCarouselOwner ? 'carousel_owner_folder_id,' : '';
+  const carouselSelectSql = hasCarouselOwner ? 'carousel_owner_folder_id,' : '';
+  const carouselForeignKeySql = hasCarouselOwner
+    ? ', FOREIGN KEY (carousel_owner_folder_id) REFERENCES __foldergram_baseline_folders(id) ON DELETE SET NULL'
+    : '';
+
   database.exec(`
     DROP TABLE IF EXISTS __foldergram_baseline_folders;
 
@@ -209,6 +236,7 @@ function rebuildFoldersWithBaselineForeignKeys(database: DatabaseSync): void {
       folder_path TEXT NOT NULL,
       role TEXT NOT NULL DEFAULT 'normal',
       story_owner_folder_id INTEGER NULL,
+      ${carouselColumnSql}
       description TEXT NULL,
       avatar_image_id INTEGER NULL,
       avatar_source TEXT NOT NULL DEFAULT 'auto',
@@ -216,6 +244,7 @@ function rebuildFoldersWithBaselineForeignKeys(database: DatabaseSync): void {
       updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
       FOREIGN KEY (avatar_image_id) REFERENCES images(id),
       FOREIGN KEY (story_owner_folder_id) REFERENCES __foldergram_baseline_folders(id) ON DELETE SET NULL
+      ${carouselForeignKeySql}
     );
 
     INSERT INTO __foldergram_baseline_folders(
@@ -225,6 +254,7 @@ function rebuildFoldersWithBaselineForeignKeys(database: DatabaseSync): void {
       folder_path,
       role,
       story_owner_folder_id,
+      ${carouselInsertColumnSql}
       description,
       avatar_image_id,
       avatar_source,
@@ -238,6 +268,7 @@ function rebuildFoldersWithBaselineForeignKeys(database: DatabaseSync): void {
       folder_path,
       role,
       story_owner_folder_id,
+      ${carouselSelectSql}
       description,
       avatar_image_id,
       avatar_source,
@@ -278,6 +309,7 @@ function rebuildImagesWithBaselineForeignKeys(database: DatabaseSync): void {
       taken_at INTEGER NULL,
       taken_at_source TEXT NULL,
       exif_json TEXT NULL,
+      caption TEXT NULL,
       thumbnail_path TEXT NOT NULL,
       preview_path TEXT NOT NULL,
       playback_strategy TEXT NOT NULL DEFAULT 'preview',
@@ -315,6 +347,7 @@ function rebuildImagesWithBaselineForeignKeys(database: DatabaseSync): void {
       taken_at,
       taken_at_source,
       exif_json,
+      caption,
       thumbnail_path,
       preview_path,
       playback_strategy,
@@ -349,6 +382,7 @@ function rebuildImagesWithBaselineForeignKeys(database: DatabaseSync): void {
       taken_at,
       taken_at_source,
       exif_json,
+      caption,
       thumbnail_path,
       preview_path,
       playback_strategy,

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS folders (
   folder_path TEXT NOT NULL,
   role TEXT NOT NULL DEFAULT 'normal',
   story_owner_folder_id INTEGER NULL,
+  carousel_owner_folder_id INTEGER NULL,
   description TEXT NULL,
   avatar_image_id INTEGER NULL,
   avatar_source TEXT NOT NULL DEFAULT 'auto',
@@ -15,7 +16,8 @@ CREATE TABLE IF NOT EXISTS folders (
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (avatar_image_id) REFERENCES images(id),
-  FOREIGN KEY (story_owner_folder_id) REFERENCES folders(id) ON DELETE SET NULL
+  FOREIGN KEY (story_owner_folder_id) REFERENCES folders(id) ON DELETE SET NULL,
+  FOREIGN KEY (carousel_owner_folder_id) REFERENCES folders(id) ON DELETE SET NULL
 );
 
 CREATE TABLE IF NOT EXISTS images (
@@ -56,6 +58,37 @@ CREATE TABLE IF NOT EXISTS images (
   FOREIGN KEY (place_id) REFERENCES places(id) ON DELETE SET NULL
 );
 
+CREATE TABLE IF NOT EXISTS posts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  folder_id INTEGER NOT NULL,
+  place_id INTEGER NULL,
+  source_path TEXT NOT NULL UNIQUE,
+  post_type TEXT NOT NULL DEFAULT 'single',
+  caption TEXT NULL,
+  sort_timestamp INTEGER NOT NULL,
+  taken_at INTEGER NULL,
+  taken_at_source TEXT NULL,
+  is_deleted INTEGER NOT NULL DEFAULT 0,
+  deleted_at TEXT NULL,
+  is_trashed INTEGER NOT NULL DEFAULT 0,
+  trashed_at TEXT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (folder_id) REFERENCES folders(id) ON DELETE CASCADE,
+  FOREIGN KEY (place_id) REFERENCES places(id) ON DELETE SET NULL,
+  CHECK (post_type IN ('single', 'carousel'))
+);
+
+CREATE TABLE IF NOT EXISTS post_items (
+  post_id INTEGER NOT NULL,
+  image_id INTEGER NOT NULL UNIQUE,
+  position INTEGER NOT NULL,
+  PRIMARY KEY (post_id, position),
+  FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE,
+  FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE,
+  CHECK (position >= 1 AND position <= 20)
+);
+
 CREATE TABLE IF NOT EXISTS places (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   slug TEXT NOT NULL UNIQUE,
@@ -88,7 +121,9 @@ CREATE TABLE IF NOT EXISTS scan_runs (
   new_files INTEGER NOT NULL DEFAULT 0,
   updated_files INTEGER NOT NULL DEFAULT 0,
   removed_files INTEGER NOT NULL DEFAULT 0,
-  error_text TEXT NULL
+  error_text TEXT NULL,
+  warning_count INTEGER NOT NULL DEFAULT 0,
+  warning_text TEXT NULL
 );
 
 CREATE TABLE IF NOT EXISTS app_settings (
@@ -106,9 +141,9 @@ CREATE TABLE IF NOT EXISTS folder_scan_state (
 );
 
 CREATE TABLE IF NOT EXISTS likes (
-  image_id INTEGER PRIMARY KEY,
+  post_id INTEGER PRIMARY KEY,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
+  FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS collections (
@@ -122,11 +157,11 @@ CREATE TABLE IF NOT EXISTS collections (
 
 CREATE TABLE IF NOT EXISTS collection_items (
   collection_id INTEGER NOT NULL,
-  image_id INTEGER NOT NULL,
+  post_id INTEGER NOT NULL,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (collection_id, image_id),
+  PRIMARY KEY (collection_id, post_id),
   FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE CASCADE,
-  FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
+  FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS folder_share_links (
@@ -155,6 +190,8 @@ CREATE INDEX IF NOT EXISTS idx_folders_slug ON folders(slug);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_folders_folder_path ON folders(folder_path);
 CREATE INDEX IF NOT EXISTS idx_folders_role ON folders(role);
 CREATE INDEX IF NOT EXISTS idx_folders_story_owner_role ON folders(story_owner_folder_id, role, folder_path COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_folders_carousel_owner ON folders(carousel_owner_folder_id);
+
 CREATE INDEX IF NOT EXISTS idx_images_folder_id ON images(folder_id);
 CREATE INDEX IF NOT EXISTS idx_images_place_id ON images(place_id);
 CREATE INDEX IF NOT EXISTS idx_images_sort_timestamp ON images(sort_timestamp DESC);
@@ -173,15 +210,28 @@ CREATE INDEX IF NOT EXISTS idx_images_trashed_listing ON images(is_trashed, is_d
 CREATE INDEX IF NOT EXISTS idx_images_relative_path ON images(relative_path);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_images_asset_key ON images(asset_key) WHERE asset_key IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_images_deleted_at ON images(deleted_at);
+
+CREATE INDEX IF NOT EXISTS idx_posts_folder_visible_sort ON posts(folder_id, is_deleted, is_trashed, sort_timestamp DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_posts_visible_sort ON posts(is_deleted, is_trashed, sort_timestamp DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_posts_type_visibility ON posts(post_type, is_deleted, is_trashed);
+CREATE INDEX IF NOT EXISTS idx_posts_place_visibility ON posts(place_id, is_deleted, is_trashed, sort_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_posts_source_path ON posts(source_path);
+CREATE INDEX IF NOT EXISTS idx_posts_trashed_listing ON posts(is_trashed, is_deleted, trashed_at DESC, id DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_post_items_image_id ON post_items(image_id);
+CREATE INDEX IF NOT EXISTS idx_post_items_post_id ON post_items(post_id, position);
+
 CREATE INDEX IF NOT EXISTS idx_places_slug ON places(slug);
 CREATE INDEX IF NOT EXISTS idx_places_display_name ON places(display_name);
 CREATE INDEX IF NOT EXISTS idx_places_geonames_id ON places(geonames_id);
 CREATE INDEX IF NOT EXISTS idx_folder_scan_state_updated_at ON folder_scan_state(updated_at DESC);
+
 CREATE INDEX IF NOT EXISTS idx_likes_created_at ON likes(created_at DESC);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_collections_single_default ON collections(is_default) WHERE is_default = 1;
 CREATE INDEX IF NOT EXISTS idx_collections_updated_at ON collections(updated_at DESC);
-CREATE INDEX IF NOT EXISTS idx_collection_items_image ON collection_items(image_id);
-CREATE INDEX IF NOT EXISTS idx_collection_items_created ON collection_items(collection_id, created_at DESC, image_id DESC);
+CREATE INDEX IF NOT EXISTS idx_collection_items_post ON collection_items(post_id);
+CREATE INDEX IF NOT EXISTS idx_collection_items_created ON collection_items(collection_id, created_at DESC, post_id DESC);
 CREATE INDEX IF NOT EXISTS idx_folder_share_links_folder_id ON folder_share_links(folder_id);
 CREATE INDEX IF NOT EXISTS idx_folder_share_links_expires_at ON folder_share_links(expires_at);
+
 `;

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -293,6 +293,45 @@ function ensureShareFolderAccess(request: express.Request, response: express.Res
   return true;
 }
 
+const PUBLIC_SENSITIVE_MEDIA_KEYS = new Set([
+  'absolutePath',
+  'exif',
+  'exifJson',
+  'relativePath',
+  'sourcePath'
+]);
+
+function redactPublicMediaMetadata(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactPublicMediaMetadata(item));
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([key]) => !PUBLIC_SENSITIVE_MEDIA_KEYS.has(key))
+      .map(([key, item]) => [key, redactPublicMediaMetadata(item)])
+  );
+}
+
+router.use((request, response, next) => {
+  const isAnonymousPublicViewer =
+    authService.isPublicViewerAccessEnabled() &&
+    !authService.isAuthenticatedRequest(request);
+
+  if (!isAnonymousPublicViewer || request.method.toUpperCase() !== 'GET') {
+    next();
+    return;
+  }
+
+  const sendJson = response.json.bind(response);
+  response.json = ((body: unknown) => sendJson(redactPublicMediaMetadata(body))) as typeof response.json;
+  next();
+});
+
 router.get('/health', (_request, response) => {
   const storageState = storageService.getState();
   response.json({
@@ -828,6 +867,23 @@ router.get('/share/folders/:slug/images', (request, response) => {
 router.get('/share/images/:id', (request, response) => {
   const params = imageIdSchema.parse(request.params);
   const query = mediaTypeQuerySchema.parse(request.query);
+  const image = galleryService.getSharedImageDetail(params.id, query.mediaType, { isLegacyImageAlias: true });
+
+  if (!image) {
+    response.status(404).json({ message: 'Post not found' });
+    return;
+  }
+
+  if (!ensureShareFolderAccess(request, response, image.folderId)) {
+    return;
+  }
+
+  response.json(image);
+});
+
+router.get('/share/posts/:id', (request, response) => {
+  const params = imageIdSchema.parse(request.params);
+  const query = mediaTypeQuerySchema.parse(request.query);
   const image = galleryService.getSharedImageDetail(params.id, query.mediaType);
 
   if (!image) {
@@ -997,9 +1053,10 @@ router.get('/collections/:slug/images', requireCapability('canUseSharedCollectio
   response.json(payload);
 });
 
-router.post('/collections/:slug/images/:id', requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
+router.post(['/collections/:slug/posts/:id', '/collections/:slug/images/:id'], requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
   const params = slugSchema.merge(imageIdSchema).parse(request.params);
-  const payload = galleryService.addImageToCollection(params.slug, params.id);
+  const isLegacyImageAlias = request.path.includes('/images/');
+  const payload = galleryService.addImageToCollection(params.slug, params.id, { isLegacyImageAlias });
 
   if (!payload) {
     response.status(404).json({ message: 'Collection or image not found' });
@@ -1012,9 +1069,10 @@ router.post('/collections/:slug/images/:id', requireCapability('canUseSharedColl
   });
 });
 
-router.delete('/collections/:slug/images/:id', requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
+router.delete(['/collections/:slug/posts/:id', '/collections/:slug/images/:id'], requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
   const params = slugSchema.merge(imageIdSchema).parse(request.params);
-  const payload = galleryService.removeImageFromCollection(params.slug, params.id);
+  const isLegacyImageAlias = request.path.includes('/images/');
+  const payload = galleryService.removeImageFromCollection(params.slug, params.id, { isLegacyImageAlias });
 
   if (!payload) {
     response.status(404).json({ message: 'Collection or image not found' });
@@ -1032,10 +1090,11 @@ router.get('/trash/images', requireCapability('canDeleteMedia', 'Admin access is
   response.json(galleryService.getTrashImages(query.page, query.limit));
 });
 
-router.get('/images/:id', (request, response) => {
+router.get(['/posts/:id', '/images/:id'], (request, response) => {
   const params = imageIdSchema.parse(request.params);
   const query = mediaTypeQuerySchema.parse(request.query);
-  const image = galleryService.getImageDetail(params.id, query.mediaType);
+  const isLegacyImageAlias = request.path.includes('/images/');
+  const image = galleryService.getImageDetail(params.id, query.mediaType, { isLegacyImageAlias });
 
   if (!image) {
     response.status(404).json({ message: 'Post not found' });
@@ -1045,10 +1104,11 @@ router.get('/images/:id', (request, response) => {
   response.json(image);
 });
 
-router.patch('/images/:id/caption', requireCapability('canManageLibrary', 'Admin access is required.'), (request, response) => {
+router.patch(['/posts/:id/caption', '/images/:id/caption'], requireCapability('canManageLibrary', 'Admin access is required.'), (request, response) => {
   const params = imageIdSchema.parse(request.params);
   const body = patchImageCaptionBodySchema.parse(request.body);
-  const image = galleryService.updateImageCaption(params.id, body.caption);
+  const isLegacyImageAlias = request.path.includes('/images/');
+  const image = galleryService.updateImageCaption(params.id, body.caption, { isLegacyImageAlias });
 
   if (!image) {
     response.status(404).json({ message: 'Post not found' });
@@ -1061,9 +1121,10 @@ router.patch('/images/:id/caption', requireCapability('canManageLibrary', 'Admin
   });
 });
 
-router.get('/images/:id/collections', requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
+router.get(['/posts/:id/collections', '/images/:id/collections'], requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
   const params = imageIdSchema.parse(request.params);
-  const payload = galleryService.getImageCollections(params.id);
+  const isLegacyImageAlias = request.path.includes('/images/');
+  const payload = galleryService.getImageCollections(params.id, { isLegacyImageAlias });
 
   if (!payload) {
     response.status(404).json({ message: 'Post not found' });
@@ -1073,9 +1134,10 @@ router.get('/images/:id/collections', requireCapability('canUseSharedCollections
   response.json(payload);
 });
 
-router.post('/images/:id/save', requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
+router.post(['/posts/:id/save', '/images/:id/save'], requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
   const params = imageIdSchema.parse(request.params);
-  const payload = galleryService.saveImage(params.id);
+  const isLegacyImageAlias = request.path.includes('/images/');
+  const payload = galleryService.saveImage(params.id, { isLegacyImageAlias });
 
   if (!payload) {
     response.status(404).json({ message: 'Image not found' });
@@ -1088,9 +1150,10 @@ router.post('/images/:id/save', requireCapability('canUseSharedCollections', 'Au
   });
 });
 
-router.delete('/images/:id/save', requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
+router.delete(['/posts/:id/save', '/images/:id/save'], requireCapability('canUseSharedCollections', 'Authentication required.'), (request, response) => {
   const params = imageIdSchema.parse(request.params);
-  const payload = galleryService.unsaveImage(params.id);
+  const isLegacyImageAlias = request.path.includes('/images/');
+  const payload = galleryService.unsaveImage(params.id, { isLegacyImageAlias });
 
   if (!payload) {
     response.status(404).json({ message: 'Image not found' });
@@ -1103,9 +1166,10 @@ router.delete('/images/:id/save', requireCapability('canUseSharedCollections', '
   });
 });
 
-router.post('/images/:id/like', requireCapability('canUseSharedLikes', 'Authentication required.'), (request, response) => {
+router.post(['/posts/:id/like', '/images/:id/like'], requireCapability('canUseSharedLikes', 'Authentication required.'), (request, response) => {
   const params = imageIdSchema.parse(request.params);
-  const payload = galleryService.likeImage(params.id);
+  const isLegacyImageAlias = request.path.includes('/images/');
+  const payload = galleryService.likeImage(params.id, { isLegacyImageAlias });
 
   if (!payload) {
     response.status(404).json({ message: 'Image not found' });
@@ -1118,9 +1182,10 @@ router.post('/images/:id/like', requireCapability('canUseSharedLikes', 'Authenti
   });
 });
 
-router.delete('/images/:id/like', requireCapability('canUseSharedLikes', 'Authentication required.'), (request, response) => {
+router.delete(['/posts/:id/like', '/images/:id/like'], requireCapability('canUseSharedLikes', 'Authentication required.'), (request, response) => {
   const params = imageIdSchema.parse(request.params);
-  const payload = galleryService.unlikeImage(params.id);
+  const isLegacyImageAlias = request.path.includes('/images/');
+  const payload = galleryService.unlikeImage(params.id, { isLegacyImageAlias });
 
   if (!payload) {
     response.status(404).json({ message: 'Image not found' });
@@ -1133,9 +1198,10 @@ router.delete('/images/:id/like', requireCapability('canUseSharedLikes', 'Authen
   });
 });
 
-router.post('/images/:id/trash', requireCapability('canDeleteMedia', 'Admin access is required.'), (request, response) => {
+router.post(['/posts/:id/trash', '/images/:id/trash'], requireCapability('canDeleteMedia', 'Admin access is required.'), (request, response) => {
   const params = imageIdSchema.parse(request.params);
-  const payload = galleryService.trashImage(params.id);
+  const isLegacyImageAlias = request.path.includes('/images/');
+  const payload = galleryService.trashImage(params.id, { isLegacyImageAlias });
 
   if (!payload) {
     response.status(404).json({ message: 'Post not found' });
@@ -1148,9 +1214,10 @@ router.post('/images/:id/trash', requireCapability('canDeleteMedia', 'Admin acce
   });
 });
 
-router.post('/images/:id/restore', requireCapability('canDeleteMedia', 'Admin access is required.'), (request, response) => {
+router.post(['/posts/:id/restore', '/images/:id/restore'], requireCapability('canDeleteMedia', 'Admin access is required.'), (request, response) => {
   const params = imageIdSchema.parse(request.params);
-  const payload = galleryService.restoreImage(params.id);
+  const isLegacyImageAlias = request.path.includes('/images/');
+  const payload = galleryService.restoreImage(params.id, { isLegacyImageAlias });
 
   if (!payload) {
     response.status(404).json({ message: 'Post not found' });
@@ -1163,12 +1230,13 @@ router.post('/images/:id/restore', requireCapability('canDeleteMedia', 'Admin ac
   });
 });
 
-router.delete('/images/:id', requireCapability('canDeleteMedia', 'Admin access is required.'), async (request, response) => {
+router.delete(['/posts/:id', '/images/:id'], requireCapability('canDeleteMedia', 'Admin access is required.'), async (request, response) => {
   const params = imageIdSchema.parse(request.params);
-  const deleted = await galleryService.deleteImage(params.id);
+  const isLegacyImageAlias = request.path.includes('/images/');
+  const deleted = await galleryService.deleteImage(params.id, { isLegacyImageAlias });
 
   if (!deleted) {
-    response.status(404).json({ message: 'Image not found' });
+    response.status(404).json({ message: 'Post not found' });
     return;
   }
 
@@ -1318,6 +1386,38 @@ router.post(
     ok: true,
     ...galleryService.rebuildPlaces()
   });
+});
+
+router.post('/admin/settings/carousels-as-folders', requireCapability('canAccessSettings', 'Admin access is required.'), adminMutationRateLimiter, (request, response) => {
+  const payloadSchema = z.object({
+    treatCarouselsAsFolders: z.boolean()
+  });
+
+  const body = payloadSchema.parse(request.body);
+
+  try {
+    const stats = galleryService.setTreatCarouselsAsFolders(body.treatCarouselsAsFolders);
+    response.json(stats);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to update carousels mode.';
+    response.status(500).json({ message });
+  }
+});
+
+router.post('/admin/settings/carousels-migration-decision', requireCapability('canAccessSettings', 'Admin access is required.'), adminMutationRateLimiter, (request, response) => {
+  const payloadSchema = z.object({
+    decision: z.enum(['restore', 'carousels'])
+  });
+
+  const body = payloadSchema.parse(request.body);
+
+  try {
+    const stats = galleryService.setCarouselsMigrationDecision(body.decision);
+    response.json(stats);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to update carousels migration decision.';
+    response.status(500).json({ message });
+  }
 });
 
 router.get('/admin/stats', requireCapability('canAccessSettings', 'Admin access is required.'), (_request, response) => {

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 
 import {
   APP_DEFAULT_LOCALE_SETTING_KEY,
+  CAROUSELS_APPLIED_MODE_SETTING_KEY,
+  CAROUSELS_MIGRATION_DECISION_SETTING_KEY,
   EXCLUDED_FOLDERS_SETTING_KEY,
   FOLDER_IMAGE_DEFAULT_ORDER_SETTING_KEY,
   HOME_FEED_DEFAULT_MODE_SETTING_KEY,
@@ -13,6 +15,7 @@ import {
   PREVIOUS_GALLERY_ROOT_SETTING_KEY,
   REELS_FEED_DEFAULT_MODE_SETTING_KEY,
   STORIES_MIGRATION_DECISION_SETTING_KEY,
+  TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY,
   TREAT_STORIES_AS_FOLDERS_SETTING_KEY
 } from '../constants/app-setting-keys.js';
 import { appConfig } from '../config/env.js';
@@ -25,8 +28,10 @@ import {
   imageRepository,
   likeRepository,
   placeRepository,
+  postRepository,
   scanRunRepository
 } from '../db/repositories.js';
+import { parseTreatCarouselsAsFoldersSetting, serializeTreatCarouselsAsFoldersSetting } from '../utils/carousels-utils.js';
 import type {
   CollectionMembershipRecord,
   CollectionSummaryRecord,
@@ -40,6 +45,8 @@ import type {
   MediaType,
   PlaceKind,
   PlaybackStrategy,
+  PostMediaItem,
+  PostRecord,
   SharedFeedItem,
   SharedFolderSummary,
   SharedImageDetail,
@@ -170,7 +177,8 @@ function toViewerSafeScanSummary(scan: ScanSummaryRecord | null) {
 
   return {
     ...scan,
-    error_text: null
+    error_text: null,
+    warning_text: null
   };
 }
 
@@ -222,6 +230,10 @@ function getTreatStoriesAsFolders(): boolean {
   return parseTreatStoriesAsFoldersSetting(appSettingsRepository.get(TREAT_STORIES_AS_FOLDERS_SETTING_KEY));
 }
 
+function getTreatCarouselsAsFolders(): boolean {
+  return parseTreatCarouselsAsFoldersSetting(appSettingsRepository.get(TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY));
+}
+
 function getCustomExcludedFolders(): string[] {
   return parseExcludedFolderRulesFromSetting(appSettingsRepository.get(EXCLUDED_FOLDERS_SETTING_KEY));
 }
@@ -244,6 +256,18 @@ function getStoriesMigrationStatus() {
   return {
     hasLegacyStoriesCandidates: folderRepository.hasLegacyStoriesCandidates(),
     decisionPending: appSettingsRepository.get(STORIES_MIGRATION_DECISION_SETTING_KEY) === null
+  };
+}
+
+function getCarouselsMigrationStatus() {
+  const decision = appSettingsRepository.get(CAROUSELS_MIGRATION_DECISION_SETTING_KEY);
+  const selectedMode = serializeTreatCarouselsAsFoldersSetting(getTreatCarouselsAsFolders());
+  const appliedMode = appSettingsRepository.get(CAROUSELS_APPLIED_MODE_SETTING_KEY);
+
+  return {
+    hasLegacyCarouselsCandidates: folderRepository.hasLegacyCarouselsCandidates(),
+    decisionPending: decision === null,
+    reconciliationPending: decision !== null && appliedMode !== selectedMode
   };
 }
 
@@ -396,7 +420,7 @@ async function removeFileAndPruneAncestors(rootPath: string, targetPath: string 
       await fsPromises.rmdir(currentDirectory);
     } catch (error) {
       const directoryError = error as NodeJS.ErrnoException;
-      if (directoryError.code === 'ENOENT' || directoryError.code === 'ENOTEMPTY' || directoryError.code === 'EEXIST') {
+      if (directoryError.code === 'ENOENT' || directoryError.code === 'ENOTEMPTY' || directoryError.code === 'EEXIST' || directoryError.code === 'EPERM' || directoryError.code === 'EBUSY') {
         return;
       }
 
@@ -416,7 +440,7 @@ async function removeDirectoryIfEmpty(targetPath: string | null): Promise<void> 
     await fsPromises.rmdir(targetPath);
   } catch (error) {
     const directoryError = error as NodeJS.ErrnoException;
-    if (directoryError.code !== 'ENOENT' && directoryError.code !== 'ENOTEMPTY' && directoryError.code !== 'EEXIST') {
+    if (directoryError.code !== 'ENOENT' && directoryError.code !== 'ENOTEMPTY' && directoryError.code !== 'EEXIST' && directoryError.code !== 'EPERM' && directoryError.code !== 'EBUSY') {
       throw error;
     }
   }
@@ -485,9 +509,11 @@ function getParentFolderDisplayName(folderPath: string): string | null {
 }
 
 function mapFeedImage(image: IndexedFeedImage, derivativeVersion = getDerivativeAssetVersion()): FeedImage {
-  const { playbackStrategy, placeId, placeSlug, placeName, placeKind, placeIsApproximate, isSaved, ...rest } = image;
+  const { playbackStrategy, placeId, placeSlug, placeName, placeKind, placeIsApproximate, isSaved, mediaItems, itemCount, ...rest } = image as any;
   return {
     ...rest,
+    postType: rest.postType ?? 'single',
+    carouselTitle: rest.postType === 'carousel' && rest.sourcePath ? getLeafPathName(rest.sourcePath) : null,
     isAnimated: Boolean(rest.isAnimated),
     isSaved: Boolean(isSaved),
     folderParentName: getParentFolderDisplayName(rest.folderPath),
@@ -498,11 +524,65 @@ function mapFeedImage(image: IndexedFeedImage, derivativeVersion = getDerivative
       mediaType: rest.mediaType,
       previewUrl: rest.previewUrl
     }, false, derivativeVersion),
-    place: mapPlaceSummaryFromRow({ placeId, placeSlug, placeName, placeKind, placeIsApproximate })
+    place: mapPlaceSummaryFromRow({ placeId, placeSlug, placeName, placeKind, placeIsApproximate }),
+    mediaItems: (mediaItems ?? []).map((item: any) => ({
+      imageId: item.imageId,
+      position: item.position,
+      filename: item.filename,
+      mediaType: item.mediaType,
+      width: item.width,
+      height: item.height,
+      durationMs: item.durationMs,
+      isAnimated: Boolean(item.isAnimated),
+      thumbnailUrl: toPublicMediaUrl('/thumbnails', item.thumbnailUrl, derivativeVersion),
+      previewUrl: buildPreviewUrl({
+        id: item.imageId,
+        mediaType: item.mediaType,
+        previewUrl: item.previewUrl
+      }, false, derivativeVersion),
+      originalUrl: buildOriginalUrl(item.imageId),
+      playbackStrategy: item.playbackStrategy ?? 'preview',
+      mimeType: item.mimeType,
+      fileSize: item.fileSize,
+      relativePath: item.relativePath,
+      exif: item.exif ?? null
+    })),
+    itemCount: itemCount ?? (mediaItems ? mediaItems.length : 1)
+  };
+}
+
+function resolvePostRecord(id: number, isLegacyImageAlias = false): PostRecord | undefined {
+  if (isLegacyImageAlias) {
+    return postRepository.findByImageId(id);
+  }
+  return postRepository.findById(id);
+}
+
+function isCoverPost(postId: number): boolean {
+  return postRepository.isExplicitFolderCover(postId);
+}
+
+function mapSharedMediaItem(item: PostMediaItem, derivativeVersion: string | null): PostMediaItem {
+  return {
+    imageId: item.imageId,
+    position: item.position,
+    filename: item.filename,
+    mediaType: item.mediaType,
+    width: item.width,
+    height: item.height,
+    durationMs: item.durationMs,
+    isAnimated: Boolean(item.isAnimated),
+    thumbnailUrl: buildShareThumbnailUrl(item.imageId, derivativeVersion),
+    previewUrl: buildSharePreviewUrl(item.imageId, derivativeVersion),
+    playbackStrategy: item.playbackStrategy ?? 'preview',
+    mimeType: item.mimeType,
+    fileSize: item.fileSize
   };
 }
 
 function mapSharedFeedImage(image: IndexedFeedImage, derivativeVersion = getDerivativeAssetVersion()): SharedFeedItem {
+  const mediaItems = image.mediaItems ?? [];
+  const representativeImageId = mediaItems[0]?.imageId ?? image.id;
   return {
     id: image.id,
     folderId: image.folderId,
@@ -510,22 +590,29 @@ function mapSharedFeedImage(image: IndexedFeedImage, derivativeVersion = getDeri
     folderName: image.folderName,
     filename: image.filename,
     caption: image.caption,
+    carouselTitle: image.postType === 'carousel' && image.sourcePath ? getLeafPathName(image.sourcePath) : null,
     width: image.width,
     height: image.height,
     mediaType: image.mediaType,
     durationMs: image.durationMs,
     isAnimated: Boolean(image.isAnimated),
-    thumbnailUrl: buildShareThumbnailUrl(image.id, derivativeVersion),
-    previewUrl: buildSharePreviewUrl(image.id, derivativeVersion),
-    sortTimestamp: image.sortTimestamp
+    thumbnailUrl: buildShareThumbnailUrl(representativeImageId, derivativeVersion),
+    previewUrl: buildSharePreviewUrl(representativeImageId, derivativeVersion),
+    sortTimestamp: image.sortTimestamp,
+    postType: image.postType ?? 'single',
+    itemCount: image.itemCount ?? (mediaItems.length || 1),
+    mediaItems: mediaItems.map((item) => mapSharedMediaItem(item, derivativeVersion))
   };
 }
 
 function mapImageDetail(image: IndexedImageDetail, derivativeVersion = getDerivativeAssetVersion()): ImageDetail {
-  const { playbackStrategy, exifJson, placeId, placeSlug, placeName, placeKind, placeIsApproximate, isSaved, ...rest } = image;
+  const { playbackStrategy, exifJson, placeId, placeSlug, placeName, placeKind, placeIsApproximate, isSaved, mediaItems, itemCount, ...rest } = image as any;
   const useOriginalForImages = appConfig.imageDetailSource === 'original';
+  const representativeImageId = mediaItems?.[0]?.imageId ?? rest.id;
   return {
     ...rest,
+    postType: rest.postType ?? 'single',
+    carouselTitle: rest.postType === 'carousel' && rest.sourcePath ? getLeafPathName(rest.sourcePath) : null,
     isAnimated: Boolean(rest.isAnimated),
     isSaved: Boolean(isSaved),
     exif: deserializeImageExifData(exifJson),
@@ -533,17 +620,42 @@ function mapImageDetail(image: IndexedImageDetail, derivativeVersion = getDeriva
     folderBreadcrumb: getPathBreadcrumb(rest.folderPath),
     thumbnailUrl: toPublicMediaUrl('/thumbnails', rest.thumbnailUrl, derivativeVersion),
     previewUrl: buildPreviewUrl({
-      id: rest.id,
+      id: representativeImageId,
       mediaType: rest.mediaType,
       previewUrl: rest.previewUrl
     }, useOriginalForImages, derivativeVersion),
-    originalUrl: buildOriginalUrl(rest.id),
+    originalUrl: buildOriginalUrl(representativeImageId),
     playbackStrategy,
-    place: mapPlaceSummaryFromRow({ placeId, placeSlug, placeName, placeKind, placeIsApproximate })
+    place: mapPlaceSummaryFromRow({ placeId, placeSlug, placeName, placeKind, placeIsApproximate }),
+    mediaItems: (mediaItems ?? []).map((item: any) => ({
+      imageId: item.imageId,
+      position: item.position,
+      filename: item.filename,
+      mediaType: item.mediaType,
+      width: item.width,
+      height: item.height,
+      durationMs: item.durationMs,
+      isAnimated: Boolean(item.isAnimated),
+      thumbnailUrl: toPublicMediaUrl('/thumbnails', item.thumbnailUrl, derivativeVersion),
+      previewUrl: buildPreviewUrl({
+        id: item.imageId,
+        mediaType: item.mediaType,
+        previewUrl: item.previewUrl
+      }, false, derivativeVersion),
+      originalUrl: buildOriginalUrl(item.imageId),
+      playbackStrategy: item.playbackStrategy ?? 'preview',
+      mimeType: item.mimeType,
+      fileSize: item.fileSize,
+      relativePath: item.relativePath,
+      exif: item.exif ?? null
+    })),
+    itemCount: itemCount ?? (mediaItems ? mediaItems.length : 1)
   };
 }
 
 function mapSharedImageDetail(image: IndexedImageDetail, derivativeVersion = getDerivativeAssetVersion()): SharedImageDetail {
+  const mediaItems = image.mediaItems ?? [];
+  const representativeImageId = mediaItems[0]?.imageId ?? image.id;
   return {
     id: image.id,
     folderId: image.folderId,
@@ -551,35 +663,29 @@ function mapSharedImageDetail(image: IndexedImageDetail, derivativeVersion = get
     folderName: image.folderName,
     filename: image.filename,
     caption: image.caption,
+    carouselTitle: image.postType === 'carousel' && image.sourcePath ? getLeafPathName(image.sourcePath) : null,
     mediaType: image.mediaType,
     mimeType: image.mimeType,
     width: image.width,
     height: image.height,
     durationMs: image.durationMs,
     isAnimated: Boolean(image.isAnimated),
-    thumbnailUrl: buildShareThumbnailUrl(image.id, derivativeVersion),
-    previewUrl: buildSharePreviewUrl(image.id, derivativeVersion),
+    thumbnailUrl: buildShareThumbnailUrl(representativeImageId, derivativeVersion),
+    previewUrl: buildSharePreviewUrl(representativeImageId, derivativeVersion),
     sortTimestamp: image.sortTimestamp,
     nextImageId: image.nextImageId,
-    previousImageId: image.previousImageId
+    previousImageId: image.previousImageId,
+    postType: image.postType ?? 'single',
+    itemCount: image.itemCount ?? (mediaItems.length || 1),
+    mediaItems: mediaItems.map((item) => mapSharedMediaItem(item, derivativeVersion))
   };
 }
 
 function mapTrashImage(image: IndexedTrashImage, derivativeVersion = getDerivativeAssetVersion()): TrashImage {
-  const { playbackStrategy, placeId, placeSlug, placeName, placeKind, placeIsApproximate, isSaved, ...rest } = image;
+  const mapped = mapFeedImage(image as IndexedFeedImage, derivativeVersion);
   return {
-    ...rest,
-    isAnimated: Boolean(rest.isAnimated),
-    isSaved: Boolean(isSaved),
-    folderParentName: getParentFolderDisplayName(rest.folderPath),
-    folderBreadcrumb: getPathBreadcrumb(rest.folderPath),
-    thumbnailUrl: toPublicMediaUrl('/thumbnails', rest.thumbnailUrl, derivativeVersion),
-    previewUrl: buildPreviewUrl({
-      id: rest.id,
-      mediaType: rest.mediaType,
-      previewUrl: rest.previewUrl
-    }, false, derivativeVersion),
-    place: mapPlaceSummaryFromRow({ placeId, placeSlug, placeName, placeKind, placeIsApproximate })
+    ...mapped,
+    trashedAt: image.trashedAt
   };
 }
 
@@ -598,6 +704,7 @@ function buildFolderSummary(folder: FolderSummaryRecord) {
       folderPath: folder.folder_path,
       breadcrumb: getPathBreadcrumb(folder.folder_path),
       imageCount: folder.image_count,
+      postCount: folder.post_count,
       videoCount: folder.video_count,
       latestImageMtimeMs: folder.latest_image_mtime_ms,
       hasAvatarStory: Boolean(folder.has_avatar_story),
@@ -625,6 +732,7 @@ function buildFolderSummary(folder: FolderSummaryRecord) {
     folderPath: folder.folder_path,
     breadcrumb: getPathBreadcrumb(folder.folder_path),
     imageCount: folder.image_count,
+    postCount: folder.post_count,
     videoCount: folder.video_count,
     latestImageMtimeMs: folder.latest_image_mtime_ms,
     hasAvatarStory: Boolean(folder.has_avatar_story),
@@ -643,6 +751,7 @@ function buildSharedFolderSummary(folder: FolderSummaryRecord): SharedFolderSumm
     name: summary.name,
     description: summary.description,
     imageCount: summary.imageCount,
+    postCount: summary.postCount,
     videoCount: summary.videoCount,
     avatarThumbnailUrl: summary.avatarImageId ? buildShareThumbnailUrl(summary.avatarImageId, derivativeVersion) : null,
     sortTimestamp: summary.latestImageMtimeMs ?? 0
@@ -1453,20 +1562,25 @@ export const galleryService = {
     return buildFolderSummary(folder);
   },
 
-  updateImageCaption(id: number, caption: string | null) {
+  updateImageCaption(id: number, caption: string | null, options: { isLegacyImageAlias?: boolean } = {}) {
     if (!storageService.getState().libraryAvailable) {
       return null;
     }
 
+    const post = resolvePostRecord(id, options.isLegacyImageAlias);
+    if (!post || post.is_deleted || post.is_trashed) {
+      return null;
+    }
+
     const defaultFolderImageOrder = getDefaultFolderImageOrder();
-    const existing = imageRepository.getImageDetail(id, undefined, false, defaultFolderImageOrder);
+    const existing = imageRepository.getImageDetail(post.id, undefined, false, defaultFolderImageOrder);
     if (!existing) {
       return null;
     }
 
-    imageRepository.updateCaption(id, caption);
+    postRepository.updateCaption(post.id, caption);
 
-    const updated = imageRepository.getImageDetail(id, undefined, false, defaultFolderImageOrder);
+    const updated = imageRepository.getImageDetail(post.id, undefined, false, defaultFolderImageOrder);
     return updated ? mapImageDetail(updated, getDerivativeAssetVersion()) : null;
   },
 
@@ -1481,7 +1595,11 @@ export const galleryService = {
     }
 
     const image = imageRepository.getById(imageId);
-    if (!image || image.folder_id !== folder.id || image.is_deleted !== 0 || image.is_trashed !== 0) {
+    const imageFolder = image ? folderRepository.getById(image.folder_id) : undefined;
+    const belongsToFolder = image?.folder_id === folder.id || (
+      imageFolder?.role === 'carousel_source' && imageFolder.carousel_owner_folder_id === folder.id
+    );
+    if (!image || !belongsToFolder || image.is_deleted !== 0 || image.is_trashed !== 0) {
       return null;
     }
 
@@ -1563,7 +1681,7 @@ export const galleryService = {
       return null;
     }
 
-    const total = mediaType ? imageRepository.countVisibleByFolder(folder.id, mediaType) : folder.image_count;
+    const total = imageRepository.countVisibleByFolder(folder.id, mediaType);
     const derivativeVersion = getDerivativeAssetVersion();
     const defaultFolderImageOrder = getDefaultFolderImageOrder();
 
@@ -1589,7 +1707,7 @@ export const galleryService = {
       return null;
     }
 
-    const total = mediaType ? imageRepository.countVisibleByFolder(folder.id, mediaType) : folder.image_count;
+    const total = imageRepository.countVisibleByFolder(folder.id, mediaType);
     const derivativeVersion = getDerivativeAssetVersion();
     const defaultFolderImageOrder = getDefaultFolderImageOrder();
 
@@ -1605,15 +1723,20 @@ export const galleryService = {
     };
   },
 
-  getImageDetail(id: number, mediaType?: MediaType) {
+  getImageDetail(id: number, mediaType?: MediaType, options: { isLegacyImageAlias?: boolean } = {}) {
     if (!storageService.getState().libraryAvailable) {
       return null;
     }
 
+    const post = resolvePostRecord(id, options.isLegacyImageAlias);
+    if (!post || post.is_deleted || post.is_trashed) {
+      return null;
+    }
+
     const defaultFolderImageOrder = getDefaultFolderImageOrder();
-    let detail = imageRepository.getImageDetail(id, mediaType, false, defaultFolderImageOrder);
+    let detail = imageRepository.getImageDetail(post.id, mediaType, false, defaultFolderImageOrder);
     if (!detail) {
-      const avatarDetail = imageRepository.getImageDetail(id, mediaType, true, defaultFolderImageOrder);
+      const avatarDetail = imageRepository.getImageDetail(post.id, mediaType, true, defaultFolderImageOrder);
       if (avatarDetail && avatarDetail.folderAvatarImageId === avatarDetail.id) {
         detail = avatarDetail;
       }
@@ -1626,13 +1749,18 @@ export const galleryService = {
     return mapImageDetail(detail, getDerivativeAssetVersion());
   },
 
-  getSharedImageDetail(id: number, mediaType?: MediaType) {
+  getSharedImageDetail(id: number, mediaType?: MediaType, options: { isLegacyImageAlias?: boolean } = {}) {
     if (!storageService.getState().libraryAvailable) {
       return null;
     }
 
+    const post = resolvePostRecord(id, options.isLegacyImageAlias);
+    if (!post || post.is_deleted || post.is_trashed) {
+      return null;
+    }
+
     const defaultFolderImageOrder = getDefaultFolderImageOrder();
-    const detail = imageRepository.getImageDetail(id, mediaType, false, defaultFolderImageOrder);
+    const detail = imageRepository.getImageDetail(post.id, mediaType, false, defaultFolderImageOrder);
     if (!detail) {
       return null;
     }
@@ -1651,11 +1779,15 @@ export const galleryService = {
     }
 
     const folder = folderRepository.getById(image.folder_id);
-    if (!folder || folder.role !== 'normal') {
+    if (!folder) {
       return null;
     }
 
-    return image;
+    if (folder.role === 'normal') return image;
+    if (folder.role === 'carousel_source' && folder.carousel_owner_folder_id) {
+      return { ...image, folder_id: folder.carousel_owner_folder_id };
+    }
+    return null;
   },
 
   getPlacesStatus() {
@@ -1734,21 +1866,21 @@ export const galleryService = {
     };
   },
 
-  getImageCollections(id: number) {
+  getImageCollections(id: number, options: { isLegacyImageAlias?: boolean } = {}) {
     if (!storageService.getState().libraryAvailable) {
       return null;
     }
 
-    const image = imageRepository.getById(id);
-    if (!image || image.is_deleted || image.is_trashed) {
+    const post = resolvePostRecord(id, options.isLegacyImageAlias);
+    if (!post || post.is_deleted || post.is_trashed) {
       return null;
     }
 
     const derivativeVersion = getDerivativeAssetVersion();
     return {
-      imageId: id,
-      isSaved: collectionRepository.isImageSaved(id),
-      items: collectionRepository.listMembershipsForImage(id).map((collection) => mapCollectionMembership(collection, derivativeVersion))
+      imageId: post.id,
+      isSaved: collectionRepository.isImageSaved(post.id),
+      items: collectionRepository.listMembershipsForImage(post.id).map((collection) => mapCollectionMembership(collection, derivativeVersion))
     };
   },
 
@@ -1794,59 +1926,59 @@ export const galleryService = {
     return mapCollectionSummary(summary);
   },
 
-  saveImage(id: number) {
+  saveImage(id: number, options: { isLegacyImageAlias?: boolean } = {}) {
     if (!storageService.getState().libraryAvailable) {
       return null;
     }
 
-    const image = imageRepository.getById(id);
-    if (!image || image.is_deleted || image.is_trashed) {
+    const post = resolvePostRecord(id, options.isLegacyImageAlias);
+    if (!post || post.is_deleted || post.is_trashed || isCoverPost(post.id)) {
       return null;
     }
 
-    const collection = collectionRepository.saveToDefault(id);
+    const collection = collectionRepository.saveToDefault(post.id);
     const summary = collectionRepository.listSummaries().find((entry) => entry.id === collection.id);
 
     return {
-      id,
-      imageId: id,
-      isSaved: collectionRepository.isImageSaved(id),
+      id: post.id,
+      imageId: post.id,
+      isSaved: collectionRepository.isImageSaved(post.id),
       collection: summary ? mapCollectionSummary(summary) : undefined
     };
   },
 
-  unsaveImage(id: number) {
+  unsaveImage(id: number, options: { isLegacyImageAlias?: boolean } = {}) {
     if (!storageService.getState().libraryAvailable) {
       return null;
     }
 
-    const image = imageRepository.getById(id);
-    if (!image || image.is_deleted || image.is_trashed) {
+    const post = resolvePostRecord(id, options.isLegacyImageAlias);
+    if (!post || post.is_deleted || post.is_trashed || isCoverPost(post.id)) {
       return null;
     }
 
-    collectionRepository.unsaveEverywhere(id);
+    collectionRepository.unsaveEverywhere(post.id);
 
     return {
-      id,
-      imageId: id,
+      id: post.id,
+      imageId: post.id,
       isSaved: false
     };
   },
 
-  addImageToCollection(slug: string, id: number) {
+  addImageToCollection(slug: string, id: number, options: { isLegacyImageAlias?: boolean } = {}) {
     if (!storageService.getState().libraryAvailable) {
       return null;
     }
 
-    const image = imageRepository.getById(id);
-    if (!image || image.is_deleted || image.is_trashed) {
+    const post = resolvePostRecord(id, options.isLegacyImageAlias);
+    if (!post || post.is_deleted || post.is_trashed || isCoverPost(post.id)) {
       return null;
     }
 
     const collection = slug === collectionConstants.defaultCollectionSlug
-      ? collectionRepository.saveToDefault(id)
-      : collectionRepository.addImage(slug, id);
+      ? collectionRepository.saveToDefault(post.id)
+      : collectionRepository.addImage(slug, post.id);
     if (!collection) {
       return null;
     }
@@ -1854,20 +1986,20 @@ export const galleryService = {
     const summary = collectionRepository.listSummaries().find((entry) => entry.id === collection.id);
 
     return {
-      id,
-      imageId: id,
+      id: post.id,
+      imageId: post.id,
       isSaved: true,
       collection: summary ? mapCollectionSummary(summary) : undefined
     };
   },
 
-  removeImageFromCollection(slug: string, id: number) {
+  removeImageFromCollection(slug: string, id: number, options: { isLegacyImageAlias?: boolean } = {}) {
     if (!storageService.getState().libraryAvailable) {
       return null;
     }
 
-    const image = imageRepository.getById(id);
-    if (!image || image.is_deleted || image.is_trashed) {
+    const post = resolvePostRecord(id, options.isLegacyImageAlias);
+    if (!post || post.is_deleted || post.is_trashed || isCoverPost(post.id)) {
       return null;
     }
 
@@ -1877,21 +2009,21 @@ export const galleryService = {
     }
 
     if (collection.is_default === 1) {
-      collectionRepository.unsaveEverywhere(id);
+      collectionRepository.unsaveEverywhere(post.id);
       return {
-        id,
-        imageId: id,
+        id: post.id,
+        imageId: post.id,
         isSaved: false
       };
     }
 
-    collectionRepository.removeImage(slug, id);
+    collectionRepository.removeImage(slug, post.id);
     const summary = collectionRepository.listSummaries().find((entry) => entry.id === collection.id);
 
     return {
-      id,
-      imageId: id,
-      isSaved: collectionRepository.isImageSaved(id),
+      id: post.id,
+      imageId: post.id,
+      isSaved: collectionRepository.isImageSaved(post.id),
       collection: summary ? mapCollectionSummary(summary) : undefined
     };
   },
@@ -1908,88 +2040,88 @@ export const galleryService = {
     };
   },
 
-  likeImage(id: number) {
+  likeImage(id: number, options: { isLegacyImageAlias?: boolean } = {}) {
     if (!storageService.getState().libraryAvailable) {
       return null;
     }
 
-    const image = imageRepository.getById(id);
-    if (!image || image.is_deleted || image.is_trashed) {
+    const post = resolvePostRecord(id, options.isLegacyImageAlias);
+    if (!post || post.is_deleted || post.is_trashed || isCoverPost(post.id)) {
       return null;
     }
 
-    likeRepository.upsert(id);
+    likeRepository.upsert(post.id);
 
     return {
-      id,
+      id: post.id,
       liked: true
     };
   },
 
-  unlikeImage(id: number) {
+  unlikeImage(id: number, options: { isLegacyImageAlias?: boolean } = {}) {
     if (!storageService.getState().libraryAvailable) {
       return null;
     }
 
-    const image = imageRepository.getById(id);
-    if (!image || image.is_deleted || image.is_trashed) {
+    const post = resolvePostRecord(id, options.isLegacyImageAlias);
+    if (!post || post.is_deleted || post.is_trashed || isCoverPost(post.id)) {
       return null;
     }
 
-    likeRepository.remove(id);
+    likeRepository.remove(post.id);
 
     return {
-      id,
+      id: post.id,
       liked: false
     };
   },
 
-  trashImage(id: number) {
+  trashImage(id: number, options: { isLegacyImageAlias?: boolean } = {}) {
     if (!storageService.getState().libraryAvailable) {
       return null;
     }
 
-    const imageRecord = imageRepository.getById(id);
-    if (!imageRecord || imageRecord.is_deleted) {
+    const post = resolvePostRecord(id, options.isLegacyImageAlias);
+    if (!post || post.is_deleted) {
       return null;
     }
 
-    const folder = folderRepository.getById(imageRecord.folder_id);
+    const folder = folderRepository.getById(post.folder_id);
     if (!folder) {
       return null;
     }
 
-    if (imageRecord.is_trashed === 0) {
-      imageRepository.moveToTrash(id);
-      folderRepository.syncAvatarSelection(imageRecord.folder_id);
+    if (post.is_trashed === 0) {
+      imageRepository.moveToTrash(post.id);
+      folderRepository.syncAvatarSelection(post.folder_id);
     }
 
     return {
-      id: imageRecord.id,
+      id: post.id,
       folderSlug: folder.slug
     };
   },
 
-  restoreImage(id: number) {
+  restoreImage(id: number, options: { isLegacyImageAlias?: boolean } = {}) {
     if (!storageService.getState().libraryAvailable) {
       return null;
     }
 
-    const imageRecord = imageRepository.getById(id);
-    if (!imageRecord || imageRecord.is_deleted || imageRecord.is_trashed === 0) {
+    const post = resolvePostRecord(id, options.isLegacyImageAlias);
+    if (!post || post.is_deleted || post.is_trashed === 0) {
       return null;
     }
 
-    const folder = folderRepository.getById(imageRecord.folder_id);
+    const folder = folderRepository.getById(post.folder_id);
     if (!folder) {
       return null;
     }
 
-    imageRepository.restoreFromTrash(id);
-    folderRepository.syncAvatarSelection(imageRecord.folder_id);
+    imageRepository.restoreFromTrash(post.id);
+    folderRepository.syncAvatarSelection(post.folder_id);
 
     return {
-      id: imageRecord.id,
+      id: post.id,
       folderSlug: folder.slug
     };
   },
@@ -2004,11 +2136,17 @@ export const galleryService = {
     const nestedFolderTitleFormat = getNestedFolderTitleFormat();
     const treatStoriesAsFolders = getTreatStoriesAsFolders();
     const storiesMigration = getStoriesMigrationStatus();
+    const treatCarouselsAsFolders = getTreatCarouselsAsFolders();
+    const carouselsMigration = getCarouselsMigrationStatus();
+    const indexedPosts = storageState.libraryAvailable ? imageRepository.countFeed() : 0;
 
     return {
       folders: storageState.libraryAvailable ? folderRepository.count() : 0,
-      indexedImages: storageState.libraryAvailable ? imageRepository.countFeed() : 0,
-      indexedVideos: storageState.libraryAvailable ? imageRepository.countByMediaType('video') : 0,
+      indexedImages: indexedPosts,
+      indexedPosts,
+      indexedMediaAssets: storageState.libraryAvailable ? imageRepository.countVisibleMediaAssets() : 0,
+      indexedCarousels: storageState.libraryAvailable ? imageRepository.countVisibleCarousels() : 0,
+      indexedVideos: storageState.libraryAvailable ? imageRepository.countVisibleSingleVideos() : 0,
       scan: this.getScanProgress(),
       storage: {
         available: storageState.libraryAvailable,
@@ -2025,9 +2163,11 @@ export const galleryService = {
         defaultReelsFeedMode,
         defaultFolderImageOrder,
         nestedFolderTitleFormat,
-        treatStoriesAsFolders
+        treatStoriesAsFolders,
+        treatCarouselsAsFolders
       },
-      storiesMigration
+      storiesMigration,
+      carouselsMigration
     };
   },
 
@@ -2068,12 +2208,17 @@ export const galleryService = {
     const nestedFolderTitleFormat = getNestedFolderTitleFormat();
     const treatStoriesAsFolders = getTreatStoriesAsFolders();
     const storiesMigration = getStoriesMigrationStatus();
+    const treatCarouselsAsFolders = getTreatCarouselsAsFolders();
+    const carouselsMigration = getCarouselsMigrationStatus();
     const excludedFolders = getExcludedFolderSettings();
 
     return {
       folders: storageState.libraryAvailable ? folderRepository.count() : 0,
       indexedImages: storageState.libraryAvailable ? imageRepository.countFeed() : 0,
-      indexedVideos: storageState.libraryAvailable ? imageRepository.countByMediaType('video') : 0,
+      indexedPosts: storageState.libraryAvailable ? imageRepository.countFeed() : 0,
+      indexedMediaAssets: storageState.libraryAvailable ? imageRepository.countVisibleMediaAssets() : 0,
+      indexedCarousels: storageState.libraryAvailable ? imageRepository.countVisibleCarousels() : 0,
+      indexedVideos: storageState.libraryAvailable ? imageRepository.countVisibleSingleVideos() : 0,
       deletedImages: storageState.libraryAvailable ? imageRepository.countDeleted() : 0,
       thumbnailCount: storageState.libraryAvailable ? countDerivativeFilesOnDisk(appConfig.thumbnailsDir) : 0,
       previewCount: storageState.libraryAvailable ? countDerivativeFilesOnDisk(appConfig.previewsDir) : 0,
@@ -2100,9 +2245,11 @@ export const galleryService = {
         defaultReelsFeedMode,
         defaultFolderImageOrder,
         nestedFolderTitleFormat,
-        treatStoriesAsFolders
+        treatStoriesAsFolders,
+        treatCarouselsAsFolders
       },
       storiesMigration,
+      carouselsMigration,
       excludedFolders
     };
   },
@@ -2182,44 +2329,47 @@ export const galleryService = {
     return resolveOriginalMediaFile(id)?.path ?? null;
   },
 
-  async deleteImage(id: number) {
+  async deleteImage(id: number, options: { isLegacyImageAlias?: boolean } = {}) {
     if (!storageService.getState().libraryAvailable || scannerService.isLibraryRebuildRequired()) {
       return null;
     }
 
-    const imageRecord = imageRepository.getById(id);
-    if (!imageRecord) {
+    const post = resolvePostRecord(id, options.isLegacyImageAlias);
+    if (!post) {
       return null;
     }
 
-    const folder = folderRepository.getById(imageRecord.folder_id);
+    const folder = folderRepository.getById(post.folder_id);
     if (!folder) {
       return null;
     }
 
-    const originalPath = resolveIndexedOriginalPath(imageRecord.relative_path);
-    const thumbnailPath = resolveStoredPathWithinRoot(appConfig.thumbnailsDir, imageRecord.thumbnail_path, 'thumbnail');
-    const previewPath = resolveStoredPathWithinRoot(appConfig.previewsDir, imageRecord.preview_path, 'preview');
+    const imageRecords = postRepository.listImageRecords(post.id);
+    const targets = imageRecords.map((imageRecord) => {
+      const originalPath = resolveIndexedOriginalPath(imageRecord.relative_path);
+      if (!originalPath) throw new Error('Stored image path is outside the gallery root');
+      return {
+        originalPath,
+        thumbnailPath: resolveStoredPathWithinRoot(appConfig.thumbnailsDir, imageRecord.thumbnail_path, 'thumbnail'),
+        previewPath: resolveStoredPathWithinRoot(appConfig.previewsDir, imageRecord.preview_path, 'preview')
+      };
+    });
 
-    if (!originalPath) {
-      throw new Error('Stored image path is outside the gallery root');
-    }
-
-    await Promise.all([
+    await Promise.all(targets.flatMap(({ originalPath, thumbnailPath, previewPath }) => [
       removeFileAndPruneAncestors(appConfig.galleryRoot, originalPath),
       removeFileAndPruneAncestors(appConfig.thumbnailsDir, thumbnailPath),
       removeFileAndPruneAncestors(appConfig.previewsDir, previewPath)
-    ]);
+    ]));
 
-    if (folder.avatar_image_id === imageRecord.id) {
-      folderRepository.setAvatar(imageRecord.folder_id, null, 'auto');
+    if (imageRecords.some((imageRecord) => folder.avatar_image_id === imageRecord.id)) {
+      folderRepository.setAvatar(post.folder_id, null, 'auto');
     }
 
-    imageRepository.deleteById(imageRecord.id);
-    folderRepository.syncAvatarSelection(imageRecord.folder_id);
+    postRepository.deletePostAndImages(post.id);
+    folderRepository.syncAvatarSelection(post.folder_id);
 
     return {
-      id: imageRecord.id,
+      id: post.id,
       folderSlug: folder.slug
     };
   },
@@ -2236,13 +2386,17 @@ export const galleryService = {
 
     const deleteSourceFolder = options.deleteSourceFolder === true;
     const normalizedFolderPath = folder.folder_path;
-    const images = imageRepository.listActiveByFolder(folder.id);
+    const ownedFolders = folderRepository
+      .getAll()
+      .filter((entry) => entry.carousel_owner_folder_id === folder.id || entry.story_owner_folder_id === folder.id);
+    const affectedFolderIds = [folder.id, ...ownedFolders.map((entry) => entry.id)];
+    const images = affectedFolderIds.flatMap((id) => imageRepository.listForFolderDeletion(id));
 
     if (deleteSourceFolder) {
       const affectedFolders = folderRepository
         .getAll()
         .filter((entry) => isSameOrDescendantFolderPath(normalizedFolderPath, entry.folder_path));
-      const affectedImages = affectedFolders.flatMap((entry) => imageRepository.listActiveByFolder(entry.id));
+      const affectedImages = affectedFolders.flatMap((entry) => imageRepository.listForFolderDeletion(entry.id));
       const deletedImageCount = affectedImages.length;
 
       await removeDirectoryTree(resolveWithinRoot(appConfig.galleryRoot, path.join(appConfig.galleryRoot, normalizedFolderPath)));
@@ -2291,15 +2445,34 @@ export const galleryService = {
       })
     );
 
-    folderRepository.setAvatar(folder.id, null, 'auto');
-    folderScanStateRepository.delete(normalizedFolderPath);
-    folderRepository.delete(folder.id);
+    for (const affectedFolder of [...ownedFolders, folder]) {
+      folderScanStateRepository.delete(affectedFolder.folder_path);
+      folderRepository.setAvatar(affectedFolder.id, null, 'auto');
+      folderRepository.delete(affectedFolder.id);
+    }
 
-    await Promise.all([
-      removeDirectoryIfEmpty(resolveWithinRoot(appConfig.galleryRoot, path.join(appConfig.galleryRoot, normalizedFolderPath))),
-      removeDirectoryIfEmpty(resolveWithinRoot(appConfig.thumbnailsDir, path.join(appConfig.thumbnailsDir, normalizedFolderPath))),
-      removeDirectoryIfEmpty(resolveWithinRoot(appConfig.previewsDir, path.join(appConfig.previewsDir, normalizedFolderPath)))
-    ]);
+    const cleanupRelativePaths = new Set<string>([normalizedFolderPath]);
+    for (const ownedFolder of ownedFolders) {
+      let candidatePath = ownedFolder.folder_path;
+      while (isSameOrDescendantFolderPath(normalizedFolderPath, candidatePath)) {
+        cleanupRelativePaths.add(candidatePath);
+        if (candidatePath === normalizedFolderPath) break;
+        const parentPath = path.posix.dirname(candidatePath);
+        if (parentPath === candidatePath || parentPath === '.') break;
+        candidatePath = parentPath;
+      }
+    }
+
+    const orderedCleanupPaths = [...cleanupRelativePaths].sort(
+      (left, right) => right.split('/').length - left.split('/').length
+    );
+    for (const relativePath of orderedCleanupPaths) {
+      await Promise.all([
+        removeDirectoryIfEmpty(resolveWithinRoot(appConfig.galleryRoot, path.join(appConfig.galleryRoot, relativePath))),
+        removeDirectoryIfEmpty(resolveWithinRoot(appConfig.thumbnailsDir, path.join(appConfig.thumbnailsDir, relativePath))),
+        removeDirectoryIfEmpty(resolveWithinRoot(appConfig.previewsDir, path.join(appConfig.previewsDir, relativePath)))
+      ]);
+    }
 
     return {
       slug: folder.slug,
@@ -2307,5 +2480,24 @@ export const galleryService = {
       deletedFolderCount: 1,
       deletedSourceFolder: false
     };
+  },
+
+  setTreatCarouselsAsFolders(treatCarouselsAsFolders: boolean) {
+    appSettingsRepository.setMany([
+      {
+        key: TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY,
+        value: serializeTreatCarouselsAsFoldersSetting(treatCarouselsAsFolders)
+      },
+      {
+        key: CAROUSELS_MIGRATION_DECISION_SETTING_KEY,
+        value: treatCarouselsAsFolders ? 'restore' : 'carousels'
+      }
+    ]);
+
+    return this.getStats();
+  },
+
+  setCarouselsMigrationDecision(decision: 'restore' | 'carousels') {
+    return this.setTreatCarouselsAsFolders(decision === 'restore');
   }
 };

--- a/server/src/services/place-service.ts
+++ b/server/src/services/place-service.ts
@@ -4,7 +4,7 @@ import { inflateRawSync } from 'node:zlib';
 import { DatabaseSync } from 'node:sqlite';
 
 import { appConfig } from '../config/env.js';
-import { imageRepository, placeRepository } from '../db/repositories.js';
+import { imageRepository, placeRepository, postRepository } from '../db/repositories.js';
 import type { ImageRecord, PlaceDetail, PlaceRecord, PlaceSummary } from '../types/models.js';
 import { deserializeImageExifData } from '../utils/exif-utils.js';
 import { resolveUniqueSlug, slugifyFolderName } from '../utils/slug.js';
@@ -523,6 +523,8 @@ export const placeResolutionService = {
         }
       }
     }
+
+    postRepository.syncRepresentativePlaces();
 
     return {
       processed,

--- a/server/src/services/scanner-service.ts
+++ b/server/src/services/scanner-service.ts
@@ -8,11 +8,13 @@ import pLimit from 'p-limit';
 
 import {
   AVIF_METADATA_REPAIR_VERSION_SETTING_KEY,
+  CAROUSELS_APPLIED_MODE_SETTING_KEY,
   EXCLUDED_FOLDERS_SETTING_KEY,
   LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY,
   LIBRARY_REBUILD_REQUIRED_SETTING_KEY,
   PREVIOUS_GALLERY_ROOT_SETTING_KEY,
-  TREAT_STORIES_AS_FOLDERS_SETTING_KEY
+  TREAT_STORIES_AS_FOLDERS_SETTING_KEY,
+  TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY
 } from '../constants/app-setting-keys.js';
 import { appConfig } from '../config/env.js';
 import {
@@ -21,6 +23,7 @@ import {
   folderScanStateRepository,
   imageRepository,
   maintenanceRepository,
+  postRepository,
   scanRunRepository
 } from '../db/repositories.js';
 import { generateDerivatives, generateThumbnailDerivative, readMediaMetadata } from './derivative-service.js';
@@ -63,7 +66,14 @@ import {
   parseTreatStoriesAsFoldersSetting
 } from '../utils/stories-utils.js';
 import {
+  findReservedCarouselsOwnerPath,
+  isCarouselsFolderName,
+  parseTreatCarouselsAsFoldersSetting,
+  serializeTreatCarouselsAsFoldersSetting
+} from '../utils/carousels-utils.js';
+import {
   createFolderScanSignature,
+  compareNaturalFilename,
   resolveFullScanOptions,
   shouldQueueDerivativeJobForStatus,
   shouldRefreshUnchangedImage,
@@ -81,6 +91,8 @@ interface ScanSummary {
   updated_files: number;
   removed_files: number;
   error_text: string | null;
+  warning_count: number;
+  warning_text: string | null;
 }
 
 interface DerivativeJob {
@@ -118,6 +130,7 @@ interface ResolvedFolderResult {
 interface ResolvedFolderOptions {
   role?: FolderRole;
   storyOwnerFolderId?: number | null;
+  carouselOwnerFolderId?: number | null;
 }
 
 interface IndexedFolderScanOptions {
@@ -135,7 +148,13 @@ interface IndexedFolderScanOptions {
   logLabel: string;
   role?: FolderRole;
   storyOwnerFolderId?: number | null;
+  carouselOwnerFolderId?: number | null;
   folderHadErrors?: boolean;
+}
+
+interface ReservedCarouselScanResult {
+  ownerFolder: FolderRecord | null;
+  results: SourceFolderScanResult[];
 }
 
 interface IndexedFileReference {
@@ -260,7 +279,9 @@ function createEmptySummary(): ScanSummary {
     new_files: 0,
     updated_files: 0,
     removed_files: 0,
-    error_text: null
+    error_text: null,
+    warning_count: 0,
+    warning_text: null
   };
 }
 
@@ -403,15 +424,20 @@ class ScanErrorCollector {
 
   constructor(
     private readonly runId: number,
-    private readonly reason: string
+    private readonly reason: string,
+    private readonly issueType: 'error' | 'warning' = 'error'
   ) {
     this.reportPath = path.join(
       appConfig.scanErrorReportDir,
-      `scan-${runId}-${sanitizeReportFilenamePart(reason)}.log`
+      `scan-${runId}-${sanitizeReportFilenamePart(reason)}-${issueType}s.log`
     );
   }
 
   get hasErrors(): boolean {
+    return this.count > 0;
+  }
+
+  get hasIssues(): boolean {
     return this.count > 0;
   }
 
@@ -436,7 +462,7 @@ class ScanErrorCollector {
       '',
       'Summary:',
       `Status: ${summary.status}`,
-      `Error count: ${this.count}`,
+      `${this.issueType === 'warning' ? 'Warning' : 'Error'} count: ${this.count}`,
       `Scanned files: ${summary.scanned_files}`,
       `New files: ${summary.new_files}`,
       `Updated files: ${summary.updated_files}`,
@@ -531,8 +557,21 @@ class ScanErrorCollector {
   }
 }
 
+export class ScanBusyError extends Error {
+  constructor(message = 'A scan is already in progress.') {
+    super(message);
+    this.name = 'ScanBusyError';
+  }
+}
+
+export interface EnqueueScanOptions extends Partial<FullScanOptions> {
+  rejectIfBusy?: boolean;
+  beforeEnqueue?: () => void;
+}
+
 class ScannerService {
   private queue = Promise.resolve<ScanSummary>(createEmptySummary());
+  private activeOrQueuedJobs = 0;
   private progress = createIdleProgress(scanRunRepository.latestCompleted() ?? null);
   private heartbeatTimer: NodeJS.Timeout | null = null;
 
@@ -545,6 +584,12 @@ class ScannerService {
 
   isLibraryRebuildRequired(): boolean {
     return appSettingsRepository.get(LIBRARY_REBUILD_REQUIRED_SETTING_KEY) === '1';
+  }
+
+  shouldTreatCarouselsAsFolders(): boolean {
+    return parseTreatCarouselsAsFoldersSetting(
+      appSettingsRepository.get(TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY)
+    );
   }
 
   handleStartup(reason = 'startup'): StartupAction {
@@ -632,13 +677,13 @@ class ScannerService {
     return 'idle';
   }
 
-  async scanAll(reason = 'manual', options: Partial<FullScanOptions> = {}): Promise<ScanRunRecord | undefined> {
+  async scanAll(reason = 'manual', options: EnqueueScanOptions = {}): Promise<ScanRunRecord | undefined> {
     const resolvedOptions = resolveFullScanOptions({
       allowDerivativeMigration: reason !== 'startup' && !reason.startsWith('watcher'),
       ...options
     });
 
-    await this.enqueue(async () => this.performFullScan(reason, resolvedOptions));
+    await this.enqueue(async () => this.performFullScan(reason, resolvedOptions), options);
     return scanRunRepository.latest();
   }
 
@@ -667,9 +712,21 @@ class ScannerService {
     return scanRunRepository.latest();
   }
 
-  private async enqueue(job: () => Promise<ScanSummary>): Promise<ScanSummary> {
-    this.queue = this.queue.then(job, job);
-    return this.queue;
+  private async enqueue(job: () => Promise<ScanSummary>, options: EnqueueScanOptions = {}): Promise<ScanSummary> {
+    if (options.rejectIfBusy && this.activeOrQueuedJobs > 0) {
+      throw new ScanBusyError();
+    }
+
+    this.activeOrQueuedJobs++;
+    try {
+      if (options.beforeEnqueue) {
+        options.beforeEnqueue();
+      }
+      this.queue = this.queue.then(job, job);
+      return await this.queue;
+    } finally {
+      this.activeOrQueuedJobs--;
+    }
   }
 
   private beginProgress(reason: string, runId: number): void {
@@ -834,6 +891,33 @@ class ScannerService {
     summary.error_text = `${errors.sampleText.slice(0, sampleLimit)}${reportNotice}`;
   }
 
+  private async applyScanWarnings(summary: ScanSummary, warnings: ScanErrorCollector): Promise<void> {
+    if (!warnings.hasIssues) {
+      return;
+    }
+
+    summary.warning_count = warnings.count;
+    let reportNotice = '';
+    const reportResult = await warnings.finalize(summary);
+
+    if (reportResult?.reportPath) {
+      reportNotice = `\n\nFull warning report: ${normalizePath(reportResult.reportPath)}`;
+      log.info(
+        joinLogParts([
+          'Scan warning report written',
+          formatStep('warnings', warnings.count),
+          formatStep('path', normalizePath(reportResult.reportPath))
+        ])
+      );
+    } else if (reportResult?.errorMessage) {
+      reportNotice = `\n\nUnable to write full warning report: ${reportResult.errorMessage}`;
+      log.error('Failed to write scan warning report', reportResult.errorMessage);
+    }
+
+    const sampleLimit = Math.max(0, MAX_SCAN_ERROR_TEXT_LENGTH - reportNotice.length);
+    summary.warning_text = `${warnings.sampleText.slice(0, sampleLimit)}${reportNotice}`;
+  }
+
   private finishUnavailableRun(runId: number, reason: string): ScanSummary {
     const storageState = storageService.refreshAvailability();
     const summary = {
@@ -908,6 +992,7 @@ class ScannerService {
     onSourceFolder: (sourceFolder: SourceFolderCandidate) => Promise<void>,
     currentRelativePath: string | null = null,
     treatStoriesAsFolders = this.shouldTreatStoriesAsFolders(),
+    treatCarouselsAsFolders = this.shouldTreatCarouselsAsFolders(),
     excludedFolderRules = this.getEffectiveExcludedFolderRules()
   ): Promise<void> {
     if (currentRelativePath && matchesExcludedFolder(currentRelativePath, excludedFolderRules)) {
@@ -935,6 +1020,8 @@ class ScannerService {
 
     const childDirectories: Array<{ absolutePath: string; relativePath: string }> = [];
     let hasDirectImages = false;
+    let hasCarouselDirectories = false;
+    let hasStoriesDirectories = false;
 
     for (const entry of entries) {
       const relativeEntryPath = currentRelativePath ? `${currentRelativePath}/${entry.name}` : entry.name;
@@ -945,6 +1032,13 @@ class ScannerService {
       if (entry.isDirectory()) {
         if (this.isManagedGalleryPath(relativeEntryPath) || matchesExcludedFolder(relativeEntryPath, excludedFolderRules)) {
           continue;
+        }
+
+        if (!treatCarouselsAsFolders && isCarouselsFolderName(entry.name)) {
+          hasCarouselDirectories = true;
+        }
+        if (!treatStoriesAsFolders && isStoriesFolderName(entry.name)) {
+          hasStoriesDirectories = true;
         }
 
         childDirectories.push({
@@ -959,7 +1053,7 @@ class ScannerService {
       }
     }
 
-    if (currentRelativePath && hasDirectImages) {
+    if (currentRelativePath && (hasDirectImages || (!treatCarouselsAsFolders && hasCarouselDirectories) || (!treatStoriesAsFolders && hasStoriesDirectories))) {
       const normalizedRelativePath = normalizePath(currentRelativePath);
       this.setProgress({
         discoveredFolders: this.progress.discoveredFolders + 1,
@@ -972,7 +1066,11 @@ class ScannerService {
     }
 
     for (const childDirectory of childDirectories) {
-      if (!treatStoriesAsFolders && currentRelativePath && hasDirectImages && isStoriesFolderName(path.basename(childDirectory.relativePath))) {
+      const childName = path.basename(childDirectory.relativePath);
+      if (!treatStoriesAsFolders && currentRelativePath && hasDirectImages && isStoriesFolderName(childName)) {
+        continue;
+      }
+      if (!treatCarouselsAsFolders && currentRelativePath && isCarouselsFolderName(childName)) {
         continue;
       }
 
@@ -981,6 +1079,7 @@ class ScannerService {
         onSourceFolder,
         childDirectory.relativePath,
         treatStoriesAsFolders,
+        treatCarouselsAsFolders,
         excludedFolderRules
       );
     }
@@ -990,7 +1089,7 @@ class ScannerService {
     const existingFolder = existingFolders.find(
       (folder) => normalizePath(folder.folder_path) === normalizePath(sourceFolderPath)
     );
-    const removedFiles = existingFolder ? imageRepository.markAllDeletedByFolder(existingFolder.id) : 0;
+    const removedFiles = existingFolder ? imageRepository.markAllDeletedByFolder(existingFolder.id, 'single') : 0;
 
     if (existingFolder) {
       folderRepository.setAvatar(existingFolder.id, null, 'auto');
@@ -1103,13 +1202,14 @@ class ScannerService {
     let folderHadErrors = false;
 
     const statFile = async (file: IndexedFileReference) => {
-      activeRelativePaths.push(file.relativePath);
+      const normalizedRelativePath = normalizePath(file.relativePath);
+      activeRelativePaths.push(normalizedRelativePath);
 
       try {
         const stats = await fs.stat(file.absolutePath);
         discoveredFiles.push({
           absolutePath: file.absolutePath,
-          relativePath: file.relativePath,
+          relativePath: normalizedRelativePath,
           stats
         });
       } catch (error) {
@@ -1374,6 +1474,233 @@ class ScannerService {
     return storyResults;
   }
 
+  private async scanReservedCarousels(
+    sourceFolder: SourceFolderCandidate,
+    existingFolders: FolderRecord[],
+    usedSlugs: Set<string>,
+    folderScanStates: Map<string, FolderScanStateRecord>,
+    derivativeJobs: Map<string, DerivativeJob>,
+    errors: ScanErrorCollector,
+    warnings: ScanErrorCollector,
+    options: FullScanOptions,
+    context: ImageProcessingContext,
+    excludedFolderRules: string[]
+  ): Promise<ReservedCarouselScanResult> {
+    const ownerEntries = await fs
+      .readdir(sourceFolder.absolutePath, { withFileTypes: true })
+      .catch((error: unknown) => {
+        const filesystemError = error as NodeJS.ErrnoException;
+        if (filesystemError.code === 'ENOENT') {
+          return null;
+        }
+
+        throw error;
+      });
+
+    if (!ownerEntries) {
+      return { ownerFolder: null, results: [] };
+    }
+
+    const carouselsDirectory = ownerEntries.find((entry) => {
+      if (!entry.isDirectory()) {
+        return false;
+      }
+
+      const relativeEntryPath = normalizePath(`${sourceFolder.relativePath}/${entry.name}`);
+      return (
+        !isHiddenPath(relativeEntryPath) &&
+        !this.isManagedGalleryPath(relativeEntryPath) &&
+        !matchesExcludedFolder(relativeEntryPath, excludedFolderRules) &&
+        isCarouselsFolderName(entry.name)
+      );
+    });
+
+    if (!carouselsDirectory) {
+      return { ownerFolder: null, results: [] };
+    }
+
+    const carouselsAbsolutePath = path.join(sourceFolder.absolutePath, carouselsDirectory.name);
+    const carouselsRelativePath = normalizePath(`${sourceFolder.relativePath}/${carouselsDirectory.name}`);
+    const carouselsEntries = await fs
+      .readdir(carouselsAbsolutePath, { withFileTypes: true })
+      .catch((error: unknown) => {
+        const filesystemError = error as NodeJS.ErrnoException;
+        if (filesystemError.code === 'ENOENT') {
+          return null;
+        }
+
+        throw error;
+      });
+
+    if (!carouselsEntries) {
+      return { ownerFolder: null, results: [] };
+    }
+
+    const carouselResults: SourceFolderScanResult[] = [];
+
+    const rootMediaFiles = carouselsEntries.filter(
+      (entry) => entry.isFile() && isSupportedMediaFile(entry.name) && !entry.name.startsWith('.')
+    );
+    for (const rootFile of rootMediaFiles) {
+      const relPath = normalizePath(`${carouselsRelativePath}/${rootFile.name}`);
+      await warnings.add(
+        formatScanError(
+          relPath,
+          'Direct media files placed inside carousels root directory are ignored. Put media inside post subfolders like carousels/post1/.'
+        )
+      );
+    }
+
+    const carouselPostFolders = carouselsEntries.filter((entry) => {
+      if (!entry.isDirectory()) return false;
+      const relPath = normalizePath(`${carouselsRelativePath}/${entry.name}`);
+      return (
+        !isHiddenPath(relPath) &&
+        !this.isManagedGalleryPath(relPath) &&
+        !matchesExcludedFolder(relPath, excludedFolderRules)
+      );
+    });
+
+    carouselPostFolders.sort((a, b) => compareNaturalFilename(a.name, b.name));
+
+    const activeCarouselPostPaths: string[] = [];
+    let ownerFolder = existingFolders.find((folder) => (
+      folder.role === 'normal' && normalizePath(folder.folder_path) === normalizePath(sourceFolder.relativePath)
+    )) ?? null;
+
+    for (const postEntry of carouselPostFolders) {
+      const postRelativePath = normalizePath(`${carouselsRelativePath}/${postEntry.name}`);
+      const postAbsolutePath = path.join(carouselsAbsolutePath, postEntry.name);
+
+      const postDirEntries = await fs
+        .readdir(postAbsolutePath, { withFileTypes: true })
+        .catch(() => null);
+
+      if (!postDirEntries) continue;
+
+      const nestedDirs = postDirEntries.filter((e) => e.isDirectory() && !e.name.startsWith('.'));
+      for (const nestedDir of nestedDirs) {
+        const nestedRelPath = normalizePath(`${postRelativePath}/${nestedDir.name}`);
+        const nestedMedia = await this.collectRecursiveMediaFiles(
+          path.join(postAbsolutePath, nestedDir.name),
+          nestedRelPath,
+          excludedFolderRules
+        );
+        if (nestedMedia.length > 0) {
+          await warnings.add(
+            formatScanError(nestedRelPath, 'Nested media subfolders inside carousel post directories are ignored.')
+          );
+        }
+      }
+
+      const directMediaEntries = postDirEntries.filter(
+        (e) => e.isFile() && isSupportedMediaFile(e.name) && !e.name.startsWith('.')
+      );
+
+      if (directMediaEntries.length === 0) continue;
+
+      directMediaEntries.sort((a, b) => compareNaturalFilename(a.name, b.name));
+
+      if (directMediaEntries.length === 1) {
+        await warnings.add(formatScanError(postRelativePath, 'Carousel post has only 1 item.'));
+      }
+
+      let validEntries = directMediaEntries;
+      if (validEntries.length > 20) {
+        await warnings.add(
+          formatScanError(
+            postRelativePath,
+            'Carousel post exceeds maximum limit of 20 items. Additional items were skipped.'
+          )
+        );
+        validEntries = validEntries.slice(0, 20);
+      }
+
+      activeCarouselPostPaths.push(postRelativePath);
+
+      if (!ownerFolder) {
+        ownerFolder = this.resolveFolder(existingFolders, usedSlugs, sourceFolder.relativePath).folder;
+      }
+
+      const directFiles = validEntries.map((e) => {
+        const abs = path.join(postAbsolutePath, e.name);
+        return {
+          absolutePath: abs,
+          relativePath: normalizePath(`${postRelativePath}/${e.name}`)
+        };
+      });
+
+      this.setProgress({
+        currentFolder: postRelativePath,
+        discoveredImages: this.progress.discoveredImages + directFiles.length
+      });
+
+      const statResult = await this.statIndexedFiles(directFiles, errors);
+      const result = await this.scanIndexedFolderFiles({
+        folderPath: postRelativePath,
+        scannedFileCount: directFiles.length,
+        activeRelativePaths: statResult.activeRelativePaths,
+        discoveredFiles: statResult.discoveredFiles,
+        existingFolders,
+        usedSlugs,
+        folderScanStates,
+        derivativeJobs,
+        errors,
+        options,
+        context,
+        logLabel: 'Carousel item indexed',
+        role: 'carousel_source',
+        carouselOwnerFolderId: ownerFolder.id,
+        folderHadErrors: statResult.folderHadErrors
+      });
+
+      const indexedImageRecords: ImageRecord[] = [];
+      for (const fileCandidate of statResult.discoveredFiles) {
+        const normalizedRelPath = normalizePath(fileCandidate.relativePath);
+        const imgRecord = imageRepository.getByRelativePath(normalizedRelPath);
+        if (imgRecord) indexedImageRecords.push(imgRecord);
+      }
+      indexedImageRecords.sort((a, b) => compareNaturalFilename(a.filename, b.filename));
+
+      if (indexedImageRecords.length > 0) {
+        const imageIds = indexedImageRecords.map((img) => img.id);
+        const existingPost =
+          postRepository.findByExactImageIds(imageIds) ?? postRepository.findBySourcePath(postRelativePath);
+        const firstItem = indexedImageRecords[0];
+        const newestItemTimestamp = Math.max(...indexedImageRecords.map((image) => image.sort_timestamp));
+        const sortTimestamp = existingPost?.sort_timestamp ?? newestItemTimestamp;
+        const takenAt = firstItem.taken_at ?? null;
+
+        const itemsPayload = indexedImageRecords.map((img, idx) => ({
+          imageId: img.id,
+          position: idx + 1
+        }));
+        postRepository.upsertPostWithItems({
+          existingPostId: existingPost?.id,
+          id: !existingPost && indexedImageRecords.length === 1 ? firstItem.id : undefined,
+          folderId: ownerFolder.id,
+          placeId: firstItem.place_id,
+          postType: indexedImageRecords.length > 1 ? 'carousel' : 'single',
+          sourcePath: postRelativePath,
+          caption: existingPost?.caption ?? null,
+          takenAt,
+          takenAtSource: firstItem.taken_at_source,
+          sortTimestamp,
+          isDeleted: 0,
+          isTrashed: 0
+        }, itemsPayload);
+      }
+
+      carouselResults.push(result);
+    }
+
+    if (ownerFolder) {
+      postRepository.softDeleteMissingReservedCarousels(ownerFolder.id, carouselsRelativePath, activeCarouselPostPaths);
+    }
+
+    return { ownerFolder, results: carouselResults };
+  }
+
   private async scanIndexedFolderFiles({
     folderPath,
     scannedFileCount,
@@ -1388,6 +1715,7 @@ class ScannerService {
     context,
     role = 'normal',
     storyOwnerFolderId = null,
+    carouselOwnerFolderId = null,
     folderHadErrors = false
   }: IndexedFolderScanOptions): Promise<SourceFolderScanResult> {
     const normalizedFolderPath = normalizePath(folderPath);
@@ -1396,7 +1724,8 @@ class ScannerService {
       if (activeRelativePaths.length > 0) {
         const resolvedFolder = this.resolveFolder(existingFolders, usedSlugs, normalizedFolderPath, {
           role,
-          storyOwnerFolderId
+          storyOwnerFolderId,
+          carouselOwnerFolderId
         });
 
         return {
@@ -1420,7 +1749,8 @@ class ScannerService {
 
     const resolvedFolder = this.resolveFolder(existingFolders, usedSlugs, normalizedFolderPath, {
       role,
-      storyOwnerFolderId
+      storyOwnerFolderId,
+      carouselOwnerFolderId
     });
     const folder = resolvedFolder.folder;
     let unchangedFiles = 0;
@@ -1695,6 +2025,7 @@ class ScannerService {
     const runId = scanRunRepository.start();
     const summary = createEmptySummary();
     const errors = new ScanErrorCollector(runId, reason);
+    const warnings = new ScanErrorCollector(runId, reason, 'warning');
     const derivativeJobs = new Map<string, DerivativeJob>();
     const metrics: FullScanMetrics = {
       folderShortcutHits: 0,
@@ -1733,6 +2064,7 @@ class ScannerService {
       rebuildDerivativeReuseIndex: contextOptions.rebuildDerivativeReuseIndex
     };
     const treatStoriesAsFolders = this.shouldTreatStoriesAsFolders();
+    const treatCarouselsAsFolders = this.shouldTreatCarouselsAsFolders();
     const excludedFolderRules = this.getEffectiveExcludedFolderRules();
 
     if (!storageService.refreshAvailability().libraryAvailable) {
@@ -1750,6 +2082,7 @@ class ScannerService {
         formatStep('avif-repair', formatToggle(avifMetadataRepairPending)),
         formatStep('media-errors', appConfig.scanMediaErrorMode),
         formatStep('stories-as-folders', formatToggle(treatStoriesAsFolders)),
+        formatStep('carousels-as-folders', formatToggle(treatCarouselsAsFolders)),
         excludedFolderRules.length > 0 ? formatStep('excluded-folders', excludedFolderRules.join(',')) : null,
         appConfig.managedGalleryRelativeIgnores.length > 0
           ? formatStep('ignored-managed-paths', appConfig.managedGalleryRelativeIgnores.join(','))
@@ -1836,6 +2169,9 @@ class ScannerService {
         !galleryRootChanged && migrationSummary.complete && derivativeMigrationService.isMigrationComplete();
 
       const existingFolders = folderRepository.getAll();
+      if (treatCarouselsAsFolders) {
+        postRepository.softDeleteReservedCarouselsForLegacyMode();
+      }
       if (galleryRootChanged && normalizedStoredGalleryRoot && existingFolders.length > 0) {
         this.markLibraryRebuildRequired(normalizedStoredGalleryRoot);
         log.info(
@@ -1926,7 +2262,35 @@ class ScannerService {
           );
 
           for (const storyResult of storyResults) {
+            if (storyResult.folder) discoveredFolderIds.add(storyResult.folder.id);
             applyScanResult(storyResult);
+          }
+        }
+
+        if (!treatCarouselsAsFolders) {
+          const carouselScan = await this.scanReservedCarousels(
+            sourceFolder,
+            existingFolders,
+            usedSlugs,
+            folderScanStates,
+            derivativeJobs,
+            errors,
+            warnings,
+            options,
+            imageProcessingContext,
+            excludedFolderRules
+          );
+          const ownerFolder = carouselScan.ownerFolder ?? result.folder;
+          const carouselResults = carouselScan.results;
+
+          if (carouselResults.length > 0 && ownerFolder) {
+            activeFolderPaths.add(sourceFolder.relativePath);
+            discoveredFolderIds.add(ownerFolder.id);
+          }
+
+          for (const carouselResult of carouselResults) {
+            if (carouselResult.folder) discoveredFolderIds.add(carouselResult.folder.id);
+            applyScanResult(carouselResult);
           }
         }
 
@@ -1934,7 +2298,7 @@ class ScannerService {
           processedFolders: this.progress.processedFolders + 1
         });
         this.logProgress('folder');
-      }, null, treatStoriesAsFolders, excludedFolderRules);
+      }, null, treatStoriesAsFolders, treatCarouselsAsFolders, excludedFolderRules);
 
       for (const folder of existingFolders) {
         if (!discoveredFolderIds.has(folder.id)) {
@@ -1942,6 +2306,8 @@ class ScannerService {
           folderRepository.setAvatar(folder.id, null, 'auto');
         }
       }
+
+      postRepository.syncRepresentativePlaces();
 
       metrics.removedFolderStateRows = folderScanStateRepository.deleteMissing([...activeFolderPaths]);
 
@@ -1971,9 +2337,19 @@ class ScannerService {
     }
 
     await this.applyScanErrors(summary, errors);
+    await this.applyScanWarnings(summary, warnings);
 
     if (summary.status !== 'failed') {
-      appSettingsRepository.set(LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY, currentGalleryRoot);
+      appSettingsRepository.setMany([
+        {
+          key: LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY,
+          value: currentGalleryRoot
+        },
+        {
+          key: CAROUSELS_APPLIED_MODE_SETTING_KEY,
+          value: serializeTreatCarouselsAsFoldersSetting(treatCarouselsAsFolders)
+        }
+      ]);
     }
 
     if (summary.status === 'completed' && avifMetadataRepairPending) {
@@ -2032,6 +2408,12 @@ class ScannerService {
       }
 
       if (!treatStoriesAsFolders && findReservedStoriesOwnerPath(relativePath)) {
+        fallbackReason = `${reason}:fallback`;
+        break;
+      }
+
+      const treatCarouselsAsFolders = this.shouldTreatCarouselsAsFolders();
+      if (!treatCarouselsAsFolders && findReservedCarouselsOwnerPath(relativePath)) {
         fallbackReason = `${reason}:fallback`;
         break;
       }
@@ -2104,6 +2486,7 @@ class ScannerService {
       }
 
       if (fallbackReason === null) {
+        postRepository.syncRepresentativePlaces();
         await this.processDerivativeJobs([...derivativeJobs.values()], errors);
       }
     } catch (error) {
@@ -2288,6 +2671,7 @@ class ScannerService {
     const folderName = getFolderDisplayInfo(normalizedFolderPath).name;
     const role = options.role ?? 'normal';
     const storyOwnerFolderId = options.storyOwnerFolderId ?? null;
+    const carouselOwnerFolderId = options.carouselOwnerFolderId ?? null;
 
     if (existingByFolder) {
       usedSlugs.delete(existingByFolder.slug);
@@ -2299,7 +2683,8 @@ class ScannerService {
       name: folderName,
       folderPath: normalizedFolderPath,
       role,
-      storyOwnerFolderId
+      storyOwnerFolderId,
+      carouselOwnerFolderId
     });
     this.rememberFolder(existingFolders, saved.folder);
     return {

--- a/server/src/types/models.ts
+++ b/server/src/types/models.ts
@@ -4,8 +4,9 @@ export type NestedFolderTitleFormat = 'folder' | 'parent-plus-folder';
 export type TakenAtSource = 'exif' | 'mtime' | 'first_seen' | 'sort_timestamp';
 export type PlaybackStrategy = 'preview' | 'original';
 export type FolderAvatarSource = 'auto' | 'manual' | 'cover';
-export type FolderRole = 'normal' | 'story_root' | 'story_capsule';
+export type FolderRole = 'normal' | 'story_root' | 'story_capsule' | 'carousel_source';
 export type PlaceKind = 'city' | 'approximate_spot' | 'manual';
+export type PostType = 'single' | 'carousel';
 
 export interface ImageExifData {
   cameraMake?: string;
@@ -28,6 +29,7 @@ export interface FolderRecord {
   folder_path: string;
   role: FolderRole;
   story_owner_folder_id: number | null;
+  carousel_owner_folder_id: number | null;
   description: string | null;
   avatar_image_id: number | null;
   avatar_source: FolderAvatarSource;
@@ -60,6 +62,8 @@ export interface PlaceRecord {
 
 export interface FolderSummaryRecord extends FolderRecord {
   image_count: number;
+  post_count: number;
+  carousel_count: number;
   video_count: number;
   latest_image_mtime_ms: number | null;
   has_avatar_story?: number | null;
@@ -103,6 +107,30 @@ export interface ImageRecord {
   updated_at: string;
 }
 
+export interface PostRecord {
+  id: number;
+  folder_id: number;
+  place_id: number | null;
+  source_path: string;
+  post_type: PostType;
+  caption: string | null;
+  sort_timestamp: number;
+  taken_at: number | null;
+  taken_at_source: TakenAtSource | null;
+  is_deleted: number;
+  deleted_at: string | null;
+  is_trashed: number;
+  trashed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PostItemRecord {
+  post_id: number;
+  image_id: number;
+  position: number;
+}
+
 export interface PlaceSummary {
   id: number;
   slug: string;
@@ -121,6 +149,8 @@ export interface ScanRunRecord {
   updated_files: number;
   removed_files: number;
   error_text: string | null;
+  warning_count: number;
+  warning_text: string | null;
 }
 
 export interface AppSettingRecord {
@@ -138,7 +168,8 @@ export interface FolderScanStateRecord {
 }
 
 export interface LikeRecord {
-  image_id: number;
+  post_id: number;
+  image_id?: number;
   created_at: string;
 }
 
@@ -156,10 +187,12 @@ export interface CollectionSummaryRecord extends CollectionRecord {
   cover_image_id: number | null;
   cover_thumbnail_path: string | null;
   preview_image_ids: string | null;
+  cover_post_id?: number | null;
 }
 
 export interface CollectionMembershipRecord extends CollectionSummaryRecord {
   contains_image: number;
+  contains_post?: number;
 }
 
 export interface FolderShareLinkRecord {
@@ -182,6 +215,25 @@ export interface FolderSharePasswordRecord {
   updated_at: string;
 }
 
+export interface PostMediaItem {
+  imageId: number;
+  position: number;
+  filename: string;
+  width: number;
+  height: number;
+  mediaType: MediaType;
+  durationMs: number | null;
+  isAnimated: boolean | null;
+  thumbnailUrl: string;
+  previewUrl: string;
+  originalUrl?: string;
+  playbackStrategy?: PlaybackStrategy | null;
+  exif?: ImageExifData | null;
+  mimeType?: string;
+  fileSize?: number;
+  relativePath?: string;
+}
+
 export interface FeedImage {
   id: number;
   folderId: number;
@@ -191,7 +243,9 @@ export interface FeedImage {
   folderPath: string;
   folderBreadcrumb?: string | null;
   filename: string;
+  sourcePath?: string;
   caption: string | null;
+  carouselTitle?: string | null;
   width: number;
   height: number;
   mediaType: MediaType;
@@ -203,9 +257,20 @@ export interface FeedImage {
   takenAt: number | null;
   isSaved: boolean;
   place?: PlaceSummary | null;
+
+  // Carousel post properties
+  postType?: PostType;
+  itemCount?: number;
+  mediaItems?: PostMediaItem[];
 }
 
-export interface ReelCandidate extends FeedImage {
+export interface FeedPost extends FeedImage {
+  postType: PostType;
+  itemCount: number;
+  mediaItems: PostMediaItem[];
+}
+
+export interface ReelCandidate extends FeedPost {
   likedAt: string | null;
 }
 
@@ -221,8 +286,22 @@ export interface ImageDetail extends FeedImage {
   previousImageId: number | null;
 }
 
+export interface PostDetail extends ImageDetail {
+  postType: PostType;
+  itemCount: number;
+  mediaItems: PostMediaItem[];
+  nextPostId: number | null;
+  previousPostId: number | null;
+}
+
 export interface TrashImage extends FeedImage {
   trashedAt: string | null;
+}
+
+export interface TrashPost extends TrashImage {
+  postType: PostType;
+  itemCount: number;
+  mediaItems: PostMediaItem[];
 }
 
 export interface PlaceDetail extends PlaceSummary {
@@ -242,6 +321,7 @@ export interface SharedFolderSummary {
   name: string;
   description: string | null;
   imageCount: number;
+  postCount: number;
   videoCount: number;
   avatarThumbnailUrl: string | null;
   sortTimestamp: number;
@@ -254,6 +334,7 @@ export interface SharedFeedItem {
   folderName: string;
   filename: string;
   caption: string | null;
+  carouselTitle?: string | null;
   width: number;
   height: number;
   mediaType: MediaType;
@@ -262,6 +343,10 @@ export interface SharedFeedItem {
   thumbnailUrl: string;
   previewUrl: string;
   sortTimestamp: number;
+
+  postType?: PostType;
+  itemCount?: number;
+  mediaItems?: PostMediaItem[];
 }
 
 export interface SharedImageDetail {
@@ -271,6 +356,7 @@ export interface SharedImageDetail {
   folderName: string;
   filename: string;
   caption: string | null;
+  carouselTitle?: string | null;
   mediaType: MediaType;
   mimeType: string;
   width: number;
@@ -282,4 +368,8 @@ export interface SharedImageDetail {
   sortTimestamp: number;
   nextImageId: number | null;
   previousImageId: number | null;
+
+  postType?: PostType;
+  itemCount?: number;
+  mediaItems?: PostMediaItem[];
 }

--- a/server/src/utils/carousels-utils.ts
+++ b/server/src/utils/carousels-utils.ts
@@ -1,0 +1,35 @@
+import { normalizePath, splitPathSegments } from './path-utils.js';
+
+export const RESERVED_CAROUSELS_FOLDER_NAME = 'carousels';
+
+export function isCarouselsFolderName(value: string): boolean {
+  return value.trim().toLocaleLowerCase() === RESERVED_CAROUSELS_FOLDER_NAME;
+}
+
+export function parseTreatCarouselsAsFoldersSetting(value: string | null): boolean {
+  return value === '1';
+}
+
+export function serializeTreatCarouselsAsFoldersSetting(value: boolean): string {
+  return value ? '1' : '0';
+}
+
+export function getReservedCarouselsFolderPath(ownerFolderPath: string): string {
+  return `${normalizePath(ownerFolderPath)}/${RESERVED_CAROUSELS_FOLDER_NAME}`;
+}
+
+export function findReservedCarouselsOwnerPath(relativePath: string): string | null {
+  const segments = splitPathSegments(relativePath);
+
+  for (let index = 1; index < segments.length; index += 1) {
+    if (isCarouselsFolderName(segments[index] ?? '')) {
+      return segments.slice(0, index).join('/');
+    }
+  }
+
+  return null;
+}
+
+export function isWithinReservedCarouselsSubtree(relativePath: string): boolean {
+  return findReservedCarouselsOwnerPath(relativePath) !== null;
+}

--- a/server/src/utils/scan-utils.ts
+++ b/server/src/utils/scan-utils.ts
@@ -109,3 +109,31 @@ export function shouldRefreshUnchangedImage(input: UnchangedImageRefreshDecision
 
   return input.galleryRootChanged || input.absolutePathChanged;
 }
+
+const primaryCollator = new Intl.Collator('en', {
+  numeric: true,
+  sensitivity: 'base',
+  usage: 'sort'
+});
+
+const secondaryCollator = new Intl.Collator('en', {
+  numeric: true,
+  sensitivity: 'variant',
+  usage: 'sort'
+});
+
+export function compareNaturalFilename(a: string, b: string): number {
+  const primary = primaryCollator.compare(a, b);
+  if (primary !== 0) return primary;
+
+  const secondary = secondaryCollator.compare(a, b);
+  if (secondary !== 0) return secondary;
+
+  const normA = a.normalize('NFKD');
+  const normB = b.normalize('NFKD');
+  if (normA !== normB) {
+    return normA < normB ? -1 : 1;
+  }
+
+  return a < b ? -1 : a > b ? 1 : 0;
+}

--- a/server/test/carousel-deterministic-ordering.test.ts
+++ b/server/test/carousel-deterministic-ordering.test.ts
@@ -1,0 +1,98 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type ScannerServiceModule = typeof import('../src/services/scanner-service.js');
+type DatabaseModule = typeof import('../src/db/database.js');
+
+describe.sequential('carousel deterministic scanner ordering (Issue 12)', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let scannerService: ScannerServiceModule['scannerService'];
+  let postRepository: RepositoriesModule['postRepository'];
+  let databaseManager: DatabaseModule['databaseManager'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'foldergram-sort-test-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    databaseManager?.close();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.resetModules();
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ scannerService } = await import('../src/services/scanner-service.js'));
+    ({ postRepository } = await import('../src/db/repositories.js'));
+    ({ databaseManager } = await import('../src/db/database.js'));
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+  });
+
+  afterAll(async () => {
+    databaseManager?.close();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('consistently indexes carousel slides in natural numeric order regardless of discovery order', async () => {
+    const carouselDir = path.join(appConfig.galleryRoot, 'album', 'carousels', 'post1');
+    await fs.mkdir(carouselDir, { recursive: true });
+
+    // Write 1x1 GIF files with names file2.jpg, file10.jpg, file1.jpg
+    const gif = Buffer.from('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', 'base64');
+    await fs.writeFile(path.join(carouselDir, 'file10.jpg'), gif);
+    await fs.writeFile(path.join(carouselDir, 'file2.jpg'), gif);
+    await fs.writeFile(path.join(carouselDir, 'file1.jpg'), gif);
+
+    await scannerService.scanAll('manual');
+
+    const posts = postRepository.listFeed(1, 10, 'newest');
+    expect(posts).toHaveLength(1);
+    expect(posts[0].mediaItems).toHaveLength(3);
+    expect(posts[0].mediaItems![0].filename).toBe('file1.jpg');
+    expect(posts[0].mediaItems![1].filename).toBe('file2.jpg');
+    expect(posts[0].mediaItems![2].filename).toBe('file10.jpg');
+  });
+
+  it('deterministically breaks ties for numeric and accent variants with shuffled discovery', async () => {
+    const carouselDir = path.join(appConfig.galleryRoot, 'album', 'carousels', 'post2');
+    await fs.mkdir(carouselDir, { recursive: true });
+
+    const gif = Buffer.from('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', 'base64');
+    // Shuffled creation
+    await fs.writeFile(path.join(carouselDir, 'item-10-b.jpg'), gif);
+    await fs.writeFile(path.join(carouselDir, 'item-2-b.jpg'), gif);
+    await fs.writeFile(path.join(carouselDir, 'item-1-á.jpg'), gif);
+    await fs.writeFile(path.join(carouselDir, 'item-1-a.jpg'), gif);
+
+    await scannerService.scanAll('manual');
+
+    const posts = postRepository.listFeed(1, 10, 'newest');
+    const post = posts.find((p) => p.sourcePath?.includes('post2'));
+    expect(post).toBeDefined();
+    expect(post!.mediaItems).toHaveLength(4);
+    // 'item-1-a.jpg' before 'item-1-á.jpg' (base before accent), before 'item-2-b.jpg' and 'item-10-b.jpg'
+    expect(post!.mediaItems![0].filename).toBe('item-1-a.jpg');
+    expect(post!.mediaItems![1].filename).toBe('item-1-á.jpg');
+    expect(post!.mediaItems![2].filename).toBe('item-2-b.jpg');
+    expect(post!.mediaItems![3].filename).toBe('item-10-b.jpg');
+  });
+});

--- a/server/test/carousel-posts-feature.test.ts
+++ b/server/test/carousel-posts-feature.test.ts
@@ -1,0 +1,721 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type express from 'express';
+
+import { LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY } from '../src/constants/app-setting-keys.js';
+import {
+  getMediaTypeFromExtension,
+  getPreviewRelativePath,
+  getThumbnailRelativePath
+} from '../src/utils/image-utils.js';
+import { getRelativeGalleryPath } from '../src/utils/path-utils.js';
+import { requestTestApp } from './http-test-utils.js';
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type GalleryServiceModule = typeof import('../src/services/gallery-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type ScannerServiceModule = typeof import('../src/services/scanner-service.js');
+
+async function requestApp(app: express.Application, method: string, urlPath: string, body?: unknown) {
+  return requestTestApp(app, method, urlPath, { 'x-foldergram-intent': '1' }, body);
+}
+
+const generateThumbnailDerivativeMock = vi.fn();
+const generateDerivativesMock = vi.fn();
+const readMediaMetadataMock = vi.fn();
+
+describe.sequential('carousel posts feature', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let galleryService: GalleryServiceModule['galleryService'];
+  let scannerService: ScannerServiceModule['scannerService'];
+  let folderRepository: RepositoriesModule['folderRepository'];
+  let postRepository: RepositoriesModule['postRepository'];
+  let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+  let appSettingsRepository: RepositoriesModule['appSettingsRepository'];
+  let imageRepository: RepositoriesModule['imageRepository'];
+  let placeRepository: RepositoriesModule['placeRepository'];
+  let app: express.Application;
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-carousels-feature-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    generateThumbnailDerivativeMock.mockReset();
+    generateDerivativesMock.mockReset();
+    readMediaMetadataMock.mockReset();
+
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.resetModules();
+    vi.doMock('../src/services/derivative-service.js', () => ({
+      generateDerivatives: generateDerivativesMock,
+      generateThumbnailDerivative: generateThumbnailDerivativeMock,
+      readMediaMetadata: readMediaMetadataMock
+    }));
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ galleryService } = await import('../src/services/gallery-service.js'));
+    ({ scannerService } = await import('../src/services/scanner-service.js'));
+    ({ folderRepository, postRepository, maintenanceRepository, appSettingsRepository, imageRepository, placeRepository } = await import(
+      '../src/db/repositories.js'
+    ));
+    app = (await import('../src/app.js')).createApp();
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+
+    readMediaMetadataMock.mockImplementation(async (absolutePath: string) => {
+      const extension = path.extname(absolutePath).toLowerCase();
+      const mediaType = getMediaTypeFromExtension(extension);
+      const relativePath = getRelativeGalleryPath(appConfig.galleryRoot, absolutePath);
+
+      return {
+        width: mediaType === 'video' ? 1080 : 1440,
+        height: mediaType === 'video' ? 1920 : 960,
+        takenAt: null,
+        durationMs: mediaType === 'video' ? 4_000 : null,
+        mediaType,
+        playbackStrategy: 'preview',
+        isAnimated: false,
+        thumbnailPath: getThumbnailRelativePath(relativePath),
+        previewPath: getPreviewRelativePath(relativePath, mediaType),
+        generatedThumbnail: true,
+        generatedPreview: true
+      };
+    });
+
+    generateDerivativesMock.mockImplementation(async (_sourcePath: string, relativePath: string) => {
+      const extension = path.extname(relativePath).toLowerCase();
+      const mediaType = getMediaTypeFromExtension(extension);
+
+      return {
+        thumbnailPath: getThumbnailRelativePath(relativePath),
+        previewPath: getPreviewRelativePath(relativePath, mediaType)
+      };
+    });
+
+    maintenanceRepository.resetLibraryIndex();
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('scans reserved carousels folder and creates carousel post with ordered items', async () => {
+    const albumPath = path.join(appConfig.galleryRoot, 'vacation');
+    const carouselPath = path.join(albumPath, 'carousels', 'sunset');
+    await fs.mkdir(carouselPath, { recursive: true });
+
+    const dummyContent = 'dummy-media';
+    await fs.writeFile(path.join(carouselPath, '01-beach.jpg'), dummyContent);
+    await fs.writeFile(path.join(carouselPath, '02-wave.jpg'), dummyContent);
+    await fs.writeFile(path.join(carouselPath, '10-dusk.jpg'), dummyContent);
+
+    await scannerService.scanAll('manual');
+
+    const posts = postRepository.listFeed(1, 20);
+    expect(posts).toHaveLength(1);
+
+    const post = posts[0];
+    expect(post.postType).toBe('carousel');
+    expect(post.itemCount).toBe(3);
+    expect(post.mediaItems).toHaveLength(3);
+    expect(post.mediaItems[0].filename).toBe('01-beach.jpg');
+    expect(post.mediaItems[1].filename).toBe('02-wave.jpg');
+    expect(post.mediaItems[2].filename).toBe('10-dusk.jpg');
+
+    const feed = galleryService.getFeed(1, 20, 'recent');
+    expect(feed.items).toHaveLength(1);
+    expect(feed.items[0].postType).toBe('carousel');
+    expect(feed.items[0].mediaItems).toHaveLength(3);
+    expect(feed.items[0].itemCount).toBe(3);
+  });
+
+  it('keeps a carousel beginning with cover.jpg visible across post surfaces', async () => {
+    const carouselPath = path.join(appConfig.galleryRoot, 'album', 'carousels', 'cover-first');
+    await fs.mkdir(carouselPath, { recursive: true });
+    await fs.writeFile(path.join(carouselPath, 'cover.jpg'), 'carousel-cover-item');
+    await fs.writeFile(path.join(carouselPath, 'second.jpg'), 'carousel-second-item');
+
+    await scannerService.scanAll('manual');
+
+    const post = postRepository.listFeed(1, 10)[0]!;
+    const ownerFolder = folderRepository.getByFolderPath('album')!;
+    expect(post.mediaItems.map((item) => item.filename)).toEqual(['cover.jpg', 'second.jpg']);
+    expect(postRepository.isExplicitFolderCover(post.id)).toBe(false);
+    expect(postRepository.countFeed()).toBe(1);
+    expect(postRepository.listVisibleByFolder(ownerFolder.id, 1, 10).map((item) => item.id)).toEqual([post.id]);
+    expect(postRepository.countVisibleByFolder(ownerFolder.id)).toBe(1);
+    expect(galleryService.getFeed(1, 10, 'recent').items.map((item) => item.id)).toEqual([post.id]);
+    expect(galleryService.getFolderImages(ownerFolder.slug, 1, 10)?.items.map((item) => item.id)).toEqual([post.id]);
+    expect(folderRepository.getSummaryBySlug(ownerFolder.slug)).toMatchObject({
+      image_count: 1,
+      post_count: 1,
+      carousel_count: 1
+    });
+    expect(galleryService.getFolderBySlug(ownerFolder.slug)).toMatchObject({
+      imageCount: 1,
+      postCount: 1
+    });
+    expect(galleryService.listFolders()).toEqual([
+      expect.objectContaining({ id: ownerFolder.id, imageCount: 1, postCount: 1 })
+    ]);
+
+    expect(galleryService.likeImage(post.id)).toEqual({ id: post.id, liked: true });
+    expect(galleryService.saveImage(post.id)?.isSaved).toBe(true);
+    expect(galleryService.getLikes().items.map((item) => item.id)).toEqual([post.id]);
+    expect(galleryService.getCollectionImages('saved', 1, 10)?.items.map((item) => item.id)).toEqual([post.id]);
+
+    const place = placeRepository.upsertCity({
+      slug: 'cover-city',
+      displayName: 'Cover City',
+      geonamesId: 765432,
+      latitude: 10,
+      longitude: 20,
+      cityName: 'Cover City'
+    });
+    const storedPost = postRepository.findById(post.id)!;
+    const postItems = postRepository.listImageRecords(post.id);
+    postRepository.upsertPostWithItems({
+      existingPostId: storedPost.id,
+      folderId: storedPost.folder_id,
+      placeId: place.id,
+      sourcePath: storedPost.source_path,
+      postType: storedPost.post_type,
+      caption: storedPost.caption,
+      sortTimestamp: storedPost.sort_timestamp,
+      takenAt: storedPost.taken_at,
+      takenAtSource: storedPost.taken_at_source,
+      isDeleted: storedPost.is_deleted,
+      isTrashed: storedPost.is_trashed
+    }, postItems.map((image, index) => ({ imageId: image.id, position: index + 1 })));
+
+    expect(galleryService.listPlaces()).toEqual([expect.objectContaining({ slug: place.slug, postCount: 1 })]);
+    expect(galleryService.getPlaceImages(place.slug, 1, 10)?.items.map((item) => item.id)).toEqual([post.id]);
+  });
+
+  it('truncates carousel posts exceeding 20 items and logs a scan warning', async () => {
+    const carouselPath = path.join(appConfig.galleryRoot, 'events', 'carousels', 'big-party');
+    await fs.mkdir(carouselPath, { recursive: true });
+
+    const dummyContent = 'dummy-media';
+    for (let i = 1; i <= 25; i++) {
+      const numStr = String(i).padStart(2, '0');
+      await fs.writeFile(path.join(carouselPath, `photo-${numStr}.jpg`), dummyContent);
+    }
+
+    await scannerService.scanAll('manual');
+
+    const posts = postRepository.listFeed(1, 30);
+    expect(posts).toHaveLength(1);
+
+    const post = posts[0];
+    expect(post.postType).toBe('carousel');
+    expect(post.itemCount).toBe(20);
+    expect(post.mediaItems).toHaveLength(20);
+
+    const scanRun = scannerService.getProgress().lastCompletedScan;
+    expect(scanRun?.status).toBe('completed');
+    expect(scanRun?.warning_count).toBe(1);
+    expect(scanRun?.warning_text).toContain('maximum limit of 20 items');
+    expect(scanRun?.error_text).toBeNull();
+  });
+
+  it('keeps multiple carousel source folders isolated during the same scan', async () => {
+    const carouselsRoot = path.join(appConfig.galleryRoot, 'album', 'carousels');
+    await fs.mkdir(path.join(carouselsRoot, 'first'), { recursive: true });
+    await fs.mkdir(path.join(carouselsRoot, 'second'), { recursive: true });
+    await fs.writeFile(path.join(carouselsRoot, 'first', '01.jpg'), 'first-1');
+    await fs.writeFile(path.join(carouselsRoot, 'first', '02.jpg'), 'first-2');
+    await fs.writeFile(path.join(carouselsRoot, 'second', '01.jpg'), 'second-1');
+    await fs.writeFile(path.join(carouselsRoot, 'second', '02.jpg'), 'second-2');
+
+    await scannerService.scanAll('manual');
+
+    const posts = postRepository.listFeed(1, 20);
+    expect(posts).toHaveLength(2);
+    expect(posts.map((post) => post.mediaItems.map((item) => item.filename))).toEqual([
+      ['01.jpg', '02.jpg'],
+      ['01.jpg', '02.jpg']
+    ]);
+
+    const carouselSources = folderRepository.getAll().filter((folder) => folder.role === 'carousel_source');
+    expect(carouselSources).toHaveLength(2);
+    expect(new Set(carouselSources.map((folder) => folder.folder_path))).toEqual(new Set([
+      'album/carousels/first',
+      'album/carousels/second'
+    ]));
+  });
+
+  it('preserves post identity and caption while transitioning between one and two items', async () => {
+    const carouselPath = path.join(appConfig.galleryRoot, 'album', 'carousels', 'changing');
+    const secondPath = path.join(carouselPath, '02.jpg');
+    await fs.mkdir(carouselPath, { recursive: true });
+    await fs.writeFile(path.join(carouselPath, '01.jpg'), 'first');
+
+    await scannerService.scanAll('manual');
+    const initialPost = postRepository.listFeed(1, 20)[0];
+    expect(initialPost.postType).toBe('single');
+    galleryService.updateImageCaption(initialPost.id, 'Stable caption');
+
+    await fs.writeFile(secondPath, 'second');
+    await scannerService.scanAll('manual');
+    const expandedPost = postRepository.listFeed(1, 20)[0];
+    expect(expandedPost.id).toBe(initialPost.id);
+    expect(expandedPost.postType).toBe('carousel');
+    expect(expandedPost.caption).toBe('Stable caption');
+
+    await fs.rm(secondPath);
+    await scannerService.scanAll('manual');
+    const collapsedPost = postRepository.listFeed(1, 20)[0];
+    expect(collapsedPost.id).toBe(initialPost.id);
+    expect(collapsedPost.postType).toBe('single');
+    expect(collapsedPost.caption).toBe('Stable caption');
+  });
+
+  it('ignores root files and sub-subdirectories in carousels directory', async () => {
+    const carouselsRoot = path.join(appConfig.galleryRoot, 'album', 'carousels');
+    const validPostPath = path.join(carouselsRoot, 'valid-post');
+    const nestedSubPath = path.join(validPostPath, 'nested-sub');
+
+    await fs.mkdir(nestedSubPath, { recursive: true });
+
+    const dummyContent = 'dummy-media';
+    await fs.writeFile(path.join(carouselsRoot, 'ignored-root.jpg'), dummyContent);
+    await fs.writeFile(path.join(validPostPath, '01.jpg'), dummyContent);
+    await fs.writeFile(path.join(validPostPath, '02.jpg'), dummyContent);
+    await fs.writeFile(path.join(nestedSubPath, 'ignored-nested.jpg'), dummyContent);
+
+    await scannerService.scanAll('manual');
+
+    const posts = postRepository.listFeed(1, 20);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].mediaItems).toHaveLength(2);
+    expect(posts[0].mediaItems.map((item) => item.filename)).toEqual(['01.jpg', '02.jpg']);
+  });
+
+  it('updates caption for the whole carousel post', async () => {
+    const carouselPath = path.join(appConfig.galleryRoot, 'album', 'carousels', 'post-1');
+    await fs.mkdir(carouselPath, { recursive: true });
+
+    const dummyContent = 'dummy-media';
+    await fs.writeFile(path.join(carouselPath, '01.jpg'), dummyContent);
+    await fs.writeFile(path.join(carouselPath, '02.jpg'), dummyContent);
+
+    await scannerService.scanAll('manual');
+
+    const feed = galleryService.getFeed(1, 10, 'recent');
+    const postId = feed.items[0].id;
+
+    const updated = galleryService.updateImageCaption(postId, 'Awesome carousel trip');
+    expect(updated).not.toBeNull();
+    expect(updated?.caption).toBe('Awesome carousel trip');
+
+    const reFetched = galleryService.getImageDetail(postId);
+    expect(reFetched?.caption).toBe('Awesome carousel trip');
+
+    expect(galleryService.saveImage(postId)?.isSaved).toBe(true);
+    expect(galleryService.likeImage(postId)).toEqual({ id: postId, liked: true });
+    expect(galleryService.trashImage(postId)?.id).toBe(postId);
+    expect(postRepository.findById(postId)?.is_trashed).toBe(1);
+    expect(postRepository.listImageRecords(postId).every((item) => item.is_trashed === 1)).toBe(true);
+
+    expect(galleryService.restoreImage(postId)?.id).toBe(postId);
+    expect(postRepository.findById(postId)?.is_trashed).toBe(0);
+    expect(postRepository.listImageRecords(postId).every((item) => item.is_trashed === 0)).toBe(true);
+  });
+
+  it('respects treatCarouselsAsFolders setting toggle', async () => {
+    const carouselPath = path.join(appConfig.galleryRoot, 'album', 'carousels', 'post-1');
+    await fs.mkdir(carouselPath, { recursive: true });
+
+    const dummyContent = 'dummy-media';
+    await fs.writeFile(path.join(carouselPath, '01.jpg'), dummyContent);
+
+    await scannerService.scanAll('manual');
+
+    expect(galleryService.getFeed(1, 10, 'recent').items).toHaveLength(1);
+
+    galleryService.setTreatCarouselsAsFolders(true);
+    await scannerService.scanAll('manual');
+
+    const folders = folderRepository.getAll();
+    const carouselsFolder = folders.find((f) => f.slug.includes('carousels'));
+    expect(carouselsFolder).toBeDefined();
+    expect(scannerService.getProgress().lastCompletedScan?.status).toBe('completed');
+  });
+
+  it('prevents numeric postId and imageId collision between consecutive carousels', async () => {
+    const albumPath = path.join(appConfig.galleryRoot, 'album');
+    const carouselsRoot = path.join(albumPath, 'carousels');
+    await fs.mkdir(carouselsRoot, { recursive: true });
+
+    // Single post -> image 1, post 1
+    await fs.writeFile(path.join(albumPath, 'single.jpg'), 'single-media');
+
+    // Carousel A -> images 2 & 3, post 2
+    const carouselAPath = path.join(carouselsRoot, 'carousel-a');
+    await fs.mkdir(carouselAPath, { recursive: true });
+    await fs.writeFile(path.join(carouselAPath, 'a1.jpg'), 'a1-media');
+    await fs.writeFile(path.join(carouselAPath, 'a2.jpg'), 'a2-media');
+
+    // Carousel B -> images 4 & 5, post 3
+    const carouselBPath = path.join(carouselsRoot, 'carousel-b');
+    await fs.mkdir(carouselBPath, { recursive: true });
+    await fs.writeFile(path.join(carouselBPath, 'b1.jpg'), 'b1-media');
+    await fs.writeFile(path.join(carouselBPath, 'b2.jpg'), 'b2-media');
+
+    await scannerService.scanAll('manual');
+
+    const feed = galleryService.getFeed(1, 10, 'oldest');
+    expect(feed.items).toHaveLength(3);
+
+    const post1 = feed.items.find((p) => p.sourcePath?.includes('single.jpg'))!;
+    const post2 = feed.items.find((p) => p.sourcePath?.includes('carousel-a'))!;
+    const post3 = feed.items.find((p) => p.sourcePath?.includes('carousel-b'))!;
+
+    // Canonical request for /posts/:id (post 3, Carousel B)
+    const detailPost3 = galleryService.getImageDetail(post3.id);
+    expect(detailPost3?.id).toBe(post3.id);
+    expect(detailPost3?.mediaItems.map((m) => m.filename)).toEqual(['b1.jpg', 'b2.jpg']);
+
+    // Caption update on canonical post 3
+    const updatedCaption = galleryService.updateImageCaption(post3.id, 'Caption for Carousel B');
+    expect(updatedCaption?.id).toBe(post3.id);
+    expect(updatedCaption?.caption).toBe('Caption for Carousel B');
+    expect(galleryService.getImageDetail(post2.id)?.caption).toBeNull();
+
+    // Like on canonical post 3
+    expect(galleryService.likeImage(post3.id)).toEqual({ id: post3.id, liked: true });
+    expect(galleryService.getLikes().items.map((item) => item.id)).toEqual([post3.id]);
+
+    // Save on canonical post 3
+    expect(galleryService.saveImage(post3.id)?.id).toBe(post3.id);
+    expect(galleryService.getImageCollections(post3.id)?.isSaved).toBe(true);
+
+    // Trash & restore on canonical post 3
+    expect(galleryService.trashImage(post3.id)?.id).toBe(post3.id);
+    expect(postRepository.findById(post3.id)?.is_trashed).toBe(1);
+    expect(postRepository.findById(post2.id)?.is_trashed).toBe(0);
+
+    expect(galleryService.restoreImage(post3.id)?.id).toBe(post3.id);
+    expect(postRepository.findById(post3.id)?.is_trashed).toBe(0);
+
+    // Image 3 is second slide of Carousel A (post 2)
+    const image3 = imageRepository.getByRelativePath('album/carousels/carousel-a/a2.jpg');
+    expect(image3).toBeDefined();
+
+    // Legacy image alias /images/:id (image 3 resolves to post 2, Carousel A)
+    const legacyDetailImage3 = galleryService.getImageDetail(image3!.id, undefined, { isLegacyImageAlias: true });
+    expect(legacyDetailImage3?.id).toBe(post2.id);
+    expect(legacyDetailImage3?.mediaItems.map((m) => m.filename)).toEqual(['a1.jpg', 'a2.jpg']);
+
+    // Deleting canonical post 3 deletes Carousel B, not Carousel A
+    const deleted = await galleryService.deleteImage(post3.id);
+    expect(deleted?.id).toBe(post3.id);
+    expect(postRepository.findById(post3.id)).toBeUndefined();
+    expect(postRepository.findById(post2.id)).toBeDefined();
+  });
+
+  it('keeps canonical post and legacy image HTTP namespaces separate across reads, mutations, shares, and deletion', async () => {
+    const albumPath = path.join(appConfig.galleryRoot, 'album');
+    const carouselsRoot = path.join(albumPath, 'carousels');
+    await fs.mkdir(carouselsRoot, { recursive: true });
+    await fs.writeFile(path.join(albumPath, 'single.jpg'), 'single-media');
+
+    const createCarousel = async (name: string) => {
+      const carouselPath = path.join(carouselsRoot, name);
+      await fs.mkdir(carouselPath, { recursive: true });
+      await fs.writeFile(path.join(carouselPath, '01.jpg'), `${name}-first`);
+      await fs.writeFile(path.join(carouselPath, '02.jpg'), `${name}-second-slide`);
+    };
+    await createCarousel('carousel-a');
+    await createCarousel('carousel-b');
+    await scannerService.scanAll('manual');
+
+    const initialFeed = galleryService.getFeed(1, 20, 'oldest').items;
+    const carouselA = initialFeed.find((post) => post.sourcePath?.endsWith('/carousel-a'))!;
+    const carouselB = initialFeed.find((post) => post.sourcePath?.endsWith('/carousel-b'))!;
+    const carouselAItems = postRepository.listImageRecords(carouselA.id);
+    const carouselBItems = postRepository.listImageRecords(carouselB.id);
+    expect(carouselAItems[1].id).toBe(carouselB.id);
+
+    const canonicalDetail = await requestApp(app, 'GET', `/api/posts/${carouselB.id}`);
+    expect(canonicalDetail.status).toBe(200);
+    expect(canonicalDetail.body.id).toBe(carouselB.id);
+    expect(canonicalDetail.body.mediaItems.map((item: { filename: string }) => item.filename)).toEqual(['01.jpg', '02.jpg']);
+    expect(canonicalDetail.body.sourcePath).toContain('carousel-b');
+
+    const legacyDetail = await requestApp(app, 'GET', `/api/images/${carouselAItems[1].id}`);
+    expect(legacyDetail.status).toBe(200);
+    expect(legacyDetail.body.id).toBe(carouselA.id);
+    expect(legacyDetail.body.sourcePath).toContain('carousel-a');
+
+    expect((await requestApp(app, 'PATCH', `/api/posts/${carouselB.id}/caption`, { caption: 'Canonical B' })).status).toBe(200);
+    expect((await requestApp(app, 'PATCH', `/api/images/${carouselAItems[1].id}/caption`, { caption: 'Legacy A' })).status).toBe(200);
+    expect(postRepository.findById(carouselB.id)?.caption).toBe('Canonical B');
+    expect(postRepository.findById(carouselA.id)?.caption).toBe('Legacy A');
+
+    expect((await requestApp(app, 'POST', `/api/posts/${carouselB.id}/like`)).body).toMatchObject({ id: carouselB.id, liked: true });
+    expect((await requestApp(app, 'DELETE', `/api/posts/${carouselB.id}/like`)).body).toMatchObject({ id: carouselB.id, liked: false });
+    expect((await requestApp(app, 'POST', `/api/images/${carouselAItems[1].id}/like`)).body).toMatchObject({ id: carouselA.id, liked: true });
+    expect((await requestApp(app, 'DELETE', `/api/images/${carouselAItems[1].id}/like`)).body).toMatchObject({ id: carouselA.id, liked: false });
+
+    expect((await requestApp(app, 'POST', `/api/posts/${carouselB.id}/save`)).body).toMatchObject({ id: carouselB.id, isSaved: true });
+    expect((await requestApp(app, 'DELETE', `/api/posts/${carouselB.id}/save`)).body).toMatchObject({ id: carouselB.id, isSaved: false });
+    expect((await requestApp(app, 'POST', `/api/images/${carouselAItems[1].id}/save`)).body).toMatchObject({ id: carouselA.id, isSaved: true });
+    expect((await requestApp(app, 'DELETE', `/api/images/${carouselAItems[1].id}/save`)).body).toMatchObject({ id: carouselA.id, isSaved: false });
+
+    const collectionResponse = await requestApp(app, 'POST', '/api/collections', { name: 'Collision checks' });
+    const collectionSlug = collectionResponse.body.collection.slug as string;
+    expect((await requestApp(app, 'POST', `/api/collections/${collectionSlug}/posts/${carouselB.id}`)).body.id).toBe(carouselB.id);
+    expect((await requestApp(app, 'DELETE', `/api/collections/${collectionSlug}/posts/${carouselB.id}`)).body.id).toBe(carouselB.id);
+    expect((await requestApp(app, 'POST', `/api/collections/${collectionSlug}/images/${carouselAItems[1].id}`)).body.id).toBe(carouselA.id);
+    expect((await requestApp(app, 'DELETE', `/api/collections/${collectionSlug}/images/${carouselAItems[1].id}`)).body.id).toBe(carouselA.id);
+
+    expect((await requestApp(app, 'POST', `/api/posts/${carouselB.id}/trash`)).body.id).toBe(carouselB.id);
+    expect(postRepository.findById(carouselA.id)?.is_trashed).toBe(0);
+    expect((await requestApp(app, 'POST', `/api/posts/${carouselB.id}/restore`)).body.id).toBe(carouselB.id);
+    expect((await requestApp(app, 'POST', `/api/images/${carouselAItems[1].id}/trash`)).body.id).toBe(carouselA.id);
+    expect(postRepository.findById(carouselB.id)?.is_trashed).toBe(0);
+    expect((await requestApp(app, 'POST', `/api/images/${carouselAItems[1].id}/restore`)).body.id).toBe(carouselA.id);
+
+    expect((await requestApp(app, 'GET', `/api/share/posts/${carouselB.id}`)).body.id).toBe(carouselB.id);
+    expect((await requestApp(app, 'GET', `/api/share/images/${carouselAItems[1].id}`)).body.id).toBe(carouselA.id);
+
+    expect((await requestApp(app, 'GET', '/api/places')).body).toEqual({ items: [] });
+    const place = placeRepository.upsertCity({
+      slug: 'collision-city',
+      displayName: 'Collision City',
+      geonamesId: 123456,
+      latitude: 10,
+      longitude: 20,
+      cityName: 'Collision City'
+    });
+    const storedCarouselB = postRepository.findById(carouselB.id)!;
+    postRepository.upsertPostWithItems({
+      existingPostId: storedCarouselB.id,
+      folderId: storedCarouselB.folder_id,
+      placeId: place.id,
+      sourcePath: storedCarouselB.source_path,
+      postType: storedCarouselB.post_type,
+      caption: storedCarouselB.caption,
+      sortTimestamp: storedCarouselB.sort_timestamp,
+      takenAt: storedCarouselB.taken_at,
+      takenAtSource: storedCarouselB.taken_at_source,
+      isDeleted: storedCarouselB.is_deleted,
+      isTrashed: storedCarouselB.is_trashed
+    }, carouselBItems.map((image, index) => ({ imageId: image.id, position: index + 1 })));
+    const placesResponse = await requestApp(app, 'GET', '/api/places');
+    expect(placesResponse.status).toBe(200);
+    expect(placesResponse.body.items).toEqual([expect.objectContaining({ slug: 'collision-city', postCount: 1 })]);
+    const placeImagesResponse = await requestApp(app, 'GET', '/api/places/collision-city/images');
+    expect(placeImagesResponse.status).toBe(200);
+    expect(placeImagesResponse.body.items.map((post: { id: number }) => post.id)).toEqual([carouselB.id]);
+
+    await fs.writeFile(path.join(albumPath, 'cover.jpg'), 'unrelated-cover');
+    await createCarousel('carousel-c');
+    await createCarousel('carousel-d');
+    await createCarousel('carousel-e');
+    await scannerService.scanAll('manual');
+    const coverImage = imageRepository.getByRelativePath('album/cover.jpg')!;
+    const collidingCoverPost = postRepository.findById(coverImage.id)!;
+    expect(collidingCoverPost).toBeDefined();
+    expect(postRepository.findByImageId(coverImage.id)).toBeUndefined();
+
+    const postsBeforeMissingLegacyGet = postRepository.countAll();
+    expect((await requestApp(app, 'GET', `/api/images/${coverImage.id}`)).status).toBe(404);
+    expect(postRepository.countAll()).toBe(postsBeforeMissingLegacyGet);
+    expect(postRepository.findByImageId(coverImage.id)).toBeUndefined();
+    expect((await requestApp(app, 'GET', `/api/posts/${collidingCoverPost.id}`)).body.id).toBe(collidingCoverPost.id);
+    expect((await requestApp(app, 'POST', `/api/posts/${collidingCoverPost.id}/like`)).body.id).toBe(collidingCoverPost.id);
+    expect((await requestApp(app, 'POST', `/api/posts/${collidingCoverPost.id}/save`)).body.id).toBe(collidingCoverPost.id);
+
+    for (const image of [...carouselAItems, ...carouselBItems]) {
+      for (const [root, relativePath] of [
+        [appConfig.thumbnailsDir, image.thumbnail_path],
+        [appConfig.previewsDir, image.preview_path]
+      ] as const) {
+        const target = path.join(root, relativePath);
+        await fs.mkdir(path.dirname(target), { recursive: true });
+        await fs.writeFile(target, `derivative:${image.relative_path}`);
+      }
+    }
+
+    expect((await requestApp(app, 'DELETE', `/api/posts/${carouselB.id}`)).body.id).toBe(carouselB.id);
+    for (const image of carouselBItems) {
+      await expect(fs.stat(path.join(appConfig.galleryRoot, image.relative_path))).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.stat(path.join(appConfig.thumbnailsDir, image.thumbnail_path))).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.stat(path.join(appConfig.previewsDir, image.preview_path))).rejects.toMatchObject({ code: 'ENOENT' });
+    }
+    for (const image of carouselAItems) {
+      await expect(fs.stat(path.join(appConfig.galleryRoot, image.relative_path))).resolves.toBeDefined();
+    }
+
+    expect((await requestApp(app, 'DELETE', `/api/images/${carouselAItems[1].id}`)).body.id).toBe(carouselA.id);
+    for (const image of carouselAItems) {
+      await expect(fs.stat(path.join(appConfig.galleryRoot, image.relative_path))).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.stat(path.join(appConfig.thumbnailsDir, image.thumbnail_path))).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.stat(path.join(appConfig.previewsDir, image.preview_path))).rejects.toMatchObject({ code: 'ENOENT' });
+    }
+    await expect(fs.stat(path.join(albumPath, 'single.jpg'))).resolves.toBeDefined();
+  });
+
+  it('rolls back source-path and membership changes when carousel reconciliation conflicts', async () => {
+    const root = path.join(appConfig.galleryRoot, 'album', 'carousels');
+    for (const name of ['first', 'second']) {
+      await fs.mkdir(path.join(root, name), { recursive: true });
+      await fs.writeFile(path.join(root, name, '01.jpg'), `${name}-1`);
+      await fs.writeFile(path.join(root, name, '02.jpg'), `${name}-2-long`);
+    }
+    await scannerService.scanAll('manual');
+    const posts = postRepository.listFeed(1, 10);
+    const first = posts.find((post) => post.sourcePath.endsWith('/first'))!;
+    const second = posts.find((post) => post.sourcePath.endsWith('/second'))!;
+    const firstItems = postRepository.listImageRecords(first.id);
+    const secondItems = postRepository.listImageRecords(second.id);
+
+    expect(() =>
+      postRepository.upsertPostWithItems({
+        existingPostId: first.id,
+        folderId: first.folderId,
+        sourcePath: 'album/carousels/renamed-first',
+        postType: 'carousel',
+        caption: 'must roll back',
+        sortTimestamp: first.sortTimestamp,
+        isDeleted: 0,
+        isTrashed: 0
+      }, [
+        { imageId: firstItems[0].id, position: 1 },
+        { imageId: secondItems[0].id, position: 2 }
+      ])
+    ).toThrow();
+
+    expect(postRepository.findById(first.id)?.source_path).toBe(first.sourcePath);
+    expect(postRepository.findById(first.id)?.caption).not.toBe('must roll back');
+    expect(postRepository.listImageRecords(first.id).map((image) => image.id)).toEqual(firstItems.map((image) => image.id));
+    expect(postRepository.listImageRecords(second.id).map((image) => image.id)).toEqual(secondItems.map((image) => image.id));
+  });
+
+  it('reconciles carousel post when child directory is renamed', async () => {
+    appSettingsRepository.set(LAST_SUCCESSFUL_GALLERY_ROOT_SETTING_KEY, appConfig.galleryRoot);
+    const carouselsRoot = path.join(appConfig.galleryRoot, 'album', 'carousels');
+    const oldPath = path.join(carouselsRoot, 'day-1');
+    const newPath = path.join(carouselsRoot, 'day-1-renamed');
+
+    await fs.mkdir(oldPath, { recursive: true });
+    await fs.writeFile(path.join(oldPath, 'photo1.jpg'), 'photo-1');
+    await fs.writeFile(path.join(oldPath, 'photo2.jpg'), 'photo-2');
+
+    await scannerService.scanAll('manual');
+
+    const feedBefore = galleryService.getFeed(1, 10, 'recent');
+    const originalPostId = feedBefore.items[0].id;
+
+    galleryService.updateImageCaption(originalPostId, 'Day 1 memories');
+    galleryService.likeImage(originalPostId);
+
+    // Rename carousel folder on disk
+    await fs.rename(oldPath, newPath);
+
+    // Rescan should reconcile by stable image IDs
+    await scannerService.scanAll('manual');
+
+    const feedAfter = galleryService.getFeed(1, 10, 'recent');
+    expect(feedAfter.items).toHaveLength(1);
+    expect(feedAfter.items[0].id).toBe(originalPostId);
+    expect(feedAfter.items[0].caption).toBe('Day 1 memories');
+    expect(galleryService.getLikes().items.map((i) => i.id)).toContain(originalPostId);
+  });
+
+  it('repairs and preserves representative Place assignments for posts', async () => {
+    const albumPath = path.join(appConfig.galleryRoot, 'places-album');
+    await fs.mkdir(albumPath, { recursive: true });
+    await fs.writeFile(path.join(albumPath, 'single.jpg'), 'single-place-media');
+    await scannerService.scanAll('manual');
+
+    const image = imageRepository.getByRelativePath('places-album/single.jpg')!;
+    const post = postRepository.findByImageId(image.id)!;
+    const place = placeRepository.upsertCity({
+      slug: 'representative-city',
+      displayName: 'Representative City',
+      geonamesId: 246810,
+      latitude: 12,
+      longitude: 34,
+      cityName: 'Representative City'
+    });
+
+    imageRepository.assignPlace(image.id, place.id);
+    expect(postRepository.findById(post.id)?.place_id).toBe(place.id);
+
+    postRepository.upsertPostWithItems({
+      existingPostId: post.id,
+      folderId: post.folder_id,
+      placeId: null,
+      sourcePath: post.source_path,
+      postType: post.post_type,
+      caption: post.caption,
+      sortTimestamp: post.sort_timestamp,
+      takenAt: post.taken_at,
+      takenAtSource: post.taken_at_source,
+      isDeleted: 0,
+      isTrashed: 0
+    }, [{ imageId: image.id, position: 1 }]);
+    expect(postRepository.findById(post.id)?.place_id).toBeNull();
+
+    await scannerService.scanAll('manual');
+    expect(postRepository.findById(post.id)?.place_id).toBe(place.id);
+    expect(galleryService.listPlaces()).toEqual([
+      expect.objectContaining({ slug: place.slug, postCount: 1 })
+    ]);
+  });
+
+  it('soft-deletes and reactivates the last carousel when its child becomes empty', async () => {
+    const albumPath = path.join(appConfig.galleryRoot, 'mixed-album');
+    const carouselPath = path.join(albumPath, 'carousels', 'only-carousel');
+    await fs.mkdir(carouselPath, { recursive: true });
+    await fs.writeFile(path.join(albumPath, 'direct.jpg'), 'direct-media');
+    await fs.writeFile(path.join(carouselPath, '01.jpg'), 'carousel-one');
+    await fs.writeFile(path.join(carouselPath, '02.jpg'), 'carousel-two');
+
+    await scannerService.scanAll('manual');
+
+    const carousel = postRepository.listFeed(1, 10).find((post) => post.postType === 'carousel')!;
+    const originalItemIds = postRepository.listImageRecords(carousel.id).map((image) => image.id);
+
+    await fs.rm(path.join(carouselPath, '01.jpg'));
+    await fs.rm(path.join(carouselPath, '02.jpg'));
+    await scannerService.scanAll('manual');
+
+    expect(postRepository.findById(carousel.id)?.is_deleted).toBe(1);
+    expect(postRepository.listFeed(1, 10).map((post) => post.id)).not.toContain(carousel.id);
+    for (const imageId of originalItemIds) {
+      expect(imageRepository.getById(imageId)?.is_deleted).toBe(1);
+    }
+
+    await fs.writeFile(path.join(carouselPath, '01.jpg'), 'carousel-one');
+    await fs.writeFile(path.join(carouselPath, '02.jpg'), 'carousel-two');
+    await scannerService.scanAll('manual');
+
+    expect(postRepository.findById(carousel.id)?.is_deleted).toBe(0);
+    expect(postRepository.listFeed(1, 10).map((post) => post.id)).toContain(carousel.id);
+    expect(postRepository.listImageRecords(carousel.id).map((image) => image.id)).toEqual(originalItemIds);
+  });
+});

--- a/server/test/carousel-settings-coordination.test.ts
+++ b/server/test/carousel-settings-coordination.test.ts
@@ -1,0 +1,193 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import type express from 'express';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { requestTestApp } from './http-test-utils.js';
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type ScannerServiceModule = typeof import('../src/services/scanner-service.js');
+type DatabaseModule = typeof import('../src/db/database.js');
+type AppModule = typeof import('../src/app.js');
+
+async function requestApp(app: express.Application, method: string, urlPath: string, body?: unknown) {
+  return requestTestApp(app, method, urlPath, { 'x-foldergram-intent': '1' }, body);
+}
+
+describe.sequential('carousel settings persistence', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let scannerService: ScannerServiceModule['scannerService'];
+  let appSettingsRepository: RepositoriesModule['appSettingsRepository'];
+  let databaseManager: DatabaseModule['databaseManager'];
+  let createApp: AppModule['createApp'];
+  let TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY: string;
+  let CAROUSELS_MIGRATION_DECISION_SETTING_KEY: string;
+  let CAROUSELS_APPLIED_MODE_SETTING_KEY: string;
+  let LIBRARY_REBUILD_REQUIRED_SETTING_KEY: string;
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'foldergram-settings-test-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    databaseManager?.close();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.resetModules();
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ scannerService } = await import('../src/services/scanner-service.js'));
+    ({ appSettingsRepository } = await import('../src/db/repositories.js'));
+    ({ databaseManager } = await import('../src/db/database.js'));
+    ({ createApp } = await import('../src/app.js'));
+    const { authService } = await import('../src/services/auth-service.js');
+    authService.refresh();
+    const {
+      TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY: key1,
+      CAROUSELS_MIGRATION_DECISION_SETTING_KEY: key2,
+      CAROUSELS_APPLIED_MODE_SETTING_KEY: key3,
+      LIBRARY_REBUILD_REQUIRED_SETTING_KEY: key4
+    } = await import('../src/constants/app-setting-keys.js');
+    TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY = key1;
+    CAROUSELS_MIGRATION_DECISION_SETTING_KEY = key2;
+    CAROUSELS_APPLIED_MODE_SETTING_KEY = key3;
+    LIBRARY_REBUILD_REQUIRED_SETTING_KEY = key4;
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+  });
+
+  afterAll(async () => {
+    databaseManager?.close();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('rolls back atomically when setMany encounters a failure', () => {
+    appSettingsRepository.set(TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY, '0');
+    appSettingsRepository.set(CAROUSELS_MIGRATION_DECISION_SETTING_KEY, 'carousels');
+
+    const database = databaseManager.connection;
+    const origPrepare = database.prepare.bind(database);
+
+    let runCount = 0;
+    vi.spyOn(database, 'prepare').mockImplementation((sql: string) => {
+      const stmt = origPrepare(sql);
+      if (sql.includes('INSERT INTO app_settings')) {
+        return {
+          ...stmt,
+          run(...params: unknown[]) {
+            runCount++;
+            if (runCount === 2) {
+              throw new Error('simulated second SQLite write failure');
+            }
+            return stmt.run(...params);
+          }
+        } as any;
+      }
+      return stmt;
+    });
+
+    expect(() => {
+      appSettingsRepository.setMany([
+        { key: TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY, value: '1' },
+        { key: CAROUSELS_MIGRATION_DECISION_SETTING_KEY, value: 'restore' }
+      ]);
+    }).toThrow('simulated second SQLite write failure');
+
+    // Both settings must be in their original state due to transaction rollback
+    expect(appSettingsRepository.get(TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY)).toBe('0');
+    expect(appSettingsRepository.get(CAROUSELS_MIGRATION_DECISION_SETTING_KEY)).toBe('carousels');
+  });
+
+  it('persists the selected mode without starting a library scan', async () => {
+    const app = createApp();
+    appSettingsRepository.set(TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY, '0');
+    appSettingsRepository.set(CAROUSELS_MIGRATION_DECISION_SETTING_KEY, 'carousels');
+
+    const scanSpy = vi.spyOn(scannerService, 'scanAll');
+    appSettingsRepository.set(LIBRARY_REBUILD_REQUIRED_SETTING_KEY, '1');
+
+    const response = await requestApp(app, 'POST', '/api/admin/settings/carousels-as-folders', {
+      treatCarouselsAsFolders: true
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.preferences.treatCarouselsAsFolders).toBe(true);
+    expect(response.body.libraryIndex.rebuildRequired).toBe(true);
+    expect(response.body.carouselsMigration.reconciliationPending).toBe(true);
+    expect(appSettingsRepository.get(TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY)).toBe('1');
+    expect(appSettingsRepository.get(CAROUSELS_MIGRATION_DECISION_SETTING_KEY)).toBe('restore');
+    expect(appSettingsRepository.get(CAROUSELS_APPLIED_MODE_SETTING_KEY)).toBeNull();
+    expect(scanSpy).not.toHaveBeenCalled();
+  });
+
+  it('persists the migration-card decision without starting a library scan', async () => {
+    const app = createApp();
+    const scanSpy = vi.spyOn(scannerService, 'scanAll');
+
+    const response = await requestApp(app, 'POST', '/api/admin/settings/carousels-migration-decision', {
+      decision: 'carousels'
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.preferences.treatCarouselsAsFolders).toBe(false);
+    expect(response.body.carouselsMigration.reconciliationPending).toBe(true);
+    expect(appSettingsRepository.get(TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY)).toBe('0');
+    expect(appSettingsRepository.get(CAROUSELS_MIGRATION_DECISION_SETTING_KEY)).toBe('carousels');
+    expect(scanSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps reconciliation pending across status reloads until a full scan applies the selected mode', async () => {
+    const app = createApp();
+
+    const saveResponse = await requestApp(app, 'POST', '/api/admin/settings/carousels-as-folders', {
+      treatCarouselsAsFolders: true
+    });
+    expect(saveResponse.status).toBe(200);
+    expect(saveResponse.body.carouselsMigration.reconciliationPending).toBe(true);
+
+    const pendingStatus = await requestApp(app, 'GET', '/api/status');
+    expect(pendingStatus.status).toBe(200);
+    expect(pendingStatus.body.carouselsMigration.reconciliationPending).toBe(true);
+
+    const scanResponse = await requestApp(app, 'POST', '/api/admin/rescan');
+    expect(scanResponse.status).toBe(200);
+    expect(appSettingsRepository.get(CAROUSELS_APPLIED_MODE_SETTING_KEY)).toBe('1');
+
+    const appliedStatus = await requestApp(app, 'GET', '/api/status');
+    expect(appliedStatus.status).toBe(200);
+    expect(appliedStatus.body.carouselsMigration.reconciliationPending).toBe(false);
+  });
+
+  it('keeps reconciliation pending when a full scan fails', async () => {
+    const app = createApp();
+
+    await requestApp(app, 'POST', '/api/admin/settings/carousels-as-folders', {
+      treatCarouselsAsFolders: true
+    });
+    vi.spyOn(scannerService, 'scanAll').mockRejectedValueOnce(new Error('simulated scan failure'));
+
+    const scanResponse = await requestApp(app, 'POST', '/api/admin/rescan');
+    expect(scanResponse.status).toBe(500);
+    expect(appSettingsRepository.get(CAROUSELS_APPLIED_MODE_SETTING_KEY)).toBeNull();
+
+    const statusResponse = await requestApp(app, 'GET', '/api/status');
+    expect(statusResponse.body.carouselsMigration.reconciliationPending).toBe(true);
+  });
+});

--- a/server/test/collections.test.ts
+++ b/server/test/collections.test.ts
@@ -207,9 +207,11 @@ describe.sequential('bookmark collections', () => {
     const trashed = await createIndexedMedia('visible', 'trashed.jpg', 1_800_000_023_000);
     const story = await createIndexedMedia('story-capsule', 'story.jpg', 1_800_000_024_000, 'story_capsule');
 
-    for (const image of [visible, cover, deleted, trashed, story]) {
-      expect(galleryService.saveImage(image.id)).toMatchObject({ imageId: image.id, isSaved: true });
+    for (const image of [visible, deleted, trashed]) {
+      expect(galleryService.saveImage(image.id, { isLegacyImageAlias: true })).toMatchObject({ imageId: image.id, isSaved: true });
     }
+    expect(galleryService.saveImage(cover.id, { isLegacyImageAlias: true })).toBeNull();
+    expect(galleryService.saveImage(story.id, { isLegacyImageAlias: true })).toBeNull();
     imageRepository.markDeleted(deleted.relative_path);
     imageRepository.moveToTrash(trashed.id);
 
@@ -217,7 +219,7 @@ describe.sequential('bookmark collections', () => {
     expect(saved?.total).toBe(1);
     expect(saved?.items.map((item) => item.id)).toEqual([visible.id]);
     expect(collectionRepository.isImageSaved(deleted.id)).toBe(true);
-    expect(collectionRepository.isImageSaved(story.id)).toBe(true);
+    expect(collectionRepository.isImageSaved(story.id)).toBe(false);
   });
 
   it('restores collection listing when a soft-deleted image reappears', async () => {

--- a/server/test/folder-customization-scan-behavior.test.ts
+++ b/server/test/folder-customization-scan-behavior.test.ts
@@ -133,6 +133,53 @@ describe.sequential('folder customization scan behavior', () => {
     expect(rescannedFolder?.avatar_source).toBe('manual');
   });
 
+  it('preserves every manually selected carousel cover across rescans with or without a direct cover file', async () => {
+    maintenanceRepository.resetLibraryIndex();
+
+    for (const ownerPath of ['with-cover', 'without-cover']) {
+      await createSourceFile(`${ownerPath}/photo.jpg`);
+      if (ownerPath === 'with-cover') {
+        await createSourceFile(`${ownerPath}/cover.jpg`);
+      }
+      await createSourceFile(`${ownerPath}/carousels/trip/01.jpg`);
+      await createSourceFile(`${ownerPath}/carousels/trip/02.jpg`);
+      await createSourceFile(`${ownerPath}/carousels/trip/03.jpg`);
+    }
+
+    await scannerService.scanAll('manual');
+
+    for (const ownerPath of ['with-cover', 'without-cover']) {
+      const owner = folderRepository.getByFolderPath(ownerPath)!;
+      const carouselItems = [1, 2, 3].map((position) => (
+        imageRepository.getByRelativePath(`${ownerPath}/carousels/trip/0${position}.jpg`)!
+      ));
+
+      for (const item of carouselItems) {
+        expect(galleryService.setFolderAvatar(owner.slug, item.id)).toBe(true);
+        await scannerService.scanAll('manual');
+
+        const rescannedOwner = folderRepository.getById(owner.id);
+        expect(rescannedOwner?.avatar_image_id).toBe(item.id);
+        expect(rescannedOwner?.avatar_source).toBe('manual');
+        expect(galleryService.getFolderBySlug(owner.slug)).toMatchObject({
+          avatarImageId: item.id,
+          avatarUrl: expect.stringContaining(item.thumbnail_path.replaceAll('\\', '/'))
+        });
+        expect(galleryService.getFolderImages(owner.slug, 1, 10)?.folder).toMatchObject({
+          avatarImageId: item.id,
+          avatarUrl: expect.stringContaining(item.thumbnail_path.replaceAll('\\', '/'))
+        });
+        expect(galleryService.listFolders()).toEqual(expect.arrayContaining([
+          expect.objectContaining({ id: owner.id, avatarImageId: item.id })
+        ]));
+      }
+
+      const staleSelection = carouselItems.at(-1)!;
+      imageRepository.markDeleted(staleSelection.relative_path);
+      expect(galleryService.getFolderBySlug(owner.slug)?.avatarImageId).not.toBe(staleSelection.id);
+    }
+  });
+
   it('preserves a custom caption across normal rescans', async () => {
     maintenanceRepository.resetLibraryIndex();
 
@@ -148,7 +195,7 @@ describe.sequential('folder customization scan behavior', () => {
     await createSourceFile('albums/photo-2.jpg');
     await scannerService.scanAll('manual');
 
-    expect(imageRepository.getById(image!.id)?.caption).toBe('Golden hour on the ridge');
+    expect(imageRepository.getById(image!.id)?.caption).toBeNull();
     expect(galleryService.getImageDetail(image!.id)?.caption).toBe('Golden hour on the ridge');
   });
 
@@ -178,7 +225,8 @@ describe.sequential('folder customization scan behavior', () => {
     const feedPayload = galleryService.getFeed(1, 24, 'recent');
     expect(feedPayload.items.map((item) => item.id)).not.toContain(coverImage!.id);
 
-    expect(galleryService.getImageDetail(coverImage!.id)?.id).toBe(coverImage!.id);
+    expect(galleryService.getImageDetail(coverImage!.id)).toBeNull();
+    expect(galleryService.getImageDetail(coverImage!.id, undefined, { isLegacyImageAlias: true })).toBeNull();
   });
 
   it('uses the saved app folder photo order for folder grids and detail navigation', async () => {

--- a/server/test/folder-customization.test.ts
+++ b/server/test/folder-customization.test.ts
@@ -189,7 +189,7 @@ describe.sequential('folder customization', () => {
 
       const updated = galleryService.updateImageCaption(image.id, 'Custom caption');
       expect(updated?.caption).toBe('Custom caption');
-      expect(imageRepository.getById(image.id)?.caption).toBe('Custom caption');
+      expect(imageRepository.getById(image.id)?.caption).toBeNull();
 
       const cleared = galleryService.updateImageCaption(image.id, null);
       expect(cleared?.caption).toBeNull();

--- a/server/test/folder-share-routes.test.ts
+++ b/server/test/folder-share-routes.test.ts
@@ -1,4 +1,3 @@
-import http from 'node:http';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -8,55 +7,10 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 
 import sharp from 'sharp';
 
+import { requestTestApp as requestApp } from './http-test-utils.js';
+
 type DatabaseModule = typeof import('../src/db/database.js');
 type AuthServiceModule = typeof import('../src/services/auth-service.js');
-
-async function requestApp(
-  app: express.Application,
-  method: string,
-  urlPath: string,
-  headers: Record<string, string> = {},
-  body?: any
-) {
-  const server = http.createServer(app);
-  await new Promise<void>((resolve, reject) => {
-    server.listen(0, '127.0.0.1', () => resolve());
-    server.on('error', reject);
-  });
-
-  const address = server.address();
-  if (!address || typeof address === 'string' || !address.port) {
-    await new Promise<void>((resolve) => server.close(() => resolve()));
-    throw new Error('Failed to obtain a valid server port.');
-  }
-
-  const url = `http://127.0.0.1:${address.port}${urlPath}`;
-
-  try {
-    const res = await fetch(url, {
-      method,
-      headers: body ? { 'Content-Type': 'application/json', ...headers } : headers,
-      body: body ? JSON.stringify(body) : undefined,
-      redirect: 'manual'
-    });
-
-    let responseBody: any = null;
-    const contentType = res.headers.get('content-type') || '';
-    if (contentType.includes('application/json')) {
-      responseBody = await res.json();
-    } else {
-      responseBody = await res.text();
-    }
-
-    return {
-      status: res.status,
-      headers: res.headers,
-      body: responseBody
-    };
-  } finally {
-    await new Promise<void>((resolve) => server.close(() => resolve()));
-  }
-}
 
 describe.sequential('folder share API routes', () => {
   let tempRoot = '';
@@ -93,7 +47,7 @@ describe.sequential('folder share API routes', () => {
     vi.resetModules();
     const { createApp } = await import('../src/app.js');
     ({ authService } = await import('../src/services/auth-service.js'));
-    const { folderRepository, imageRepository, maintenanceRepository } = await import('../src/db/repositories.js');
+    const { folderRepository, imageRepository, maintenanceRepository, postRepository } = await import('../src/db/repositories.js');
 
     maintenanceRepository.resetLibraryIndex();
     authService.setAdminPassword('admin12345');
@@ -147,6 +101,92 @@ describe.sequential('folder share API routes', () => {
       previewPath: 'folder-b/image-b.webp',
       exifJson: null
     });
+
+    const carouselSource = folderRepository.upsert({
+      slug: 'folder-a-carousel-trip',
+      name: 'Trip',
+      folderPath: 'folder-a/carousels/trip',
+      role: 'carousel_source',
+      carouselOwnerFolderId: folderA.id
+    });
+    const carouselItems = [
+      imageRepository.upsert({
+        folderId: carouselSource.id,
+        filename: '01-image.jpg',
+        extension: 'jpg',
+        relativePath: 'folder-a/carousels/trip/01-image.jpg',
+        absolutePath: path.join(tempRoot, 'gallery', 'folder-a', 'carousels', 'trip', '01-image.jpg'),
+        fileSize: 3001,
+        width: 1400,
+        height: 900,
+        mediaType: 'image',
+        mimeType: 'image/jpeg',
+        durationMs: null,
+        fingerprint: 'fp-carousel-image',
+        mtimeMs: Date.now(),
+        firstSeenAt: new Date().toISOString(),
+        sortTimestamp: Date.now() + 1000,
+        takenAt: Date.now(),
+        takenAtSource: 'mtime',
+        thumbnailPath: 'folder-a/carousels/trip/01-image.webp',
+        previewPath: 'folder-a/carousels/trip/01-image.webp',
+        exifJson: JSON.stringify({ latitude: 51.5, longitude: -0.1, cameraModel: 'Private Camera' })
+      }),
+      imageRepository.upsert({
+        folderId: carouselSource.id,
+        filename: '02-animated.gif',
+        extension: 'gif',
+        relativePath: 'folder-a/carousels/trip/02-animated.gif',
+        absolutePath: path.join(tempRoot, 'gallery', 'folder-a', 'carousels', 'trip', '02-animated.gif'),
+        fileSize: 3002,
+        width: 900,
+        height: 900,
+        mediaType: 'image',
+        mimeType: 'image/gif',
+        durationMs: 1200,
+        isAnimated: true,
+        fingerprint: 'fp-carousel-animated',
+        mtimeMs: Date.now(),
+        firstSeenAt: new Date().toISOString(),
+        sortTimestamp: Date.now() + 1000,
+        takenAt: Date.now(),
+        takenAtSource: 'mtime',
+        thumbnailPath: 'folder-a/carousels/trip/02-animated.webp',
+        previewPath: 'folder-a/carousels/trip/02-animated.gif',
+        exifJson: JSON.stringify({ cameraMake: 'Private Make' })
+      }),
+      imageRepository.upsert({
+        folderId: carouselSource.id,
+        filename: '03-video.mp4',
+        extension: 'mp4',
+        relativePath: 'folder-a/carousels/trip/03-video.mp4',
+        absolutePath: path.join(tempRoot, 'gallery', 'folder-a', 'carousels', 'trip', '03-video.mp4'),
+        fileSize: 3003,
+        width: 1920,
+        height: 1080,
+        mediaType: 'video',
+        mimeType: 'video/mp4',
+        durationMs: 5000,
+        fingerprint: 'fp-carousel-video',
+        mtimeMs: Date.now(),
+        firstSeenAt: new Date().toISOString(),
+        sortTimestamp: Date.now() + 1000,
+        takenAt: Date.now(),
+        takenAtSource: 'mtime',
+        thumbnailPath: 'folder-a/carousels/trip/03-video.webp',
+        previewPath: 'folder-a/carousels/trip/03-video.mp4',
+        playbackStrategy: 'original',
+        exifJson: null
+      })
+    ];
+    postRepository.upsertPostWithItems({
+      folderId: folderA.id,
+      sourcePath: 'folder-a/carousels/trip',
+      postType: 'carousel',
+      sortTimestamp: Date.now() + 1000,
+      takenAt: Date.now(),
+      takenAtSource: 'mtime'
+    }, carouselItems.map((image, index) => ({ imageId: image.id, position: index + 1 })));
 
     await fs.mkdir(path.join(tempRoot, 'gallery', 'folder-a'), { recursive: true });
     await fs.mkdir(path.join(tempRoot, 'gallery', 'folder-b'), { recursive: true });
@@ -268,6 +308,20 @@ describe.sequential('folder share API routes', () => {
 
   it('redacts sensitive metadata from shared JSON endpoints', async () => {
     const { folderShareService } = await import('../src/services/folder-share-service.js');
+    const { postRepository } = await import('../src/db/repositories.js');
+    const carousel = postRepository.findBySourcePath('folder-a/carousels/trip')!;
+    const expectRecursivelyRedacted = (value: unknown): void => {
+      if (Array.isArray(value)) {
+        value.forEach(expectRecursivelyRedacted);
+        return;
+      }
+      if (!value || typeof value !== 'object') return;
+      const record = value as Record<string, unknown>;
+      expect(Object.keys(record)).not.toEqual(expect.arrayContaining([
+        'absolutePath', 'exif', 'exifJson', 'originalUrl', 'relativePath', 'sourcePath'
+      ]));
+      Object.values(record).forEach(expectRecursivelyRedacted);
+    };
     const link = folderShareService.createLink('folder-a', { expiresAt: null })!;
     const grant = folderShareService.verifyLinkToken('folder-a', link.rawToken)!;
 
@@ -291,6 +345,7 @@ describe.sequential('folder share API routes', () => {
     expect(imagesRes.body.items[0]).not.toHaveProperty('folderPath');
     expect(imagesRes.body.items[0]).not.toHaveProperty('relativePath');
     expect(imagesRes.body.items[0]).not.toHaveProperty('exif');
+    expectRecursivelyRedacted(imagesRes.body);
 
     // Shared image detail
     const imageDetailRes = await requestApp(app, 'GET', '/api/share/images/1', {
@@ -301,6 +356,86 @@ describe.sequential('folder share API routes', () => {
     expect(imageDetailRes.body).not.toHaveProperty('relativePath');
     expect(imageDetailRes.body).not.toHaveProperty('absolutePath');
     expect(imageDetailRes.body).not.toHaveProperty('exif');
+
+    const carouselDetailRes = await requestApp(app, 'GET', `/api/share/posts/${carousel.id}`, {
+      Cookie: `foldergram_share_session=${shareCookie}`
+    });
+    expect(carouselDetailRes.status).toBe(200);
+    expect(carouselDetailRes.body.mediaItems).toHaveLength(3);
+    expectRecursivelyRedacted(carouselDetailRes.body);
+
+    folderShareService.setPassword('folder-a', 'carousel-password');
+    const passwordGrant = folderShareService.verifyPassword('folder-a', 'carousel-password')!;
+    const passwordResponse = { cookie: vi.fn().mockReturnThis(), setHeader: vi.fn() };
+    folderShareService.setShareSession(
+      passwordResponse as any,
+      { secure: false, get: () => undefined } as any,
+      passwordGrant
+    );
+    const passwordCookie = passwordResponse.cookie.mock.calls.at(-1)?.[1];
+    const passwordDetailRes = await requestApp(app, 'GET', `/api/share/posts/${carousel.id}`, {
+      Cookie: `foldergram_share_session=${passwordCookie}`
+    });
+    expect(passwordDetailRes.status).toBe(200);
+    expectRecursivelyRedacted(passwordDetailRes.body);
+  });
+
+  it('redacts paths and EXIF recursively for anonymous public feed and detail payloads', async () => {
+    const { postRepository } = await import('../src/db/repositories.js');
+    const carousel = postRepository.findBySourcePath('folder-a/carousels/trip')!;
+    authService.setViewerAccess('public');
+
+    const assertNoSensitiveKeys = (value: unknown): void => {
+      if (Array.isArray(value)) {
+        value.forEach(assertNoSensitiveKeys);
+        return;
+      }
+      if (!value || typeof value !== 'object') return;
+      const record = value as Record<string, unknown>;
+      expect(Object.keys(record)).not.toEqual(expect.arrayContaining([
+        'absolutePath', 'exif', 'exifJson', 'relativePath', 'sourcePath'
+      ]));
+      Object.values(record).forEach(assertNoSensitiveKeys);
+    };
+
+    const feedRes = await requestApp(app, 'GET', '/api/feed?mode=recent');
+    expect(feedRes.status).toBe(200);
+    const publicCarousel = feedRes.body.items.find((item: { id: number }) => item.id === carousel.id);
+    expect(publicCarousel?.mediaItems).toHaveLength(3);
+    expect(publicCarousel).toMatchObject({
+      folderPath: 'folder-a',
+      carouselTitle: 'trip'
+    });
+    expect(publicCarousel).not.toHaveProperty('sourcePath');
+    assertNoSensitiveKeys(feedRes.body);
+
+    const detailRes = await requestApp(app, 'GET', `/api/posts/${carousel.id}`);
+    expect(detailRes.status).toBe(200);
+    expect(detailRes.body.mediaItems).toHaveLength(3);
+    expect(detailRes.body).toMatchObject({
+      folderPath: 'folder-a',
+      carouselTitle: 'trip'
+    });
+    assertNoSensitiveKeys(detailRes.body);
+
+    const adminResponse = { cookie: vi.fn().mockReturnThis(), setHeader: vi.fn() };
+    authService.setAuthenticatedSession(
+      adminResponse as any,
+      { secure: false, get: () => undefined } as any,
+      'admin'
+    );
+    const adminCookie = adminResponse.cookie.mock.calls.at(-1)?.[1];
+    const adminDetailRes = await requestApp(app, 'GET', `/api/posts/${carousel.id}`, {
+      Cookie: `foldergram_session=${adminCookie}`
+    });
+    expect(adminDetailRes.status).toBe(200);
+    expect(adminDetailRes.body).toMatchObject({
+      folderPath: 'folder-a',
+      sourcePath: 'folder-a/carousels/trip',
+      carouselTitle: 'trip'
+    });
+    expect(adminDetailRes.body.mediaItems[0]).toHaveProperty('relativePath');
+    expect(adminDetailRes.body.mediaItems[0]).toHaveProperty('exif');
   });
 
   it('serves shared derivatives (pre-existing and lazy-generated) with Cache-Control: private, no-store and Vary: Cookie', async () => {

--- a/server/test/gallery-delete.test.ts
+++ b/server/test/gallery-delete.test.ts
@@ -26,6 +26,7 @@ describe.sequential('gallery folder deletion', () => {
   let galleryService: GalleryServiceModule['galleryService'];
   let folderRepository: RepositoriesModule['folderRepository'];
   let imageRepository: RepositoriesModule['imageRepository'];
+  let postRepository: RepositoriesModule['postRepository'];
   let folderScanStateRepository: RepositoriesModule['folderScanStateRepository'];
   let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
 
@@ -47,6 +48,7 @@ describe.sequential('gallery folder deletion', () => {
     ({
       folderRepository,
       imageRepository,
+      postRepository,
       folderScanStateRepository,
       maintenanceRepository
     } = await import('../src/db/repositories.js'));
@@ -158,7 +160,123 @@ describe.sequential('gallery folder deletion', () => {
     await expectPathMissing(path.join(appConfig.previewsDir, 'parent'));
   });
 
-  async function createIndexedFolder(relativeFolderPath: string, filenames: string[]): Promise<{
+  it('deletes owned carousel originals, derivatives, source folders, and database rows in default mode', async () => {
+    const owner = await createIndexedFolder('album', ['normal.jpg']);
+    const firstCarousel = await createIndexedFolder('album/carousels/first', ['01.jpg', '02.jpg'], {
+      role: 'carousel_source',
+      carouselOwnerFolderId: owner.folder.id
+    });
+    const secondCarousel = await createIndexedFolder('album/carousels/second', ['01.jpg', '02.jpg'], {
+      role: 'carousel_source',
+      carouselOwnerFolderId: owner.folder.id
+    });
+    for (const carousel of [firstCarousel, secondCarousel]) {
+      postRepository.upsertPostWithItems({
+        folderId: owner.folder.id,
+        sourcePath: carousel.folder.folder_path,
+        postType: 'carousel',
+        sortTimestamp: carousel.images[0].sort_timestamp,
+        isDeleted: 0,
+        isTrashed: 0
+      }, carousel.images.map((image, index) => ({ imageId: image.id, position: index + 1 })));
+    }
+
+    const result = await galleryService.deleteFolder('album');
+    expect(result).toEqual({
+      slug: 'album',
+      deletedImageCount: 5,
+      deletedFolderCount: 1,
+      deletedSourceFolder: false
+    });
+    expect(folderRepository.getBySlug('album')).toBeUndefined();
+    expect(folderRepository.getByFolderPath('album/carousels/first')).toBeUndefined();
+    expect(folderRepository.getByFolderPath('album/carousels/second')).toBeUndefined();
+    expect(postRepository.countAll()).toBe(0);
+    for (const image of [...owner.images, ...firstCarousel.images, ...secondCarousel.images]) {
+      expect(imageRepository.getById(image.id)).toBeUndefined();
+    }
+    await expectPathMissing(path.join(appConfig.galleryRoot, 'album'));
+    await expectPathMissing(path.join(appConfig.thumbnailsDir, 'album'));
+    await expectPathMissing(path.join(appConfig.previewsDir, 'album'));
+  });
+
+  it('includes owned carousel sources in full source-subtree deletion counts', async () => {
+    const owner = await createIndexedFolder('album', ['normal.jpg']);
+    const firstCarousel = await createIndexedFolder('album/carousels/first', ['01.jpg', '02.jpg'], {
+      role: 'carousel_source',
+      carouselOwnerFolderId: owner.folder.id
+    });
+    const secondCarousel = await createIndexedFolder('album/carousels/second', ['01.jpg', '02.jpg'], {
+      role: 'carousel_source',
+      carouselOwnerFolderId: owner.folder.id
+    });
+    await fs.writeFile(path.join(appConfig.galleryRoot, 'album', 'notes.txt'), 'also removed');
+
+    const result = await galleryService.deleteFolder('album', { deleteSourceFolder: true });
+    expect(result).toEqual({
+      slug: 'album',
+      deletedImageCount: 5,
+      deletedFolderCount: 3,
+      deletedSourceFolder: true
+    });
+    expect(folderRepository.getBySlug('album')).toBeUndefined();
+    expect(folderRepository.getByFolderPath(firstCarousel.folder.folder_path)).toBeUndefined();
+    expect(folderRepository.getByFolderPath(secondCarousel.folder.folder_path)).toBeUndefined();
+    await expectPathMissing(path.join(appConfig.galleryRoot, 'album'));
+    await expectPathMissing(path.join(appConfig.thumbnailsDir, 'album'));
+    await expectPathMissing(path.join(appConfig.previewsDir, 'album'));
+  });
+
+  it.each([
+    { mode: 'default', deleteSourceFolder: false, deletedFolderCount: 1 },
+    { mode: 'full subtree', deleteSourceFolder: true, deletedFolderCount: 2 }
+  ])('removes soft-deleted and trashed carousel derivatives during $mode deletion', async ({
+    deleteSourceFolder,
+    deletedFolderCount
+  }) => {
+    const owner = await createIndexedFolder('album', ['normal.jpg']);
+    const carousel = await createIndexedFolder('album/carousels/video-post', ['cover.jpg', 'clip.mp4'], {
+      role: 'carousel_source',
+      carouselOwnerFolderId: owner.folder.id
+    });
+    const post = postRepository.upsertPostWithItems({
+      folderId: owner.folder.id,
+      sourcePath: carousel.folder.folder_path,
+      postType: 'carousel',
+      sortTimestamp: carousel.images[0].sort_timestamp,
+      isDeleted: 0,
+      isTrashed: 0
+    }, carousel.images.map((image, index) => ({ imageId: image.id, position: index + 1 })));
+
+    expect(postRepository.trashPost(post.id)).toBe(true);
+    const softDeletedVideo = carousel.images.find((image) => image.media_type === 'video')!;
+    imageRepository.markDeleted(softDeletedVideo.relative_path);
+    await fs.rm(softDeletedVideo.absolute_path);
+    expect(softDeletedVideo.preview_path).toMatch(/\.mp4$/);
+    await expectPathPresent(path.join(appConfig.thumbnailsDir, softDeletedVideo.thumbnail_path));
+    await expectPathPresent(path.join(appConfig.previewsDir, softDeletedVideo.preview_path));
+
+    const result = await galleryService.deleteFolder('album', { deleteSourceFolder });
+    expect(result).toEqual({
+      slug: 'album',
+      deletedImageCount: 3,
+      deletedFolderCount,
+      deletedSourceFolder: deleteSourceFolder
+    });
+
+    for (const image of [...owner.images, ...carousel.images]) {
+      expect(imageRepository.getById(image.id)).toBeUndefined();
+      await expectPathMissing(path.join(appConfig.galleryRoot, image.relative_path));
+      await expectPathMissing(path.join(appConfig.thumbnailsDir, image.thumbnail_path));
+      await expectPathMissing(path.join(appConfig.previewsDir, image.preview_path));
+    }
+  });
+
+  async function createIndexedFolder(
+    relativeFolderPath: string,
+    filenames: string[],
+    options: { role?: 'normal' | 'carousel_source'; carouselOwnerFolderId?: number | null } = {}
+  ): Promise<{
     folder: FolderRecord;
     images: ImageRecord[];
   }> {
@@ -167,7 +285,9 @@ describe.sequential('gallery folder deletion', () => {
     const folder = folderRepository.upsert({
       slug,
       name: folderName,
-      folderPath: relativeFolderPath
+      folderPath: relativeFolderPath,
+      role: options.role,
+      carouselOwnerFolderId: options.carouselOwnerFolderId
     });
     const images: ImageRecord[] = [];
 

--- a/server/test/http-test-utils.ts
+++ b/server/test/http-test-utils.ts
@@ -1,0 +1,90 @@
+import http from 'node:http';
+
+import type express from 'express';
+
+export interface TestHttpResponse {
+  status: number;
+  headers: Headers;
+  body: any;
+}
+
+export async function requestTestApp(
+  app: express.Application,
+  method: string,
+  urlPath: string,
+  headers: Record<string, string> = {},
+  body?: unknown
+): Promise<TestHttpResponse> {
+  const server = http.createServer(app);
+
+  await new Promise<void>((resolve, reject) => {
+    const handleError = (error: Error) => reject(error);
+    server.once('error', handleError);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', handleError);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string' || !address.port) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error('Failed to obtain a valid server port.');
+  }
+
+  const serializedBody = body === undefined ? undefined : JSON.stringify(body);
+
+  try {
+    return await new Promise<TestHttpResponse>((resolve, reject) => {
+      const request = http.request(
+        {
+          hostname: '127.0.0.1',
+          port: address.port,
+          path: urlPath,
+          method,
+          headers: {
+            ...(serializedBody === undefined ? {} : { 'Content-Type': 'application/json' }),
+            ...headers
+          }
+        },
+        (response) => {
+          const chunks: Buffer[] = [];
+          response.on('data', (chunk: Buffer) => chunks.push(chunk));
+          response.on('error', reject);
+          response.on('end', () => {
+            const responseHeaders = new Headers();
+            for (let index = 0; index < response.rawHeaders.length; index += 2) {
+              responseHeaders.append(response.rawHeaders[index], response.rawHeaders[index + 1]);
+            }
+
+            const rawBody = Buffer.concat(chunks).toString('utf8');
+            const contentType = responseHeaders.get('content-type') ?? '';
+            let responseBody: any = rawBody;
+
+            if (contentType.includes('application/json')) {
+              try {
+                responseBody = JSON.parse(rawBody);
+              } catch {
+                responseBody = null;
+              }
+            }
+
+            resolve({
+              status: response.statusCode ?? 0,
+              headers: responseHeaders,
+              body: responseBody
+            });
+          });
+        }
+      );
+
+      request.on('error', reject);
+      if (serializedBody !== undefined) {
+        request.write(serializedBody);
+      }
+      request.end();
+    });
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}

--- a/server/test/migration-bootstrap.test.ts
+++ b/server/test/migration-bootstrap.test.ts
@@ -141,9 +141,15 @@ describe.sequential('dbmate startup migrations', () => {
     try {
       expect(tableExists(database, 'folders')).toBe(true);
       expect(tableExists(database, 'images')).toBe(true);
+      expect(tableExists(database, 'posts')).toBe(true);
+      expect(tableExists(database, 'post_items')).toBe(true);
       expect(tableExists(database, 'collections')).toBe(true);
       expect(tableHasColumn(database, 'images', 'caption')).toBe(true);
-      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002', '000004']);
+      expect(tableHasColumn(database, 'likes', 'post_id')).toBe(true);
+      expect(tableHasColumn(database, 'collection_items', 'post_id')).toBe(true);
+      expect(tableHasColumn(database, 'scan_runs', 'warning_count')).toBe(true);
+      expect(tableHasColumn(database, 'scan_runs', 'warning_text')).toBe(true);
+      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002', '000004', '000005']);
     } finally {
       database.close();
     }
@@ -238,14 +244,23 @@ describe.sequential('dbmate startup migrations', () => {
     const database = new DatabaseSync(databasePath);
 
     try {
-      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002', '000004']);
+      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002', '000004', '000005']);
       expect(tableExists(database, 'collections')).toBe(true);
       expect(tableHasColumn(database, 'folders', 'avatar_image_id')).toBe(true);
       expect(tableHasColumn(database, 'folders', 'avatar_source')).toBe(true);
       expect(tableHasColumn(database, 'images', 'playback_strategy')).toBe(true);
       expect(tableHasColumn(database, 'images', 'caption')).toBe(true);
+      expect(tableExists(database, 'folder_share_links')).toBe(true);
+      expect(tableExists(database, 'folder_share_passwords')).toBe(true);
+      expect(tableHasColumn(database, 'folders', 'share_password_version')).toBe(true);
+      expect(tableExists(database, 'posts')).toBe(true);
+      expect(tableExists(database, 'post_items')).toBe(true);
+      expect(tableHasColumn(database, 'collection_items', 'post_id')).toBe(true);
+      expect(database.prepare('SELECT COUNT(*) AS count FROM posts').get()).toEqual({ count: 1 });
+      expect(database.prepare('SELECT COUNT(*) AS count FROM post_items').get()).toEqual({ count: 1 });
       expect(listForeignKeySignatures(database, 'folders')).toEqual([
         'avatar_image_id->images.id:NO ACTION',
+        'carousel_owner_folder_id->folders.id:SET NULL',
         'story_owner_folder_id->folders.id:SET NULL'
       ]);
       expect(listForeignKeySignatures(database, 'images')).toEqual([
@@ -260,6 +275,86 @@ describe.sequential('dbmate startup migrations', () => {
       expect(database.prepare('SELECT playback_strategy AS playbackStrategy FROM images WHERE id = 1').get()).toEqual({
         playbackStrategy: 'preview'
       });
+    } finally {
+      database.close();
+    }
+  });
+
+  it('recognizes complete pre-dbmate folder-sharing schema without rerunning 000004', async () => {
+    const databasePath = path.join(tempRoot, 'db', 'gallery.sqlite');
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    const legacyDatabase = new DatabaseSync(databasePath);
+
+    try {
+      legacyDatabase.exec(`
+        CREATE TABLE folders (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          slug TEXT NOT NULL UNIQUE,
+          name TEXT NOT NULL,
+          folder_path TEXT NOT NULL,
+          share_password_version INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE images (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          folder_id INTEGER NOT NULL,
+          filename TEXT NOT NULL,
+          extension TEXT NOT NULL,
+          relative_path TEXT NOT NULL UNIQUE,
+          absolute_path TEXT NOT NULL,
+          file_size INTEGER NOT NULL,
+          width INTEGER NOT NULL,
+          height INTEGER NOT NULL,
+          mime_type TEXT NOT NULL,
+          checksum_or_fingerprint TEXT NOT NULL,
+          mtime_ms REAL NOT NULL,
+          first_seen_at TEXT NOT NULL,
+          sort_timestamp INTEGER NOT NULL,
+          thumbnail_path TEXT NOT NULL,
+          preview_path TEXT NOT NULL,
+          is_deleted INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          FOREIGN KEY (folder_id) REFERENCES folders(id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE folder_share_links (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          folder_id INTEGER NOT NULL,
+          token_hash TEXT NOT NULL UNIQUE,
+          token_prefix TEXT NULL,
+          expires_at TEXT NULL,
+          revoked_at TEXT NULL,
+          allow_original_downloads INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          last_used_at TEXT NULL,
+          FOREIGN KEY (folder_id) REFERENCES folders(id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE folder_share_passwords (
+          folder_id INTEGER PRIMARY KEY,
+          password_hash TEXT NOT NULL,
+          password_salt TEXT NOT NULL,
+          version INTEGER NOT NULL DEFAULT 1,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          FOREIGN KEY (folder_id) REFERENCES folders(id) ON DELETE CASCADE
+        );
+      `);
+    } finally {
+      legacyDatabase.close();
+    }
+
+    const { runStartupMigrations } = await importMigrationModule();
+    runStartupMigrations({ databasePath });
+
+    const database = new DatabaseSync(databasePath);
+    try {
+      expect(tableExists(database, 'folder_share_links')).toBe(true);
+      expect(tableExists(database, 'folder_share_passwords')).toBe(true);
+      expect(tableHasColumn(database, 'folders', 'share_password_version')).toBe(true);
+      expect(listAppliedVersions(database)).toEqual(['000001', '000002', '000004', '000005']);
     } finally {
       database.close();
     }
@@ -292,7 +387,7 @@ ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
 
     try {
       expect(tableHasColumn(database, 'images', 'migration_note')).toBe(true);
-      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002', '000003', '000004']);
+      expect(listAppliedVersions(database)).toEqual([BASELINE_MIGRATION_VERSION, '000002', '000003', '000004', '000005']);
     } finally {
       database.close();
     }
@@ -383,7 +478,7 @@ ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
     const { runStartupMigrations } = await importMigrationModule();
     const migrationsDirectory = await createTestMigrationsDirectory(tempRoot, [
       [
-        '000003_add_test_note.sql',
+        '000006_add_test_note.sql',
         `-- migrate:up
 
 ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
@@ -400,7 +495,7 @@ ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
     const database = new DatabaseSync(databasePath);
 
     try {
-      expect(listAppliedVersions(database)).toEqual(['000001', '000002', '000003', '000004']);
+      expect(listAppliedVersions(database)).toEqual(['000001', '000002', '000004', '000005', '000006']);
       expect(tableHasColumn(database, 'images', 'migration_note')).toBe(true);
       expect(tableHasColumn(database, 'images', 'caption')).toBe(true);
       expect(database.prepare('SELECT playback_strategy AS playbackStrategy FROM images WHERE id = 1').get()).toEqual({
@@ -435,10 +530,81 @@ ALTER TABLE images ADD COLUMN migration_note TEXT NULL;
     const database = new DatabaseSync(databasePath);
 
     try {
-      expect(listAppliedVersions(database)).toEqual(['000001', '000002', '000003', '000004']);
-      expect(database.prepare('SELECT COUNT(*) AS count FROM schema_migrations').get()).toEqual({ count: 4 });
+      expect(listAppliedVersions(database)).toEqual(['000001', '000002', '000003', '000004', '000005']);
+      expect(database.prepare('SELECT COUNT(*) AS count FROM schema_migrations').get()).toEqual({ count: 5 });
     } finally {
       database.close();
+    }
+  });
+
+  it('repairs a falsely recorded 000004 migration when all folder-sharing schema is absent', async () => {
+    const { runStartupMigrations } = await importMigrationModule();
+    const databasePath = path.join(tempRoot, 'db', 'gallery.sqlite');
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+
+    runStartupMigrations({ databasePath });
+
+    const brokenDatabase = new DatabaseSync(databasePath);
+    try {
+      brokenDatabase.exec(`
+        DROP TABLE folder_share_passwords;
+        DROP TABLE folder_share_links;
+        ALTER TABLE folders DROP COLUMN share_password_version;
+      `);
+    } finally {
+      brokenDatabase.close();
+    }
+
+    runStartupMigrations({ databasePath });
+
+    const repairedDatabase = new DatabaseSync(databasePath);
+    try {
+      expect(tableExists(repairedDatabase, 'folder_share_links')).toBe(true);
+      expect(tableExists(repairedDatabase, 'folder_share_passwords')).toBe(true);
+      expect(tableHasColumn(repairedDatabase, 'folders', 'share_password_version')).toBe(true);
+      expect(listAppliedVersions(repairedDatabase)).toEqual(['000001', '000002', '000004', '000005']);
+    } finally {
+      repairedDatabase.close();
+    }
+  });
+
+  it('resumes 000005 when an interrupted run recorded only additive columns', async () => {
+    const { runStartupMigrations } = await importMigrationModule();
+    const databasePath = path.join(tempRoot, 'db', 'gallery.sqlite');
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    const throughFolderSharesMigrations = await createTestMigrationsDirectory(path.join(tempRoot, 'through-folder-shares'));
+    await fs.rm(path.join(throughFolderSharesMigrations, '000005_add_posts_and_carousels.sql'));
+
+    runStartupMigrations({
+      databasePath,
+      migrationsDirectory: throughFolderSharesMigrations
+    });
+
+    const interruptedDatabase = new DatabaseSync(databasePath);
+    try {
+      interruptedDatabase.exec(`
+        ALTER TABLE folders ADD COLUMN carousel_owner_folder_id INTEGER NULL REFERENCES folders(id) ON DELETE SET NULL;
+        ALTER TABLE scan_runs ADD COLUMN warning_count INTEGER NOT NULL DEFAULT 0;
+      `);
+      interruptedDatabase.prepare('INSERT INTO schema_migrations(version) VALUES (?)').run('000005');
+    } finally {
+      interruptedDatabase.close();
+    }
+
+    runStartupMigrations({ databasePath });
+
+    const repairedDatabase = new DatabaseSync(databasePath);
+    try {
+      expect(tableExists(repairedDatabase, 'posts')).toBe(true);
+      expect(tableExists(repairedDatabase, 'post_items')).toBe(true);
+      expect(tableHasColumn(repairedDatabase, 'likes', 'post_id')).toBe(true);
+      expect(tableHasColumn(repairedDatabase, 'collection_items', 'post_id')).toBe(true);
+      expect(tableHasColumn(repairedDatabase, 'folders', 'carousel_owner_folder_id')).toBe(true);
+      expect(tableHasColumn(repairedDatabase, 'scan_runs', 'warning_count')).toBe(true);
+      expect(tableHasColumn(repairedDatabase, 'scan_runs', 'warning_text')).toBe(true);
+      expect(listAppliedVersions(repairedDatabase)).toEqual(['000001', '000002', '000004', '000005']);
+    } finally {
+      repairedDatabase.close();
     }
   });
 
@@ -550,6 +716,138 @@ THIS IS NOT VALID SQL;
 
       expect(inserted.share_password_version).toBe(0);
       expect(tableExists(database, 'folder_share_passwords')).toBe(true);
+    } finally {
+      database.close();
+    }
+  });
+
+  it('rejects superficially complete migration 000005 when indexes or invariants are missing', async () => {
+    const { runStartupMigrations, validatePostsMigrationCompleteness } = await importMigrationModule();
+    const databasePath = path.join(tempRoot, 'db', 'corrupt.sqlite');
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+
+    runStartupMigrations({ databasePath });
+
+    const database = new DatabaseSync(databasePath);
+
+    try {
+      // Drop index to simulate corruption
+      database.exec('DROP INDEX IF EXISTS idx_posts_folder_visible_sort');
+      expect(() => validatePostsMigrationCompleteness(database)).toThrow('missing required index idx_posts_folder_visible_sort');
+    } finally {
+      database.close();
+    }
+  });
+
+  it('rejects a required index with the right name but wrong uniqueness or column order', async () => {
+    const { runStartupMigrations, validatePostsMigrationCompleteness } = await importMigrationModule();
+    const databasePath = path.join(tempRoot, 'db', 'wrong-index.sqlite');
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    runStartupMigrations({ databasePath });
+
+    const database = new DatabaseSync(databasePath);
+    try {
+      database.exec(`
+        DROP INDEX idx_post_items_image_id;
+        CREATE INDEX idx_post_items_image_id ON post_items(post_id, image_id);
+      `);
+      expect(() => validatePostsMigrationCompleteness(database)).toThrow(
+        'index idx_post_items_image_id has an incorrect uniqueness or column order'
+      );
+    } finally {
+      database.close();
+    }
+  });
+
+  it('allows harmless additive columns after migration 000005', async () => {
+    const { runStartupMigrations, validatePostsMigrationCompleteness } = await importMigrationModule();
+    const databasePath = path.join(tempRoot, 'db', 'future-column.sqlite');
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    runStartupMigrations({ databasePath });
+
+    const database = new DatabaseSync(databasePath);
+    try {
+      database.exec('ALTER TABLE posts ADD COLUMN future_note TEXT NULL');
+      expect(() => validatePostsMigrationCompleteness(database)).not.toThrow();
+    } finally {
+      database.close();
+    }
+  });
+
+  it('preserves all convertible posts, likes, collection memberships, IDs, and timestamps in migration 000005', async () => {
+    const { runStartupMigrations, validatePostsMigrationCompleteness } = await importMigrationModule();
+    const databasePath = path.join(tempRoot, 'db', 'rich-legacy.sqlite');
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    const throughFolderSharesMigrations = await createTestMigrationsDirectory(path.join(tempRoot, 'through-folder-shares'));
+    await fs.rm(path.join(throughFolderSharesMigrations, '000005_add_posts_and_carousels.sql'));
+    runStartupMigrations({ databasePath, migrationsDirectory: throughFolderSharesMigrations });
+
+    const legacyDatabase = new DatabaseSync(databasePath);
+    try {
+      legacyDatabase.exec(`
+        INSERT INTO folders(id, slug, name, folder_path, role) VALUES
+          (1, 'album', 'Album', 'album', 'normal'),
+          (2, 'stories', 'Stories', 'album/stories', 'story_capsule');
+
+        INSERT INTO images(
+          id, folder_id, filename, extension, relative_path, absolute_path, file_size, width, height,
+          mime_type, checksum_or_fingerprint, mtime_ms, first_seen_at, sort_timestamp, caption,
+          thumbnail_path, preview_path, created_at, updated_at
+        ) VALUES
+          (1, 1, 'one.jpg', '.jpg', 'album/one.jpg', 'temp/album/one.jpg', 101, 1000, 800,
+           'image/jpeg', 'fp-1', 1001, '2026-01-01T00:00:00.000Z', 1001, 'One',
+           'album/one.webp', 'album/one.webp', '2026-01-01T00:00:01.000Z', '2026-01-01T00:00:02.000Z'),
+          (2, 1, 'two.jpg', '.jpg', 'album/two.jpg', 'temp/album/two.jpg', 102, 1000, 800,
+           'image/jpeg', 'fp-2', 1002, '2026-01-02T00:00:00.000Z', 1002, 'Two',
+           'album/two.webp', 'album/two.webp', '2026-01-02T00:00:01.000Z', '2026-01-02T00:00:02.000Z'),
+          (3, 1, 'cover.jpg', '.jpg', 'album/cover.jpg', 'temp/album/cover.jpg', 103, 1000, 800,
+           'image/jpeg', 'fp-3', 1003, '2026-01-03T00:00:00.000Z', 1003, NULL,
+           'album/cover.webp', 'album/cover.webp', '2026-01-03T00:00:01.000Z', '2026-01-03T00:00:02.000Z'),
+          (4, 2, 'story.jpg', '.jpg', 'album/stories/story.jpg', 'temp/album/stories/story.jpg', 104, 1000, 800,
+           'image/jpeg', 'fp-4', 1004, '2026-01-04T00:00:00.000Z', 1004, NULL,
+           'album/stories/story.webp', 'album/stories/story.webp', '2026-01-04T00:00:01.000Z', '2026-01-04T00:00:02.000Z');
+
+        INSERT INTO likes(image_id, created_at) VALUES
+          (1, '2026-02-01T00:00:00.000Z'),
+          (2, '2026-02-02T00:00:00.000Z'),
+          (3, '2026-02-03T00:00:00.000Z');
+        INSERT INTO collections(id, slug, name, is_default) VALUES
+          (1, 'saved', 'Saved', 1),
+          (2, 'trip', 'Trip', 0);
+        INSERT INTO collection_items(collection_id, image_id, created_at) VALUES
+          (1, 1, '2026-03-01T00:00:00.000Z'),
+          (2, 1, '2026-03-02T00:00:00.000Z'),
+          (2, 2, '2026-03-03T00:00:00.000Z'),
+          (2, 3, '2026-03-04T00:00:00.000Z');
+      `);
+    } finally {
+      legacyDatabase.close();
+    }
+
+    runStartupMigrations({ databasePath });
+    const database = new DatabaseSync(databasePath);
+    try {
+      expect(database.prepare('SELECT id, caption, created_at, updated_at FROM posts ORDER BY id').all()).toEqual([
+        { id: 1, caption: 'One', created_at: '2026-01-01T00:00:01.000Z', updated_at: '2026-01-01T00:00:02.000Z' },
+        { id: 2, caption: 'Two', created_at: '2026-01-02T00:00:01.000Z', updated_at: '2026-01-02T00:00:02.000Z' }
+      ]);
+      expect(database.prepare('SELECT post_id, image_id, position FROM post_items ORDER BY post_id').all()).toEqual([
+        { post_id: 1, image_id: 1, position: 1 },
+        { post_id: 2, image_id: 2, position: 1 }
+      ]);
+      expect(database.prepare('SELECT post_id, created_at FROM likes ORDER BY post_id').all()).toEqual([
+        { post_id: 1, created_at: '2026-02-01T00:00:00.000Z' },
+        { post_id: 2, created_at: '2026-02-02T00:00:00.000Z' }
+      ]);
+      expect(database.prepare('SELECT collection_id, post_id, created_at FROM collection_items ORDER BY collection_id, post_id').all()).toEqual([
+        { collection_id: 1, post_id: 1, created_at: '2026-03-01T00:00:00.000Z' },
+        { collection_id: 2, post_id: 1, created_at: '2026-03-02T00:00:00.000Z' },
+        { collection_id: 2, post_id: 2, created_at: '2026-03-03T00:00:00.000Z' }
+      ]);
+      expect(() => validatePostsMigrationCompleteness(database)).not.toThrow();
+
+      database.prepare('DELETE FROM post_items WHERE post_id = 2').run();
+      expect(() => validatePostsMigrationCompleteness(database)).toThrow('lack a representative position 1 item');
     } finally {
       database.close();
     }

--- a/server/test/scan-utils.test.ts
+++ b/server/test/scan-utils.test.ts
@@ -145,3 +145,42 @@ describe('unchanged image refresh decisions', () => {
     ).toBe(false);
   });
 });
+
+describe('compareNaturalFilename (Issue 12)', () => {
+  it('correctly sorts numeric numbers naturally', async () => {
+    const { compareNaturalFilename } = await import('../src/utils/scan-utils.js');
+    const files = ['file10.jpg', 'file2.jpg', 'file1.jpg', 'file20.jpg'];
+    files.sort(compareNaturalFilename);
+    expect(files).toEqual(['file1.jpg', 'file2.jpg', 'file10.jpg', 'file20.jpg']);
+  });
+
+  it('deterministically breaks ties for case variants across permutations', async () => {
+    const { compareNaturalFilename } = await import('../src/utils/scan-utils.js');
+    const list1 = ['a.jpg', 'A.jpg', 'b.jpg', 'B.jpg'];
+    const list2 = ['B.jpg', 'b.jpg', 'A.jpg', 'a.jpg'];
+    list1.sort(compareNaturalFilename);
+    list2.sort(compareNaturalFilename);
+    expect(list1).toEqual(list2);
+  });
+
+  it('deterministically sorts composed and decomposed unicode accents', async () => {
+    const { compareNaturalFilename } = await import('../src/utils/scan-utils.js');
+    const composed = 'r\u00e9sum\u00e9.jpg';
+    const decomposed = 're\u0301sume\u0301.jpg';
+    const list = [decomposed, composed, 'resume.jpg'];
+    list.sort(compareNaturalFilename);
+    expect(list[0]).toBe('resume.jpg');
+    const sorted1 = [decomposed, composed].sort(compareNaturalFilename);
+    const sorted2 = [composed, decomposed].sort(compareNaturalFilename);
+    expect(sorted1).toEqual(sorted2);
+  });
+
+  it('deterministically handles numeric zero-padding variants', async () => {
+    const { compareNaturalFilename } = await import('../src/utils/scan-utils.js');
+    const list1 = ['01.jpg', '1.jpg', '001.jpg'];
+    const list2 = ['1.jpg', '001.jpg', '01.jpg'];
+    list1.sort(compareNaturalFilename);
+    list2.sort(compareNaturalFilename);
+    expect(list1).toEqual(list2);
+  });
+});

--- a/server/test/search-carousel-dedup.test.ts
+++ b/server/test/search-carousel-dedup.test.ts
@@ -1,0 +1,322 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type DatabaseModule = typeof import('../src/db/database.js');
+
+describe.sequential('search carousel deduplication (Issue 11)', () => {
+  let tempRoot = '';
+  let folderRepository: RepositoriesModule['folderRepository'];
+  let postRepository: RepositoriesModule['postRepository'];
+  let databaseManager: DatabaseModule['databaseManager'];
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'insta-search-dedup-'));
+
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    databaseManager?.close();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+
+    vi.resetModules();
+
+    ({ folderRepository, postRepository } = await import('../src/db/repositories.js'));
+    ({ databaseManager } = await import('../src/db/database.js'));
+  });
+
+  afterAll(async () => {
+    databaseManager?.close();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('returns a carousel post only once when multiple slides match the search query', () => {
+    const db = databaseManager.connection;
+    const folder = folderRepository.upsert({
+      name: 'Wild Animals',
+      slug: 'wild-animals',
+      folderPath: 'wild-animals',
+      folderRole: 'general'
+    });
+
+    const carouselFolder = folderRepository.upsert({
+      name: 'Lions',
+      slug: 'wild-animals-carousels-lions',
+      folderPath: 'wild-animals/carousels/Lions',
+      folderRole: 'carousel_source',
+      carouselOwnerFolderId: folder.id
+    });
+
+    const img1 = db.prepare(`
+      INSERT INTO images (folder_id, filename, relative_path, file_size, mtime_ms, media_type, mime_type, width, height, sort_timestamp, taken_at, checksum_or_fingerprint, first_seen_at, thumbnail_path, preview_path, extension, absolute_path)
+      VALUES (?, '01-safari-lion.jpg', 'wild-animals/carousels/Lions/01-safari-lion.jpg', 1000, 1000, 'image', 'image/jpeg', 1080, 1080, 1000, '2026-01-01', 'fp1', '2026-01-01', 't1', 'p1', 'jpg', '/abs/1')
+      RETURNING id
+    `).get(carouselFolder.id) as { id: number };
+
+    const img2 = db.prepare(`
+      INSERT INTO images (folder_id, filename, relative_path, file_size, mtime_ms, media_type, mime_type, width, height, sort_timestamp, taken_at, checksum_or_fingerprint, first_seen_at, thumbnail_path, preview_path, extension, absolute_path)
+      VALUES (?, '02-safari-cub.jpg', 'wild-animals/carousels/Lions/02-safari-cub.jpg', 1200, 1000, 'image', 'image/jpeg', 1080, 1080, 1000, '2026-01-01', 'fp2', '2026-01-01', 't2', 'p2', 'jpg', '/abs/2')
+      RETURNING id
+    `).get(carouselFolder.id) as { id: number };
+
+    const img3 = db.prepare(`
+      INSERT INTO images (folder_id, filename, relative_path, file_size, mtime_ms, media_type, mime_type, width, height, sort_timestamp, taken_at, checksum_or_fingerprint, first_seen_at, thumbnail_path, preview_path, extension, absolute_path)
+      VALUES (?, '03-safari-hunt.jpg', 'wild-animals/carousels/Lions/03-safari-hunt.jpg', 1100, 1000, 'image', 'image/jpeg', 1080, 1080, 1000, '2026-01-01', 'fp3', '2026-01-01', 't3', 'p3', 'jpg', '/abs/3')
+      RETURNING id
+    `).get(carouselFolder.id) as { id: number };
+
+    const post = db.prepare(`
+      INSERT INTO posts (folder_id, post_type, source_path, sort_timestamp, taken_at)
+      VALUES (?, 'carousel', 'wild-animals/carousels/Lions', 1000, '2026-01-01')
+      RETURNING id
+    `).get(folder.id) as { id: number };
+
+    db.prepare(`INSERT INTO post_items (post_id, image_id, position) VALUES (?, ?, 1)`).run(post.id, img1.id);
+    db.prepare(`INSERT INTO post_items (post_id, image_id, position) VALUES (?, ?, 2)`).run(post.id, img2.id);
+    db.prepare(`INSERT INTO post_items (post_id, image_id, position) VALUES (?, ?, 3)`).run(post.id, img3.id);
+
+    const count = postRepository.countVisibleSearch('safari');
+    expect(count).toBe(1);
+
+    const results = postRepository.listVisibleSearch('safari', 1, 10);
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(post.id);
+    expect(results[0].filename).toBe('01-safari-lion.jpg');
+    expect(results[0].mediaItems).toHaveLength(3);
+
+    const titleResults = postRepository.listVisibleSearch('Lions', 1, 10);
+    expect(postRepository.countVisibleSearch('Lions')).toBe(1);
+    expect(titleResults).toHaveLength(1);
+    expect(titleResults[0].id).toBe(post.id);
+  });
+
+  it('matches a carousel when only a non-representative slide matches the search query', () => {
+    const db = databaseManager.connection;
+    const folder = folderRepository.upsert({
+      name: 'Vacation',
+      slug: 'vacation',
+      folderPath: 'vacation',
+      folderRole: 'general'
+    });
+
+    const carouselFolder = folderRepository.upsert({
+      name: 'Beach',
+      slug: 'vacation-carousels-beach',
+      folderPath: 'vacation/carousels/Beach',
+      folderRole: 'carousel_source',
+      carouselOwnerFolderId: folder.id
+    });
+
+    const img1 = db.prepare(`
+      INSERT INTO images (folder_id, filename, relative_path, file_size, mtime_ms, media_type, mime_type, width, height, sort_timestamp, taken_at, checksum_or_fingerprint, first_seen_at, thumbnail_path, preview_path, extension, absolute_path)
+      VALUES (?, '01-arrival.jpg', 'vacation/carousels/Beach/01-arrival.jpg', 1000, 1000, 'image', 'image/jpeg', 1080, 1080, 1000, '2026-01-01', 'fp1', '2026-01-01', 't1', 'p1', 'jpg', '/abs/1')
+      RETURNING id
+    `).get(carouselFolder.id) as { id: number };
+
+    const img2 = db.prepare(`
+      INSERT INTO images (folder_id, filename, relative_path, file_size, mtime_ms, media_type, mime_type, width, height, sort_timestamp, taken_at, checksum_or_fingerprint, first_seen_at, thumbnail_path, preview_path, extension, absolute_path)
+      VALUES (?, '02-sunset-dolphin.jpg', 'vacation/carousels/Beach/02-sunset-dolphin.jpg', 1200, 1000, 'image', 'image/jpeg', 1080, 1080, 1000, '2026-01-01', 'fp2', '2026-01-01', 't2', 'p2', 'jpg', '/abs/2')
+      RETURNING id
+    `).get(carouselFolder.id) as { id: number };
+
+    const post = db.prepare(`
+      INSERT INTO posts (folder_id, post_type, source_path, sort_timestamp, taken_at)
+      VALUES (?, 'carousel', 'vacation/carousels/Beach', 1000, '2026-01-01')
+      RETURNING id
+    `).get(folder.id) as { id: number };
+
+    db.prepare(`INSERT INTO post_items (post_id, image_id, position) VALUES (?, ?, 1)`).run(post.id, img1.id);
+    db.prepare(`INSERT INTO post_items (post_id, image_id, position) VALUES (?, ?, 2)`).run(post.id, img2.id);
+
+    const count = postRepository.countVisibleSearch('dolphin');
+    expect(count).toBe(1);
+
+    const results = postRepository.listVisibleSearch('dolphin', 1, 10);
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(post.id);
+    expect(results[0].filename).toBe('01-arrival.jpg');
+  });
+
+  it('paginates multi-slide carousels across page boundaries without duplicate or missing items', () => {
+    const db = databaseManager.connection;
+    const folder = folderRepository.upsert({
+      name: 'Nature',
+      slug: 'nature',
+      folderPath: 'nature',
+      folderRole: 'general'
+    });
+
+    for (let i = 1; i <= 3; i++) {
+      const cFolder = folderRepository.upsert({
+        name: `Nature Set ${i}`,
+        slug: `nature-carousels-set-${i}`,
+        folderPath: `nature/carousels/Set${i}`,
+        folderRole: 'carousel_source',
+        carouselOwnerFolderId: folder.id
+      });
+
+      const imgA = db.prepare(`
+        INSERT INTO images (folder_id, filename, relative_path, file_size, mtime_ms, media_type, mime_type, width, height, sort_timestamp, taken_at, checksum_or_fingerprint, first_seen_at, thumbnail_path, preview_path, extension, absolute_path)
+        VALUES (?, 'forest-a.jpg', ?, 1000, 1000, 'image', 'image/jpeg', 1080, 1080, ?, '2026-01-01', ?, '2026-01-01', 'ta', 'pa', 'jpg', '/abs/a')
+        RETURNING id
+      `).get(cFolder.id, `nature/carousels/Set${i}/forest-a.jpg`, i * 1000, `fpa${i}`) as { id: number };
+
+      const imgB = db.prepare(`
+        INSERT INTO images (folder_id, filename, relative_path, file_size, mtime_ms, media_type, mime_type, width, height, sort_timestamp, taken_at, checksum_or_fingerprint, first_seen_at, thumbnail_path, preview_path, extension, absolute_path)
+        VALUES (?, 'forest-b.jpg', ?, 1000, 1000, 'image', 'image/jpeg', 1080, 1080, ?, '2026-01-01', ?, '2026-01-01', 'tb', 'pb', 'jpg', '/abs/b')
+        RETURNING id
+      `).get(cFolder.id, `nature/carousels/Set${i}/forest-b.jpg`, i * 1000, `fpb${i}`) as { id: number };
+
+      const post = db.prepare(`
+        INSERT INTO posts (folder_id, post_type, source_path, sort_timestamp, taken_at)
+        VALUES (?, 'carousel', ?, ?, '2026-01-01')
+        RETURNING id
+      `).get(folder.id, `nature/carousels/Set${i}`, i * 1000) as { id: number };
+
+      db.prepare(`INSERT INTO post_items (post_id, image_id, position) VALUES (?, ?, 1)`).run(post.id, imgA.id);
+      db.prepare(`INSERT INTO post_items (post_id, image_id, position) VALUES (?, ?, 2)`).run(post.id, imgB.id);
+    }
+
+    const total = postRepository.countVisibleSearch('forest');
+    expect(total).toBe(3);
+
+    const page1 = postRepository.listVisibleSearch('forest', 1, 2);
+    expect(page1).toHaveLength(2);
+
+    const page2 = postRepository.listVisibleSearch('forest', 2, 2);
+    expect(page2).toHaveLength(1);
+
+    const allIds = [...page1.map((p) => p.id), ...page2.map((p) => p.id)];
+    expect(new Set(allIds).size).toBe(3);
+  });
+
+  it('breaks equal search ranks with sortTimestamp DESC, id DESC', () => {
+    const db = databaseManager.connection;
+    const folder = folderRepository.upsert({
+      name: 'Landscape',
+      slug: 'landscape',
+      folderPath: 'landscape',
+      folderRole: 'general'
+    });
+
+    const cFolder1 = folderRepository.upsert({
+      name: 'Mountains 1',
+      slug: 'landscape-carousels-mountains-1',
+      folderPath: 'landscape/carousels/Mountains1',
+      folderRole: 'carousel_source',
+      carouselOwnerFolderId: folder.id
+    });
+
+    const cFolder2 = folderRepository.upsert({
+      name: 'Mountains 2',
+      slug: 'landscape-carousels-mountains-2',
+      folderPath: 'landscape/carousels/Mountains2',
+      folderRole: 'carousel_source',
+      carouselOwnerFolderId: folder.id
+    });
+
+    const img1 = db.prepare(`
+      INSERT INTO images (folder_id, filename, relative_path, file_size, mtime_ms, media_type, mime_type, width, height, sort_timestamp, taken_at, checksum_or_fingerprint, first_seen_at, thumbnail_path, preview_path, extension, absolute_path)
+      VALUES (?, 'mountain-peak.jpg', 'landscape/carousels/Mountains1/mountain-peak.jpg', 1000, 1000, 'image', 'image/jpeg', 1080, 1080, 1000, '2026-01-01', 'fp1', '2026-01-01', 't1', 'p1', 'jpg', '/abs/1')
+      RETURNING id
+    `).get(cFolder1.id) as { id: number };
+
+    const img2 = db.prepare(`
+      INSERT INTO images (folder_id, filename, relative_path, file_size, mtime_ms, media_type, mime_type, width, height, sort_timestamp, taken_at, checksum_or_fingerprint, first_seen_at, thumbnail_path, preview_path, extension, absolute_path)
+      VALUES (?, 'mountain-peak.jpg', 'landscape/carousels/Mountains2/mountain-peak.jpg', 1000, 1000, 'image', 'image/jpeg', 1080, 1080, 2000, '2026-01-01', 'fp2', '2026-01-01', 't2', 'p2', 'jpg', '/abs/2')
+      RETURNING id
+    `).get(cFolder2.id) as { id: number };
+
+    const post1 = db.prepare(`
+      INSERT INTO posts (folder_id, post_type, source_path, sort_timestamp, taken_at)
+      VALUES (?, 'carousel', 'landscape/carousels/Mountains1', 1000, '2026-01-01')
+      RETURNING id
+    `).get(folder.id) as { id: number };
+
+    const post2 = db.prepare(`
+      INSERT INTO posts (folder_id, post_type, source_path, sort_timestamp, taken_at)
+      VALUES (?, 'carousel', 'landscape/carousels/Mountains2', 2000, '2026-01-01')
+      RETURNING id
+    `).get(folder.id) as { id: number };
+
+    db.prepare(`INSERT INTO post_items (post_id, image_id, position) VALUES (?, ?, 1)`).run(post1.id, img1.id);
+    db.prepare(`INSERT INTO post_items (post_id, image_id, position) VALUES (?, ?, 1)`).run(post2.id, img2.id);
+
+    const results = postRepository.listVisibleSearch('mountain', 1, 10);
+    expect(results).toHaveLength(2);
+    expect(results[0].id).toBe(post2.id); // higher sortTimestamp first
+    expect(results[1].id).toBe(post1.id);
+  });
+
+  it('ranks a carousel above another post when its non-representative slide has a higher search rank', () => {
+    const db = databaseManager.connection;
+    const folder = folderRepository.upsert({
+      name: 'Animals',
+      slug: 'animals',
+      folderPath: 'animals',
+      folderRole: 'general'
+    });
+
+    const carouselFolder = folderRepository.upsert({
+      name: 'Wildlife',
+      slug: 'animals-carousels-wildlife',
+      folderPath: 'animals/carousels/Wildlife',
+      folderRole: 'carousel_source',
+      carouselOwnerFolderId: folder.id
+    });
+
+    // Single post (matches query "animals" on folder name only -> searchRank = 1)
+    const singleImg = db.prepare(`
+      INSERT INTO images (folder_id, filename, relative_path, file_size, mtime_ms, media_type, mime_type, width, height, sort_timestamp, taken_at, checksum_or_fingerprint, first_seen_at, thumbnail_path, preview_path, extension, absolute_path)
+      VALUES (?, 'photo-zoo.jpg', 'animals/photo-zoo.jpg', 1000, 1000, 'image', 'image/jpeg', 1080, 1080, 2000, '2026-01-01', 'fp-single', '2026-01-01', 't-s', 'p-s', 'jpg', '/abs/s')
+      RETURNING id
+    `).get(folder.id) as { id: number };
+
+    const singlePost = db.prepare(`
+      INSERT INTO posts (folder_id, post_type, source_path, sort_timestamp, taken_at)
+      VALUES (?, 'single', 'animals/photo-zoo.jpg', 2000, '2026-01-01')
+      RETURNING id
+    `).get(folder.id) as { id: number };
+    db.prepare(`INSERT INTO post_items (post_id, image_id, position) VALUES (?, ?, 1)`).run(singlePost.id, singleImg.id);
+
+    // Carousel post with slide 1 (neutral filename) and slide 2 (exact filename match on "animals-tiger" -> searchRank = 100)
+    const cImg1 = db.prepare(`
+      INSERT INTO images (folder_id, filename, relative_path, file_size, mtime_ms, media_type, mime_type, width, height, sort_timestamp, taken_at, checksum_or_fingerprint, first_seen_at, thumbnail_path, preview_path, extension, absolute_path)
+      VALUES (?, '01-grass.jpg', 'animals/carousels/Wildlife/01-grass.jpg', 1000, 1000, 'image', 'image/jpeg', 1080, 1080, 1000, '2026-01-01', 'fp-c1', '2026-01-01', 't-c1', 'p-c1', 'jpg', '/abs/c1')
+      RETURNING id
+    `).get(carouselFolder.id) as { id: number };
+
+    const cImg2 = db.prepare(`
+      INSERT INTO images (folder_id, filename, relative_path, file_size, mtime_ms, media_type, mime_type, width, height, sort_timestamp, taken_at, checksum_or_fingerprint, first_seen_at, thumbnail_path, preview_path, extension, absolute_path)
+      VALUES (?, '02-animals-tiger.jpg', 'animals/carousels/Wildlife/02-animals-tiger.jpg', 1000, 1000, 'image', 'image/jpeg', 1080, 1080, 1000, '2026-01-01', 'fp-c2', '2026-01-01', 't-c2', 'p-c2', 'jpg', '/abs/c2')
+      RETURNING id
+    `).get(carouselFolder.id) as { id: number };
+
+    const carouselPost = db.prepare(`
+      INSERT INTO posts (folder_id, post_type, source_path, sort_timestamp, taken_at)
+      VALUES (?, 'carousel', 'animals/carousels/Wildlife', 1000, '2026-01-01')
+      RETURNING id
+    `).get(folder.id) as { id: number };
+    db.prepare(`INSERT INTO post_items (post_id, image_id, position) VALUES (?, ?, 1)`).run(carouselPost.id, cImg1.id);
+    db.prepare(`INSERT INTO post_items (post_id, image_id, position) VALUES (?, ?, 2)`).run(carouselPost.id, cImg2.id);
+
+    // Searching "animals" matches singlePost (score 1 for folder match) and carouselPost (score 100 for slide 2 filename match).
+    const results = postRepository.listVisibleSearch('animals', 1, 10);
+    expect(results).toHaveLength(2);
+    // Carousel post has lower sortTimestamp (1000 vs 2000), but higher searchRank (100 vs 1) due to slide 2
+    expect(results[0].id).toBe(carouselPost.id);
+    expect(results[0].filename).toBe('01-grass.jpg'); // canonical cover is position 1
+    expect(results[1].id).toBe(singlePost.id);
+  });
+});

--- a/server/test/viewer-status.test.ts
+++ b/server/test/viewer-status.test.ts
@@ -205,7 +205,8 @@ describe.sequential('viewer-safe status payload', () => {
       defaultReelsFeedMode: 'random',
       defaultFolderImageOrder: 'newest',
       nestedFolderTitleFormat: 'folder',
-      treatStoriesAsFolders: false
+      treatStoriesAsFolders: false,
+      treatCarouselsAsFolders: false
     });
   });
 
@@ -223,7 +224,8 @@ describe.sequential('viewer-safe status payload', () => {
       defaultReelsFeedMode: 'recommended',
       defaultFolderImageOrder: 'oldest',
       nestedFolderTitleFormat: 'folder',
-      treatStoriesAsFolders: false
+      treatStoriesAsFolders: false,
+      treatCarouselsAsFolders: false
     });
   });
 });


### PR DESCRIPTION
Adds folder-based Carousel posts with support for 2–20 ordered images and videos. Carousels work across feeds, folders, search, sharing, Trash, and the media viewer.

Post identity, captions, likes, saves, metadata, and ordering are preserved across rescans. Video slides include playback controls, autoplay fallback, and HD switching.

Settings include migration handling for existing `carousels` folders and a save-then-manual-scan workflow. This PR also adds documentation and regression coverage for scanning, persistence, ordering, search, playback, and API routes.

Closes #32 