### PR TITLE
feat: add option to disable download buttons for original media

### DIFF
--- a/client/src/api/gallery.ts
+++ b/client/src/api/gallery.ts
@@ -597,6 +597,14 @@ export function updateCarouselsMode(treatCarouselsAsFolders: boolean) {
   });
 }
 
+export function updateAllowDownloads(allowDownloads: boolean) {
+  return requestJson<AppStats>('/api/admin/settings/allow-downloads', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ allowDownloads })
+  });
+}
+
 export function updateCarouselsMigrationDecision(decision: 'restore' | 'carousels') {
   return requestJson<AppStats>('/api/admin/settings/carousels-migration-decision', {
     method: 'POST',

--- a/client/src/components/FeedCard.vue
+++ b/client/src/components/FeedCard.vue
@@ -256,7 +256,7 @@
         </div>
         <div class="flex items-center gap-[0.65rem]">
           <a
-            v-if="isHomeContext"
+            v-if="isHomeContext && appStore.allowDownloads"
             class="inline-flex items-center justify-center w-8 h-8 border-0 bg-transparent cursor-pointer color-inherit transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px"
             :href="downloadOriginalMediaUrl"
             download

--- a/client/src/components/PostViewer.vue
+++ b/client/src/components/PostViewer.vue
@@ -484,6 +484,7 @@
             </button>
             <!-- Download original -->
             <a
+              v-if="appStore.allowDownloads"
               class="viewer__sidebar-action inline-flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer text-text transition-[opacity,transform] duration-180 hover:opacity-72 hover:-translate-y-px"
               :href="downloadOriginalMediaUrl"
               download

--- a/client/src/components/ReelActionRail.vue
+++ b/client/src/components/ReelActionRail.vue
@@ -38,6 +38,7 @@
     </div>
 
     <a
+      v-if="appStore.allowDownloads"
       class="reel-action-rail__button"
       :href="downloadOriginalMediaUrl"
       download
@@ -64,6 +65,7 @@ import { useI18n } from 'vue-i18n';
 import { RouterLink } from 'vue-router';
 
 import { useAuthStore } from '../stores/auth';
+import { useAppStore } from '../stores/app';
 import { useLikesStore } from '../stores/likes';
 import type { FeedItem } from '../types/api';
 import { getOriginalMediaDownloadUrl } from '../utils/original-media';
@@ -78,6 +80,7 @@ defineEmits<{
 }>();
 
 const authStore = useAuthStore();
+const appStore = useAppStore();
 const likesStore = useLikesStore();
 const { t } = useI18n();
 const isLiked = computed(() => likesStore.isLiked(props.item.id));

--- a/client/src/components/StoriesModal.vue
+++ b/client/src/components/StoriesModal.vue
@@ -102,7 +102,7 @@
 
             <div class="story-stage__controls">
               <a
-                v-if="downloadOriginalMediaUrl"
+                v-if="appStore.allowDownloads && downloadOriginalMediaUrl"
                 class="story-stage__control-button"
                 :href="downloadOriginalMediaUrl"
                 download

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -272,6 +272,11 @@
         "enabledDescription": "Legacy mode is enabled. carousels folders remain ordinary app folders.",
         "disabledDescription": "Reserved carousel mode is enabled. Each direct child of AppFolder/carousels becomes one post."
       },
+      "allowDownloads": {
+        "label": "Allow downloading original files",
+        "toggleLabel": "Toggle download buttons",
+        "description": "When disabled, the download buttons are hidden so viewers cannot download the original images or videos. Useful for public or shared galleries where you want browsing without copying the media."
+      },
       "excludedFolders": {
         "label": "Excluded source folders",
         "description": "Skip matching folders anywhere by name or by exact relative path under the gallery root. Hidden paths and app-managed storage stay excluded automatically.",
@@ -327,6 +332,7 @@
           "excludedFolders": "excluded folders",
           "storiesFolderHandling": "stories folder handling",
           "carouselsFolderHandling": "carousel folder handling",
+          "allowDownloads": "download buttons",
           "homeFeedDefault": "Home feed default",
           "reelsFeedDefault": "Reels feed default",
           "appFolderOrder": "app folder order",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -272,6 +272,11 @@
         "enabledDescription": "El modo heredado está activo. Las carpetas carousels siguen siendo carpetas normales.",
         "disabledDescription": "El modo carrusel está activo. Cada hijo directo de AppFolder/carousels se convierte en una publicación."
       },
+      "allowDownloads": {
+        "label": "Permitir descargar archivos originales",
+        "toggleLabel": "Alternar botones de descarga",
+        "description": "Cuando está desactivado, los botones de descarga se ocultan para que los visitantes no puedan descargar las imágenes o videos originales. Útil para galerías públicas o compartidas donde quieres navegación sin copiar el contenido."
+      },
       "excludedFolders": {
         "label": "Carpetas de origen excluidas",
         "description": "Omite carpetas coincidentes en cualquier lugar por nombre o por ruta relativa exacta bajo la raíz de la galería. Las rutas ocultas y el almacenamiento administrado por la app siguen excluyéndose automáticamente.",
@@ -327,6 +332,7 @@
           "excludedFolders": "carpetas excluidas",
           "storiesFolderHandling": "comportamiento de las carpetas stories",
           "carouselsFolderHandling": "comportamiento de las carpetas de carrusel",
+          "allowDownloads": "botones de descarga",
           "homeFeedDefault": "predeterminado del feed de Inicio",
           "reelsFeedDefault": "predeterminado de Reels",
           "appFolderOrder": "orden de las carpetas de la app",

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -272,6 +272,11 @@
         "enabledDescription": "旧版模式已启用。carousels 文件夹仍是普通应用文件夹。",
         "disabledDescription": "轮播模式已启用。AppFolder/carousels 的每个直接子文件夹会成为一篇帖子。"
       },
+      "allowDownloads": {
+        "label": "允许下载原始文件",
+        "toggleLabel": "切换下载按钮",
+        "description": "关闭后，下载按钮会被隐藏，访客将无法下载原始图片或视频。适合公开或共享的相册，便于浏览但不便于复制媒体内容。"
+      },
       "excludedFolders": {
         "label": "排除的源文件夹",
         "description": "按名称或图库根目录下的精确相对路径跳过匹配文件夹。隐藏路径和应用管理的存储仍会自动排除。",
@@ -327,6 +332,7 @@
           "excludedFolders": "排除文件夹",
           "storiesFolderHandling": "stories 文件夹行为",
           "carouselsFolderHandling": "轮播文件夹处理",
+          "allowDownloads": "下载按钮",
           "homeFeedDefault": "首页动态默认项",
           "reelsFeedDefault": "短片默认项",
           "appFolderOrder": "应用文件夹顺序",

--- a/client/src/stores/app.ts
+++ b/client/src/stores/app.ts
@@ -111,6 +111,7 @@ export const useAppStore = defineStore('app', {
     nestedFolderTitleFormat: (state) => state.stats?.preferences.nestedFolderTitleFormat ?? 'folder',
     treatStoriesAsFolders: (state) => state.stats?.preferences.treatStoriesAsFolders === true,
     treatCarouselsAsFolders: (state) => state.stats?.preferences.treatCarouselsAsFolders === true,
+    allowDownloads: (state) => state.stats?.preferences.allowDownloads !== false,
     isCarouselsReconciliationPending: (state) => state.stats?.carouselsMigration?.reconciliationPending === true
   },
   actions: {

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -585,6 +585,7 @@ export interface AppStatus {
     nestedFolderTitleFormat?: NestedFolderTitleFormat;
     treatStoriesAsFolders: boolean;
     treatCarouselsAsFolders: boolean;
+    allowDownloads: boolean;
   };
   storiesMigration: {
     hasLegacyStoriesCandidates: boolean;

--- a/client/src/views/SettingsView.test.ts
+++ b/client/src/views/SettingsView.test.ts
@@ -65,7 +65,8 @@ function createAppStatus(
       defaultFolderImageOrder,
       nestedFolderTitleFormat: 'folder',
       treatStoriesAsFolders: false,
-      treatCarouselsAsFolders: false
+      treatCarouselsAsFolders: false,
+      allowDownloads: true
     },
     storiesMigration: {
       hasLegacyStoriesCandidates: false,

--- a/client/src/views/SettingsView.vue
+++ b/client/src/views/SettingsView.vue
@@ -1006,6 +1006,28 @@
                 </button>
               </div>
 
+              <div class="grid gap-3 border-t border-border px-6 py-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+                <div class="min-w-0">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <p class="m-0 text-[0.96rem] font-semibold text-text">{{ t('settings.general.allowDownloads.label') }}</p>
+                  </div>
+                  <p class="m-0 mt-[0.25rem] text-[0.84rem] text-muted">{{ t('settings.general.allowDownloads.description') }}</p>
+                </div>
+                <button
+                  class="inline-flex items-center justify-end border-0 bg-transparent p-0 cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
+                  type="button"
+                  role="switch"
+                  :aria-checked="allowDownloads"
+                  :disabled="savingGeneralSettings || waitingForInitialStatus"
+                  @click="toggleAllowDownloadsSetting"
+                >
+                  <span class="sr-only">{{ t('settings.general.allowDownloads.toggleLabel') }}</span>
+                  <span class="inline-flex h-7 w-12 items-center rounded-full p-[0.15rem] transition-colors duration-180" :class="allowDownloads ? 'bg-accent' : 'bg-[color-mix(in_srgb,var(--border)_88%,var(--surface-alt)_12%)]'">
+                    <span class="h-[1.35rem] w-[1.35rem] rounded-full bg-white shadow-[0_2px_8px_rgba(0,0,0,0.18)] transition-transform duration-180" :class="allowDownloads ? 'translate-x-[1.2rem]' : 'translate-x-0'" />
+                  </span>
+                </button>
+              </div>
+
               <div class="grid gap-4 px-6 py-4">
                 <div class="min-w-0">
                   <div class="flex flex-wrap items-center gap-2">
@@ -1366,7 +1388,8 @@ import {
   updateNestedFolderTitleFormat,
   updateReelsFeedDefault,
   updateStoriesMode,
-  updateCarouselsMode
+  updateCarouselsMode,
+  updateAllowDownloads
 } from '../api/gallery';
 import { SUPPORTED_LOCALES, type SupportedLocale } from '../locales';
 import { useAppStore } from '../stores/app';
@@ -1419,9 +1442,11 @@ const savedLocaleSelection = ref<SupportedLocale | null>(appStore.savedDefaultLo
 const localeSelectionHydrated = ref(false);
 const storiesMode = ref(false);
 const carouselsMode = ref(false);
+const allowDownloads = ref(true);
 const feedDefaultsHydrated = ref(false);
 const storiesModeHydrated = ref(false);
 const carouselsModeHydrated = ref(false);
+const allowDownloadsHydrated = ref(false);
 const activeGeneralSettingsMenu = ref<'home' | 'reels' | 'folder' | 'nestedTitle' | null>(null);
 const showStoriesAnnouncementStructure = ref(false);
 const showCarouselsAnnouncementStructure = ref(false);
@@ -1672,6 +1697,11 @@ function syncCarouselsModeFromSaved() {
   carouselsModeHydrated.value = true;
 }
 
+function syncAllowDownloadsFromSaved() {
+  allowDownloads.value = appStore.allowDownloads;
+  allowDownloadsHydrated.value = true;
+}
+
 function syncExcludedFoldersFromSaved() {
   customExcludedFoldersDraft.value = formatExcludedFolderRules(adminStats.value?.excludedFolders.customExcludedFolders ?? []);
   excludedFoldersHydrated.value = true;
@@ -1760,6 +1790,7 @@ const savedFolderImageOrderDefault = computed(() => appStore.defaultFolderImageO
 const savedNestedFolderTitleFormat = computed(() => appStore.nestedFolderTitleFormat);
 const savedStoriesMode = computed(() => appStore.treatStoriesAsFolders);
 const savedCarouselsMode = computed(() => appStore.treatCarouselsAsFolders);
+const savedAllowDownloads = computed(() => appStore.allowDownloads);
 const savedCustomExcludedFolders = computed(() => adminStats.value?.excludedFolders.customExcludedFolders ?? []);
 const envExcludedFolders = computed(() => adminStats.value?.excludedFolders.envExcludedFolders ?? []);
 const effectiveExcludedFolders = computed(() => adminStats.value?.excludedFolders.effectiveExcludedFolders ?? []);
@@ -1828,6 +1859,7 @@ const feedDefaultsDirty = computed(
 );
 const storiesModeDirty = computed(() => storiesModeHydrated.value && storiesMode.value !== savedStoriesMode.value);
 const carouselsModeDirty = computed(() => carouselsModeHydrated.value && carouselsMode.value !== savedCarouselsMode.value);
+const allowDownloadsDirty = computed(() => allowDownloadsHydrated.value && allowDownloads.value !== savedAllowDownloads.value);
 const storiesScanRequired = computed(() => storiesModeDirty.value || storiesModeRequiresDecision.value);
 const carouselsScanRequired = computed(
   () => carouselsModeDirty.value || carouselsModeRequiresDecision.value || appStore.isCarouselsReconciliationPending
@@ -1851,7 +1883,7 @@ const hasUnsavedFolderRuleChanges = computed(
   () => excludedFoldersDirty.value || hasUnsavedReservedFolderRuleChanges.value
 );
 const generalSettingsDirty = computed(
-  () => localeDirty.value || feedDefaultsDirty.value || storiesModeDirty.value || carouselsModeDirty.value || excludedFoldersDirty.value || storiesModeRequiresDecision.value || carouselsModeRequiresDecision.value
+  () => localeDirty.value || feedDefaultsDirty.value || storiesModeDirty.value || carouselsModeDirty.value || allowDownloadsDirty.value || excludedFoldersDirty.value || storiesModeRequiresDecision.value || carouselsModeRequiresDecision.value
 );
 const showSavedDefaultLocaleNotice = computed(
   () => savedLocaleSelection.value !== null && appStore.locale !== savedLocaleSelection.value
@@ -2701,6 +2733,11 @@ function toggleCarouselsModeSetting() {
   selectCarouselsMode(!carouselsMode.value, showCarouselsMigrationNotice.value);
 }
 
+function toggleAllowDownloadsSetting() {
+  allowDownloads.value = !allowDownloads.value;
+  void saveGeneralSettings();
+}
+
 function chooseCarouselsMigrationMode(value: boolean) {
   selectCarouselsMode(value, true);
 }
@@ -2738,6 +2775,7 @@ async function saveGeneralSettings() {
   const shouldSaveExcludedFolders = excludedFoldersDirty.value;
   const shouldSaveStories = storiesModeDirty.value || storiesModeRequiresDecision.value;
   const shouldSaveCarousels = carouselsModeDirty.value || carouselsModeRequiresDecision.value;
+  const shouldSaveAllowDownloads = allowDownloadsDirty.value;
   const shouldSaveHome = homeFeedDefaultDirty.value;
   const shouldSaveReels = reelsFeedDefaultDirty.value;
   const shouldSaveFolderOrder = folderImageOrderDirty.value;
@@ -2819,6 +2857,15 @@ async function saveGeneralSettings() {
         if (appStore.stats.carouselsMigration) {
           appStore.stats.carouselsMigration.decisionPending = false;
         }
+      }
+    }
+
+    if (shouldSaveAllowDownloads) {
+      const payload = await updateAllowDownloads(allowDownloads.value);
+      savedParts.push(t('settings.general.feedback.parts.allowDownloads'));
+      allowDownloads.value = payload.preferences.allowDownloads;
+      if (appStore.stats) {
+        appStore.stats.preferences.allowDownloads = payload.preferences.allowDownloads;
       }
     }
 
@@ -3049,6 +3096,7 @@ onMounted(async () => {
     syncFeedDefaultsFromSaved();
     syncStoriesModeFromSaved();
     syncCarouselsModeFromSaved();
+    syncAllowDownloadsFromSaved();
   }
   await placesStore.fetchStatus();
   await loadAdminStats().catch(() => {});
@@ -3084,6 +3132,10 @@ watch(
 
     if (!carouselsModeHydrated.value || savingGeneralSettings.value || !carouselsModeDirty.value) {
       syncCarouselsModeFromSaved();
+    }
+
+    if (!allowDownloadsHydrated.value || savingGeneralSettings.value || !allowDownloadsDirty.value) {
+      syncAllowDownloadsFromSaved();
     }
   },
   {

--- a/server/src/constants/app-setting-keys.ts
+++ b/server/src/constants/app-setting-keys.ts
@@ -23,5 +23,6 @@ export const AUTH_VIEWER_PASSWORD_HASH_SETTING_KEY = 'auth.viewer_password_hash'
 export const AUTH_VIEWER_PASSWORD_SALT_SETTING_KEY = 'auth.viewer_password_salt';
 export const SHARE_SESSION_SECRET_SETTING_KEY = 'share.session_secret';
 export const TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY = 'library.treat_carousels_as_folders';
+export const ALLOW_DOWNLOADS_SETTING_KEY = 'library.allow_downloads';
 export const CAROUSELS_MIGRATION_DECISION_SETTING_KEY = 'library.carousels_migration_decision';
 export const CAROUSELS_APPLIED_MODE_SETTING_KEY = 'library.carousels_applied_mode';

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -89,6 +89,9 @@ const nestedFolderTitleFormatBodySchema = z.object({
 const storiesModeBodySchema = z.object({
   treatStoriesAsFolders: z.boolean()
 });
+const allowDownloadsBodySchema = z.object({
+  allowDownloads: z.boolean()
+});
 const excludedFoldersBodySchema = z.object({
   rules: z.array(z.string()).default([])
 });
@@ -574,6 +577,15 @@ router.put(
   (request, response) => {
     const body = storiesModeBodySchema.parse(request.body);
     response.json(galleryService.setTreatStoriesAsFolders(body.treatStoriesAsFolders));
+  }
+);
+
+router.put(
+  '/admin/settings/allow-downloads',
+  requireCapability('canAccessSettings', 'Admin access is required.'),
+  (request, response) => {
+    const body = allowDownloadsBodySchema.parse(request.body);
+    response.json(galleryService.setAllowDownloads(body.allowDownloads));
   }
 );
 

--- a/server/src/services/gallery-service.ts
+++ b/server/src/services/gallery-service.ts
@@ -3,6 +3,7 @@ import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 
 import {
+  ALLOW_DOWNLOADS_SETTING_KEY,
   APP_DEFAULT_LOCALE_SETTING_KEY,
   CAROUSELS_APPLIED_MODE_SETTING_KEY,
   CAROUSELS_MIGRATION_DECISION_SETTING_KEY,
@@ -233,6 +234,10 @@ function getTreatStoriesAsFolders(): boolean {
 
 function getTreatCarouselsAsFolders(): boolean {
   return parseTreatCarouselsAsFoldersSetting(appSettingsRepository.get(TREAT_CAROUSELS_AS_FOLDERS_SETTING_KEY));
+}
+
+function getAllowDownloads(): boolean {
+  return appSettingsRepository.get(ALLOW_DOWNLOADS_SETTING_KEY) !== 'false';
 }
 
 function getCustomExcludedFolders(): string[] {
@@ -2139,6 +2144,7 @@ export const galleryService = {
     const storiesMigration = getStoriesMigrationStatus();
     const treatCarouselsAsFolders = getTreatCarouselsAsFolders();
     const carouselsMigration = getCarouselsMigrationStatus();
+    const allowDownloads = getAllowDownloads();
     const indexedPosts = storageState.libraryAvailable ? imageRepository.countFeed() : 0;
 
     return {
@@ -2165,7 +2171,8 @@ export const galleryService = {
         defaultFolderImageOrder,
         nestedFolderTitleFormat,
         treatStoriesAsFolders,
-        treatCarouselsAsFolders
+        treatCarouselsAsFolders,
+        allowDownloads
       },
       storiesMigration,
       carouselsMigration
@@ -2211,6 +2218,7 @@ export const galleryService = {
     const storiesMigration = getStoriesMigrationStatus();
     const treatCarouselsAsFolders = getTreatCarouselsAsFolders();
     const carouselsMigration = getCarouselsMigrationStatus();
+    const allowDownloads = getAllowDownloads();
     const excludedFolders = getExcludedFolderSettings();
 
     return {
@@ -2247,7 +2255,8 @@ export const galleryService = {
         defaultFolderImageOrder,
         nestedFolderTitleFormat,
         treatStoriesAsFolders,
-        treatCarouselsAsFolders
+        treatCarouselsAsFolders,
+        allowDownloads
       },
       storiesMigration,
       carouselsMigration,
@@ -2468,5 +2477,10 @@ export const galleryService = {
 
   setCarouselsMigrationDecision(decision: 'restore' | 'carousels') {
     return this.setTreatCarouselsAsFolders(decision === 'restore');
+  },
+
+  setAllowDownloads(allowDownloads: boolean) {
+    appSettingsRepository.set(ALLOW_DOWNLOADS_SETTING_KEY, allowDownloads ? 'true' : 'false');
+    return this.getStats();
   }
 };

--- a/server/test/viewer-status.test.ts
+++ b/server/test/viewer-status.test.ts
@@ -206,7 +206,8 @@ describe.sequential('viewer-safe status payload', () => {
       defaultFolderImageOrder: 'newest',
       nestedFolderTitleFormat: 'folder',
       treatStoriesAsFolders: false,
-      treatCarouselsAsFolders: false
+      treatCarouselsAsFolders: false,
+      allowDownloads: true
     });
   });
 
@@ -225,7 +226,8 @@ describe.sequential('viewer-safe status payload', () => {
       defaultFolderImageOrder: 'oldest',
       nestedFolderTitleFormat: 'folder',
       treatStoriesAsFolders: false,
-      treatCarouselsAsFolders: false
+      treatCarouselsAsFolders: false,
+      allowDownloads: true
     });
   });
 });


### PR DESCRIPTION
## What this does

Adds a user-controlled **"Allow downloading original files"** setting (Settings → General Settings, stored as `library.allow_downloads`, default **enabled**).

When turned **off**, the download buttons are hidden across the app so viewers cannot download the original images or videos:
- PostViewer (image & video detail)
- ReelActionRail (reels)
- StoriesModal (stories)
- FeedCard (home feed card)

When turned **on** (the default), behavior is unchanged for everyone.

## Why

Foldergram is a photo/video gallery that people increasingly share publicly (e.g. via a Cloudflare tunnel or a public/shared URL). Once a gallery is public, the download buttons let any visitor instantly save the original media at full resolution — which is often not what the owner wants for a portfolio, client gallery, or personal collection.

This gives the **owner the choice** instead of forcing a behavior:
- Keep downloads **on** for a personal/private library.
- Turn downloads **off** for a public or shared gallery where browsing is the goal and copying the originals isn't.

It respects the existing access model — the setting is an admin-controlled toggle (requires admin), so it composes cleanly with the public-viewer / password-protected modes.

## What changed

- **Server**: new setting key `library.allow_downloads`, exposed in the status/preferences payload, and a new admin API endpoint `PUT /api/admin/settings/allow-downloads`.
- **Client**: a toggle in Settings → General Settings, plus conditional rendering of the download buttons in the 4 components that show them.
- **Locales**: English, Spanish, and Chinese.
- **Tests**: updated status/preferences assertions; all existing tests pass (335 tests, 61 files).

Default is **enabled**, so this is a strictly additive, non-breaking change for existing installs.

## Testing

- `pnpm build` — server and client compile cleanly.
- `pnpm test` — 335 tests pass across 61 files.
