### PR TITLE
Fix transactional and crash-recoverable permanent post deletion

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1623,7 +1623,10 @@ Permanently deletes every physical member of the post:
 - each preview derivative
 
 A single-item post has one member; a carousel has all of its ordered members
-removed. The endpoint then updates the index and folder avatar state.
+removed. Files are quarantined before the post, its relationships, and folder
+avatar state are updated in one database transaction. A pre-commit failure
+restores the files and leaves the post unchanged. Interrupted operations are
+recovered automatically without making a committed deletion visible again.
 
 Success:
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -129,9 +129,11 @@ Instead it:
 - keeps their historical row data
 - reactivates them if the same relative path reappears later
 
-Direct user-triggered delete actions are different. Those remove the source file
-and derivatives first, then mark or remove the indexed records as part of the
-delete flow.
+Direct user-triggered permanent delete actions are different. Foldergram first
+moves the source files and derivatives into private quarantine areas within their
+configured storage roots. It then removes the post and related index records in
+one database transaction. If either step fails before the transaction commits,
+the quarantined files are restored and the post remains unchanged.
 
 ## Trash versus permanent delete
 
@@ -141,6 +143,15 @@ Foldergram also supports a separate user trash state for admin delete flows.
 - trashed posts are hidden from feed, folder, detail, likes, and collections surfaces
 - restoring a trashed post makes it visible again without a rescan
 - permanently deleting a post removes the original file plus derivatives
+
+Interrupted permanent deletions are recovered automatically at server startup
+and before another permanent deletion. If the database still contains the post,
+Foldergram restores its quarantined files. If the database transaction already
+committed, Foldergram keeps the post deleted and retries quarantine cleanup.
+Only empty source and derivative directories are pruned. Scans, index rebuilds,
+thumbnail rebuilds, lazy derivative generation, and permanent deletions run one
+at a time so indexing or derivative work cannot race a deletion or remove its
+quarantine data.
 
 This is separate from scan-time `is_deleted`, which tracks missing files on disk.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -14,6 +14,9 @@ optional admin/viewer/public access gate for homelab and LAN use.
 - you run it on your own machine or behind a trusted local-network or reverse-proxy setup
 - the app is not exposed directly to the public internet without additional protection
 - the built-in auth story is a small role-based password gate, not a multi-user account system
+- processes and accounts with write access to the configured gallery, thumbnail,
+  and preview roots are trusted not to replace directories while Foldergram is
+  performing a delete or recovery operation
 
 ## Password protection
 
@@ -144,7 +147,19 @@ when skip mode records supported-media failures.
 
 Delete flows resolve target files and directories inside configured roots before
 removing them. If a stored path falls outside the expected root, the operation
-throws instead of deleting blindly.
+throws instead of deleting blindly. Permanent deletion also rejects symbolic-link
+path components, verifies file and parent-directory identities around each
+filesystem mutation, and serializes its own scans, rebuilds, lazy derivative
+generation, recovery, and deletion work.
+
+This confinement guarantee covers Foldergram's own concurrent operations and
+filesystem state present when an operation is validated. It is not a security
+boundary against another process or account that can write to those same roots
+and deliberately swap a checked directory at the exact moment of a rename or
+unlink. Preventing that race requires platform-specific directory-handle-relative
+filesystem operations that Foldergram does not currently use. Keep these storage
+roots private to the account running Foldergram and pause other filesystem writers
+during permanent deletion or recovery.
 
 ## Storage availability behavior
 

--- a/server/src/db/repositories.ts
+++ b/server/src/db/repositories.ts
@@ -1271,14 +1271,51 @@ export const postRepository = {
   },
 
   deletePostAndImages(postId: number): { id: number; folderSlug: string } | undefined {
-    const post = this.findById(postId);
-    if (!post) return undefined;
-    const folder = folderRepository.getById(post.folder_id);
-    const imageIds = this.listImageRecords(post.id).map((image) => image.id);
-    database.prepare('DELETE FROM posts WHERE id = ?').run(post.id);
-    const deleteImage = database.prepare('DELETE FROM images WHERE id = ?');
-    for (const imageId of imageIds) deleteImage.run(imageId);
-    return { id: post.id, folderSlug: folder?.slug ?? '' };
+    database.exec('BEGIN IMMEDIATE');
+    try {
+      const post = this.findById(postId);
+      if (!post) {
+        database.exec('ROLLBACK');
+        return undefined;
+      }
+
+      const folder = folderRepository.getById(post.folder_id);
+      const imageIds = this.listImageRecords(post.id).map((image) => image.id);
+      const affectedAvatarFolderIds = new Set<number>([post.folder_id]);
+
+      if (imageIds.length > 0) {
+        const placeholders = imageIds.map(() => '?').join(', ');
+        const avatarRows = database
+          .prepare(`SELECT id FROM folders WHERE avatar_image_id IN (${placeholders})`)
+          .all(...imageIds) as Array<{ id: number }>;
+        for (const avatarRow of avatarRows) {
+          affectedAvatarFolderIds.add(avatarRow.id);
+        }
+
+        database
+          .prepare(`UPDATE folders SET avatar_image_id = NULL, avatar_source = 'auto', updated_at = ? WHERE avatar_image_id IN (${placeholders})`)
+          .run(nowIso(), ...imageIds);
+      }
+
+      database.prepare('DELETE FROM likes WHERE post_id = ?').run(post.id);
+      database.prepare('DELETE FROM collection_items WHERE post_id = ?').run(post.id);
+      database.prepare('DELETE FROM post_items WHERE post_id = ?').run(post.id);
+      database.prepare('DELETE FROM posts WHERE id = ?').run(post.id);
+      const deleteImage = database.prepare('DELETE FROM images WHERE id = ?');
+      for (const imageId of imageIds) {
+        deleteImage.run(imageId);
+      }
+
+      for (const folderId of affectedAvatarFolderIds) {
+        folderRepository.syncAvatarSelection(folderId);
+      }
+
+      database.exec('COMMIT');
+      return { id: post.id, folderSlug: folder?.slug ?? '' };
+    } catch (error) {
+      database.exec('ROLLBACK');
+      throw error;
+    }
   },
 
   hydratePostItems(posts: FeedPost[]): FeedPost[] {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -22,6 +22,7 @@ import { appConfig } from "./config/env.js";
 import { createApp } from "./app.js";
 import { collectionRepository } from "./db/repositories.js";
 import { log } from "./services/log-service.js";
+import { permanentDeletionService } from "./services/permanent-deletion-service.js";
 import { scannerService } from "./services/scanner-service.js";
 import { watcherService } from "./services/watcher-service.js";
 
@@ -48,6 +49,7 @@ function logServerReady(): void {
 }
 
 async function bootstrap(): Promise<void> {
+  await permanentDeletionService.recoverPendingDeletions();
   const app = createApp();
   const server = createServer(app);
   const portVariableName = appConfig.nodeEnv === "production" ? "SERVER_PORT" : "DEV_SERVER_PORT";
@@ -95,4 +97,7 @@ async function bootstrap(): Promise<void> {
   process.on("SIGTERM", () => void shutdown("SIGTERM"));
 }
 
-void bootstrap();
+void bootstrap().catch((error: unknown) => {
+  log.error("Server startup failed", error);
+  process.exitCode = 1;
+});

--- a/server/src/routes/lazy-derivatives.ts
+++ b/server/src/routes/lazy-derivatives.ts
@@ -9,6 +9,7 @@ import type { ImageRecord } from '../types/models.js';
 import { log } from '../services/log-service.js';
 import { generatePreviewDerivative, generateThumbnailDerivative } from '../services/derivative-service.js';
 import { scannerService } from '../services/scanner-service.js';
+import { maintenanceOperationLock } from '../services/maintenance-operation-lock.js';
 import { resolveOriginalPath } from '../utils/media-paths.js';
 import { applyDerivativeErrorHeaders, applyNoStoreMediaHeaders, applyProtectedMediaHeaders } from '../utils/media-response.js';
 import { normalizePath, safeJoin } from '../utils/path-utils.js';
@@ -18,6 +19,8 @@ const inflightGenerations = new Map<string, Promise<void>>();
 const generationLimit = pLimit(appConfig.scanDerivativeConcurrency);
 
 type SendDerivativeResult = 'sent' | 'aborted';
+
+class DerivativeRecordNotFoundError extends Error {}
 
 function getRequestedPath(request: express.Request): string | null {
   const rawPath = request.params.path;
@@ -33,6 +36,79 @@ function resolveDerivativePath(rootDir: string, requestedPath: string): string |
   } catch {
     return null;
   }
+}
+
+function findCurrentImageRecord(
+  requestedPath: string,
+  kind: 'thumbnail' | 'preview',
+  expectedImageId?: number
+): ImageRecord | null {
+  const imageRecord = kind === 'thumbnail'
+    ? imageRepository.getByThumbnailPath(requestedPath)
+    : imageRepository.getByPreviewPath(requestedPath);
+  if (!imageRecord || (expectedImageId !== undefined && imageRecord.id !== expectedImageId)) {
+    return null;
+  }
+  return imageRecord;
+}
+
+function sendDerivativeNotFound(response: express.Response): void {
+  applyDerivativeErrorHeaders(response);
+  response.status(404).json({ message: 'Derivative not found.' });
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function queueLazyGeneration(
+  absoluteOutputPath: string,
+  requestedPath: string,
+  kind: 'thumbnail' | 'preview',
+  expectedImageId: number
+): Promise<void> {
+  const existingGeneration = inflightGenerations.get(absoluteOutputPath);
+  if (existingGeneration) return existingGeneration;
+
+  const generationWork = generationLimit(() => maintenanceOperationLock.runExclusive(async () => {
+    const imageRecord = findCurrentImageRecord(requestedPath, kind, expectedImageId);
+    if (!imageRecord) throw new DerivativeRecordNotFoundError('Derivative no longer has an indexed image record');
+
+    // A scan or rebuild may have generated the file while this request waited
+    // for the maintenance lock.
+    if (await pathExists(absoluteOutputPath)) return;
+
+    log.info('Lazy derivative generate', {
+      kind,
+      file: requestedPath,
+      source: imageRecord.relative_path
+    });
+
+    const sourcePath = resolveOriginalPath(imageRecord.relative_path);
+    if (kind === 'thumbnail') {
+      await generateThumbnailDerivative(sourcePath, imageRecord.relative_path, false, {
+        thumbnailPath: imageRecord.thumbnail_path
+      });
+      return;
+    }
+
+    await generatePreviewDerivative(sourcePath, imageRecord.relative_path, false, {
+      previewPath: imageRecord.preview_path
+    });
+  }));
+  let trackedGeneration: Promise<void>;
+  trackedGeneration = generationWork.finally(() => {
+    if (inflightGenerations.get(absoluteOutputPath) === trackedGeneration) {
+      inflightGenerations.delete(absoluteOutputPath);
+    }
+  });
+  inflightGenerations.set(absoluteOutputPath, trackedGeneration);
+  return trackedGeneration;
 }
 
 function isConnectionTerminationError(error: unknown): boolean {
@@ -92,6 +168,12 @@ async function serveOrGenerate(
     return;
   }
 
+  const initialImageRecord = findCurrentImageRecord(requestedPath, kind);
+  if (!initialImageRecord) {
+    sendDerivativeNotFound(response);
+    return;
+  }
+
   // Fast path: file already exists.
   try {
     await fs.access(absoluteOutputPath);
@@ -119,54 +201,12 @@ async function serveOrGenerate(
     return;
   }
 
-  // Look up the source row by derivative path.
-  const imageRecord =
-    kind === 'thumbnail'
-      ? imageRepository.getByThumbnailPath(requestedPath)
-      : imageRepository.getByPreviewPath(requestedPath);
-
-  if (!imageRecord) {
-    applyDerivativeErrorHeaders(response);
-    response.status(404).json({ message: 'Derivative not found.' });
-    return;
-  }
-
-  let generationPromise = inflightGenerations.get(absoluteOutputPath);
-
-  if (!generationPromise) {
-    log.info('Lazy derivative generate', {
-      kind,
-      file: requestedPath,
-      source: imageRecord.relative_path
-    });
-
-    generationPromise = generationLimit(async () => {
-      try {
-        const sourcePath = resolveOriginalPath(imageRecord.relative_path);
-
-        if (kind === 'thumbnail') {
-          await generateThumbnailDerivative(sourcePath, imageRecord.relative_path, false, {
-            thumbnailPath: imageRecord.thumbnail_path
-          });
-          return;
-        }
-        await generatePreviewDerivative(sourcePath, imageRecord.relative_path, false, {
-          previewPath: imageRecord.preview_path
-        });
-      } finally {
-        inflightGenerations.delete(absoluteOutputPath);
-      }
-    });
-
-    inflightGenerations.set(absoluteOutputPath, generationPromise);
-  }
-
-  const queuedGeneration = generationPromise;
-  if (!queuedGeneration) {
-    applyDerivativeErrorHeaders(response);
-    response.status(500).json({ message: 'Failed to queue derivative generation.' });
-    return;
-  }
+  const queuedGeneration = queueLazyGeneration(
+    absoluteOutputPath,
+    requestedPath,
+    kind,
+    initialImageRecord.id
+  );
 
   try {
     await queuedGeneration;
@@ -175,9 +215,18 @@ async function serveOrGenerate(
       return;
     }
 
+    if (error instanceof DerivativeRecordNotFoundError) {
+      sendDerivativeNotFound(response);
+      return;
+    }
     const message = error instanceof Error ? error.message : 'Failed to generate derivative.';
     applyDerivativeErrorHeaders(response);
     response.status(500).json({ message });
+    return;
+  }
+
+  if (!findCurrentImageRecord(requestedPath, kind, initialImageRecord.id)) {
+    sendDerivativeNotFound(response);
     return;
   }
 
@@ -211,6 +260,12 @@ export async function serveDerivativeForImage(
     return;
   }
 
+  const initialImageRecord = findCurrentImageRecord(requestedPath, kind, imageRecord.id);
+  if (!initialImageRecord) {
+    sendDerivativeNotFound(response);
+    return;
+  }
+
   try {
     await fs.access(absoluteOutputPath);
     try {
@@ -237,36 +292,12 @@ export async function serveDerivativeForImage(
     return;
   }
 
-  let generationPromise = inflightGenerations.get(absoluteOutputPath);
-
-  if (!generationPromise) {
-    log.info('Lazy derivative generate', {
-      kind,
-      file: requestedPath,
-      source: imageRecord.relative_path
-    });
-
-    generationPromise = generationLimit(async () => {
-      try {
-        const sourcePath = resolveOriginalPath(imageRecord.relative_path);
-
-        if (kind === 'thumbnail') {
-          await generateThumbnailDerivative(sourcePath, imageRecord.relative_path, false, {
-            thumbnailPath: imageRecord.thumbnail_path
-          });
-          return;
-        }
-
-        await generatePreviewDerivative(sourcePath, imageRecord.relative_path, false, {
-          previewPath: imageRecord.preview_path
-        });
-      } finally {
-        inflightGenerations.delete(absoluteOutputPath);
-      }
-    });
-
-    inflightGenerations.set(absoluteOutputPath, generationPromise);
-  }
+  const generationPromise = queueLazyGeneration(
+    absoluteOutputPath,
+    requestedPath,
+    kind,
+    initialImageRecord.id
+  );
 
   try {
     await generationPromise;
@@ -275,9 +306,18 @@ export async function serveDerivativeForImage(
       return;
     }
 
+    if (error instanceof DerivativeRecordNotFoundError) {
+      sendDerivativeNotFound(response);
+      return;
+    }
     const message = error instanceof Error ? error.message : 'Failed to generate derivative.';
     applyDerivativeErrorHeaders(response);
     response.status(500).json({ message });
+    return;
+  }
+
+  if (!findCurrentImageRecord(requestedPath, kind, initialImageRecord.id)) {
+    sendDerivativeNotFound(response);
     return;
   }
 

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -69,6 +69,7 @@ import { parseTreatStoriesAsFoldersSetting, serializeTreatStoriesAsFoldersSettin
 import { scannerService } from './scanner-service.js';
 import { storageService } from './storage-service.js';
 import { geodataService, placeResolutionService } from './place-service.js';
+import { permanentDeletionService } from './permanent-deletion-service.js';
 
 type FeedMode = 'recent' | 'rediscover' | 'random';
 type ReelsFeedMode = 'recommended' | 'recent' | 'random';
@@ -2339,39 +2340,7 @@ export const galleryService = {
       return null;
     }
 
-    const folder = folderRepository.getById(post.folder_id);
-    if (!folder) {
-      return null;
-    }
-
-    const imageRecords = postRepository.listImageRecords(post.id);
-    const targets = imageRecords.map((imageRecord) => {
-      const originalPath = resolveIndexedOriginalPath(imageRecord.relative_path);
-      if (!originalPath) throw new Error('Stored image path is outside the gallery root');
-      return {
-        originalPath,
-        thumbnailPath: resolveStoredPathWithinRoot(appConfig.thumbnailsDir, imageRecord.thumbnail_path, 'thumbnail'),
-        previewPath: resolveStoredPathWithinRoot(appConfig.previewsDir, imageRecord.preview_path, 'preview')
-      };
-    });
-
-    await Promise.all(targets.flatMap(({ originalPath, thumbnailPath, previewPath }) => [
-      removeFileAndPruneAncestors(appConfig.galleryRoot, originalPath),
-      removeFileAndPruneAncestors(appConfig.thumbnailsDir, thumbnailPath),
-      removeFileAndPruneAncestors(appConfig.previewsDir, previewPath)
-    ]));
-
-    if (imageRecords.some((imageRecord) => folder.avatar_image_id === imageRecord.id)) {
-      folderRepository.setAvatar(post.folder_id, null, 'auto');
-    }
-
-    postRepository.deletePostAndImages(post.id);
-    folderRepository.syncAvatarSelection(post.folder_id);
-
-    return {
-      id: post.id,
-      folderSlug: folder.slug
-    };
+    return permanentDeletionService.deletePost(post.id);
   },
 
   async deleteFolder(slug: string, options: DeleteFolderOptions = {}) {

--- a/server/src/services/maintenance-operation-lock.ts
+++ b/server/src/services/maintenance-operation-lock.ts
@@ -1,0 +1,13 @@
+export const PERMANENT_DELETION_QUARANTINE_DIRECTORY_NAME = '.foldergram-delete-quarantine';
+
+class MaintenanceOperationLock {
+  private tail: Promise<void> = Promise.resolve();
+
+  runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.tail.then(operation, operation);
+    this.tail = result.then(() => undefined, () => undefined);
+    return result;
+  }
+}
+
+export const maintenanceOperationLock = new MaintenanceOperationLock();

--- a/server/src/services/permanent-deletion-service.ts
+++ b/server/src/services/permanent-deletion-service.ts
@@ -1,0 +1,834 @@
+import { randomUUID } from 'node:crypto';
+import fsSync from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { appConfig } from '../config/env.js';
+import { folderRepository, postRepository } from '../db/repositories.js';
+import type { ImageRecord } from '../types/models.js';
+import { normalizePath } from '../utils/path-utils.js';
+import { log } from './log-service.js';
+import {
+  maintenanceOperationLock,
+  PERMANENT_DELETION_QUARANTINE_DIRECTORY_NAME
+} from './maintenance-operation-lock.js';
+import { storageService } from './storage-service.js';
+
+const QUARANTINE_DIRECTORY_NAME = PERMANENT_DELETION_QUARANTINE_DIRECTORY_NAME;
+const JOURNAL_VERSION = 1;
+
+type DeletionRoot = 'gallery' | 'thumbnails' | 'previews';
+
+interface FileIdentity {
+  device: string;
+  inode: string;
+  size: string;
+  modifiedNanoseconds: string;
+}
+
+interface DirectoryIdentity {
+  device: string;
+  inode: string;
+}
+
+interface DirectoryGuardEntry extends DirectoryIdentity {
+  path: string;
+  followConfiguredRoot: boolean;
+}
+
+interface DirectoryGuard {
+  rootPath: string;
+  rootRealPath: string;
+  entries: DirectoryGuardEntry[];
+}
+
+interface DeletionJournalEntry {
+  root: DeletionRoot;
+  originalRelativePath: string;
+  quarantineRelativePath: string;
+  wasPresent: boolean;
+  identity: FileIdentity | null;
+}
+
+interface DeletionJournal {
+  version: typeof JOURNAL_VERSION;
+  operationId: string;
+  postId: number;
+  folderSlug: string;
+  createdAt: string;
+  entries: DeletionJournalEntry[];
+}
+
+export class SimulatedDeletionInterruptionError extends Error {
+  constructor(message = 'Simulated process termination during permanent deletion') {
+    super(message);
+    this.name = 'SimulatedDeletionInterruptionError';
+  }
+}
+
+export interface PermanentDeletionServiceHooks {
+  rename?: (sourcePath: string, destinationPath: string) => Promise<void>;
+  afterQuarantine?: (journal: Readonly<DeletionJournal>) => Promise<void> | void;
+  afterDatabaseCommit?: (journal: Readonly<DeletionJournal>) => Promise<void> | void;
+}
+
+interface ValidatedDeletionTarget {
+  root: DeletionRoot;
+  rootPath: string;
+  originalPath: string;
+  originalRelativePath: string;
+  quarantinePath: string;
+  quarantineRelativePath: string;
+  wasPresent: boolean;
+  identity: FileIdentity | null;
+}
+
+function getRootPath(root: DeletionRoot): string {
+  if (root === 'gallery') return appConfig.galleryRoot;
+  if (root === 'thumbnails') return appConfig.thumbnailsDir;
+  return appConfig.previewsDir;
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException)?.code === 'ENOENT';
+}
+
+function toIdentity(stats: Awaited<ReturnType<typeof fs.lstat>>): FileIdentity {
+  const bigintStats = stats as unknown as {
+    dev: bigint | number;
+    ino: bigint | number;
+    size: bigint | number;
+    mtimeNs?: bigint;
+    mtimeMs: number;
+  };
+
+  return {
+    device: String(bigintStats.dev),
+    inode: String(bigintStats.ino),
+    size: String(bigintStats.size),
+    modifiedNanoseconds: bigintStats.mtimeNs !== undefined
+      ? String(bigintStats.mtimeNs)
+      : String(Math.round(bigintStats.mtimeMs * 1_000_000))
+  };
+}
+
+function identitiesMatch(left: FileIdentity, right: FileIdentity): boolean {
+  return left.device === right.device &&
+    left.inode === right.inode &&
+    left.size === right.size &&
+    left.modifiedNanoseconds === right.modifiedNanoseconds;
+}
+
+function toDirectoryIdentity(stats: { dev: bigint | number; ino: bigint | number }): DirectoryIdentity {
+  return {
+    device: String(stats.dev),
+    inode: String(stats.ino)
+  };
+}
+
+function directoryIdentitiesMatch(left: DirectoryIdentity, right: DirectoryIdentity): boolean {
+  return left.device === right.device && left.inode === right.inode;
+}
+
+function isPathWithin(rootPath: string, targetPath: string): boolean {
+  const relative = path.relative(rootPath, targetPath);
+  return relative === '' || (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+}
+
+function captureDirectoryGuard(rootPath: string, directoryPath: string, label: string): DirectoryGuard {
+  const resolvedRoot = path.resolve(rootPath);
+  const resolvedDirectory = path.resolve(directoryPath);
+  if (!isPathWithin(resolvedRoot, resolvedDirectory)) {
+    throw new Error(`${label} is outside its configured root`);
+  }
+
+  const rootRealPath = fsSync.realpathSync.native(resolvedRoot);
+  const rootStats = fsSync.statSync(resolvedRoot, { bigint: true });
+  if (!rootStats.isDirectory()) throw new Error(`Configured root is not a directory: ${resolvedRoot}`);
+
+  const entries: DirectoryGuardEntry[] = [{
+    path: resolvedRoot,
+    followConfiguredRoot: true,
+    ...toDirectoryIdentity(rootStats)
+  }];
+  const relative = path.relative(resolvedRoot, resolvedDirectory);
+  let currentPath = resolvedRoot;
+  for (const segment of relative ? relative.split(path.sep) : []) {
+    currentPath = path.join(currentPath, segment);
+    const stats = fsSync.lstatSync(currentPath, { bigint: true });
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      throw new Error(`${label} traverses a non-directory or symbolic link`);
+    }
+    const realPath = fsSync.realpathSync.native(currentPath);
+    if (!isPathWithin(rootRealPath, realPath)) {
+      throw new Error(`${label} resolves outside its configured root`);
+    }
+    entries.push({
+      path: currentPath,
+      followConfiguredRoot: false,
+      ...toDirectoryIdentity(stats)
+    });
+  }
+
+  return { rootPath: resolvedRoot, rootRealPath, entries };
+}
+
+function assertDirectoryGuardStable(guard: DirectoryGuard, label: string): void {
+  if (fsSync.realpathSync.native(guard.rootPath) !== guard.rootRealPath) {
+    throw new Error(`${label} configured root changed during the filesystem operation`);
+  }
+
+  for (const entry of guard.entries) {
+    const stats = entry.followConfiguredRoot
+      ? fsSync.statSync(entry.path, { bigint: true })
+      : fsSync.lstatSync(entry.path, { bigint: true });
+    if (!stats.isDirectory() || (!entry.followConfiguredRoot && stats.isSymbolicLink()) ||
+        !directoryIdentitiesMatch(toDirectoryIdentity(stats), entry)) {
+      throw new Error(`${label} parent directory changed during the filesystem operation`);
+    }
+  }
+}
+
+function assertMatchingFileSync(targetPath: string, identity: FileIdentity, label: string): void {
+  const stats = fsSync.lstatSync(targetPath, { bigint: true });
+  if (!stats.isFile() || stats.isSymbolicLink() || !identitiesMatch(toIdentity(stats as unknown as Awaited<ReturnType<typeof fs.lstat>>), identity)) {
+    throw new Error(`${label} no longer matches the file recorded in the deletion journal`);
+  }
+}
+
+function lstatSyncIfPresent(targetPath: string): fsSync.Stats | fsSync.BigIntStats | null {
+  try {
+    return fsSync.lstatSync(targetPath, { bigint: true });
+  } catch (error) {
+    if (isMissingFileError(error)) return null;
+    throw error;
+  }
+}
+
+function resolveRelativePathWithinRoot(rootPath: string, relativePath: string, label: string): string {
+  if (!relativePath || path.isAbsolute(relativePath)) {
+    throw new Error(`${label} must be a non-empty relative path`);
+  }
+
+  const resolvedRoot = path.resolve(rootPath);
+  const resolvedPath = path.resolve(resolvedRoot, relativePath);
+  const relative = path.relative(resolvedRoot, resolvedPath);
+  if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`${label} is outside its configured root`);
+  }
+
+  return resolvedPath;
+}
+
+async function lstatIfPresent(targetPath: string, useBigInt = false): Promise<Awaited<ReturnType<typeof fs.lstat>> | null> {
+  try {
+    return useBigInt
+      ? await fs.lstat(targetPath, { bigint: true }) as unknown as Awaited<ReturnType<typeof fs.lstat>>
+      : await fs.lstat(targetPath);
+  } catch (error) {
+    if (isMissingFileError(error)) return null;
+    throw error;
+  }
+}
+
+async function assertNoSymlinkTraversal(rootPath: string, targetPath: string, label: string): Promise<void> {
+  const resolvedRoot = path.resolve(rootPath);
+  const relative = path.relative(resolvedRoot, targetPath);
+  if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`${label} is outside its configured root`);
+  }
+
+  const rootStats = await fs.stat(resolvedRoot);
+  if (!rootStats.isDirectory()) {
+    throw new Error(`Configured root is not a directory: ${resolvedRoot}`);
+  }
+
+  let currentPath = resolvedRoot;
+  for (const segment of relative.split(path.sep)) {
+    currentPath = path.join(currentPath, segment);
+    const stats = await lstatIfPresent(currentPath);
+    if (!stats) return;
+    if (stats.isSymbolicLink()) {
+      throw new Error(`${label} traverses a symbolic link`);
+    }
+  }
+}
+
+async function validateExistingFile(rootPath: string, targetPath: string, label: string): Promise<{
+  wasPresent: boolean;
+  identity: FileIdentity | null;
+}> {
+  await assertNoSymlinkTraversal(rootPath, targetPath, label);
+  const stats = await lstatIfPresent(targetPath, true);
+  if (!stats) {
+    return { wasPresent: false, identity: null };
+  }
+  if (!stats.isFile()) {
+    throw new Error(`${label} is not a regular file`);
+  }
+  return { wasPresent: true, identity: toIdentity(stats) };
+}
+
+async function ensurePrivateDirectory(rootPath: string, directoryPath: string): Promise<void> {
+  await assertNoSymlinkTraversal(rootPath, directoryPath, 'Quarantine directory');
+  await fs.mkdir(directoryPath, { recursive: true, mode: 0o700 });
+  await assertNoSymlinkTraversal(rootPath, directoryPath, 'Quarantine directory');
+  const stats = await fs.lstat(directoryPath);
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error('Quarantine path is not a private directory');
+  }
+}
+
+async function assertMatchingFile(targetPath: string, identity: FileIdentity, label: string): Promise<boolean> {
+  const stats = await lstatIfPresent(targetPath, true);
+  if (!stats) return false;
+  if (!stats.isFile() || stats.isSymbolicLink() || !identitiesMatch(toIdentity(stats), identity)) {
+    throw new Error(`${label} no longer matches the quarantined file recorded in the deletion journal`);
+  }
+  return true;
+}
+
+async function pruneEmptyAncestors(rootPath: string, startDirectory: string, stopDirectory = path.resolve(rootPath)): Promise<void> {
+  const resolvedRoot = path.resolve(rootPath);
+  const resolvedStop = path.resolve(stopDirectory);
+  let currentDirectory = path.resolve(startDirectory);
+
+  while (currentDirectory !== resolvedStop && currentDirectory !== resolvedRoot) {
+    const relative = path.relative(resolvedRoot, currentDirectory);
+    if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+      throw new Error('Directory pruning target is outside its configured root');
+    }
+
+    await assertNoSymlinkTraversal(resolvedRoot, currentDirectory, 'Directory pruning target');
+    try {
+      const directoryStats = fsSync.lstatSync(currentDirectory, { bigint: true });
+      if (!directoryStats.isDirectory() || directoryStats.isSymbolicLink()) {
+        throw new Error('Directory pruning target is not a real directory');
+      }
+      const parentGuard = captureDirectoryGuard(resolvedRoot, path.dirname(currentDirectory), 'Directory pruning target');
+      assertDirectoryGuardStable(parentGuard, 'Directory pruning target');
+      const currentStats = fsSync.lstatSync(currentDirectory, { bigint: true });
+      if (!directoryIdentitiesMatch(toDirectoryIdentity(currentStats), toDirectoryIdentity(directoryStats))) {
+        throw new Error('Directory pruning target changed during the filesystem operation');
+      }
+      fsSync.rmdirSync(currentDirectory);
+      assertDirectoryGuardStable(parentGuard, 'Directory pruning target');
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code === 'ENOENT') {
+        currentDirectory = path.dirname(currentDirectory);
+        continue;
+      }
+      if (code === 'ENOTEMPTY' || code === 'EEXIST') return;
+      throw error;
+    }
+
+    currentDirectory = path.dirname(currentDirectory);
+  }
+}
+
+function parseJournal(value: unknown): DeletionJournal {
+  if (!value || typeof value !== 'object') throw new Error('Deletion journal is not an object');
+  const candidate = value as Partial<DeletionJournal>;
+  if (candidate.version !== JOURNAL_VERSION ||
+      typeof candidate.operationId !== 'string' || !/^[0-9a-f-]{36}$/i.test(candidate.operationId) ||
+      !Number.isSafeInteger(candidate.postId) || Number(candidate.postId) <= 0 ||
+      typeof candidate.folderSlug !== 'string' ||
+      typeof candidate.createdAt !== 'string' ||
+      !Array.isArray(candidate.entries)) {
+    throw new Error('Deletion journal metadata is invalid');
+  }
+
+  for (const entry of candidate.entries) {
+    if (!entry || typeof entry !== 'object' ||
+        !['gallery', 'thumbnails', 'previews'].includes(entry.root) ||
+        typeof entry.originalRelativePath !== 'string' ||
+        typeof entry.quarantineRelativePath !== 'string' ||
+        typeof entry.wasPresent !== 'boolean' ||
+        (entry.wasPresent && (!entry.identity || typeof entry.identity !== 'object')) ||
+        (!entry.wasPresent && entry.identity !== null)) {
+      throw new Error('Deletion journal entry is invalid');
+    }
+
+    if (entry.identity && (
+      typeof entry.identity.device !== 'string' ||
+      typeof entry.identity.inode !== 'string' ||
+      typeof entry.identity.size !== 'string' ||
+      typeof entry.identity.modifiedNanoseconds !== 'string'
+    )) {
+      throw new Error('Deletion journal file identity is invalid');
+    }
+
+    const normalizedOriginalPath = normalizePath(entry.originalRelativePath);
+    if (normalizedOriginalPath === QUARANTINE_DIRECTORY_NAME || normalizedOriginalPath.startsWith(`${QUARANTINE_DIRECTORY_NAME}/`)) {
+      throw new Error('Deletion journal original path overlaps private quarantine storage');
+    }
+
+    const expectedPrefix = `${normalizePath(path.join(QUARANTINE_DIRECTORY_NAME, 'files', candidate.operationId))}/`;
+    const normalizedQuarantinePath = normalizePath(entry.quarantineRelativePath);
+    if (!normalizedQuarantinePath.startsWith(expectedPrefix) || normalizedQuarantinePath === expectedPrefix) {
+      throw new Error('Deletion journal quarantine path is invalid');
+    }
+  }
+
+  return candidate as DeletionJournal;
+}
+
+export class PermanentDeletionService {
+  private readonly renameFile: (sourcePath: string, destinationPath: string) => Promise<void>;
+
+  constructor(private readonly hooks: PermanentDeletionServiceHooks = {}) {
+    this.renameFile = hooks.rename ?? ((sourcePath, destinationPath) => fs.rename(sourcePath, destinationPath));
+  }
+
+  deletePost(postId: number): Promise<{ id: number; folderSlug: string } | null> {
+    return maintenanceOperationLock.runExclusive(async () => {
+      await this.recoverPendingDeletionsInternal();
+      return this.deletePostInternal(postId);
+    });
+  }
+
+  recoverPendingDeletions(): Promise<void> {
+    return maintenanceOperationLock.runExclusive(() => this.recoverPendingDeletionsInternal());
+  }
+
+  recoverPendingDeletionsWhileLocked(): Promise<void> {
+    return this.recoverPendingDeletionsInternal();
+  }
+
+  private async renameValidatedFile(
+    sourceRootPath: string,
+    sourcePath: string,
+    destinationRootPath: string,
+    destinationPath: string,
+    identity: FileIdentity,
+    label: string
+  ): Promise<void> {
+    const sourceGuard = captureDirectoryGuard(sourceRootPath, path.dirname(sourcePath), `${label} source`);
+    const destinationGuard = captureDirectoryGuard(destinationRootPath, path.dirname(destinationPath), `${label} destination`);
+    assertDirectoryGuardStable(sourceGuard, `${label} source`);
+    assertDirectoryGuardStable(destinationGuard, `${label} destination`);
+    assertMatchingFileSync(sourcePath, identity, `${label} source`);
+    if (lstatSyncIfPresent(destinationPath)) throw new Error(`${label} destination is already occupied`);
+
+    if (this.hooks.rename) {
+      await this.renameFile(sourcePath, destinationPath);
+    } else {
+      // Keep the final identity checks, rename, and post-checks in one event-loop turn.
+      // This closes in-process races. Pre-existing symlinks are rejected above; an
+      // external writer with access to these roots is outside the documented threat model.
+      fsSync.renameSync(sourcePath, destinationPath);
+    }
+
+    assertDirectoryGuardStable(sourceGuard, `${label} source`);
+    assertDirectoryGuardStable(destinationGuard, `${label} destination`);
+    assertMatchingFileSync(destinationPath, identity, `${label} destination`);
+  }
+
+  private unlinkValidatedFile(rootPath: string, targetPath: string, identity: FileIdentity, label: string): void {
+    const parentGuard = captureDirectoryGuard(rootPath, path.dirname(targetPath), label);
+    assertDirectoryGuardStable(parentGuard, label);
+    assertMatchingFileSync(targetPath, identity, label);
+    fsSync.unlinkSync(targetPath);
+    assertDirectoryGuardStable(parentGuard, label);
+  }
+
+  private unlinkInternalFileIfPresent(rootPath: string, targetPath: string, label: string): void {
+    const stats = lstatSyncIfPresent(targetPath);
+    if (!stats) return;
+    if (!stats.isFile() || stats.isSymbolicLink()) throw new Error(`${label} is not a regular file`);
+    this.unlinkValidatedFile(
+      rootPath,
+      targetPath,
+      toIdentity(stats as unknown as Awaited<ReturnType<typeof fs.lstat>>),
+      label
+    );
+  }
+
+  private async deletePostInternal(postId: number): Promise<{ id: number; folderSlug: string } | null> {
+    if (storageService.getState().usingInMemoryDatabase) {
+      throw new Error('Permanent deletion is unavailable while the configured database is offline');
+    }
+
+    const post = postRepository.findById(postId);
+    if (!post) return null;
+    const folderSlug = folderRepository.getById(post.folder_id)?.slug ?? '';
+    const operationId = randomUUID();
+    const targets = await this.buildValidatedTargets(operationId, postRepository.listImageRecords(post.id));
+    const journal: DeletionJournal = {
+      version: JOURNAL_VERSION,
+      operationId,
+      postId: post.id,
+      folderSlug,
+      createdAt: new Date().toISOString(),
+      entries: targets.map((target) => ({
+        root: target.root,
+        originalRelativePath: target.originalRelativePath,
+        quarantineRelativePath: target.quarantineRelativePath,
+        wasPresent: target.wasPresent,
+        identity: target.identity
+      }))
+    };
+
+    const journalPath = await this.writeJournal(journal);
+    const completedMoves = new Set<number>();
+
+    try {
+      for (const [targetIndex, target] of targets.entries()) {
+        if (!target.wasPresent) continue;
+        if (!target.identity) throw new Error('Validated deletion target is missing its file identity');
+        await ensurePrivateDirectory(target.rootPath, path.dirname(target.quarantinePath));
+        await this.renameValidatedFile(
+          target.rootPath,
+          target.originalPath,
+          target.rootPath,
+          target.quarantinePath,
+          target.identity,
+          'Quarantine move'
+        );
+        completedMoves.add(targetIndex);
+        await this.writeMoveMarker(journal, targetIndex);
+      }
+
+      await this.hooks.afterQuarantine?.(journal);
+    } catch (error) {
+      if (error instanceof SimulatedDeletionInterruptionError) throw error;
+      await this.restoreJournal(journal, journalPath, completedMoves);
+      throw error;
+    }
+
+    let deleted: { id: number; folderSlug: string } | undefined;
+    try {
+      deleted = postRepository.deletePostAndImages(post.id);
+    } catch (error) {
+      if (!postRepository.findById(post.id)) {
+        log.error('Permanent deletion transaction outcome was committed despite an error; cleanup will be retried', {
+          operationId,
+          postId: post.id,
+          error
+        });
+        await this.tryCleanupCommittedJournal(journal, journalPath);
+        return { id: post.id, folderSlug };
+      }
+
+      await this.restoreJournal(journal, journalPath, completedMoves);
+      throw error;
+    }
+
+    if (!deleted) {
+      await this.restoreJournal(journal, journalPath, completedMoves);
+      return null;
+    }
+
+    try {
+      await this.hooks.afterDatabaseCommit?.(journal);
+    } catch (error) {
+      if (error instanceof SimulatedDeletionInterruptionError) throw error;
+      log.error('Permanent deletion committed; quarantined file cleanup will be retried', {
+        operationId,
+        postId: post.id,
+        error
+      });
+      return deleted;
+    }
+
+    await this.tryCleanupCommittedJournal(journal, journalPath);
+    return deleted;
+  }
+
+  private async buildValidatedTargets(operationId: string, images: ImageRecord[]): Promise<ValidatedDeletionTarget[]> {
+    const candidates: Array<{ root: DeletionRoot; relativePath: string; label: string }> = [];
+    for (const image of images) {
+      candidates.push(
+        { root: 'gallery', relativePath: image.relative_path, label: 'Stored original path' },
+        { root: 'thumbnails', relativePath: image.thumbnail_path, label: 'Stored thumbnail path' },
+        { root: 'previews', relativePath: image.preview_path, label: 'Stored preview path' }
+      );
+    }
+
+    const targets: ValidatedDeletionTarget[] = [];
+    const seenAbsolutePaths = new Set<string>();
+    for (const [index, candidate] of candidates.entries()) {
+      const rootPath = getRootPath(candidate.root);
+      const normalizedCandidatePath = normalizePath(candidate.relativePath).replace(/^\/+/, '');
+      if (normalizedCandidatePath === QUARANTINE_DIRECTORY_NAME || normalizedCandidatePath.startsWith(`${QUARANTINE_DIRECTORY_NAME}/`)) {
+        throw new Error(`${candidate.label} overlaps private quarantine storage`);
+      }
+      const originalPath = resolveRelativePathWithinRoot(rootPath, candidate.relativePath, candidate.label);
+      const pathKey = process.platform === 'win32' ? originalPath.toLocaleLowerCase() : originalPath;
+      if (seenAbsolutePaths.has(pathKey)) continue;
+      seenAbsolutePaths.add(pathKey);
+
+      const originalRelativePath = normalizePath(path.relative(rootPath, originalPath));
+      const quarantineRelativePath = normalizePath(path.join(
+        QUARANTINE_DIRECTORY_NAME,
+        'files',
+        operationId,
+        `${String(index).padStart(4, '0')}-${candidate.root}`
+      ));
+      const quarantinePath = resolveRelativePathWithinRoot(rootPath, quarantineRelativePath, 'Quarantine path');
+      const fileState = await validateExistingFile(rootPath, originalPath, candidate.label);
+      await assertNoSymlinkTraversal(rootPath, quarantinePath, 'Quarantine path');
+      if (await lstatIfPresent(quarantinePath)) {
+        throw new Error('Quarantine destination is already occupied');
+      }
+
+      targets.push({
+        root: candidate.root,
+        rootPath,
+        originalPath,
+        originalRelativePath,
+        quarantinePath,
+        quarantineRelativePath,
+        ...fileState
+      });
+    }
+
+    return targets;
+  }
+
+  private async writeJournal(journal: DeletionJournal): Promise<string> {
+    const journalDirectory = path.join(appConfig.galleryRoot, QUARANTINE_DIRECTORY_NAME, 'journals');
+    await ensurePrivateDirectory(appConfig.galleryRoot, journalDirectory);
+    const finalPath = resolveRelativePathWithinRoot(
+      appConfig.galleryRoot,
+      path.join(QUARANTINE_DIRECTORY_NAME, 'journals', `${journal.operationId}.json`),
+      'Deletion journal path'
+    );
+    const temporaryPath = `${finalPath}.${randomUUID()}.tmp`;
+    const directoryGuard = captureDirectoryGuard(appConfig.galleryRoot, journalDirectory, 'Deletion journal directory');
+    assertDirectoryGuardStable(directoryGuard, 'Deletion journal directory');
+    if (lstatSyncIfPresent(finalPath) || lstatSyncIfPresent(temporaryPath)) {
+      throw new Error('Deletion journal destination is already occupied');
+    }
+    const fileDescriptor = fsSync.openSync(temporaryPath, 'wx', 0o600);
+    try {
+      fsSync.writeFileSync(fileDescriptor, `${JSON.stringify(journal)}\n`, 'utf8');
+      fsSync.fsyncSync(fileDescriptor);
+    } finally {
+      fsSync.closeSync(fileDescriptor);
+    }
+    assertDirectoryGuardStable(directoryGuard, 'Deletion journal directory');
+    fsSync.renameSync(temporaryPath, finalPath);
+    assertDirectoryGuardStable(directoryGuard, 'Deletion journal directory');
+    await this.syncDirectoryIfSupported(journalDirectory);
+    return finalPath;
+  }
+
+  private getMoveMarkerPath(journal: DeletionJournal, entryIndex: number): string {
+    return resolveRelativePathWithinRoot(
+      appConfig.galleryRoot,
+      path.join(QUARANTINE_DIRECTORY_NAME, 'journals', `${journal.operationId}.${entryIndex}.moved`),
+      'Deletion move marker path'
+    );
+  }
+
+  private async writeMoveMarker(journal: DeletionJournal, entryIndex: number): Promise<void> {
+    const markerPath = this.getMoveMarkerPath(journal, entryIndex);
+    const markerDirectory = path.dirname(markerPath);
+    const directoryGuard = captureDirectoryGuard(appConfig.galleryRoot, markerDirectory, 'Deletion move marker directory');
+    assertDirectoryGuardStable(directoryGuard, 'Deletion move marker directory');
+    const fileDescriptor = fsSync.openSync(markerPath, 'wx', 0o600);
+    try {
+      fsSync.writeFileSync(fileDescriptor, 'moved\n', 'utf8');
+      fsSync.fsyncSync(fileDescriptor);
+    } finally {
+      fsSync.closeSync(fileDescriptor);
+    }
+    assertDirectoryGuardStable(directoryGuard, 'Deletion move marker directory');
+    await this.syncDirectoryIfSupported(markerDirectory);
+  }
+
+  private async hasMoveMarker(journal: DeletionJournal, entryIndex: number): Promise<boolean> {
+    const markerPath = this.getMoveMarkerPath(journal, entryIndex);
+    await assertNoSymlinkTraversal(appConfig.galleryRoot, markerPath, 'Deletion move marker path');
+    const stats = await lstatIfPresent(markerPath);
+    if (!stats) return false;
+    if (!stats.isFile() || stats.isSymbolicLink()) {
+      throw new Error('Deletion move marker is not a regular file');
+    }
+    return true;
+  }
+
+  private async removeMoveMarkers(journal: DeletionJournal): Promise<void> {
+    for (const entryIndex of journal.entries.keys()) {
+      this.unlinkInternalFileIfPresent(
+        appConfig.galleryRoot,
+        this.getMoveMarkerPath(journal, entryIndex),
+        'Deletion move marker'
+      );
+    }
+  }
+
+  private async restoreJournal(
+    journal: DeletionJournal,
+    journalPath: string,
+    completedMoves: ReadonlySet<number> = new Set()
+  ): Promise<void> {
+    const restoreErrors: unknown[] = [];
+    for (let entryIndex = journal.entries.length - 1; entryIndex >= 0; entryIndex -= 1) {
+      try {
+        const moveCompleted = completedMoves.has(entryIndex) || await this.hasMoveMarker(journal, entryIndex);
+        await this.restoreEntry(journal.entries[entryIndex], moveCompleted);
+      } catch (error) {
+        restoreErrors.push(error);
+      }
+    }
+
+    if (restoreErrors.length > 0) {
+      const restoreError = new AggregateError(restoreErrors, `Unable to restore ${restoreErrors.length} quarantined deletion target(s)`);
+      log.error('Permanent deletion rollback requires recovery', {
+        operationId: journal.operationId,
+        postId: journal.postId,
+        error: restoreError
+      });
+      throw restoreError;
+    }
+
+    await this.removeMoveMarkers(journal);
+    this.unlinkInternalFileIfPresent(appConfig.galleryRoot, journalPath, 'Deletion journal');
+  }
+
+  private async restoreEntry(entry: DeletionJournalEntry, moveCompleted: boolean): Promise<void> {
+    if (!entry.wasPresent || !entry.identity) return;
+    const rootPath = getRootPath(entry.root);
+    const originalPath = resolveRelativePathWithinRoot(rootPath, entry.originalRelativePath, 'Journal original path');
+    const quarantinePath = resolveRelativePathWithinRoot(rootPath, entry.quarantineRelativePath, 'Journal quarantine path');
+    await assertNoSymlinkTraversal(rootPath, originalPath, 'Journal original path');
+    await assertNoSymlinkTraversal(rootPath, quarantinePath, 'Journal quarantine path');
+
+    const quarantineExists = await assertMatchingFile(quarantinePath, entry.identity, 'Quarantined file');
+    const originalStats = await lstatIfPresent(originalPath, true);
+    if (!quarantineExists) {
+      if (originalStats?.isFile() && identitiesMatch(toIdentity(originalStats), entry.identity)) {
+        return;
+      }
+      if (!moveCompleted) {
+        return;
+      }
+      if (!originalStats || !originalStats.isFile() || !identitiesMatch(toIdentity(originalStats), entry.identity)) {
+        throw new Error(`Cannot restore missing quarantined file: ${entry.originalRelativePath}`);
+      }
+    }
+    if (originalStats) {
+      throw new Error(`Cannot restore quarantined file because its original path is occupied: ${entry.originalRelativePath}`);
+    }
+
+    await this.renameValidatedFile(
+      rootPath,
+      quarantinePath,
+      rootPath,
+      originalPath,
+      entry.identity,
+      'Quarantine restore'
+    );
+  }
+
+  private async recoverPendingDeletionsInternal(): Promise<void> {
+    const journalDirectory = path.join(appConfig.galleryRoot, QUARANTINE_DIRECTORY_NAME, 'journals');
+    const directoryStats = await lstatIfPresent(journalDirectory);
+    if (!directoryStats) return;
+    await assertNoSymlinkTraversal(appConfig.galleryRoot, journalDirectory, 'Deletion journal directory');
+    if (!directoryStats.isDirectory() || directoryStats.isSymbolicLink()) {
+      throw new Error('Deletion journal path is not a directory');
+    }
+
+    const journalNames = (await fs.readdir(journalDirectory))
+      .filter((name) => name.endsWith('.json'))
+      .sort((left, right) => left.localeCompare(right));
+    if (journalNames.length > 0 && storageService.getState().usingInMemoryDatabase) {
+      throw new Error('Cannot recover permanent deletions while the configured database is offline');
+    }
+    for (const journalName of journalNames) {
+      const journalPath = resolveRelativePathWithinRoot(
+        appConfig.galleryRoot,
+        path.join(QUARANTINE_DIRECTORY_NAME, 'journals', journalName),
+        'Deletion journal path'
+      );
+      await assertNoSymlinkTraversal(appConfig.galleryRoot, journalPath, 'Deletion journal path');
+      const stats = await fs.lstat(journalPath);
+      if (!stats.isFile() || stats.isSymbolicLink()) {
+        throw new Error(`Deletion journal is not a regular file: ${journalName}`);
+      }
+      const journal = parseJournal(JSON.parse(await fs.readFile(journalPath, 'utf8')));
+
+      if (postRepository.findById(journal.postId)) {
+        await this.restoreJournal(journal, journalPath);
+        log.info('Recovered interrupted permanent deletion by restoring quarantined files', {
+          operationId: journal.operationId,
+          postId: journal.postId
+        });
+      } else {
+        await this.tryCleanupCommittedJournal(journal, journalPath);
+      }
+    }
+  }
+
+  private async tryCleanupCommittedJournal(journal: DeletionJournal, journalPath: string): Promise<void> {
+    try {
+      await this.cleanupCommittedJournal(journal, journalPath);
+    } catch (error) {
+      log.error('Permanent deletion cleanup is pending and will be retried', {
+        operationId: journal.operationId,
+        postId: journal.postId,
+        journalPath,
+        error
+      });
+    }
+  }
+
+  private async cleanupCommittedJournal(journal: DeletionJournal, journalPath: string): Promise<void> {
+    const sourceDirectories = new Map<string, { rootPath: string; directoryPath: string }>();
+    const quarantineOperationDirectories = new Map<string, { rootPath: string; directoryPath: string; stopPath: string }>();
+
+    for (const entry of journal.entries) {
+      const rootPath = getRootPath(entry.root);
+      const originalPath = resolveRelativePathWithinRoot(rootPath, entry.originalRelativePath, 'Journal original path');
+      const quarantinePath = resolveRelativePathWithinRoot(rootPath, entry.quarantineRelativePath, 'Journal quarantine path');
+      await assertNoSymlinkTraversal(rootPath, originalPath, 'Journal original path');
+      await assertNoSymlinkTraversal(rootPath, quarantinePath, 'Journal quarantine path');
+
+      if (entry.wasPresent && entry.identity) {
+        const quarantineExists = await assertMatchingFile(quarantinePath, entry.identity, 'Quarantined file');
+        if (quarantineExists) this.unlinkValidatedFile(rootPath, quarantinePath, entry.identity, 'Quarantine cleanup');
+      }
+
+      sourceDirectories.set(`${entry.root}:${path.dirname(originalPath)}`, {
+        rootPath,
+        directoryPath: path.dirname(originalPath)
+      });
+      const quarantineBase = path.join(rootPath, QUARANTINE_DIRECTORY_NAME);
+      quarantineOperationDirectories.set(entry.root, {
+        rootPath,
+        directoryPath: path.join(quarantineBase, 'files', journal.operationId),
+        stopPath: quarantineBase
+      });
+    }
+
+    for (const directory of sourceDirectories.values()) {
+      await pruneEmptyAncestors(directory.rootPath, directory.directoryPath);
+    }
+    for (const directory of quarantineOperationDirectories.values()) {
+      await pruneEmptyAncestors(directory.rootPath, directory.directoryPath, directory.stopPath);
+    }
+
+    await this.removeMoveMarkers(journal);
+    this.unlinkInternalFileIfPresent(appConfig.galleryRoot, journalPath, 'Deletion journal');
+    await this.syncDirectoryIfSupported(path.dirname(journalPath));
+  }
+
+  private async syncDirectoryIfSupported(directoryPath: string): Promise<void> {
+    try {
+      const handle = await fs.open(directoryPath, 'r');
+      try {
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
+    } catch (error) {
+      if (process.platform !== 'win32') throw error;
+    }
+  }
+}
+
+export const permanentDeletionService = new PermanentDeletionService();

--- a/server/src/services/scanner-service.ts
+++ b/server/src/services/scanner-service.ts
@@ -34,6 +34,10 @@ import {
   type DerivativeMigrationSummary
 } from './derivative-migration-service.js';
 import { libraryRelocationService } from './library-relocation-service.js';
+import {
+  maintenanceOperationLock,
+  PERMANENT_DELETION_QUARANTINE_DIRECTORY_NAME
+} from './maintenance-operation-lock.js';
 import { log } from './log-service.js';
 import { placeResolutionService } from './place-service.js';
 import { storageService } from './storage-service.js';
@@ -722,7 +726,12 @@ class ScannerService {
       if (options.beforeEnqueue) {
         options.beforeEnqueue();
       }
-      this.queue = this.queue.then(job, job);
+      const runWithMaintenanceLock = () => maintenanceOperationLock.runExclusive(async () => {
+        const { permanentDeletionService } = await import('./permanent-deletion-service.js');
+        await permanentDeletionService.recoverPendingDeletionsWhileLocked();
+        return job();
+      });
+      this.queue = this.queue.then(runWithMaintenanceLock, runWithMaintenanceLock);
       return await this.queue;
     } finally {
       this.activeOrQueuedJobs--;
@@ -959,8 +968,11 @@ class ScannerService {
   }
 
   private async resetDerivativeDirectory(targetDirectory: string): Promise<void> {
-    await fs.rm(targetDirectory, { recursive: true, force: true });
     await fs.mkdir(targetDirectory, { recursive: true });
+    const entries = await fs.readdir(targetDirectory, { withFileTypes: true });
+    await Promise.all(entries
+      .filter((entry) => entry.name !== PERMANENT_DELETION_QUARANTINE_DIRECTORY_NAME)
+      .map((entry) => fs.rm(path.join(targetDirectory, entry.name), { recursive: true, force: true })));
     await fs.writeFile(path.join(targetDirectory, DERIVATIVE_CACHE_KEEP_FILE), '');
   }
 

--- a/server/test/lazy-derivatives.test.ts
+++ b/server/test/lazy-derivatives.test.ts
@@ -18,6 +18,8 @@ type AppConfigModule = typeof import('../src/config/env.js');
 type AuthServiceModule = typeof import('../src/services/auth-service.js');
 type LazyRoutesModule = typeof import('../src/routes/lazy-derivatives.js');
 type ScannerServiceModule = typeof import('../src/services/scanner-service.js');
+type MaintenanceLockModule = typeof import('../src/services/maintenance-operation-lock.js');
+type PermanentDeletionModule = typeof import('../src/services/permanent-deletion-service.js');
 type RepositoriesModule = typeof import('../src/db/repositories.js');
 type ModelsModule = typeof import('../src/types/models.js');
 
@@ -36,8 +38,11 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
   let lazyThumbnailsRouter: LazyRoutesModule['lazyThumbnailsRouter'];
   let lazyPreviewsRouter: LazyRoutesModule['lazyPreviewsRouter'];
   let scannerService: ScannerServiceModule['scannerService'];
+  let maintenanceOperationLock: MaintenanceLockModule['maintenanceOperationLock'];
+  let permanentDeletionService: PermanentDeletionModule['permanentDeletionService'];
   let folderRepository: RepositoriesModule['folderRepository'];
   let imageRepository: RepositoriesModule['imageRepository'];
+  let postRepository: RepositoriesModule['postRepository'];
   let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
   let appSettingsRepository: RepositoriesModule['appSettingsRepository'];
 
@@ -71,7 +76,9 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
     ({ authService } = await import('../src/services/auth-service.js'));
     ({ lazyThumbnailsRouter, lazyPreviewsRouter } = await import('../src/routes/lazy-derivatives.js'));
     ({ scannerService } = await import('../src/services/scanner-service.js'));
-    ({ folderRepository, imageRepository, maintenanceRepository, appSettingsRepository } = await import('../src/db/repositories.js'));
+    ({ maintenanceOperationLock } = await import('../src/services/maintenance-operation-lock.js'));
+    ({ permanentDeletionService } = await import('../src/services/permanent-deletion-service.js'));
+    ({ folderRepository, imageRepository, postRepository, maintenanceRepository, appSettingsRepository } = await import('../src/db/repositories.js'));
 
     await Promise.all([
       fs.mkdir(appConfig.galleryRoot, { recursive: true }),
@@ -376,6 +383,108 @@ describe.sequential('DERIVATIVE_MODE lazy behavior', () => {
     expect(secondResponse.statusCode).toBe(200);
     expect(secondResponse.body).toBe(`thumbnail:${image.relative_path}`);
     expect(generateThumbnailDerivativeMock).toHaveBeenCalledOnce();
+  });
+
+  it('does not serve an existing orphaned derivative after its image record is deleted', async () => {
+    await reset('lazy');
+
+    await createSourceFile('orphaned/photo.jpg');
+    await scannerService.scanAll('test');
+    const image = imageRepository.listActive()[0]!;
+    const post = postRepository.findByImageId(image.id)!;
+    const thumbnailPath = path.join(appConfig.thumbnailsDir, image.thumbnail_path);
+    await fs.mkdir(path.dirname(thumbnailPath), { recursive: true });
+    await fs.writeFile(thumbnailPath, 'orphaned-thumbnail');
+    postRepository.deletePostAndImages(post.id);
+
+    const response = await dispatchRoute(lazyThumbnailsRouter, `/${encodeRelativePath(image.thumbnail_path)}`);
+
+    expect(response.statusCode).toBe(404);
+    expect(response.body).toEqual({ message: 'Derivative not found.' });
+    expect(generateThumbnailDerivativeMock).not.toHaveBeenCalled();
+  });
+
+  it('revalidates the image record after waiting for the maintenance lock', async () => {
+    await reset('lazy');
+
+    await createSourceFile('stale/photo.jpg');
+    await scannerService.scanAll('test');
+    const image = imageRepository.listActive()[0]!;
+    const post = postRepository.findByImageId(image.id)!;
+    let releaseLock!: () => void;
+    let reportLockAcquired!: () => void;
+    const lockAcquired = new Promise<void>((resolve) => {
+      reportLockAcquired = resolve;
+    });
+    const releaseLockPromise = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    const blocker = maintenanceOperationLock.runExclusive(async () => {
+      reportLockAcquired();
+      await releaseLockPromise;
+      postRepository.deletePostAndImages(post.id);
+    });
+    await lockAcquired;
+
+    const request = dispatchRoute(lazyThumbnailsRouter, `/${encodeRelativePath(image.thumbnail_path)}`);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    releaseLock();
+    await blocker;
+    const response = await request;
+
+    expect(response.statusCode).toBe(404);
+    expect(response.body).toEqual({ message: 'Derivative not found.' });
+    expect(generateThumbnailDerivativeMock).not.toHaveBeenCalled();
+    await expect(fs.access(path.join(appConfig.thumbnailsDir, image.thumbnail_path))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('keeps lazy generation and permanent deletion mutually exclusive', async () => {
+    await reset('lazy');
+
+    await createSourceFile('delete-race/photo.jpg');
+    await scannerService.scanAll('test');
+    const image = imageRepository.listActive()[0]!;
+    const post = postRepository.findByImageId(image.id)!;
+    let releaseGeneration!: () => void;
+    let reportGenerationStarted!: () => void;
+    const generationStarted = new Promise<void>((resolve) => {
+      reportGenerationStarted = resolve;
+    });
+    const releaseGenerationPromise = new Promise<void>((resolve) => {
+      releaseGeneration = resolve;
+    });
+    generateThumbnailDerivativeMock.mockImplementationOnce(async (_src: string, relativePath: string) => {
+      reportGenerationStarted();
+      await releaseGenerationPromise;
+      const thumbnailPath = getThumbnailRelativePath(relativePath);
+      const thumbnailAbsolutePath = path.join(appConfig.thumbnailsDir, thumbnailPath);
+      await fs.mkdir(path.dirname(thumbnailAbsolutePath), { recursive: true });
+      await fs.writeFile(thumbnailAbsolutePath, `thumbnail:${relativePath}`);
+      return { thumbnailPath, generatedThumbnail: true };
+    });
+
+    const request = dispatchRoute(lazyThumbnailsRouter, `/${encodeRelativePath(image.thumbnail_path)}`);
+    await generationStarted;
+    let deletionFinished = false;
+    const deletion = permanentDeletionService.deletePost(post.id).then((result) => {
+      deletionFinished = true;
+      return result;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(deletionFinished).toBe(false);
+    expect(postRepository.findById(post.id)).toBeDefined();
+
+    releaseGeneration();
+    const [requestOutcome, deletionOutcome] = await Promise.all([
+      request.catch((error: unknown) => error),
+      deletion
+    ]);
+
+    expect(requestOutcome).toBeDefined();
+    expect(deletionOutcome).toEqual({ id: post.id, folderSlug: 'delete-race' });
+    expect(postRepository.findById(post.id)).toBeUndefined();
+    expect(imageRepository.getById(image.id)).toBeUndefined();
+    await expect(fs.access(path.join(appConfig.thumbnailsDir, image.thumbnail_path))).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
   it('generates a missing thumbnail from the current gallery root when the cached absolute path is stale', async () => {

--- a/server/test/permanent-deletion.test.ts
+++ b/server/test/permanent-deletion.test.ts
@@ -1,0 +1,574 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type express from 'express';
+import type { FolderRecord, ImageRecord, PostRecord } from '../src/types/models.js';
+
+import { requestTestApp } from './http-test-utils.js';
+
+type AppConfigModule = typeof import('../src/config/env.js');
+type DatabaseModule = typeof import('../src/db/database.js');
+type DeletionServiceModule = typeof import('../src/services/permanent-deletion-service.js');
+type GalleryServiceModule = typeof import('../src/services/gallery-service.js');
+type RepositoriesModule = typeof import('../src/db/repositories.js');
+type ScannerServiceModule = typeof import('../src/services/scanner-service.js');
+
+const generateThumbnailDerivativeMock = vi.fn();
+const generateDerivativesMock = vi.fn();
+const readMediaMetadataMock = vi.fn();
+
+interface CreatedPost {
+  post: PostRecord;
+  images: ImageRecord[];
+  ownerFolder: FolderRecord;
+  sourceDirectory: string;
+}
+
+describe.sequential('crash-recoverable permanent post deletion', () => {
+  let tempRoot = '';
+  let appConfig: AppConfigModule['appConfig'];
+  let databaseManager: DatabaseModule['databaseManager'];
+  let PermanentDeletionService: DeletionServiceModule['PermanentDeletionService'];
+  let SimulatedDeletionInterruptionError: DeletionServiceModule['SimulatedDeletionInterruptionError'];
+  let galleryService: GalleryServiceModule['galleryService'];
+  let scannerService: ScannerServiceModule['scannerService'];
+  let folderRepository: RepositoriesModule['folderRepository'];
+  let imageRepository: RepositoriesModule['imageRepository'];
+  let postRepository: RepositoriesModule['postRepository'];
+  let likeRepository: RepositoriesModule['likeRepository'];
+  let collectionRepository: RepositoriesModule['collectionRepository'];
+  let maintenanceRepository: RepositoriesModule['maintenanceRepository'];
+  let app: express.Application;
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'foldergram-permanent-delete-'));
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('DATA_ROOT', path.join(tempRoot, 'data'));
+    vi.stubEnv('GALLERY_ROOT', path.join(tempRoot, 'gallery'));
+    vi.stubEnv('DB_DIR', path.join(tempRoot, 'db'));
+    vi.stubEnv('THUMBNAILS_DIR', path.join(tempRoot, 'thumbnails'));
+    vi.stubEnv('PREVIEWS_DIR', path.join(tempRoot, 'previews'));
+  });
+
+  beforeEach(async () => {
+    generateThumbnailDerivativeMock.mockReset();
+    generateDerivativesMock.mockReset();
+    readMediaMetadataMock.mockReset();
+    databaseManager?.close();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+    vi.resetModules();
+    vi.doMock('../src/services/derivative-service.js', () => ({
+      generateDerivatives: generateDerivativesMock,
+      generateThumbnailDerivative: generateThumbnailDerivativeMock,
+      readMediaMetadata: readMediaMetadataMock
+    }));
+
+    ({ appConfig } = await import('../src/config/env.js'));
+    ({ databaseManager } = await import('../src/db/database.js'));
+    ({ PermanentDeletionService, SimulatedDeletionInterruptionError } = await import('../src/services/permanent-deletion-service.js'));
+    ({ galleryService } = await import('../src/services/gallery-service.js'));
+    ({ scannerService } = await import('../src/services/scanner-service.js'));
+    ({
+      folderRepository,
+      imageRepository,
+      postRepository,
+      likeRepository,
+      collectionRepository,
+      maintenanceRepository
+    } = await import('../src/db/repositories.js'));
+    app = (await import('../src/app.js')).createApp();
+
+    await Promise.all([
+      fs.mkdir(appConfig.galleryRoot, { recursive: true }),
+      fs.mkdir(appConfig.thumbnailsDir, { recursive: true }),
+      fs.mkdir(appConfig.previewsDir, { recursive: true })
+    ]);
+    maintenanceRepository.resetLibraryIndex();
+    collectionRepository.ensureDefaultCollection();
+    generateThumbnailDerivativeMock.mockImplementation(async (_sourcePath: string, relativePath: string) => ({
+      thumbnailPath: `generated/${relativePath}.thumbnail.webp`,
+      generatedThumbnail: true
+    }));
+  });
+
+  afterAll(async () => {
+    databaseManager?.close();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('permanently deletes one post, its derivatives, relationships, and image row', async () => {
+    const created = await createSingle('single/photo.jpg');
+    const image = created.images[0];
+    likeRepository.upsert(created.post.id);
+    collectionRepository.saveToDefault(created.post.id);
+    folderRepository.setAvatar(created.ownerFolder.id, image.id, 'manual');
+
+    await expect(galleryService.deleteImage(created.post.id)).resolves.toEqual({
+      id: created.post.id,
+      folderSlug: created.ownerFolder.slug
+    });
+
+    expect(postRepository.findById(created.post.id)).toBeUndefined();
+    expect(imageRepository.getById(image.id)).toBeUndefined();
+    expect(likeRepository.getByPostId(created.post.id)).toBeUndefined();
+    expect(collectionRepository.isImageSaved(created.post.id)).toBe(false);
+    expect(countRows('post_items', 'post_id', created.post.id)).toBe(0);
+    expect(countRows('likes', 'post_id', created.post.id)).toBe(0);
+    expect(countRows('collection_items', 'post_id', created.post.id)).toBe(0);
+    expect(folderRepository.getById(created.ownerFolder.id)?.avatar_image_id).toBeNull();
+    await expectPostFiles(created.images, false);
+  });
+
+  it('deletes every Carousel item and derivative while preserving sibling and unrelated files', async () => {
+    const siblingSingle = await createSingle('album/sibling.jpg');
+    const deletedCarousel = await createCarousel('album', 'first', ['01.jpg', '02.jpg', '03.jpg']);
+    const siblingCarousel = await createCarousel('album', 'second', ['01.jpg', '02.jpg']);
+    const unsupportedPath = path.join(appConfig.galleryRoot, 'album', 'notes.txt');
+    await fs.writeFile(unsupportedPath, 'unrelated');
+
+    await expect(galleryService.deleteImage(deletedCarousel.post.id)).resolves.toMatchObject({ id: deletedCarousel.post.id });
+
+    expect(postRepository.findById(deletedCarousel.post.id)).toBeUndefined();
+    for (const image of deletedCarousel.images) expect(imageRepository.getById(image.id)).toBeUndefined();
+    await expectPostFiles(deletedCarousel.images, false);
+    await expect(fs.stat(deletedCarousel.sourceDirectory)).rejects.toMatchObject({ code: 'ENOENT' });
+
+    expect(postRepository.findById(siblingSingle.post.id)).toBeDefined();
+    expect(postRepository.findById(siblingCarousel.post.id)).toBeDefined();
+    await expectPostFiles(siblingSingle.images, true);
+    await expectPostFiles(siblingCarousel.images, true);
+    await expect(fs.readFile(unsupportedPath, 'utf8')).resolves.toBe('unrelated');
+  });
+
+  it('restores earlier Carousel moves and leaves every database relationship unchanged when a later move fails', async () => {
+    const created = await createCarousel('rollback', 'moving', ['01.jpg', '02.jpg']);
+    const firstImage = created.images[0];
+    likeRepository.upsert(created.post.id);
+    collectionRepository.saveToDefault(created.post.id);
+    folderRepository.setAvatar(created.ownerFolder.id, firstImage.id, 'manual');
+    let moveCount = 0;
+    const service = new PermanentDeletionService({
+      rename: async (sourcePath, destinationPath) => {
+        moveCount += 1;
+        if (moveCount === 4) throw new Error('injected second-slide move failure');
+        await fs.rename(sourcePath, destinationPath);
+      }
+    });
+
+    await expect(service.deletePost(created.post.id)).rejects.toThrow('injected second-slide move failure');
+
+    expect(postRepository.findById(created.post.id)).toEqual(created.post);
+    expect(postRepository.listImageRecords(created.post.id).map((image) => image.id)).toEqual(created.images.map((image) => image.id));
+    expect(likeRepository.getByPostId(created.post.id)).toBeDefined();
+    expect(collectionRepository.isImageSaved(created.post.id)).toBe(true);
+    expect(countRows('post_items', 'post_id', created.post.id)).toBe(2);
+    expect(countRows('likes', 'post_id', created.post.id)).toBe(1);
+    expect(countRows('collection_items', 'post_id', created.post.id)).toBe(1);
+    expect(folderRepository.getById(created.ownerFolder.id)?.avatar_image_id).toBe(firstImage.id);
+    await expectPostFiles(created.images, true);
+  });
+
+  it('restores completed moves when a later Carousel source disappears before its rename', async () => {
+    const created = await createCarousel('rollback', 'disappearing', ['01.jpg', '02.jpg']);
+    let moveCount = 0;
+    const service = new PermanentDeletionService({
+      rename: async (sourcePath, destinationPath) => {
+        moveCount += 1;
+        if (moveCount === 4) {
+          await fs.rm(sourcePath, { force: true });
+        }
+        await fs.rename(sourcePath, destinationPath);
+      }
+    });
+
+    await expect(service.deletePost(created.post.id)).rejects.toMatchObject({ code: 'ENOENT' });
+
+    expect(postRepository.findById(created.post.id)).toBeDefined();
+    expect(postRepository.listImageRecords(created.post.id)).toHaveLength(2);
+    await expectPostFiles([created.images[0]], true);
+    await expect(fs.stat(originalPath(created.images[1]))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.stat(thumbnailPath(created.images[1]))).resolves.toBeDefined();
+    await expect(fs.stat(previewPath(created.images[1]))).resolves.toBeDefined();
+    expect(await journalFiles()).toEqual([]);
+    await expect(new PermanentDeletionService().recoverPendingDeletions()).resolves.toBeUndefined();
+  });
+
+  it('restores every quarantined file when the SQLite deletion transaction fails', async () => {
+    const created = await createCarousel('rollback', 'database', ['01.jpg', '02.jpg']);
+    likeRepository.upsert(created.post.id);
+    collectionRepository.saveToDefault(created.post.id);
+    folderRepository.setAvatar(created.ownerFolder.id, created.images[0].id, 'manual');
+    databaseManager.connection.exec(`
+      CREATE TRIGGER reject_test_post_delete
+      BEFORE DELETE ON posts
+      WHEN OLD.id = ${created.post.id}
+      BEGIN
+        SELECT RAISE(ABORT, 'injected database failure');
+      END;
+    `);
+
+    await expect(new PermanentDeletionService().deletePost(created.post.id)).rejects.toThrow('injected database failure');
+
+    expect(postRepository.findById(created.post.id)).toEqual(created.post);
+    expect(postRepository.listImageRecords(created.post.id)).toHaveLength(2);
+    expect(likeRepository.getByPostId(created.post.id)).toBeDefined();
+    expect(collectionRepository.isImageSaved(created.post.id)).toBe(true);
+    expect(countRows('post_items', 'post_id', created.post.id)).toBe(2);
+    expect(countRows('likes', 'post_id', created.post.id)).toBe(1);
+    expect(countRows('collection_items', 'post_id', created.post.id)).toBe(1);
+    expect(folderRepository.getById(created.ownerFolder.id)?.avatar_image_id).toBe(created.images[0].id);
+    await expectPostFiles(created.images, true);
+  });
+
+  it('tolerates originals and derivatives that were already missing', async () => {
+    const created = await createCarousel('missing', 'partial', ['01.jpg', '02.jpg']);
+    await fs.rm(originalPath(created.images[0]), { force: true });
+    await fs.rm(thumbnailPath(created.images[1]), { force: true });
+    await fs.rm(previewPath(created.images[0]), { force: true });
+
+    await expect(galleryService.deleteImage(created.post.id)).resolves.toMatchObject({ id: created.post.id });
+
+    expect(postRepository.findById(created.post.id)).toBeUndefined();
+    for (const image of created.images) expect(imageRepository.getById(image.id)).toBeUndefined();
+    await expectPostFiles(created.images, false);
+  });
+
+  it('preserves a non-empty Carousel source directory', async () => {
+    const created = await createCarousel('keep-directory', 'carousel', ['01.jpg', '02.jpg']);
+    const unrelatedPath = path.join(created.sourceDirectory, 'metadata.json');
+    await fs.writeFile(unrelatedPath, '{"keep":true}');
+
+    await galleryService.deleteImage(created.post.id);
+
+    await expect(fs.stat(created.sourceDirectory)).resolves.toBeDefined();
+    await expect(fs.readFile(unrelatedPath, 'utf8')).resolves.toBe('{"keep":true}');
+  });
+
+  it('recovers an interruption after quarantine by restoring files when the post still exists', async () => {
+    const created = await createCarousel('recovery', 'before-commit', ['01.jpg', '02.jpg']);
+    const interruptedService = new PermanentDeletionService({
+      afterQuarantine: () => {
+        throw new SimulatedDeletionInterruptionError();
+      }
+    });
+
+    await expect(interruptedService.deletePost(created.post.id)).rejects.toBeInstanceOf(SimulatedDeletionInterruptionError);
+    expect(postRepository.findById(created.post.id)).toBeDefined();
+    await expectPostFiles(created.images, false);
+
+    await new PermanentDeletionService().recoverPendingDeletions();
+
+    expect(postRepository.findById(created.post.id)).toBeDefined();
+    expect(postRepository.listImageRecords(created.post.id)).toHaveLength(2);
+    await expectPostFiles(created.images, true);
+    expect(await journalFiles()).toEqual([]);
+  });
+
+  it('recovers an interruption after commit by cleaning quarantine without restoring the post', async () => {
+    const created = await createCarousel('recovery', 'after-commit', ['01.jpg', '02.jpg']);
+    const interruptedService = new PermanentDeletionService({
+      afterDatabaseCommit: () => {
+        throw new SimulatedDeletionInterruptionError();
+      }
+    });
+
+    await expect(interruptedService.deletePost(created.post.id)).rejects.toBeInstanceOf(SimulatedDeletionInterruptionError);
+    expect(postRepository.findById(created.post.id)).toBeUndefined();
+    await expectPostFiles(created.images, false);
+    expect(await journalFiles()).toHaveLength(1);
+
+    await new PermanentDeletionService().recoverPendingDeletions();
+
+    expect(postRepository.findById(created.post.id)).toBeUndefined();
+    for (const image of created.images) expect(imageRepository.getById(image.id)).toBeUndefined();
+    await expectPostFiles(created.images, false);
+    await expect(fs.stat(created.sourceDirectory)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(await journalFiles()).toEqual([]);
+  });
+
+  it('serializes deletion and thumbnail rebuilds in both directions', async () => {
+    const deletedFirst = await createSingle('maintenance/delete-first.jpg');
+    await createSingle('maintenance/rebuild-survivor.jpg');
+    let releaseDeletion!: () => void;
+    let reportQuarantined!: () => void;
+    const deletionPaused = new Promise<void>((resolve) => { reportQuarantined = resolve; });
+    const deletionRelease = new Promise<void>((resolve) => { releaseDeletion = resolve; });
+    const pausingDeletion = new PermanentDeletionService({
+      afterQuarantine: async () => {
+        reportQuarantined();
+        await deletionRelease;
+      }
+    });
+
+    const deletionPromise = pausingDeletion.deletePost(deletedFirst.post.id);
+    await deletionPaused;
+    let rebuildSettled = false;
+    const queuedRebuild = scannerService.rebuildThumbnails('lock-after-delete').finally(() => { rebuildSettled = true; });
+    await wait(30);
+    expect(rebuildSettled).toBe(false);
+    expect(await journalFiles()).toHaveLength(1);
+
+    releaseDeletion();
+    await deletionPromise;
+    await queuedRebuild;
+    expect(postRepository.findById(deletedFirst.post.id)).toBeUndefined();
+
+    const deletedSecond = await createSingle('maintenance/delete-second.jpg');
+    let releaseRebuild!: () => void;
+    let reportRebuildStarted!: () => void;
+    const rebuildPaused = new Promise<void>((resolve) => { reportRebuildStarted = resolve; });
+    const rebuildRelease = new Promise<void>((resolve) => { releaseRebuild = resolve; });
+    generateThumbnailDerivativeMock.mockImplementationOnce(async (_sourcePath: string, relativePath: string) => {
+      reportRebuildStarted();
+      await rebuildRelease;
+      return {
+        thumbnailPath: `generated/${relativePath}.thumbnail.webp`,
+        generatedThumbnail: true
+      };
+    });
+
+    const runningRebuild = scannerService.rebuildThumbnails('lock-before-delete');
+    await rebuildPaused;
+    let secondDeletionSettled = false;
+    const queuedDeletion = new PermanentDeletionService().deletePost(deletedSecond.post.id).finally(() => {
+      secondDeletionSettled = true;
+    });
+    await wait(30);
+    expect(secondDeletionSettled).toBe(false);
+    await expect(fs.stat(originalPath(deletedSecond.images[0]))).resolves.toBeDefined();
+    expect(await journalFiles()).toEqual([]);
+
+    releaseRebuild();
+    await runningRebuild;
+    await queuedDeletion;
+    expect(postRepository.findById(deletedSecond.post.id)).toBeUndefined();
+  });
+
+  it('keeps pending quarantine intact when committed cleanup cannot finish before a thumbnail rebuild', async () => {
+    const created = await createSingle('cleanup-pending/photo.jpg');
+    const interruptedService = new PermanentDeletionService({
+      afterDatabaseCommit: () => {
+        throw new SimulatedDeletionInterruptionError();
+      }
+    });
+    await expect(interruptedService.deletePost(created.post.id)).rejects.toBeInstanceOf(SimulatedDeletionInterruptionError);
+
+    const journalName = (await journalFiles())[0];
+    const journalPath = path.join(appConfig.galleryRoot, '.foldergram-delete-quarantine', 'journals', journalName);
+    const journal = JSON.parse(await fs.readFile(journalPath, 'utf8')) as {
+      entries: Array<{ root: string; quarantineRelativePath: string }>;
+    };
+    const thumbnailEntry = journal.entries.find((entry) => entry.root === 'thumbnails');
+    expect(thumbnailEntry).toBeDefined();
+    const quarantinedThumbnailPath = path.join(appConfig.thumbnailsDir, ...thumbnailEntry!.quarantineRelativePath.split('/'));
+    await fs.appendFile(quarantinedThumbnailPath, ':identity-changed');
+
+    await expect(scannerService.rebuildThumbnails('cleanup-pending')).resolves.toBeDefined();
+
+    expect(postRepository.findById(created.post.id)).toBeUndefined();
+    expect(await journalFiles()).toEqual([journalName]);
+    await expect(fs.stat(quarantinedThumbnailPath)).resolves.toBeDefined();
+  });
+
+  it('keeps canonical and legacy delete routes pointed at their respective posts', async () => {
+    const single = await createSingle('routes/single.jpg');
+    const carouselA = await createCarousel('routes', 'carousel-a', ['01.jpg', '02.jpg']);
+    const carouselB = await createCarousel('routes', 'carousel-b', ['01.jpg', '02.jpg']);
+    expect(carouselA.images[1].id).toBe(carouselB.post.id);
+
+    const canonical = await requestDelete(`/api/posts/${carouselB.post.id}`);
+    expect(canonical.status).toBe(200);
+    expect(canonical.body).toMatchObject({ ok: true, id: carouselB.post.id });
+    expect(postRepository.findById(carouselB.post.id)).toBeUndefined();
+    expect(postRepository.findById(carouselA.post.id)).toBeDefined();
+    await expectPostFiles(carouselA.images, true);
+
+    const legacy = await requestDelete(`/api/images/${carouselA.images[1].id}`);
+    expect(legacy.status).toBe(200);
+    expect(legacy.body).toMatchObject({ ok: true, id: carouselA.post.id });
+    expect(postRepository.findById(carouselA.post.id)).toBeUndefined();
+    expect(postRepository.findById(single.post.id)).toBeDefined();
+    await expectPostFiles(single.images, true);
+  });
+
+  it('validates every stored path before moving files and rejects traversal without touching outside files', async () => {
+    const created = await createCarousel('validation', 'carousel', ['01.jpg', '02.jpg']);
+    const outsidePath = path.join(tempRoot, 'outside.webp');
+    await fs.writeFile(outsidePath, 'outside');
+    databaseManager.connection
+      .prepare('UPDATE images SET preview_path = ? WHERE id = ?')
+      .run('../outside.webp', created.images[1].id);
+
+    await expect(galleryService.deleteImage(created.post.id)).rejects.toThrow('outside its configured root');
+
+    expect(postRepository.findById(created.post.id)).toBeDefined();
+    await expectPostFiles(created.images, true, { ignoreStoredPreviewPaths: true });
+    await expect(fs.readFile(outsidePath, 'utf8')).resolves.toBe('outside');
+  });
+
+  it('rejects a source path whose parent was replaced by a symlink outside the gallery root', async () => {
+    const created = await createSingle('symlink-guard/photo.jpg');
+    const sourceDirectory = path.dirname(originalPath(created.images[0]));
+    const escapedDirectory = path.join(tempRoot, 'escaped-source');
+    await fs.rename(sourceDirectory, escapedDirectory);
+    await fs.symlink(escapedDirectory, sourceDirectory, process.platform === 'win32' ? 'junction' : 'dir');
+
+    await expect(galleryService.deleteImage(created.post.id)).rejects.toThrow('symbolic link');
+
+    expect(postRepository.findById(created.post.id)).toBeDefined();
+    await expect(fs.readFile(path.join(escapedDirectory, 'photo.jpg'), 'utf8')).resolves.toBe('original:symlink-guard/photo.jpg');
+    await expect(fs.stat(thumbnailPath(created.images[0]))).resolves.toBeDefined();
+    await expect(fs.stat(previewPath(created.images[0]))).resolves.toBeDefined();
+    expect(await journalFiles()).toEqual([]);
+  });
+
+  async function createSingle(relativePath: string): Promise<CreatedPost> {
+    const folderPath = relativePath.split('/').slice(0, -1).join('/');
+    const ownerFolder = folderRepository.getByFolderPath(folderPath) ?? folderRepository.upsert({
+      slug: folderPath.replaceAll('/', '-'),
+      name: path.posix.basename(folderPath),
+      folderPath
+    });
+    const image = await createImage(ownerFolder.id, relativePath);
+    const post = postRepository.findByImageId(image.id);
+    expect(post).toBeDefined();
+    return { post: post!, images: [image], ownerFolder, sourceDirectory: path.dirname(originalPath(image)) };
+  }
+
+  async function createCarousel(ownerPath: string, name: string, filenames: string[]): Promise<CreatedPost> {
+    const ownerFolder = folderRepository.getByFolderPath(ownerPath) ?? folderRepository.upsert({
+      slug: ownerPath.replaceAll('/', '-'),
+      name: path.posix.basename(ownerPath),
+      folderPath: ownerPath
+    });
+    const carouselPath = `${ownerPath}/carousels/${name}`;
+    const sourceFolder = folderRepository.upsert({
+      slug: `${ownerFolder.slug}-carousel-${name}`,
+      name,
+      folderPath: carouselPath,
+      role: 'carousel_source',
+      carouselOwnerFolderId: ownerFolder.id
+    });
+    const images: ImageRecord[] = [];
+    for (const filename of filenames) {
+      images.push(await createImage(sourceFolder.id, `${carouselPath}/${filename}`));
+    }
+    const now = Date.now();
+    const post = postRepository.upsertPostWithItems({
+      folderId: ownerFolder.id,
+      sourcePath: carouselPath,
+      postType: 'carousel',
+      sortTimestamp: now,
+      takenAt: now,
+      takenAtSource: 'mtime',
+      isDeleted: 0,
+      isTrashed: 0
+    }, images.map((image, index) => ({ imageId: image.id, position: index + 1 })));
+    return {
+      post,
+      images,
+      ownerFolder,
+      sourceDirectory: path.join(appConfig.galleryRoot, ...carouselPath.split('/'))
+    };
+  }
+
+  async function createImage(folderId: number, relativePath: string): Promise<ImageRecord> {
+    const absolutePath = path.join(appConfig.galleryRoot, ...relativePath.split('/'));
+    const storedThumbnailPath = `generated/${relativePath}.thumbnail.webp`;
+    const storedPreviewPath = `generated/${relativePath}.preview.webp`;
+    const createdAt = Date.now();
+    await Promise.all([
+      writeFile(absolutePath, `original:${relativePath}`),
+      writeFile(path.join(appConfig.thumbnailsDir, ...storedThumbnailPath.split('/')), `thumbnail:${relativePath}`),
+      writeFile(path.join(appConfig.previewsDir, ...storedPreviewPath.split('/')), `preview:${relativePath}`)
+    ]);
+    const stats = await fs.stat(absolutePath);
+    return imageRepository.upsert({
+      folderId,
+      filename: path.posix.basename(relativePath),
+      extension: path.posix.extname(relativePath),
+      relativePath,
+      absolutePath,
+      fileSize: stats.size,
+      width: 1200,
+      height: 800,
+      mediaType: 'image',
+      mimeType: 'image/jpeg',
+      durationMs: null,
+      fingerprint: `${relativePath}:${stats.size}:${stats.mtimeMs}`,
+      mtimeMs: stats.mtimeMs,
+      firstSeenAt: new Date(createdAt).toISOString(),
+      sortTimestamp: createdAt,
+      takenAt: createdAt,
+      takenAtSource: 'mtime',
+      exifJson: null,
+      thumbnailPath: storedThumbnailPath,
+      previewPath: storedPreviewPath
+    });
+  }
+
+  async function writeFile(targetPath: string, contents: string): Promise<void> {
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.writeFile(targetPath, contents);
+  }
+
+  function originalPath(image: ImageRecord): string {
+    return path.join(appConfig.galleryRoot, ...image.relative_path.split('/'));
+  }
+
+  function thumbnailPath(image: ImageRecord): string {
+    return path.join(appConfig.thumbnailsDir, ...image.thumbnail_path.split('/'));
+  }
+
+  function previewPath(image: ImageRecord): string {
+    return path.join(appConfig.previewsDir, ...image.preview_path.split('/'));
+  }
+
+  async function expectPostFiles(
+    images: ImageRecord[],
+    shouldExist: boolean,
+    options: { ignoreStoredPreviewPaths?: boolean } = {}
+  ): Promise<void> {
+    for (const image of images) {
+      const paths = [originalPath(image), thumbnailPath(image)];
+      if (!options.ignoreStoredPreviewPaths) paths.push(previewPath(image));
+      for (const targetPath of paths) {
+        if (shouldExist) {
+          await expect(fs.stat(targetPath)).resolves.toBeDefined();
+        } else {
+          await expect(fs.stat(targetPath)).rejects.toMatchObject({ code: 'ENOENT' });
+        }
+      }
+    }
+  }
+
+  async function journalFiles(): Promise<string[]> {
+    const journalDirectory = path.join(appConfig.galleryRoot, '.foldergram-delete-quarantine', 'journals');
+    try {
+      return (await fs.readdir(journalDirectory)).filter((name) => name.endsWith('.json'));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
+  }
+
+  function requestDelete(urlPath: string) {
+    return requestTestApp(app, 'DELETE', urlPath, { 'x-foldergram-intent': '1' });
+  }
+
+  function wait(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+  }
+
+  function countRows(table: 'post_items' | 'likes' | 'collection_items', column: 'post_id', id: number): number {
+    return Number(
+      (databaseManager.connection.prepare(`SELECT COUNT(*) AS count FROM ${table} WHERE ${column} = ?`).get(id) as { count: number }).count
+    );
+  }
+});


### PR DESCRIPTION
Permanent deletion could leave posts in an inconsistent state when deleting one of their files failed partway through, especially for Carousel posts.

This PR moves originals and derivatives into quarantine before updating SQLite, restores them if anything fails, and recovers interrupted deletions on startup. It also prevents scans, rebuilds, and lazy derivative generation from racing deletion while preserving existing routes and client behavior.
Closes #84 